### PR TITLE
RavenDB-25119 Adds a configuration to force the use of the default search analyzer when `search` on dynamic fields without an explicitly configured analyzer.

### DIFF
--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -191,7 +191,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     internal void ApplyAnalyzerMultiTerms(in FieldMetadata binding, ReadOnlySpan<byte> originalTerm, ref ContextBoundNativeList<Slice> terms)
     {
         Analyzer analyzer = binding.Analyzer;
-        if (binding.FieldId == Constants.IndexWriter.DynamicField && binding.Mode is not (FieldIndexingMode.Exact or FieldIndexingMode.No))
+        if (binding.FieldId == Constants.IndexWriter.DynamicField && binding.Mode is not (FieldIndexingMode.Exact or FieldIndexingMode.No) && analyzer is null)
         {
             analyzer = _fieldMapping.DefaultAnalyzer;
         }

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -605,6 +605,12 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.ElapsedSinceQueriedPersistIntervalInMin", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public TimeSetting ElapsedSinceQueriedPersistInterval { get; set; }
         
+        [Description("Corax: Use default search analyzer for search query when explicit analyzer is not specified")]
+        [DefaultValue(false)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.Corax.ForceDynamicFieldSearchAnalyzerWhenMissingExplicitFieldConfiguration", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool ForceDynamicFieldsSearchAnalyzerForMissingExplicitFieldConfiguration { get; protected set; }
+        
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -605,11 +605,11 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.ElapsedSinceQueriedPersistIntervalInMin", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public TimeSetting ElapsedSinceQueriedPersistInterval { get; set; }
         
-        [Description("Corax: Use default search analyzer for search query when explicit analyzer is not specified")]
+        [Description("Use default search analyzer for dynamic fields if not set explicitly.")]
         [DefaultValue(false)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
-        [ConfigurationEntry("Indexing.Corax.ForceDynamicFieldSearchAnalyzerWhenMissingExplicitFieldConfiguration", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
-        public bool ForceDynamicFieldsSearchAnalyzerForMissingExplicitFieldConfiguration { get; protected set; }
+        [ConfigurationEntry("Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery { get; protected set; }
         
         protected override void ValidateProperty(PropertyInfo property)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1106,7 +1106,7 @@ public static class CoraxQueryBuilder
 
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, index, indexFieldsMapping, fieldsToFetch, builderParameters.HasDynamics,
             builderParameters.DynamicFields, handleSearch: true, hasBoost: builderParameters.HasBoost
-            , forceDefaultSearchAnalyzer: builderParameters.Index.Configuration.ForceDynamicFieldsSearchAnalyzerForMissingExplicitFieldConfiguration);
+            , forceDefaultSearchAnalyzer: builderParameters.Index.Configuration.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery);
 
         // Wildcard queries:
         if (searchQueryOptions is IndexSearcher.SearchQueryOptions.PhraseQueryWithWildcardAdjustments && valueAsString.Length >= 1 && (valueAsString[0] == '*' || (valueAsString.Length >= 2 && valueAsString[^1] == '*')))

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1105,7 +1105,8 @@ public static class CoraxQueryBuilder
         }
 
         var fieldMetadata = QueryBuilderHelper.GetFieldMetadata(allocator, fieldName, index, indexFieldsMapping, fieldsToFetch, builderParameters.HasDynamics,
-            builderParameters.DynamicFields, handleSearch: true, hasBoost: builderParameters.HasBoost);
+            builderParameters.DynamicFields, handleSearch: true, hasBoost: builderParameters.HasBoost
+            , forceDefaultSearchAnalyzer: builderParameters.Index.Configuration.ForceDynamicFieldsSearchAnalyzerForMissingExplicitFieldConfiguration);
 
         // Wildcard queries:
         if (searchQueryOptions is IndexSearcher.SearchQueryOptions.PhraseQueryWithWildcardAdjustments && valueAsString.Length >= 1 && (valueAsString[0] == '*' || (valueAsString.Length >= 2 && valueAsString[^1] == '*')))

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Analyzers/LuceneRavenPerFieldAnalyzerWrapper.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/Analyzers/LuceneRavenPerFieldAnalyzerWrapper.cs
@@ -15,11 +15,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers
         private Analyzer _defaultExactAnalyzer;
         private Analyzer _defaultSearchAnalyzer;
 
-        private readonly Func<string, Analyzer> _defaultSearchAnalyzerFactory;
+        public readonly Func<string, Analyzer> DefaultSearchAnalyzerFactory;
         private readonly Func<string, Analyzer> _defaultExactAnalyzerFactory;
 
         private readonly Dictionary<string, Analyzer> _analyzerMap = new Dictionary<string, Analyzer>(default(PerFieldAnalyzerComparer));
         private readonly bool _hasDynamicFields;
+
+        public bool IsExplicitField(string fieldName) => _analyzerMap?.ContainsKey(fieldName) ?? false;
 
         public struct PerFieldAnalyzerComparer : IEqualityComparer<string>
         {
@@ -71,7 +73,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers
             : this(defaultAnalyzer)
         {
             _hasDynamicFields = true;
-            _defaultSearchAnalyzerFactory = defaultSearchAnalyzerFactory ?? throw new ArgumentNullException(nameof(defaultSearchAnalyzerFactory));
+            DefaultSearchAnalyzerFactory = defaultSearchAnalyzerFactory ?? throw new ArgumentNullException(nameof(defaultSearchAnalyzerFactory));
             _defaultExactAnalyzerFactory = defaultExactAnalyzerFactory ?? throw new ArgumentNullException(nameof(defaultExactAnalyzerFactory));
         }
 
@@ -98,7 +100,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers
                         switch (fieldIndexing.Indexing)
                         {
                             case FieldIndexing.Search:
-                                return _defaultSearchAnalyzer ??= _defaultSearchAnalyzerFactory(fieldName);
+                                return _defaultSearchAnalyzer ??= DefaultSearchAnalyzerFactory(fieldName);
                             case FieldIndexing.Exact:
                                 return _defaultExactAnalyzer ??= _defaultExactAnalyzerFactory(fieldName);
                         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexingHelpers.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexingHelpers.cs
@@ -65,7 +65,7 @@ public static class LuceneIndexingHelpers
             analyzers.Add(defaultAnalyzerToUse.GetType(), defaultAnalyzerToUse);
         }
 
-        var perFieldAnalyzerWrapper = forQuerying == false && indexDefinition.HasDynamicFields
+        var perFieldAnalyzerWrapper = (forQuerying == false || index.Configuration.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery) && indexDefinition.HasDynamicFields
             ? new LuceneRavenPerFieldAnalyzerWrapper(
                 defaultAnalyzerToUse,
                 fieldName => GetOrCreateAnalyzer(fieldName, index.Configuration.DefaultSearchAnalyzerType.Value.Type, CreateStandardAnalyzer),
@@ -100,9 +100,7 @@ public static class LuceneIndexingHelpers
                     {
                         // if we have default field options then we need to take into account overrides for regular fields
 
-                        if (defaultAnalyzer == null)
-                            defaultAnalyzer = CreateDefaultAnalyzer(fieldName, index.Configuration.DefaultAnalyzerType.Value.Type);
-
+                        defaultAnalyzer ??= CreateDefaultAnalyzer(fieldName, index.Configuration.DefaultAnalyzerType.Value.Type);
                         perFieldAnalyzerWrapper.AddAnalyzer(fieldName, defaultAnalyzer);
                         continue;
                     }

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents.Queries
                 switch (methodType)
                 {
                     case MethodType.Search:
-                        return HandleSearch(query, me, metadata, parameters, analyzer, proximity);
+                        return HandleSearch(query, me, metadata, parameters, analyzer, proximity, index);
                     case MethodType.Fuzzy:
                         return HandleFuzzy(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, exact);
                     case MethodType.Proximity:
@@ -845,7 +845,7 @@ namespace Raven.Server.Documents.Queries
         }
 
         private static Lucene.Net.Search.Query HandleSearch(Query query, MethodExpression expression, QueryMetadata metadata, BlittableJsonReaderObject parameters,
-            Analyzer analyzer, int? proximity)
+            Analyzer analyzer, int? proximity, Index index)
         {
 
             QueryFieldName fieldName;
@@ -885,7 +885,7 @@ namespace Raven.Server.Documents.Queries
                     throw new InvalidQueryException("Proximity search works only on simple string terms, not wildcard or prefix ones", metadata.QueryText, parameters);
 
                 // this will return PQ, unless there is a single term
-                LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, valueAsString, type, analyzer, out var t);
+                LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, valueAsString, type, analyzer, out var t, index);
                 if (t is not PhraseQuery pq)
                     throw new InvalidQueryException("Proximity search works only on multiple search terms", metadata.QueryText, parameters);
 
@@ -899,7 +899,7 @@ namespace Raven.Server.Documents.Queries
             Lucene.Net.Search.Query firstQuery = null;
             foreach (var v in GetValues())
             {
-                if (LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, v, GetTermType(v), analyzer, out var t) == false)
+                if (LuceneQueryHelper.TryGetAnalyzedTerm(fieldName, v, GetTermType(v), analyzer, out var t, index) == false)
                     continue;
                 
                 if (firstQuery == null && q == null)

--- a/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryHelper.cs
@@ -170,7 +170,7 @@ namespace Raven.Server.Documents.Queries
         }
 
         private static ThreadLocal<LowerCaseKeywordAnalyzer> WildcardAnalyzer = new ThreadLocal<LowerCaseKeywordAnalyzer>(() => new());
-        public static bool TryGetAnalyzedTerm(string fieldName, string term, LuceneTermType type, Analyzer analyzer, out Query query, float? boost = null, float? similarity = null)
+        public static bool TryGetAnalyzedTerm(string fieldName, string term, LuceneTermType type, Analyzer analyzer, out Query query, Index index, float? boost = null, float? similarity = null)
         {
             if (type != LuceneTermType.String && type != LuceneTermType.Prefix && type != LuceneTermType.WildCard)
                 throw new InvalidOperationException("Analyzed terms can be only created from string values.");
@@ -178,7 +178,8 @@ namespace Raven.Server.Documents.Queries
             if (boost.HasValue == false)
                 boost = 1;
 
-            if (type is LuceneTermType.Prefix or LuceneTermType.WildCard)
+            bool analyzerOverriden = TryGetSearchAnalyzerForImplicitField(out analyzer);
+            if (type is LuceneTermType.Prefix or LuceneTermType.WildCard && analyzerOverriden is false)
             {
                 var analyzerToUse = analyzer switch
                 {
@@ -197,8 +198,13 @@ namespace Raven.Server.Documents.Queries
                     // in wildcard queries
                     _ => analyzer
                 };
+
+                analyzerOverriden = true;
                 Debug.Assert(analyzer != null);
             }
+
+            if (analyzerOverriden == false)
+                analyzerOverriden = TryGetSearchAnalyzerForImplicitField(out analyzer);
 
             var tokenStream = analyzer.ReusableTokenStream(fieldName, new StringReader(term));
             var terms = new List<string>();
@@ -257,6 +263,22 @@ namespace Raven.Server.Documents.Queries
 
             query = pq;
             return true;
+
+            bool TryGetSearchAnalyzerForImplicitField(out Analyzer newAnalyzer)
+            {
+                if (index.Definition.HasDynamicFields && index.Configuration.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery && analyzer is LuceneRavenPerFieldAnalyzerWrapper perFieldAnalyzerWrapper)
+                {
+                    var isExplicit = perFieldAnalyzerWrapper.IsExplicitField(fieldName);
+                    if (isExplicit == false)
+                    {
+                        newAnalyzer = perFieldAnalyzerWrapper.DefaultSearchAnalyzerFactory(fieldName);
+                        return true;
+                    }
+                }
+
+                newAnalyzer = analyzer;
+                return false;
+            }
         }
 
         public static unsafe string GetTermValue(string value, LuceneTermType type, bool exact)

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -520,7 +520,7 @@ public static class QueryBuilderHelper
 
     internal static FieldMetadata GetFieldMetadata(ByteStringContext allocator, string fieldName, Index index, IndexFieldsMapping indexMapping,
         FieldsToFetch queryMapping, bool hasDynamics, Lazy<List<string>> dynamicFields, bool isForQuery = true,
-        bool exact = false, bool isSorting = false, bool hasBoost = false, bool handleSearch = false)
+        bool exact = false, bool isSorting = false, bool hasBoost = false, bool handleSearch = false, bool forceDefaultSearchAnalyzer = false)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
         FieldMetadata metadata;
@@ -562,7 +562,12 @@ public static class QueryBuilderHelper
             var mode = exact
                 ? FieldIndexingMode.Exact
                 : FieldIndexingMode.Normal;
-            metadata = FieldMetadata.Build(allocator, fieldName, Corax.Constants.IndexWriter.DynamicField, mode, indexMapping.DefaultAnalyzer, hasBoost: hasBoost);
+            //Context: dynamic field without explicit configuration. For search query we might want to use the default search analyzer:
+            var analyzer = handleSearch && forceDefaultSearchAnalyzer 
+                ? indexMapping.SearchAnalyzer(fieldName) 
+                : indexMapping.DefaultAnalyzer;
+            
+            metadata = FieldMetadata.Build(allocator, fieldName, Corax.Constants.IndexWriter.DynamicField, mode, analyzer, hasBoost: hasBoost);
         }
 
         return metadata;

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -47,7 +47,7 @@ class configurationItem {
         "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
         "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
         "Indexing.ElapsedSinceQueriedPersistIntervalInMin",
-        "Indexing.Corax.ForceDynamicFieldSearchAnalyzerWhenMissingExplicitFieldConfiguration"
+        "Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery"
         
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -46,7 +46,8 @@ class configurationItem {
         "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
         "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
         "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
-        "Indexing.ElapsedSinceQueriedPersistIntervalInMin"
+        "Indexing.ElapsedSinceQueriedPersistIntervalInMin",
+        "Indexing.Corax.ForceDynamicFieldSearchAnalyzerWhenMissingExplicitFieldConfiguration"
         
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -85,6 +85,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
                 "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
                 "Indexing.ElapsedSinceQueriedPersistIntervalInMin",
+                "Indexing.Corax.ForceDynamicFieldSearchAnalyzerWhenMissingExplicitFieldConfiguration",
                 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -85,7 +85,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
                 "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
                 "Indexing.ElapsedSinceQueriedPersistIntervalInMin",
-                "Indexing.Corax.ForceDynamicFieldSearchAnalyzerWhenMissingExplicitFieldConfiguration",
+                "Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery",
                 
                 //Obsolete studio keys:
                 "Indexing.Static.SearchEngineType",

--- a/test/SlowTests/Issues/RavenDB-25119.cs
+++ b/test/SlowTests/Issues/RavenDB-25119.cs
@@ -1,0 +1,95 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Raven.Server.Config.Categories;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25119(ITestOutputHelper output) : RavenTestBase(output)
+{
+    
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = [false])]
+    public void UseDefaultSearchAnalyzerWhenSearchingDynamicFields(Options options, bool forceSearchDefaultAnalyzer)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        var matchField = new MatchField()
+        {
+            Name = new NameClass()
+            {
+                Translations = new Dictionary<string, string>()
+                {
+                    { "English", "Noord-Holland" },
+                    { "French", "Something something" }
+                }
+            }
+        };
+
+        session.Store(matchField);
+        session.SaveChanges();
+
+        var index = new MatchFieldsIndex(forceSearchDefaultAnalyzer);
+        index.Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        var results = session
+            .Query<MatchFieldsIndex.MatchFieldIndexResult, MatchFieldsIndex>()
+            .Search(x => x.Name_English, "Noord-Holland")
+            .ProjectInto<MatchFieldsIndex.MatchFieldIndexResult>()
+            .ToList();
+
+        Assert.Equal(forceSearchDefaultAnalyzer, results.Count > 0);
+    }
+
+    private class MatchField
+    {
+        public NameClass Name { get; set; }
+    }
+
+    private class NameClass
+    {
+        public Dictionary<string, string> Translations { get; set; }
+    }
+
+    private class MatchFieldsIndex : AbstractIndexCreationTask<MatchField>
+    {
+        public class MatchFieldIndexResult
+        {
+            public object DynamicName { get; set; }
+            public string Name_English { get; set; }
+        }
+
+        public MatchFieldsIndex()
+        {
+            //Querying overload
+        }
+        
+        public MatchFieldsIndex(bool forceSearchDefaultAnalyzer)
+        {
+            Map = matchfields => from matchfield in matchfields
+                select new MatchFieldIndexResult
+                {
+                    DynamicName = matchfield.Name.Translations.Select(kvp => CreateField(
+                        nameof(MatchField.Name) + '_' + kvp.Key, kvp.Value, new CreateFieldOptions
+                        {
+                            Indexing = FieldIndexing.Search,
+                            Storage = FieldStorage.No
+                        }))
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.ForceDynamicFieldsSearchAnalyzerForMissingExplicitFieldConfiguration)] = forceSearchDefaultAnalyzer.ToString();
+            StoreAllFields(FieldStorage.No);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-25119.cs
+++ b/test/SlowTests/Issues/RavenDB-25119.cs
@@ -13,13 +13,24 @@ namespace SlowTests.Issues;
 
 public class RavenDB_25119(ITestOutputHelper output) : RavenTestBase(output)
 {
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = [false])]
+    private void UseDefaultSearchAnalyzerWhenSearchingDynamicFields(Options options, bool forceSearchDefaultAnalyzer)
+        => UseDefaultSearchAnalyzerWhenSearchingDynamicFieldsBase(options, forceSearchDefaultAnalyzer, new MatchFieldsIndex(forceSearchDefaultAnalyzer));
     
     [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = [true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Lucene, Data = [false])]
-    public void UseDefaultSearchAnalyzerWhenSearchingDynamicFields(Options options, bool forceSearchDefaultAnalyzer)
+    private void UseDefaultSearchAnalyzerWhenSearchingDynamicFieldsJs(Options options, bool forceSearchDefaultAnalyzer)
+        => UseDefaultSearchAnalyzerWhenSearchingDynamicFieldsBase(options, forceSearchDefaultAnalyzer, new MatchFieldsIndexJs(forceSearchDefaultAnalyzer));
+
+    private void UseDefaultSearchAnalyzerWhenSearchingDynamicFieldsBase<TIndex>(Options options, bool forceSearchDefaultAnalyzer, TIndex instance) where TIndex : AbstractIndexCreationTask, new()
     {
         using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
@@ -37,13 +48,12 @@ public class RavenDB_25119(ITestOutputHelper output) : RavenTestBase(output)
 
         session.Store(matchField);
         session.SaveChanges();
-
-        var index = new MatchFieldsIndex(forceSearchDefaultAnalyzer);
+        var index = instance;
         index.Execute(store);
-        Indexes.WaitForIndexing(store);
 
+        Indexes.WaitForIndexing(store);
         var results = session
-            .Query<MatchFieldsIndex.MatchFieldIndexResult, MatchFieldsIndex>()
+            .Query<MatchFieldsIndex.MatchFieldIndexResult, TIndex>()
             .Search(x => x.Name_English, "Noord-Holland")
             .ProjectInto<MatchFieldsIndex.MatchFieldIndexResult>()
             .ToList();
@@ -59,6 +69,29 @@ public class RavenDB_25119(ITestOutputHelper output) : RavenTestBase(output)
     private class NameClass
     {
         public Dictionary<string, string> Translations { get; set; }
+    }
+
+    private class MatchFieldsIndexJs : AbstractJavaScriptIndexCreationTask
+    {
+        public MatchFieldsIndexJs()
+        {
+            //Querying overload
+        }
+
+        public MatchFieldsIndexJs(bool forceSearchDefaultAnalyzer)
+        {
+            Maps =
+            [
+                @"map(""MatchFields"", (matchField) => {
+                    return {
+                        _: Object.keys(matchField.Name.Translations).map(key => createField('Name_' + key, matchField.Name.Translations[key],
+                      {  indexing: 'Search', storage: false, termVector: null }))
+              };
+})"
+            ];
+
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery)] = forceSearchDefaultAnalyzer.ToString();
+        }
     }
 
     private class MatchFieldsIndex : AbstractIndexCreationTask<MatchField>
@@ -87,8 +120,7 @@ public class RavenDB_25119(ITestOutputHelper output) : RavenTestBase(output)
                         }))
                 };
 
-            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
-            Configuration[RavenConfiguration.GetKey(x => x.Indexing.ForceDynamicFieldsSearchAnalyzerForMissingExplicitFieldConfiguration)] = forceSearchDefaultAnalyzer.ToString();
+            Configuration[RavenConfiguration.GetKey(x => x.Indexing.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery)] = forceSearchDefaultAnalyzer.ToString();
             StoreAllFields(FieldStorage.No);
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25119

### Additional description
Adds a configuration to force the use of the default search analyzer for a dynamic field that has no explicit configuration when the search() method is used.



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?: configuration option
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
