### PR TITLE
RavenDB-25177 Switches an extensively allocating test to be run only on x64 platforms.

### DIFF
--- a/test/SlowTests/Corax/GrowableBitArrayTests.cs
+++ b/test/SlowTests/Corax/GrowableBitArrayTests.cs
@@ -13,12 +13,8 @@ using Xunit.Abstractions;
 
 namespace SlowTests.Corax;
 
-public class GrowableBitArrayTests : NoDisposalNeeded
+public class GrowableBitArrayTests(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
-    public GrowableBitArrayTests(ITestOutputHelper output) : base(output)
-    {
-    }
-
     [RavenFact(RavenTestCategory.Corax)]
     public void CanCreateEmptyBitmap()
     {
@@ -76,7 +72,7 @@ public class GrowableBitArrayTests : NoDisposalNeeded
         }
     }
     
-    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [InlineData((long)int.MaxValue - 1)]
     [InlineData((long)int.MaxValue )]
     [InlineData((long)int.MaxValue + 1)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25177

### Additional description

Switches an extensively allocating test to be run only on x64 platforms.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
