### PR TITLE
RavenDB-24955 Retry to get property from cache with escaped version

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -102,15 +102,9 @@ namespace Raven.Server.Documents
             _allocations.Add(mem);
             Memory.Copy(mem.Address, state.StringBuffer, state.StringSize);
             var lazyStringValueFromParserState = _ctx.AllocateStringValue(null, mem.Address, state.StringSize);
-            if (escapePositionsCount > 0)
-            {
-                lazyStringValueFromParserState.EscapePositions = state.EscapePositions.ToArray();
-            }
-            else
-            {
-                lazyStringValueFromParserState.EscapePositions = Array.Empty<int>();
-            }
 
+            lazyStringValueFromParserState.EscapePositions = escapePositionsCount > 0 ? state.EscapePositions.ToArray() : [];
+                
             return lazyStringValueFromParserState;
         }
 

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -475,10 +475,7 @@ namespace Sparrow.Json
         private unsafe LazyStringValue CreateLazyStringValueFromParserState()
         {
             var lazyStringValueFromParserState = _context.AllocateStringValue(null, _state.StringBuffer, _state.StringSize);
-            if (_state.EscapePositions.Count <= 0)
-                return lazyStringValueFromParserState;
-
-            lazyStringValueFromParserState.EscapePositions = _state.EscapePositions.ToArray();
+            lazyStringValueFromParserState.EscapePositions = _state.EscapePositions.Count > 0 ? _state.EscapePositions.ToArray() : [];
             return lazyStringValueFromParserState;
         }
 

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -104,7 +104,7 @@ namespace Sparrow.Json
 
             public int CompareTo(PropertyName other)
             {
-                return Comparer.CompareTo(other.Comparer);
+                return Comparer.CompareWithMetadata(other.Comparer);
             }
 
             public override string ToString()
@@ -170,7 +170,7 @@ namespace Sparrow.Json
 
         private readonly FastList<PropertyName> _docPropNames = new FastList<PropertyName>();
         private readonly SortedDictionary<PropertyName, object> _propertiesSortOrder = new SortedDictionary<PropertyName, object>();
-        private readonly Dictionary<LazyStringValue, PropertyName> _propertyNameToId = new Dictionary<LazyStringValue, PropertyName>(default(LazyStringValueStructComparer));
+        private readonly Dictionary<LazyStringValue, PropertyName> _propertyNameToId = new Dictionary<LazyStringValue, PropertyName>(LazyStringValueWithMetadataComparer.Instance);
         private bool _propertiesNeedSorting;
 
         public int PropertiesDiscovered;
@@ -210,7 +210,7 @@ namespace Sparrow.Json
 
             // PERF: The hash for the property needs to be a hash code, if its not
             //       we will be paying the cost of hash collisions in the sort checks.
-            var prop = new PropertyName(propName.GetHashCode(), propName, -1, propIndex);
+            var prop = new PropertyName(propName.GetHashCodeWithMetadata(), propName, -1, propIndex);
 
             _docPropNames.Add(prop);
             _propertiesSortOrder.Add(prop, prop);

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -38,6 +38,7 @@ namespace Sparrow.Json
         private AllocatedMemoryData _tempBuffer;
 
         private readonly Dictionary<StringSegment, LazyStringValue> _fieldNames = new Dictionary<StringSegment, LazyStringValue>(StringSegmentEqualityStructComparer.BoxedInstance);
+        private readonly Dictionary<LazyStringValue, LazyStringValue> _fieldNamesLazyStrings = new Dictionary<LazyStringValue, LazyStringValue>(LazyStringValueWithMetadataComparer.Instance);
 
         private static readonly PerCoreContainer<PathCache> _perCorePathCache = new PerCoreContainer<PathCache>();
         private PathCache _activeAllocatePathCaches;
@@ -438,6 +439,20 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LazyStringValue GetLazyStringForFieldWithCaching(LazyStringValue field)
+        {
+            EnsureNotDisposed();
+            if (_fieldNamesLazyStrings.TryGetValue(field, out LazyStringValue value))
+            {
+                // PERF: This is usually the most common scenario, so actually being contiguous improves the behavior.
+                Debug.Assert(value.IsDisposed == false);
+                return value;
+            }
+
+            return GetLazyStringForFieldWithCachingUnlikely(field);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue GetLazyStringForFieldWithCaching(string field)
         {
             EnsureNotDisposed();
@@ -457,13 +472,43 @@ namespace Sparrow.Json
             using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
             {
 #endif
-            EnsureNotDisposed();
-            LazyStringValue value = GetLazyString(key, longLived: true);
-            _fieldNames[key.Value] = value;
+                EnsureNotDisposed();
+                LazyStringValue value = GetLazyString(key, longLived: true);
+                _fieldNames[key.Value] = value;
+                _fieldNamesLazyStrings[value] = value;
 
-            //sanity check, in case the 'value' is manually disposed outside of this function
-            Debug.Assert(value.IsDisposed == false);
-            return value;
+                //sanity check, in case the 'value' is manually disposed outside of this function
+                Debug.Assert(value.IsDisposed == false);
+                return value;
+#if DEBUG || VALIDATE
+            }
+#endif
+        }
+
+
+        private unsafe LazyStringValue GetLazyStringForFieldWithCachingUnlikely(LazyStringValue key)
+        {
+#if DEBUG || VALIDATE
+            using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
+            {
+#endif
+                EnsureNotDisposed();
+                var memory = GetLongLivedMemory(key.Size + 1);
+                Memory.Copy(memory.Address, key.Buffer, key.Size);
+                // This is a marker for the numberOfEscapeSequences that follows _after_ the lazy string
+                // The GetLazyStringForFieldWithCachingUnlikely(LazyStringValue) overload is used to process values read directly 
+                // from the parser, without the escapes, and we aren't writing directly from it anyway
+                memory.Address[key.Size] = 0;
+                string keyStr = key;
+                var str = new LazyStringValue(keyStr, memory.Address, key.Size, this)
+                {
+                    EscapePositions = key.EscapePositions,
+                    AllocatedMemoryData = memory,
+                };
+                _fieldNames[keyStr] = str;
+                _fieldNamesLazyStrings[str] = str;
+
+                return str;
 #if DEBUG || VALIDATE
             }
 #endif
@@ -500,10 +545,7 @@ namespace Sparrow.Json
                 LazyStringValue result = longLived == false ? AllocateStringValue(field.Value, address, actualSize) : new LazyStringValue(field.Value, address, actualSize, this);
                 result.AllocatedMemoryData = memory;
 
-                if (state.EscapePositions.Count > 0)
-                {
-                    result.EscapePositions = state.EscapePositions.ToArray();
-                }
+                result.EscapePositions = state.EscapePositions.Count > 0 ? state.EscapePositions.ToArray() : [];  
                 return result;
             }
         }
@@ -528,10 +570,7 @@ namespace Sparrow.Json
             LazyStringValue result = longLived == false ? AllocateStringValue(null, address, size) : new LazyStringValue(null, address, size, this);
             result.AllocatedMemoryData = memory;
 
-            if (state.EscapePositions.Count > 0)
-            {
-                result.EscapePositions = state.EscapePositions.ToArray();
-            }
+            result.EscapePositions = state.EscapePositions.Count > 0 ? state.EscapePositions.ToArray() : []; 
             return result;
         }
 
@@ -913,6 +952,7 @@ namespace Sparrow.Json
                 allocatorForLongLivedValues.Dispose();
 
                 _fieldNames.Clear();
+                _fieldNamesLazyStrings.Clear(); // no need to dispose the data here, same instances as in _fieldNames 
             }
 
             if (_allocateStringValues != null)

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using Sparrow.Binary;
 using Sparrow.Utils;
@@ -18,7 +19,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(LazyStringValue x, LazyStringValue y)
         {
-            if (x == y)
+            if (ReferenceEquals(x, y))
                 return true;
             if (x == null || y == null)
                 return false;
@@ -32,6 +33,27 @@ namespace Sparrow.Json
         }
     }
 
+    internal sealed class LazyStringValueWithMetadataComparer : IEqualityComparer<LazyStringValue>
+    {
+        public static readonly LazyStringValueWithMetadataComparer Instance = new LazyStringValueWithMetadataComparer();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(LazyStringValue x, LazyStringValue y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (x == null || y == null)
+                return false;
+            return x.EqualsWithMetadata(y);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetHashCode(LazyStringValue obj)
+        {
+            return obj.GetHashCodeWithMetadata();
+        }
+    }
+    
     internal struct LazyStringValueStructComparer : IEqualityComparer<LazyStringValue>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -58,7 +80,7 @@ namespace Sparrow.Json
     }
 
     // PERF: Sealed because in CoreCLR 2.0 it will devirtualize virtual calls methods like GetHashCode.
-    public sealed unsafe class LazyStringValue : IComparable<string>, IEquatable<string>,
+    public sealed unsafe partial class LazyStringValue : IComparable<string>, IEquatable<string>,
         IComparable<LazyStringValue>, IEquatable<LazyStringValue>, IDisposable, IComparable, IConvertible, IEnumerable<char>
     {
         internal JsonOperationContext _context;
@@ -257,6 +279,54 @@ namespace Sparrow.Json
 
             return Memory.CompareInline(Buffer, other.Buffer, size) == 0;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool EqualsWithMetadata(LazyStringValue other)
+        {
+#if DEBUG
+            if (IsDisposed)
+                ThrowAlreadyDisposed();
+#endif
+
+            int size = Size;
+            var otherSize = other.Size;
+
+            if (otherSize != size)
+                return false;
+
+            ReadEscapePositions();
+            other.ReadEscapePositions();
+
+            if (EscapePositions.Length != other.EscapePositions.Length)
+                return false;
+
+            if (Memory.CompareInline(Buffer, other.Buffer, size) != 0)
+                return false;
+
+            return EscapePositions.SequenceCompareTo(other.EscapePositions) == 0; //TODO To check if this is the right way to compare
+        }
+        
+        private void ReadEscapePositions()
+        {
+            if(EscapePositions != null)
+                return;
+
+            var escapeSequencePos = Size;
+            var numberOfEscapeSequences = BlittableJsonReaderBase.ReadVariableSizeInt(Buffer, ref escapeSequencePos);
+            EscapePositions = new int[numberOfEscapeSequences]; //TODO Maybe to use array pool
+            if(ToString().Equals("A"))
+                Console.WriteLine();
+            var i = 0;
+            while (numberOfEscapeSequences > 0)
+            {
+                numberOfEscapeSequences--;
+                var bytesToSkip = BlittableJsonReaderBase.ReadVariableSizeInt(Buffer, ref escapeSequencePos);
+                EscapePositions[i] = bytesToSkip;
+                ++i;
+            }
+        }
+        
+        
 
         public int CompareTo(string other)
         {
@@ -293,7 +363,18 @@ namespace Sparrow.Json
             var result = Memory.CompareInline(Buffer, other, Math.Min(size, otherSize));
             return result == 0 ? size - otherSize : result;
         }
-
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int CompareWithMetadata(LazyStringValue other)
+        {
+            var result = CompareTo(other);
+            if(result != 0)
+                return result;
+            
+            result = EscapePositions.SequenceCompareTo(other.EscapePositions);
+            return result == 0 ? EscapePositions.Length - other.EscapePositions.Length : result;
+        }
+        
         public static bool operator !=(LazyStringValue self, LazyStringValue str) => !(self == str);
 
         public static bool operator !=(LazyStringValue self, string str) => !(self == str);
@@ -431,6 +512,7 @@ namespace Sparrow.Json
         }
 
         private int? _hashCode;
+        private int? _hashCodeWithMetadata;
 
         public override int GetHashCode()
         {
@@ -446,6 +528,31 @@ namespace Sparrow.Json
                 : (int)Hashing.XXHash64.CalculateInline(Buffer, (ulong)Size);
 
             return _hashCode.Value;
+        }
+        
+        public int GetHashCodeWithMetadata()
+        {
+#if DEBUG
+            if (IsDisposed)
+                ThrowAlreadyDisposed();
+#endif
+            ReadEscapePositions();
+
+            var escapeBytes = MemoryMarshal.Cast<int, byte>((EscapePositions ?? []).AsSpan());
+
+            if (IntPtr.Size == 4)
+            {
+                var hash = Hashing.XXHash32.CalculateInline(Buffer, Size);
+                return (int) Hashing.XXHash32.CalculateInline(escapeBytes, hash);
+            }
+            else
+            {
+                var hash = Hashing.XXHash64.CalculateInline(Buffer, (ulong)Size);
+                return (int) Hashing.XXHash64.CalculateInline(escapeBytes, hash);
+            }
+            //
+            // _hashCodeWithMetadata = (int)hash;
+            // return _hashCodeWithMetadata.Value;
         }
 
         public override string ToString()
@@ -1194,6 +1301,7 @@ namespace Sparrow.Json
             IsDisposed = false;
             AllocatedMemoryData = null;
             _hashCode = default;
+            _hashCodeWithMetadata = default;
             _context = context;
         }
 
@@ -1301,7 +1409,7 @@ namespace Sparrow.Json
                 return false;
 
             return CompareToOrdinalIgnoreCase(this.Buffer, prefix.Size,
-                       prefix.Buffer, prefix.Size) == 0;
+                prefix.Buffer, prefix.Size) == 0;
         }
 
         public void Truncate(int size)

--- a/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
+++ b/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
@@ -1,0 +1,247 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Blittable;
+
+public class PropertyNamesWithEscapedCharsTests : RavenTestBase
+{
+    public PropertyNamesWithEscapedCharsTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public async Task PropertyNameWithControlCharacter_WhenTryToAddUserLevelEscapedVersion_ShouldTreatThemAsDifferentValues()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        using var memoryStream = new MemoryStream();
+
+        using (var withControlCharacter = context.GetLazyString("a\0a"))
+        using (var withControlCharacterButEscapedInUserLevel = context.GetLazyString("a\\u0000a"))
+        using (var withNewLineAndBack = context.GetLazyString("a\n\bb"))
+        using (var withNewLineAndBackEscaped = context.GetLazyString("a\\n\\bb"))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+        {
+            writer.WriteStartObject();
+            {
+                writer.WritePropertyName(withControlCharacter);
+                writer.WriteString("someValue1");
+
+                writer.WritePropertyName(withControlCharacterButEscapedInUserLevel);
+                writer.WriteString("someValue2");
+
+                writer.WritePropertyName(withNewLineAndBack);
+                writer.WriteString("someValue3");
+
+                writer.WritePropertyName(withNewLineAndBackEscaped);
+                writer.WriteString("someValue4");
+            }
+            writer.WriteEndObject();
+        }
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using (var json = await context.ReadForMemoryAsync(memoryStream, "result"))
+        {
+            Assert.Equal(4, json.Count);
+            Assert.Equal("{\"a\\u0000a\":\"someValue1\",\"a\\\\u0000a\":\"someValue2\",\"a\\n\\bb\":\"someValue3\",\"a\\\\n\\\\bb\":\"someValue4\"}", json.ToString());
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public async Task PropertyNameWithControlCharacter_WhenCache_ShouldNotCacheTwice()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        using var memoryStream = new MemoryStream();
+
+        using (var propNameWithNull = context.GetLazyString("\na\0"))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+        {
+            writer.WriteStartObject();
+            {
+                writer.WritePropertyName(propNameWithNull);
+                writer.WriteString("a\nc");
+            }
+            writer.WriteEndObject();
+        }
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using (var _ = await context.ReadForMemoryAsync(memoryStream, "result"))
+        {
+        }
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        //Fails here while reading.
+        using (var _ = await context.ReadForMemoryAsync(memoryStream, "result"))
+        {
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public void PropertyNameWithControlCharacter_LoadingDictionaryKeyWithNullChar_ShouldNotThrowException()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc
+                {
+                    Id = "doc-1", StrDict = new Dictionary<string, string>
+                    {
+                        { "nullChar\u0000", "value" }, 
+                        { "nullChar\\u0000", "value" }, 
+                    } 
+                });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Doc>("doc-1");
+                Assert.Equal("value", doc.StrDict["nullChar\0"]);
+            }
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void Test()
+    {
+        using var store = GetDocumentStore();
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Doc
+            {
+                Id = "doc-1", StrDict = new Dictionary<string, string>
+                {
+                    { "nullChar\u0000", "value" }, 
+                    // { "nullChar\\u0000", "value" }, 
+                } 
+            });
+            session.SaveChanges();
+        }
+        using (var session = store.OpenSession())
+        {
+            var doc = session.Load<Doc>("doc-1");
+            session.Advanced.HasChanged(doc);
+            Assert.Equal("value", doc.StrDict["nullChar\0"]);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public unsafe void Test1()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        var lazyStringValue = context.GetLazyString("somevalue\u0000");
+        
+        var clientLevelEscapedValue = context.GetLazyString("somevalue\\u0000");
+
+        Assert.NotEqual(lazyStringValue, clientLevelEscapedValue, LazyStringValueWithMetadataComparer.Instance);
+        
+        //I clone here to crate a LazyStringValue without the origin string object.
+        // var value = context.AllocateStringValue(null, lazyStringValue.Buffer, lazyStringValue.Size);
+        //
+        // var expected = value.ToString();
+        // var actual = clientLevelEscapedValue.ToString();
+        // Assert.NotEqual(expected, actual);
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public unsafe void Test2()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        var value = context.GetLazyStringForFieldWithCaching("nullChar\u0000");
+        var clientLevelEscapedValue = context.GetLazyStringForFieldWithCaching("nullChar\\u0000");
+
+        Assert.NotEqual(value, clientLevelEscapedValue, LazyStringValueWithMetadataComparer.Instance);
+        
+        // var expected = context.AllocateStringValue(null, value.Buffer, value.Size);
+        // var actual = context.AllocateStringValue(null, clientLevelEscapedValue.Buffer, clientLevelEscapedValue.Size);
+        // Assert.NotEqual(expected.ToString(), actual.ToString());
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public unsafe void Test3()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+
+        var value = context.GetLazyString("\na\u0000");
+        value = context.AllocateStringValue(null, value.Buffer, value.Size);
+        
+        var clientLevelEscapedValue = context.GetLazyString("\na\\u0000");
+        clientLevelEscapedValue = context.AllocateStringValue(null, clientLevelEscapedValue.Buffer, clientLevelEscapedValue.Size);
+
+        value = context.GetLazyStringForFieldWithCaching(value);
+        //Here it takes the above value from the cache
+        clientLevelEscapedValue = context.GetLazyStringForFieldWithCaching(clientLevelEscapedValue);
+        
+        Assert.NotEqual(value, clientLevelEscapedValue, LazyStringValueWithMetadataComparer.Instance);
+        
+        // var expected = value.ToString();
+        // var actual = clientLevelEscapedValue.ToString();
+        // Assert.NotEqual(expected, actual);
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void Test4()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc
+                {
+                    Id = "doc-1", StrDict = new Dictionary<string, string>
+                    {
+                        { "nullChar\u0000", "value" }, 
+                        // { "nullChar\\u0000", "value" }, 
+                    } 
+                });
+                session.SaveChanges();
+            }
+
+            using (var anotherStore = new DocumentStore
+                   {
+                       Database = store.Database,
+                       Urls = store.Urls
+                   }.Initialize())
+            {
+                using (var session = anotherStore.OpenSession())
+                {
+                    var doc = session.Load<Doc>("doc-1");
+                    
+                    session.Advanced.AddOrPatch(
+                        "doc-2", 
+                        new Doc
+                        {
+                            StrDict = new Dictionary<string, string>
+                            {
+                                { "nullChar\u0000", "value" }, 
+                                // { "nullChar\\u0000", "value" }, 
+                            } 
+                        },
+                        x => x.StrVal, "someValue");
+                    
+                    Assert.False(session.Advanced.HasChanged(doc));
+                    Assert.Equal("value", doc.StrDict["nullChar\0"]);
+                }
+            }
+        }
+    }
+
+
+    public class Doc
+    {
+        public string Id { get; set; }
+        public string StrVal { get; set; }
+        public Dictionary<string, string> StrDict { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24955

### Additional description
### Description

`LazyStringValue` represents a sequence of bytes containing the UTF-8 value of the string.  
After the content, there is additional metadata marking which characters should be escaped.  
Characters such as `\b`, `\t`, `\r`, `\n`, `\f`, `"`, and `\\` are not actually escaped, only marked as such.  

However, all other characters with a value below 32 (control characters) are handled inconsistently:  

- When a `LazyStringValue` is created by `UnmanagedJsonParser`, control characters are only marked, just like the characters listed above.  
- When a `LazyStringValue` is created by `JsonOperationContext.GetLazyString`, control characters are converted (escaped) in place instead of being only marked.  

As a result, when the control characters are escaped, calling `LazyStringValue.ToString()` (or implicitly converting it to `string`) returns the escaped version of the string.

`JsonOperationContext.GetLazyString` is used in many places, including when storing `LazyStringValue` instances in cache.  
This leads to an inconsistency:  
We compare an unescaped value against the cached value (which is escaped), fail to find a match, and then attempt to add it, which results in an exception because the escaped key already exists in the cache.

The main issue is that `GetLazyString` unexpectedly escapes control characters in place.  

I think the "right" fix would be to change `JsonParserState.FindMaxEscapePositionAndControlCharSize` to not escape control characters in place, but that is a code path that is extremely used, and changing it can introduce new issues.  

The PR here only avoids escaping control characters for property/field names.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
