### PR TITLE
RavenDB-25237 AI Agents - watch-doc unnecessary reconnects

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -41,6 +41,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
     const isRawData = useAppSelector(chatAiAgentSelectors.isRawData);
     const document = useAppSelector(chatAiAgentSelectors.document);
     const conversationId = useAppSelector(chatAiAgentSelectors.conversationId);
+    const isDocumentDeleted = useAppSelector(chatAiAgentSelectors.isDocumentDeleted);
 
     const title = config.data?.Name ?? "AI Agent";
 
@@ -78,7 +79,7 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
                     >
                         <Icon icon="plus" /> New chat
                     </Button>
-                    {conversationId && (
+                    {conversationId && !isDocumentDeleted && (
                         <a
                             href={appUrl.forEditDoc(conversationId, databaseName)}
                             className="btn btn-secondary rounded-pill"

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
@@ -42,7 +42,7 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
 
     // Watch for document changes
     useEffect(() => {
-        if (databaseChangesApi) {
+        if (databaseChangesApi && conversationId) {
             const watchDocument = databaseChangesApi.watchDocument(conversationId, (e) => {
                 if (isLoading || e.ChangeVector === currentDocumentChangeVector) {
                     return;
@@ -150,6 +150,9 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
         dispatch(chatAiAgentActions.documentSet(null));
         dispatch(chatAiAgentActions.isWaitingForActionToolSubmitSet(false));
         dispatch(chatAiAgentActions.activePromptIndexSet(0));
+        dispatch(chatAiAgentActions.hasScrollSet(false));
+        dispatch(chatAiAgentActions.isDocumentDeletedSet(false));
+        dispatch(chatAiAgentActions.isDocumentChangedSet(false));
         chatForm.reset();
     };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25237/AI-Agents-watch-doc-unnecessary-reconnects

### Additional description

- Watch document only if conversationId exist
- Hide Edit document if document is deleted

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
