### PR TITLE
RavenDB-25039 Return index 0 when deleting not exist compare exchange.

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -245,45 +245,48 @@ namespace Raven.Server.ServerWide.Commands
         {
             using (Slice.From(context.Allocator, ActualKey, out Slice keySlice))
             {
-                if (items.ReadByKey(keySlice, out var reader))
+                if (items.ReadByKey(keySlice, out var reader) == false)
                 {
-                    if (FromBackup)
-                    {
-                        items.Delete(reader.Id);
-                        return new CompareExchangeResult
-                        {
-                            Index = index,
-                            Value = null
-                        };
-                    }
-                    var itemIndex = *(long*)reader.Read((int)ClusterStateMachine.CompareExchangeTable.Index, out var _);
-                    var storeValue = reader.Read((int)ClusterStateMachine.CompareExchangeTable.Value, out var size);
-                    var result = new BlittableJsonReaderObject(storeValue, size, context);
-
-                    if (Index == itemIndex)
-                    {
-                        result = result.Clone(context);
-                        items.Delete(reader.Id);
-                        WriteCompareExchangeTombstone(context, index);
-                        return new CompareExchangeResult
-                        {
-                            Index = index,
-                            Value = result
-                        };
-                    }
                     return new CompareExchangeResult
                     {
-                        Index = itemIndex,
+                        Index = 0,
+                        Value = null
+                    };
+                }
+
+                if (FromBackup)
+                {
+                    items.Delete(reader.Id);
+                    return new CompareExchangeResult
+                    {
+                        Index = index,
+                        Value = null
+                    };
+                }
+
+                var itemIndex = *(long*)reader.Read((int)ClusterStateMachine.CompareExchangeTable.Index, out var _);
+                var storeValue = reader.Read((int)ClusterStateMachine.CompareExchangeTable.Value, out var size);
+                var result = new BlittableJsonReaderObject(storeValue, size, context);
+
+                if (Index == itemIndex)
+                {
+                    result = result.Clone(context);
+                    items.Delete(reader.Id);
+                    WriteCompareExchangeTombstone(context, index);
+                    return new CompareExchangeResult
+                    {
+                        Index = index,
                         Value = result
                     };
                 }
+
+                return new CompareExchangeResult
+                {
+                    Index = itemIndex,
+                    Value = result
+                };
                 // if we ever decide to make replication of compare exchange, then we should write the compare exchange tombstones to schema on restore
             }
-            return new CompareExchangeResult
-            {
-                Index = index,
-                Value = null
-            };
         }
 
         private unsafe void WriteCompareExchangeTombstone(ClusterOperationContext context, long index)

--- a/test/SlowTests/Cluster/CompareExchangeTests.cs
+++ b/test/SlowTests/Cluster/CompareExchangeTests.cs
@@ -94,4 +94,13 @@ public class CompareExchangeTests : RavenTestBase
             }, 0, timeout: 15 * 1000);
         }
     }
+
+    [RavenTheory(RavenTestCategory.ClusterTransactions)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task DeletingCompareExchangeCommand_WhenNotExist_ShouldReturnFalse(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var result = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<string>("key", 3));
+        Assert.False(result.Successful);
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25039

### Additional description
The success is set by the endpoint and not by the command itself.
What we check in the endpoint is whether the index sent with the command is equal to the index we receive as the result of the command.
When the compare exchange exists, the response index is set to the index of the existing compare exchange.
In addition, we only delete if the actual index equals the expected one.
That means if the requested index equals the responded index, the command succeeded in deleting.
When the compare exchange doesn’t exist, we return the requested index, so the endpoint considers that as succeeded since the requested and response indexes are equal.

If I change the RemoveCompareExchangeCommand to return 0 when the compare exchange doesn’t exist, that will cause the endpoint to consider it as failed.
That will also match the behavior of “existing compare exchange,” since 0 is the index of a non-existing one.

## **But that’s a kind of breaking change.**

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
