### PR TITLE
RavenDB-25235 Missing ETL configuration data in backup

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -123,7 +123,8 @@ namespace Raven.Client.Documents.Operations.ETL
                 [nameof(MentorNode)] = MentorNode,
                 [nameof(PinToMentorNode)] = PinToMentorNode,
                 [nameof(AllowEtlOnNonEncryptedChannel)] = AllowEtlOnNonEncryptedChannel,
-                [nameof(Transforms)] = new DynamicJsonArray(Transforms.Select(x => x.ToJson()))
+                [nameof(Transforms)] = new DynamicJsonArray(Transforms.Select(x => x.ToJson())),
+                [nameof(Disabled)] = Disabled
             };
 
             return result;

--- a/test/SlowTests/Issues/RavenDB-25235.cs
+++ b/test/SlowTests/Issues/RavenDB-25235.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25235 :RavenTestBase
+    {
+        public RavenDB_25235(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task RestoreDisabledRavenEtl()
+        {
+            DoNotReuseServer();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    RavenEtlConfiguration etlConfiguration = new()
+                    {
+                        Name = csName,
+                        ConnectionStringName = csName,
+                        Transforms = { new Transformation { Name = $"ETL : {csName}", ApplyToAllDocuments = true } },
+                        MentorNode = "A",
+                        Disabled = true
+                    };
+                    var connectionString = new RavenConnectionString
+                    {
+                        Name = csName,
+                        Database = dbName,
+                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" },
+                    };
+
+                    Assert.NotNull(store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString)));
+                    store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    runRestore(store, backupPath);
+                    var recored = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database + "1"));
+                    Assert.Equal(1, recored.RavenEtls.Count);
+                    Assert.True(recored.RavenEtls[0].Disabled);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        private void runRestore(DocumentStore store, string backupPath)
+        {
+            var configuration = new RestoreBackupConfiguration { DatabaseName = store.Database + "1" };
+            configuration.BackupLocation = Directory.GetDirectories(backupPath).First();
+            Backup.RestoreDatabase(store, configuration);
+        }
+
+        private static async Task RunBackup(DocumentStore store, string backupPath)
+        {
+            var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+            {
+                BackupType = BackupType.Backup,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = backupPath
+                }
+            }));
+
+            _ = (BackupResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25235

### Additional description

Missing ETL configuration data at toJson

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
