### PR TITLE
RavenDB-25145 '@metadata'.'@refresh' = null in subscriptions

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/SubscriptionConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Esprima;
 using Raven.Client.Documents.Subscriptions;
@@ -20,6 +21,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using BinaryExpression = Raven.Server.Documents.Queries.AST.BinaryExpression;
 using Exception = System.Exception;
 using QueryParser = Raven.Server.Documents.Queries.Parser.QueryParser;
 
@@ -308,7 +310,8 @@ namespace Raven.Server.Documents.TcpHandlers
             if (q.Where != null)
             {
                 writer.Write("if (");
-                new JavascriptCodeQueryVisitor(writer.GetStringBuilder(), q).VisitExpression(q.Where);
+                QueryExpression modified = HandleRefresh(q.Where);
+                new JavascriptCodeQueryVisitor(writer.GetStringBuilder(), q).VisitExpression(modified);
                 writer.WriteLine(" )");
                 writer.WriteLine("{");
             }
@@ -357,6 +360,26 @@ namespace Raven.Server.Documents.TcpHandlers
                 Includes = includes?.ToArray(),
                 CounterIncludes = counterIncludes?.ToArray()
             };
+        }
+
+        private static QueryExpression HandleRefresh(QueryExpression qe)
+        {
+            // handle '@metadata'.'@refresh' = null and '@metadata'.'@refresh' != null
+            // in a special manner, turning them into exists calls for better support
+            
+            // @refresh = null is translated to "not exists(@refresh)"
+            // @refresh != null is translated to "exists(@refresh)"
+            if (qe is not BinaryExpression be)
+                return qe;
+            if (be.Operator is not OperatorType.Equal && be.Operator is not OperatorType.NotEqual)
+                return qe;
+            if (be.Left is not FieldExpression { FieldValueWithoutAlias: "@refresh" } || 
+                be.Right is not ValueExpression { Value: ValueTokenType.Null })
+                return qe;
+            var me = new MethodExpression("exists", [be.Left]);
+            if (be.Operator is not OperatorType.NotEqual)
+                return new NegatedExpression(me);
+            return me;
         }
 
         protected override async Task OnClientAckAsync(string clientReplyChangeVector)

--- a/test/SlowTests/Client/Subscriptions/RavenDB-25145.cs
+++ b/test/SlowTests/Client/Subscriptions/RavenDB-25145.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests.Client.Subscriptions;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Subscriptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Subscriptions;
+
+public class RavenDB_25145(ITestOutputHelper output) : SubscriptionTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task CanHandleMetadataRefresh()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var subscriptionCreationParams = new SubscriptionCreationOptions
+            {
+                Query = "from Things where '@metadata'.'@refresh' = null"
+            };
+            int items = await RunSubscription(store, subscriptionCreationParams);
+            Assert.Equal(2, items);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Subscriptions)]
+    public async Task CanHandleNOTMetadataRefresh()
+    {
+        using (var store = GetDocumentStore())
+        {
+            var subscriptionCreationParams = new SubscriptionCreationOptions
+            {
+                Query = "from Things where '@metadata'.'@refresh' != null"
+            };
+            int items = await RunSubscription(store, subscriptionCreationParams);
+            Assert.Equal(1, items);
+        }
+    }
+
+    private static async Task<int> RunSubscription(DocumentStore store, SubscriptionCreationOptions subscriptionCreationParams)
+    {
+        string id = await store.Subscriptions.CreateAsync(subscriptionCreationParams);
+        using (var s = store.OpenAsyncSession())
+        {
+            Thing future = new Thing();
+            await s.StoreAsync(future);
+            s.Advanced.GetMetadataFor(future)["@refresh"] = DateTime.Today.AddDays(5).ToString("O");
+            await s.StoreAsync(new Thing());
+            await s.StoreAsync(new Thing());
+            await s.SaveChangesAsync();
+        }
+
+        var worker = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+        {
+            CloseWhenNoDocsLeft = true
+        });
+        var items = 0;
+        var t = worker.Run(batch =>
+        {
+            items += batch.Items.Count;
+        });
+        var done = await Task.WhenAny(t, Task.Delay(TimeSpan.FromSeconds(30)));
+        Assert.Same(t, done);
+        return items;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25145

### Additional description

This change explicitly handles ` '@metadata'.'@refresh' = null` and ` '@metadata'.'@refresh' != null` queries for _subscriptions only_.
The reason those did not work is that the accessing a non-existent property in Jint results in `undefined`, while we compared to `null`.
This is because we translate the subscription query to java script to process it. 

This change was the minimal work required to enable this scenario without having impact anywhere else.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
