### PR TITLE
RavenDB-25246 Update tooltip for "Overlap Tokens"

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -232,10 +232,13 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
         popoverUtils.longWithHover($(".overlap-tokens"),
             {
                 content: `<small class="margin-top-xs no-padding-left">
-                              This value will be used as the default when no specific value is set in the script.
+                              <ul class="padding-left-sm">
+                                  <li>This value will be used as the default when no specific value is set in the script.</li>
+                                  <li>Only applicable when the chunking method is<br/><em>"Plain Text: Split Paragraphs"</em> or <em>"Markdown: Split Paragraphs"</em>.</li>
+                              </ul>
                           </small>`
             });
-    }    
+    }
 
     toggleIsNewConnectionStringOpen() {
         this.isNewConnectionStringOpen(!this.isNewConnectionStringOpen())


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25246/Update-tooltip-for-Overlap-Tokens

### Additional description
Update the tooltip for "Overlap Tokens"
Include information about which chunking methods support this option.

### Type of change
- [x] Bug fix (usability/cosmetics)
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
