### PR TITLE
RavenDB-25203 Explicit exception conflict resolution

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -60,38 +60,28 @@ namespace Raven.Server.Documents.ETL
             if (debugMode)
                 DocumentScript.DebugMode = true;
 
-            DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo, new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo, LoadToFunctionTranslator));
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadTo, LoadToFunctionTranslator);
 
             foreach (var collection in LoadToDestinations)
             {
                 var name = Transformation.LoadTo + collection;
-                DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
-                    (value, values) => LoadToFunctionTranslator(collection, value, values)));
+                DocumentScript.ScriptEngine.SetClrFunc(name, (value, values) => LoadToFunctionTranslator(collection, value, values));
             }
 
-            DocumentScript.ScriptEngine.SetValue(Transformation.LoadAttachment, new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadAttachment, LoadAttachment));
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadAttachment, LoadAttachment);
 
-            const string loadCounter = Transformation.CountersTransformation.Load;
-            DocumentScript.ScriptEngine.SetValue(loadCounter, new ClrFunction(DocumentScript.ScriptEngine, loadCounter, LoadCounter));
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.CountersTransformation.Load, LoadCounter);
 
-            const string loadTimeSeries = Transformation.TimeSeriesTransformation.LoadTimeSeries.Name;
-            DocumentScript.ScriptEngine.SetValue(loadTimeSeries, new ClrFunction(DocumentScript.ScriptEngine, loadTimeSeries, LoadTimeSeries));
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.TimeSeriesTransformation.LoadTimeSeries.Name, LoadTimeSeries);
 
-            DocumentScript.ScriptEngine.SetValue("getAttachments", new ClrFunction(DocumentScript.ScriptEngine, "getAttachments", GetAttachments));
+            DocumentScript.ScriptEngine.SetClrFunc("getAttachments", GetAttachments);
+            DocumentScript.ScriptEngine.SetClrFunc("hasAttachment",HasAttachment);
+            DocumentScript.ScriptEngine.SetClrFunc("getCounters",  GetCounters);
+            DocumentScript.ScriptEngine.SetClrFunc("hasCounter",  HasCounter);
+            DocumentScript.ScriptEngine.SetClrFunc("getRevisionsCount", GetRevisionsCount);
 
-            DocumentScript.ScriptEngine.SetValue("hasAttachment", new ClrFunction(DocumentScript.ScriptEngine, "hasAttachment", HasAttachment));
-
-            DocumentScript.ScriptEngine.SetValue("getCounters", new ClrFunction(DocumentScript.ScriptEngine, "getCounters", GetCounters));
-
-            DocumentScript.ScriptEngine.SetValue("hasCounter", new ClrFunction(DocumentScript.ScriptEngine, "hasCounter", HasCounter));
-
-            DocumentScript.ScriptEngine.SetValue("getRevisionsCount", new ClrFunction(DocumentScript.ScriptEngine, "getRevisionsCount", GetRevisionsCount));
-
-            const string hasTimeSeries = Transformation.TimeSeriesTransformation.HasTimeSeries.Name;
-            DocumentScript.ScriptEngine.SetValue(hasTimeSeries, new ClrFunction(DocumentScript.ScriptEngine, hasTimeSeries, HasTimeSeries));
-
-            const string getTimeSeries = Transformation.TimeSeriesTransformation.GetTimeSeries.Name;
-            DocumentScript.ScriptEngine.SetValue(getTimeSeries, new ClrFunction(DocumentScript.ScriptEngine, getTimeSeries, GetTimeSeries));
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.TimeSeriesTransformation.HasTimeSeries.Name, HasTimeSeries);
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.TimeSeriesTransformation.GetTimeSeries.Name, GetTimeSeries);
         }
 
         private JsValue LoadToFunctionTranslator(JsValue self, JsValue[] args)

--- a/src/Raven.Server/Documents/ETL/Providers/OLAP/OlapDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/OLAP/OlapDocumentTransformer.cs
@@ -43,7 +43,7 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
                 database, updateServerWideSettingsFunc: null, serverWide: false);
 
             _localFilePath = localSettings?.FolderPath ??
-                           (database.Configuration.Storage.TempPath ?? database.Configuration.Core.DataDirectory).FullPath;
+                             (database.Configuration.Storage.TempPath ?? database.Configuration.Core.DataDirectory).FullPath;
 
             _fileNameSuffix = ParquetTransformedItems.GetSafeNameForRemoteDestination($"{database.Name}-{_config.Name}-{transformation.Name}");
 
@@ -54,17 +54,16 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
         {
             base.Initialize(debugMode);
 
-            DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo, new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo, LoadToFunctionTranslator));
+            DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadTo, LoadToFunctionTranslator);
 
             foreach (var table in LoadToDestinations)
             {
                 var name = Transformation.LoadTo + table;
-                DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
-                    (self, args) => LoadToFunctionTranslator(table, args)));
+                DocumentScript.ScriptEngine.SetClrFunc(name, (self, args) => LoadToFunctionTranslator(table, args));
             }
 
-            DocumentScript.ScriptEngine.SetValue("partitionBy", new ClrFunction(DocumentScript.ScriptEngine, "partitionBy", PartitionBy));
-            DocumentScript.ScriptEngine.SetValue("noPartition", new ClrFunction(DocumentScript.ScriptEngine, "noPartition", NoPartition));
+            DocumentScript.ScriptEngine.SetClrFunc("partitionBy", PartitionBy);
+            DocumentScript.ScriptEngine.SetClrFunc("noPartition", NoPartition);
 
             var customPartitionValue = _config.CustomPartitionValue != null
                 ? new JsString(_config.CustomPartitionValue)
@@ -211,8 +210,8 @@ namespace Raven.Server.Documents.ETL.Providers.OLAP
                         $"{methodSignature} items in array {PartitionKeys} of argument 'key' must be array instances of size 2, but got '{tuple.Length}'");
 
                 sb.Append('/');
-                string val = tuple[1].IsDate() 
-                    ? tuple[1].AsDate().ToDateTime().ToString(DateFormat) 
+                string val = tuple[1].IsDate()
+                    ? tuple[1].AsDate().ToDateTime().ToString(DateFormat)
                     : tuple[1].ToString();
 
                 var partition = $"{tuple[0]}={val}";

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/AzureQueueStorage/AzureQueueStorageDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/AzureQueueStorage/AzureQueueStorageDocumentTransformer.cs
@@ -36,16 +36,13 @@ public sealed class AzureQueueStorageDocumentTransformer<T> : QueueDocumentTrans
     {
         base.Initialize(debugMode);
 
-        DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo,
-            new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo,
-                LoadToFunctionTranslatorWithAttributes));
+        DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadTo, LoadToFunctionTranslatorWithAttributes);
 
         foreach (var queueName in LoadToDestinations)
         {
             var name = Transformation.LoadTo + queueName;
 
-            DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
-                (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args)));
+            DocumentScript.ScriptEngine.SetClrFunc(name, (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args));
         }
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaDocumentTransformer.cs
@@ -34,14 +34,13 @@ public sealed class KafkaDocumentTransformer<T> : QueueDocumentTransformer<T, Ka
     {
         base.Initialize(debugMode);
 
-        DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo, new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo, LoadToFunctionTranslatorWithAttributes));
+        DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadTo, LoadToFunctionTranslatorWithAttributes);
 
         foreach (var queueName in LoadToDestinations)
         {
             var name = Transformation.LoadTo + queueName;
 
-            DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
-                (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args)));
+            DocumentScript.ScriptEngine.SetClrFunc(name, (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args));
         }
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/RabbitMq/RabbitMqDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/RabbitMq/RabbitMqDocumentTransformer.cs
@@ -37,7 +37,7 @@ public sealed class RabbitMqDocumentTransformer<T> : QueueDocumentTransformer<T,
     {
         base.Initialize(debugMode);
 
-        DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo, new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo, LoadToFunctionTranslatorWithRoutingKeyAndAttributes));
+        DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadTo, LoadToFunctionTranslatorWithRoutingKeyAndAttributes);
 
         foreach (var exchangeName in LoadToDestinations)
         {
@@ -46,8 +46,7 @@ public sealed class RabbitMqDocumentTransformer<T> : QueueDocumentTransformer<T,
 
             var name = Transformation.LoadTo + exchangeName;
 
-            DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
-                (self, args) => LoadToFunctionTranslatorWithRoutingKeyAndAttributes(exchangeName, args)));
+            DocumentScript.ScriptEngine.SetClrFunc(name, (self, args) => LoadToFunctionTranslatorWithRoutingKeyAndAttributes(exchangeName, args));
         }
     }
 

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/SqlDocumentTransformer.cs
@@ -57,12 +57,9 @@ namespace Raven.Server.Documents.ETL.Providers.SQL
         public override void Initialize(bool debugMode)
         {
             base.Initialize(debugMode);
-            
-            DocumentScript.ScriptEngine.SetValue("varchar",
-                new ClrFunction(DocumentScript.ScriptEngine, "varchar", (value, values) => ToVarcharTranslator(VarcharFunctionCall.AnsiStringType, values)));
 
-            DocumentScript.ScriptEngine.SetValue("nvarchar",
-                new ClrFunction(DocumentScript.ScriptEngine, "nvarchar", (value, values) => ToVarcharTranslator(VarcharFunctionCall.StringType, values)));
+            DocumentScript.ScriptEngine.SetClrFunc("varchar", (value, values) => ToVarcharTranslator(VarcharFunctionCall.AnsiStringType, values));
+            DocumentScript.ScriptEngine.SetClrFunc("nvarchar", (value, values) => ToVarcharTranslator(VarcharFunctionCall.StringType, values));
         }
 
         protected override string[] LoadToDestinations { get; }

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -54,14 +54,14 @@ function map(name, lambda) {
 
         protected override void OnInitializeEngine(Engine engine)
         {
-            engine.SetValue("getMetadata", new ClrFunction(_engine, "getMetadata", MetadataFor)); // for backward-compatibility only
-            engine.SetValue("metadataFor", new ClrFunction(_engine, "metadataFor", MetadataFor));
-            engine.SetValue("attachmentsFor", new ClrFunction(_engine, "attachmentsFor", AttachmentsFor));
-            engine.SetValue("timeSeriesNamesFor", new ClrFunction(_engine, "timeSeriesNamesFor", TimeSeriesNamesFor));
-            engine.SetValue("counterNamesFor", new ClrFunction(_engine, "counterNamesFor", CounterNamesFor));
-            engine.SetValue("loadAttachment", new ClrFunction(engine, "loadAttachment", LoadAttachment));
-            engine.SetValue("loadAttachments", new ClrFunction(engine, "loadAttachment", LoadAttachments));
-            engine.SetValue("id", new ClrFunction(_engine, "id", GetDocumentId));
+            engine.SetClrFunc("getMetadata", MetadataFor); // for backward-compatibility only
+            engine.SetClrFunc("metadataFor", MetadataFor);
+            engine.SetClrFunc("attachmentsFor", AttachmentsFor);
+            engine.SetClrFunc("timeSeriesNamesFor", TimeSeriesNamesFor);
+            engine.SetClrFunc("counterNamesFor", CounterNamesFor);
+            engine.SetClrFunc("loadAttachment", LoadAttachment);
+            engine.SetClrFunc("loadAttachments", LoadAttachments);
+            engine.SetClrFunc("id", GetDocumentId);
         }
 
         protected override void ProcessMaps(ObjectInstance definitions, JintPreventResolvingTasksReferenceResolver resolver, List<string> mapList, List<MapMetadata> mapReferencedCollections, out Dictionary<string, Dictionary<string, List<JavaScriptMapOperation>>> collectionFunctions)
@@ -384,9 +384,9 @@ function map(name, lambda) {
             _engine.SetValue(JavaScriptIndex.NoTracking, noTrackingObject);
 
             _engine.SetValue(JavaScriptIndex.Load, loadFunc);
-            _engine.SetValue(JavaScriptIndex.CmpXchg, new ClrFunction(_engine, JavaScriptIndex.CmpXchg, LoadCompareExchangeValue));
-            _engine.SetValue("tryConvertToNumber", new ClrFunction(_engine, "tryConvertToNumber", TryConvertToNumber));
-            _engine.SetValue("recurse", new ClrFunction(_engine, "recurse", Recurse));
+            _engine.SetClrFunc(JavaScriptIndex.CmpXchg, LoadCompareExchangeValue);
+            _engine.SetClrFunc("tryConvertToNumber", TryConvertToNumber);
+            _engine.SetClrFunc("recurse", Recurse);
 
             _engine.ExecuteWithReset(Code);
             _engine.ExecuteWithReset(mapCode);

--- a/src/Raven.Server/Documents/Patch/ConflictPatchRequest.cs
+++ b/src/Raven.Server/Documents/Patch/ConflictPatchRequest.cs
@@ -1,0 +1,39 @@
+﻿namespace Raven.Server.Documents.Patch;
+
+/// <summary>
+/// Represents a <see cref="PatchRequest"/> that resolves a conflict between documents.
+/// </summary>
+public sealed class ConflictPatchRequest : ScriptRunnerCache.Key
+{
+    private readonly string _script;
+
+    public ConflictPatchRequest(string script)
+    {
+        _script = script;
+    }
+
+    public override void GenerateScript(ScriptRunner runner)
+    {
+        runner.AddScript($@"
+function resolve(docs, hasTombstone, resolveToTombstone){{ 
+
+{_script}
+
+}}");
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (ReferenceEquals(null, obj))
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj.GetType() != this.GetType())
+            return false;
+        return Equals((ConflictPatchRequest)obj);
+    }
+
+    private bool Equals(ConflictPatchRequest other) => string.Equals(_script, other._script);
+
+    public override int GetHashCode() => _script != null ? _script.GetHashCode() : 0;
+}

--- a/src/Raven.Server/Documents/Patch/ConflictPatchRequest.cs
+++ b/src/Raven.Server/Documents/Patch/ConflictPatchRequest.cs
@@ -1,4 +1,10 @@
-﻿namespace Raven.Server.Documents.Patch;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Jint.Native;
+
+namespace Raven.Server.Documents.Patch;
 
 /// <summary>
 /// Represents a <see cref="PatchRequest"/> that resolves a conflict between documents.
@@ -7,6 +13,22 @@ public sealed class ConflictPatchRequest : ScriptRunnerCache.Key
 {
     private readonly string _script;
 
+    /// <summary>
+    /// Functions that are forbidden when performing a conflict resolution script.
+    /// </summary>
+    private static readonly string[] ForbiddenFunctionsNames =
+    [
+        "put",
+        "del",
+        "load",
+        "loadPath",
+    ];
+
+    private static readonly (string name, Func<JsValue, JsValue[], JsValue> func)[] ForbiddenFunctions =
+        ForbiddenFunctionsNames
+            .Select<string, (string name, Func<JsValue, JsValue[], JsValue> func)>(name => (name, (_, _) => throw new InvalidOperationException($"Calling '{name}' in conflict resolution script is forbidden.")))
+            .ToArray();
+    
     public ConflictPatchRequest(string script)
     {
         _script = script;
@@ -14,6 +36,12 @@ public sealed class ConflictPatchRequest : ScriptRunnerCache.Key
 
     public override void GenerateScript(ScriptRunner runner)
     {
+        // override forbidden
+        foreach ((string name, Func<JsValue, JsValue[], JsValue> func) in ForbiddenFunctions)
+        {
+            runner.SetClrFunction(name, func);
+        }
+        
         runner.AddScript($@"
 function resolve(docs, hasTombstone, resolveToTombstone){{ 
 

--- a/src/Raven.Server/Documents/Patch/EngineExtensions.cs
+++ b/src/Raven.Server/Documents/Patch/EngineExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Jint;
+using Jint.Native;
+using Jint.Runtime.Interop;
+
+namespace Raven.Server.Documents.Patch;
+
+internal static class EngineExtensions
+{
+    /// <summary>
+    /// Sets the <paramref name="func"/> under a specific <paramref name="name"/>.
+    /// </summary>
+    public static void SetFunc(this Engine engine, string name, Func<JsValue, JsValue[], JsValue> func) => engine.SetValue(name, new ClrFunction(engine, name, func));
+}

--- a/src/Raven.Server/Documents/Patch/EngineExtensions.cs
+++ b/src/Raven.Server/Documents/Patch/EngineExtensions.cs
@@ -10,5 +10,5 @@ internal static class EngineExtensions
     /// <summary>
     /// Sets the <paramref name="func"/> under a specific <paramref name="name"/>.
     /// </summary>
-    public static void SetFunc(this Engine engine, string name, Func<JsValue, JsValue[], JsValue> func) => engine.SetValue(name, new ClrFunction(engine, name, func));
+    public static void SetClrFunc(this Engine engine, string name, Func<JsValue, JsValue[], JsValue> func) => engine.SetValue(name, new ClrFunction(engine, name, func));
 }

--- a/src/Raven.Server/Documents/Patch/PatchConflict.cs
+++ b/src/Raven.Server/Documents/Patch/PatchConflict.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client;
+using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -35,7 +36,7 @@ namespace Raven.Server.Documents.Patch
             _fstDocumentConflict = docs[0];
         }
 
-        public bool TryResolveConflict(DocumentsOperationContext context, PatchRequest patch, out BlittableJsonReaderObject resolved)
+        public bool TryResolveConflict(DocumentsOperationContext context, ConflictPatchRequest patch, out BlittableJsonReaderObject resolved)
         {
             using (_database.Scripts.GetScriptRunner(patch, false, out var run))
             using (var result = run.Run(context, context, "resolve", [_docs, _hasTombstone, TombstoneResolverValue]))

--- a/src/Raven.Server/Documents/Patch/PatchConflict.cs
+++ b/src/Raven.Server/Documents/Patch/PatchConflict.cs
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Patch
         public bool TryResolveConflict(DocumentsOperationContext context, PatchRequest patch, out BlittableJsonReaderObject resolved)
         {
             using (_database.Scripts.GetScriptRunner(patch, false, out var run))
-            using (var result = run.Run(context, context, "resolve", new object[] { _docs, _hasTombstone, TombstoneResolverValue }))
+            using (var result = run.Run(context, context, "resolve", [_docs, _hasTombstone, TombstoneResolverValue]))
             {
                 if (result.IsNull)
                 {

--- a/src/Raven.Server/Documents/Patch/PatchRequest.cs
+++ b/src/Raven.Server/Documents/Patch/PatchRequest.cs
@@ -100,12 +100,8 @@ function execute(doc, args){{
 }}";
                 
                 case PatchRequestType.Conflict:
-                    return $@"
-function resolve(docs, hasTombstone, resolveToTombstone){{ 
+                    throw new Exception($"Use {nameof(ConflictPatchRequest)} to represent a patch request that is a result of a conflict");
 
-{Script}
-
-}}";
                 case PatchRequestType.EtlBehaviorFunctions:
                     return Script;
                 default:

--- a/src/Raven.Server/Documents/Patch/PatchRequest.cs
+++ b/src/Raven.Server/Documents/Patch/PatchRequest.cs
@@ -100,7 +100,7 @@ function execute(doc, args){{
 }}";
                 
                 case PatchRequestType.Conflict:
-                    throw new Exception($"Use {nameof(ConflictPatchRequest)} to represent a patch request that is a result of a conflict");
+                    throw new NotSupportedException($"Use {nameof(ConflictPatchRequest)} to represent a patch request that is a result of a conflict");
 
                 case PatchRequestType.EtlBehaviorFunctions:
                     return Script;

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -283,14 +283,14 @@ namespace Raven.Server.Documents.Patch
                 });
 
                 JavaScriptUtils = new JavaScriptUtils(_runner, ScriptEngine);
-                SetFunc(GetMetadataMethod, JavaScriptUtils.GetMetadata);
-                SetFunc("metadataFor", JavaScriptUtils.GetMetadata);
-                SetFunc("id", JavaScriptUtils.GetDocumentId);
-                SetFunc("count", JavaScriptUtils.Count);
-                SetFunc("key", JavaScriptUtils.Key);
-                SetFunc("sum", JavaScriptUtils.Sum);
+                ScriptEngine.SetFunc(GetMetadataMethod, JavaScriptUtils.GetMetadata);
+                ScriptEngine.SetFunc("metadataFor", JavaScriptUtils.GetMetadata);
+                ScriptEngine.SetFunc("id", JavaScriptUtils.GetDocumentId);
+                ScriptEngine.SetFunc("count", JavaScriptUtils.Count);
+                ScriptEngine.SetFunc("key", JavaScriptUtils.Key);
+                ScriptEngine.SetFunc("sum", JavaScriptUtils.Sum);
 
-                SetFunc("output", OutputDebug);
+                ScriptEngine.SetFunc("output", OutputDebug);
 
                 //console.log
                 ObjectInstance consoleObject = new JsObject(ScriptEngine);
@@ -323,41 +323,41 @@ namespace Raven.Server.Documents.Patch
                 // includes - backward compatibility
                 ScriptEngine.SetValue("include", includeDocumentFunc);
 
-                SetFunc("load", LoadDocument);
-                SetFunc("LoadDocument", ThrowOnLoadDocument);
+                ScriptEngine.SetFunc("load", LoadDocument);
+                ScriptEngine.SetFunc("LoadDocument", ThrowOnLoadDocument);
 
-                SetFunc("loadPath", LoadDocumentByPath);
-                SetFunc("del", DeleteDocument);
-                SetFunc("DeleteDocument", ThrowOnDeleteDocument);
-                SetFunc("put", PutDocument);
-                SetFunc("PutDocument", ThrowOnPutDocument);
-                SetFunc("cmpxchg", CompareExchange);
+                ScriptEngine.SetFunc("loadPath", LoadDocumentByPath);
+                ScriptEngine.SetFunc("del", DeleteDocument);
+                ScriptEngine.SetFunc("DeleteDocument", ThrowOnDeleteDocument);
+                ScriptEngine.SetFunc("put", PutDocument);
+                ScriptEngine.SetFunc("PutDocument", ThrowOnPutDocument);
+                ScriptEngine.SetFunc("cmpxchg", CompareExchange);
 
-                SetFunc("counter", GetCounter);
-                SetFunc("counterRaw", GetCounterRaw);
-                SetFunc("incrementCounter", IncrementCounter);
-                SetFunc("deleteCounter", DeleteCounter);
+                ScriptEngine.SetFunc("counter", GetCounter);
+                ScriptEngine.SetFunc("counterRaw", GetCounterRaw);
+                ScriptEngine.SetFunc("incrementCounter", IncrementCounter);
+                ScriptEngine.SetFunc("deleteCounter", DeleteCounter);
 
-                SetFunc("lastModified", GetLastModified);
+                ScriptEngine.SetFunc("lastModified", GetLastModified);
 
-                SetFunc("startsWith", StartsWith);
-                SetFunc("endsWith", EndsWith);
-                SetFunc("regex", Regex);
+                ScriptEngine.SetFunc("startsWith", StartsWith);
+                ScriptEngine.SetFunc("endsWith", EndsWith);
+                ScriptEngine.SetFunc("regex", Regex);
 
-                SetFunc("Raven_ExplodeArgs", ExplodeArgs);
-                SetFunc("Raven_Min", Raven_Min);
-                SetFunc("Raven_Max", Raven_Max);
+                ScriptEngine.SetFunc("Raven_ExplodeArgs", ExplodeArgs);
+                ScriptEngine.SetFunc("Raven_Min", Raven_Min);
+                ScriptEngine.SetFunc("Raven_Max", Raven_Max);
 
-                SetFunc("convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString);
-                SetFunc("convertToTimeSpanString", ConvertToTimeSpanString);
-                SetFunc("compareDates", CompareDates);
+                ScriptEngine.SetFunc("convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString);
+                ScriptEngine.SetFunc("convertToTimeSpanString", ConvertToTimeSpanString);
+                ScriptEngine.SetFunc("compareDates", CompareDates);
 
-                SetFunc("toStringWithFormat", ToStringWithFormat);
+                ScriptEngine.SetFunc("toStringWithFormat", ToStringWithFormat);
 
-                SetFunc("scalarToRawString", ScalarToRawString);
+                ScriptEngine.SetFunc("scalarToRawString", ScalarToRawString);
 
                 //TimeSeries
-                SetFunc("timeseries", TimeSeries);
+                ScriptEngine.SetFunc("timeseries", TimeSeries);
                 ScriptEngine.Execute(ScriptRunnerCache.PolyfillJs);
 
                 foreach (var script in scriptsSource)
@@ -378,8 +378,6 @@ namespace Raven.Server.Documents.Patch
                     ScriptEngine.SetValue(ts.Key, NamedInvokeTimeSeriesFunction(ts.Key));
                 }
             }
-
-            private void SetFunc(string name, Func<JsValue, JsValue[], JsValue> func) => ScriptEngine.SetValue(name, new ClrFunction(ScriptEngine, name, func));
 
             private (string Id, BlittableJsonReaderObject Doc) GetIdAndDocFromArg(JsValue docArg, string signature)
             {

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -283,14 +283,14 @@ namespace Raven.Server.Documents.Patch
                 });
 
                 JavaScriptUtils = new JavaScriptUtils(_runner, ScriptEngine);
-                ScriptEngine.SetValue(GetMetadataMethod, new ClrFunction(ScriptEngine, GetMetadataMethod, JavaScriptUtils.GetMetadata));
-                ScriptEngine.SetValue("metadataFor", new ClrFunction(ScriptEngine, GetMetadataMethod, JavaScriptUtils.GetMetadata));
-                ScriptEngine.SetValue("id", new ClrFunction(ScriptEngine, "id", JavaScriptUtils.GetDocumentId));
-                ScriptEngine.SetValue("count", new ClrFunction(ScriptEngine, "count", JavaScriptUtils.Count));
-                ScriptEngine.SetValue("key", new ClrFunction(ScriptEngine, "key", JavaScriptUtils.Key));
-                ScriptEngine.SetValue("sum", new ClrFunction(ScriptEngine, "sum", JavaScriptUtils.Sum));
+                SetFunc(GetMetadataMethod, JavaScriptUtils.GetMetadata);
+                SetFunc("metadataFor", JavaScriptUtils.GetMetadata);
+                SetFunc("id", JavaScriptUtils.GetDocumentId);
+                SetFunc("count", JavaScriptUtils.Count);
+                SetFunc("key", JavaScriptUtils.Key);
+                SetFunc("sum", JavaScriptUtils.Sum);
 
-                ScriptEngine.SetValue("output", new ClrFunction(ScriptEngine, "output", OutputDebug));
+                SetFunc("output", OutputDebug);
 
                 //console.log
                 ObjectInstance consoleObject = new JsObject(ScriptEngine);
@@ -324,40 +324,40 @@ namespace Raven.Server.Documents.Patch
                 ScriptEngine.SetValue("include", includeDocumentFunc);
 
                 SetFunc("load", LoadDocument);
-                ScriptEngine.SetValue("LoadDocument", new ClrFunction(ScriptEngine, "LoadDocument", ThrowOnLoadDocument));
+                SetFunc("LoadDocument", ThrowOnLoadDocument);
 
-                ScriptEngine.SetValue("loadPath", new ClrFunction(ScriptEngine, "loadPath", LoadDocumentByPath));
-                ScriptEngine.SetValue("del", new ClrFunction(ScriptEngine, "del", DeleteDocument));
-                ScriptEngine.SetValue("DeleteDocument", new ClrFunction(ScriptEngine, "DeleteDocument", ThrowOnDeleteDocument));
-                ScriptEngine.SetValue("put", new ClrFunction(ScriptEngine, "put", PutDocument));
-                ScriptEngine.SetValue("PutDocument", new ClrFunction(ScriptEngine, "PutDocument", ThrowOnPutDocument));
-                ScriptEngine.SetValue("cmpxchg", new ClrFunction(ScriptEngine, "cmpxchg", CompareExchange));
+                SetFunc("loadPath", LoadDocumentByPath);
+                SetFunc("del", DeleteDocument);
+                SetFunc("DeleteDocument", ThrowOnDeleteDocument);
+                SetFunc("put", PutDocument);
+                SetFunc("PutDocument", ThrowOnPutDocument);
+                SetFunc("cmpxchg", CompareExchange);
 
-                ScriptEngine.SetValue("counter", new ClrFunction(ScriptEngine, "counter", GetCounter));
-                ScriptEngine.SetValue("counterRaw", new ClrFunction(ScriptEngine, "counterRaw", GetCounterRaw));
-                ScriptEngine.SetValue("incrementCounter", new ClrFunction(ScriptEngine, "incrementCounter", IncrementCounter));
-                ScriptEngine.SetValue("deleteCounter", new ClrFunction(ScriptEngine, "deleteCounter", DeleteCounter));
+                SetFunc("counter", GetCounter);
+                SetFunc("counterRaw", GetCounterRaw);
+                SetFunc("incrementCounter", IncrementCounter);
+                SetFunc("deleteCounter", DeleteCounter);
 
-                ScriptEngine.SetValue("lastModified", new ClrFunction(ScriptEngine, "lastModified", GetLastModified));
+                SetFunc("lastModified", GetLastModified);
 
-                ScriptEngine.SetValue("startsWith", new ClrFunction(ScriptEngine, "startsWith", StartsWith));
-                ScriptEngine.SetValue("endsWith", new ClrFunction(ScriptEngine, "endsWith", EndsWith));
-                ScriptEngine.SetValue("regex", new ClrFunction(ScriptEngine, "regex", Regex));
+                SetFunc("startsWith", StartsWith);
+                SetFunc("endsWith", EndsWith);
+                SetFunc("regex", Regex);
 
-                ScriptEngine.SetValue("Raven_ExplodeArgs", new ClrFunction(ScriptEngine, "Raven_ExplodeArgs", ExplodeArgs));
-                ScriptEngine.SetValue("Raven_Min", new ClrFunction(ScriptEngine, "Raven_Min", Raven_Min));
-                ScriptEngine.SetValue("Raven_Max", new ClrFunction(ScriptEngine, "Raven_Max", Raven_Max));
+                SetFunc("Raven_ExplodeArgs", ExplodeArgs);
+                SetFunc("Raven_Min", Raven_Min);
+                SetFunc("Raven_Max", Raven_Max);
 
-                ScriptEngine.SetValue("convertJsTimeToTimeSpanString", new ClrFunction(ScriptEngine, "convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString));
-                ScriptEngine.SetValue("convertToTimeSpanString", new ClrFunction(ScriptEngine, "convertToTimeSpanString", ConvertToTimeSpanString));
-                ScriptEngine.SetValue("compareDates", new ClrFunction(ScriptEngine, "compareDates", CompareDates));
+                SetFunc("convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString);
+                SetFunc("convertToTimeSpanString", ConvertToTimeSpanString);
+                SetFunc("compareDates", CompareDates);
 
-                ScriptEngine.SetValue("toStringWithFormat", new ClrFunction(ScriptEngine, "toStringWithFormat", ToStringWithFormat));
+                SetFunc("toStringWithFormat", ToStringWithFormat);
 
-                ScriptEngine.SetValue("scalarToRawString", new ClrFunction(ScriptEngine, "scalarToRawString", ScalarToRawString));
+                SetFunc("scalarToRawString", ScalarToRawString);
 
                 //TimeSeries
-                ScriptEngine.SetValue("timeseries", new ClrFunction(ScriptEngine, "timeseries", TimeSeries));
+                SetFunc("timeseries", TimeSeries);
                 ScriptEngine.Execute(ScriptRunnerCache.PolyfillJs);
 
                 foreach (var script in scriptsSource)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -283,14 +283,14 @@ namespace Raven.Server.Documents.Patch
                 });
 
                 JavaScriptUtils = new JavaScriptUtils(_runner, ScriptEngine);
-                ScriptEngine.SetFunc(GetMetadataMethod, JavaScriptUtils.GetMetadata);
-                ScriptEngine.SetFunc("metadataFor", JavaScriptUtils.GetMetadata);
-                ScriptEngine.SetFunc("id", JavaScriptUtils.GetDocumentId);
-                ScriptEngine.SetFunc("count", JavaScriptUtils.Count);
-                ScriptEngine.SetFunc("key", JavaScriptUtils.Key);
-                ScriptEngine.SetFunc("sum", JavaScriptUtils.Sum);
+                ScriptEngine.SetClrFunc(GetMetadataMethod, JavaScriptUtils.GetMetadata);
+                ScriptEngine.SetClrFunc("metadataFor", JavaScriptUtils.GetMetadata);
+                ScriptEngine.SetClrFunc("id", JavaScriptUtils.GetDocumentId);
+                ScriptEngine.SetClrFunc("count", JavaScriptUtils.Count);
+                ScriptEngine.SetClrFunc("key", JavaScriptUtils.Key);
+                ScriptEngine.SetClrFunc("sum", JavaScriptUtils.Sum);
 
-                ScriptEngine.SetFunc("output", OutputDebug);
+                ScriptEngine.SetClrFunc("output", OutputDebug);
 
                 //console.log
                 ObjectInstance consoleObject = new JsObject(ScriptEngine);
@@ -323,41 +323,41 @@ namespace Raven.Server.Documents.Patch
                 // includes - backward compatibility
                 ScriptEngine.SetValue("include", includeDocumentFunc);
 
-                ScriptEngine.SetFunc("load", LoadDocument);
-                ScriptEngine.SetFunc("LoadDocument", ThrowOnLoadDocument);
+                ScriptEngine.SetClrFunc("load", LoadDocument);
+                ScriptEngine.SetClrFunc("LoadDocument", ThrowOnLoadDocument);
 
-                ScriptEngine.SetFunc("loadPath", LoadDocumentByPath);
-                ScriptEngine.SetFunc("del", DeleteDocument);
-                ScriptEngine.SetFunc("DeleteDocument", ThrowOnDeleteDocument);
-                ScriptEngine.SetFunc("put", PutDocument);
-                ScriptEngine.SetFunc("PutDocument", ThrowOnPutDocument);
-                ScriptEngine.SetFunc("cmpxchg", CompareExchange);
+                ScriptEngine.SetClrFunc("loadPath", LoadDocumentByPath);
+                ScriptEngine.SetClrFunc("del", DeleteDocument);
+                ScriptEngine.SetClrFunc("DeleteDocument", ThrowOnDeleteDocument);
+                ScriptEngine.SetClrFunc("put", PutDocument);
+                ScriptEngine.SetClrFunc("PutDocument", ThrowOnPutDocument);
+                ScriptEngine.SetClrFunc("cmpxchg", CompareExchange);
 
-                ScriptEngine.SetFunc("counter", GetCounter);
-                ScriptEngine.SetFunc("counterRaw", GetCounterRaw);
-                ScriptEngine.SetFunc("incrementCounter", IncrementCounter);
-                ScriptEngine.SetFunc("deleteCounter", DeleteCounter);
+                ScriptEngine.SetClrFunc("counter", GetCounter);
+                ScriptEngine.SetClrFunc("counterRaw", GetCounterRaw);
+                ScriptEngine.SetClrFunc("incrementCounter", IncrementCounter);
+                ScriptEngine.SetClrFunc("deleteCounter", DeleteCounter);
 
-                ScriptEngine.SetFunc("lastModified", GetLastModified);
+                ScriptEngine.SetClrFunc("lastModified", GetLastModified);
 
-                ScriptEngine.SetFunc("startsWith", StartsWith);
-                ScriptEngine.SetFunc("endsWith", EndsWith);
-                ScriptEngine.SetFunc("regex", Regex);
+                ScriptEngine.SetClrFunc("startsWith", StartsWith);
+                ScriptEngine.SetClrFunc("endsWith", EndsWith);
+                ScriptEngine.SetClrFunc("regex", Regex);
 
-                ScriptEngine.SetFunc("Raven_ExplodeArgs", ExplodeArgs);
-                ScriptEngine.SetFunc("Raven_Min", Raven_Min);
-                ScriptEngine.SetFunc("Raven_Max", Raven_Max);
+                ScriptEngine.SetClrFunc("Raven_ExplodeArgs", ExplodeArgs);
+                ScriptEngine.SetClrFunc("Raven_Min", Raven_Min);
+                ScriptEngine.SetClrFunc("Raven_Max", Raven_Max);
 
-                ScriptEngine.SetFunc("convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString);
-                ScriptEngine.SetFunc("convertToTimeSpanString", ConvertToTimeSpanString);
-                ScriptEngine.SetFunc("compareDates", CompareDates);
+                ScriptEngine.SetClrFunc("convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString);
+                ScriptEngine.SetClrFunc("convertToTimeSpanString", ConvertToTimeSpanString);
+                ScriptEngine.SetClrFunc("compareDates", CompareDates);
 
-                ScriptEngine.SetFunc("toStringWithFormat", ToStringWithFormat);
+                ScriptEngine.SetClrFunc("toStringWithFormat", ToStringWithFormat);
 
-                ScriptEngine.SetFunc("scalarToRawString", ScalarToRawString);
+                ScriptEngine.SetClrFunc("scalarToRawString", ScalarToRawString);
 
                 //TimeSeries
-                ScriptEngine.SetFunc("timeseries", TimeSeries);
+                ScriptEngine.SetClrFunc("timeseries", TimeSeries);
                 ScriptEngine.Execute(ScriptRunnerCache.PolyfillJs);
 
                 foreach (var script in scriptsSource)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -323,7 +323,7 @@ namespace Raven.Server.Documents.Patch
                 // includes - backward compatibility
                 ScriptEngine.SetValue("include", includeDocumentFunc);
 
-                ScriptEngine.SetValue("load", new ClrFunction(ScriptEngine, "load", LoadDocument));
+                SetFunc("load", LoadDocument);
                 ScriptEngine.SetValue("LoadDocument", new ClrFunction(ScriptEngine, "LoadDocument", ThrowOnLoadDocument));
 
                 ScriptEngine.SetValue("loadPath", new ClrFunction(ScriptEngine, "loadPath", LoadDocumentByPath));
@@ -378,6 +378,8 @@ namespace Raven.Server.Documents.Patch
                     ScriptEngine.SetValue(ts.Key, NamedInvokeTimeSeriesFunction(ts.Key));
                 }
             }
+
+            private void SetFunc(string name, Func<JsValue, JsValue[], JsValue> func) => ScriptEngine.SetValue(name, new ClrFunction(ScriptEngine, name, func));
 
             private (string Id, BlittableJsonReaderObject Doc) GetIdAndDocFromArg(JsValue docArg, string signature)
             {

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -52,6 +52,12 @@ namespace Raven.Server.Documents.Patch
         private static readonly string MaxStepsForScriptConfigurationKey = RavenConfiguration.GetKey(x => x.Patching.MaxStepsForScript);
         private static readonly string AllowStringCompilationKey = RavenConfiguration.GetKey(x => x.Patching.AllowStringCompilation);
 
+        /// <summary>
+        /// This class holds a <see cref="SingleRun"/> with its underlying <see cref="Engine"/>.
+        ///
+        /// It uses one of the two fields to hold it. It's either <see cref="Value"/> that is a strong reference or
+        /// <see cref="WeakValue"/> that the value might be moved to when <see cref="RunIdleOperations"/> is performed.
+        /// </summary>
         public sealed class Holder
         {
             public Holder(long generation)
@@ -65,17 +71,17 @@ namespace Raven.Server.Documents.Patch
             public WeakReference<SingleRun> WeakValue;
         }
 
-        private readonly ConcurrentQueue<Holder> _cache = new ConcurrentQueue<Holder>();
+        private readonly ConcurrentQueue<Holder> _cache = new();
         private readonly ScriptRunnerCache _parent;
         internal readonly bool _enableClr;
         private readonly DateTime _creationTime;
-        public readonly List<Prepared<Script>> ScriptsSource = new List<Prepared<Script>>();
+        private readonly List<Prepared<Script>> _scriptsSource = new();
 
         public int NumberOfCachedScripts => _cache.Count(x =>
             x.Value != null ||
             x.WeakValue?.TryGetTarget(out _) == true);
 
-        internal readonly Dictionary<string, DeclaredFunction> TimeSeriesDeclaration = new Dictionary<string, DeclaredFunction>();
+        private readonly Dictionary<string, DeclaredFunction> _timeSeriesDeclaration = new();
 
         public long Runs;
         private DateTime _lastRun;
@@ -100,7 +106,7 @@ namespace Raven.Server.Documents.Patch
                 ["CachedScriptsCount"] = _cache.Count
             };
             if (detailed)
-                djv["ScriptsSource"] = ScriptsSource;
+                djv["ScriptsSource"] = _scriptsSource;
 
             return djv;
         }
@@ -115,7 +121,7 @@ namespace Raven.Server.Documents.Patch
                     // we cannot be sure about projected elements, they might use strict mode reserved words like 'package'
                     strict = false;
                 }
-                ScriptsSource.Add(Engine.PrepareScript(script, strict: strict));
+                _scriptsSource.Add(Engine.PrepareScript(script, strict: strict));
             }
             catch (Exception e)
             {
@@ -125,7 +131,7 @@ namespace Raven.Server.Documents.Patch
 
         public void AddTimeSeriesDeclaration(DeclaredFunction func)
         {
-            TimeSeriesDeclaration.Add(func.Name, func);
+            _timeSeriesDeclaration.Add(func.Name, func);
         }
 
         public ReturnRun GetRunner(bool ignoreValidationErrors, out SingleRun run)
@@ -150,7 +156,7 @@ namespace Raven.Server.Documents.Patch
                 }
                 else
                 {
-                    holder.Value = new SingleRun(_parent.Database, _parent.Configuration, this, ScriptsSource, ignoreValidationErrors);
+                    holder.Value = new SingleRun(_parent.Database, _parent.Configuration, this, _scriptsSource, ignoreValidationErrors);
                 }
             }
 
@@ -373,7 +379,7 @@ namespace Raven.Server.Documents.Patch
                     }
                 }
 
-                foreach (var ts in runner.TimeSeriesDeclaration)
+                foreach (var ts in runner._timeSeriesDeclaration)
                 {
                     ScriptEngine.SetValue(ts.Key, NamedInvokeTimeSeriesFunction(ts.Key));
                 }
@@ -1011,7 +1017,7 @@ namespace Raven.Server.Documents.Patch
 
             public override string ToString()
             {
-                return string.Join(Environment.NewLine, _runner.ScriptsSource);
+                return string.Join(Environment.NewLine, _runner._scriptsSource);
             }
 
             private static JsValue GetLastModified(JsValue self, JsValue[] args)
@@ -1628,7 +1634,7 @@ namespace Raven.Server.Documents.Patch
             {
                 AssertValidDatabaseContext("InvokeTimeSeriesFunction");
 
-                if (_runner.TimeSeriesDeclaration.TryGetValue(name, out var func) == false)
+                if (_runner._timeSeriesDeclaration.TryGetValue(name, out var func) == false)
                     throw new InvalidOperationException($"Failed to invoke time series function. Unknown time series name '{name}'.");
 
                 object[] tsFunctionArgs = GetTimeSeriesFunctionArgs(name, args, out string docId, out var lazyIds);
@@ -2093,7 +2099,7 @@ namespace Raven.Server.Documents.Patch
                 return JavaScriptUtils.TranslateToJs(ScriptEngine, _jsonCtx, document);
             }
 
-            private JsValue[] _args = Array.Empty<JsValue>();
+            private JsValue[] _args = [];
             private readonly JintPreventResolvingTasksReferenceResolver _refResolver = new JintPreventResolvingTasksReferenceResolver();
 
             public ScriptRunnerResult Run(JsonOperationContext jsonCtx, DocumentsOperationContext docCtx, string method, object[] args, QueryTimingsScope scope = null, CancellationToken token = default)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -25,7 +25,6 @@ using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Patching;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Config;
-using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Queries;
@@ -82,6 +81,7 @@ namespace Raven.Server.Documents.Patch
             x.WeakValue?.TryGetTarget(out _) == true);
 
         private readonly Dictionary<string, DeclaredFunction> _timeSeriesDeclaration = new();
+        private Dictionary<string, Func<JsValue, JsValue[], JsValue>> _clrFunctions = null;
 
         public long Runs;
         private DateTime _lastRun;
@@ -132,6 +132,16 @@ namespace Raven.Server.Documents.Patch
         public void AddTimeSeriesDeclaration(DeclaredFunction func)
         {
             _timeSeriesDeclaration.Add(func.Name, func);
+        }
+
+        /// <summary>
+        /// Sets a clr function <paramref name="func"/> under <see cref="name"/>.
+        /// If the function was set before, it will be overwritten.
+        /// </summary>
+        public void SetClrFunction(string name, Func<JsValue, JsValue[], JsValue> func)
+        {
+            _clrFunctions ??= new Dictionary<string, Func<JsValue, JsValue[], JsValue>>();
+            _clrFunctions[name] = func;
         }
 
         public ReturnRun GetRunner(bool ignoreValidationErrors, out SingleRun run)
@@ -365,6 +375,15 @@ namespace Raven.Server.Documents.Patch
                 //TimeSeries
                 ScriptEngine.SetClrFunc("timeseries", TimeSeries);
                 ScriptEngine.Execute(ScriptRunnerCache.PolyfillJs);
+
+                // Clr Functions, apply if any
+                if (runner._clrFunctions != null)
+                {
+                    foreach ((string name, Func<JsValue, JsValue[], JsValue> value) in runner._clrFunctions)
+                    {
+                        ScriptEngine.SetClrFunc(name, value);
+                    }
+                }
 
                 foreach (var script in scriptsSource)
                 {

--- a/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
+++ b/src/Raven.Server/Documents/Replication/ResolveConflictOnReplicationConfigurationChange.cs
@@ -31,7 +31,7 @@ namespace Raven.Server.Documents.Replication
         public ResolveConflictOnReplicationConfigurationChange(ReplicationLoader replicationLoader, Logger log)
         {
             _replicationLoader = replicationLoader ??
-                throw new ArgumentNullException($"{nameof(ResolveConflictOnReplicationConfigurationChange)} must have replicationLoader instance");
+                                 throw new ArgumentNullException($"{nameof(ResolveConflictOnReplicationConfigurationChange)} must have replicationLoader instance");
             _database = _replicationLoader.Database;
             _log = log;
         }
@@ -58,6 +58,7 @@ namespace Raven.Server.Documents.Replication
                     _log.Info("Waited for 60 seconds to close 'ResolveConflictOnReplicationConfigurationChange' gracefully, will dispose it anyway.");
                 }
             }
+
             _runOnce.Dispose();
         }
 
@@ -127,11 +128,11 @@ namespace Raven.Server.Documents.Replication
                             if (ScriptConflictResolversCache.TryGetValue(collection, out var scriptResolver) && scriptResolver != null)
                             {
                                 if (TryResolveConflictByScriptInternal(
-                                    context,
-                                    scriptResolver,
-                                    conflicts,
-                                    collection,
-                                    resolvedConflict: out resolved))
+                                        context,
+                                        scriptResolver,
+                                        conflicts,
+                                        collection,
+                                        resolvedConflict: out resolved))
                                 {
                                     resolved.Flags = resolved.Flags.Strip(DocumentFlags.FromReplication);
                                     resolvedConflicts.Add((resolved, maxConflictEtag, ResolvedToLatest: false));
@@ -232,6 +233,7 @@ namespace Raven.Server.Documents.Replication
                     ScriptConflictResolversCache = new Dictionary<string, ScriptResolver>();
                 return;
             }
+
             var copy = new Dictionary<string, ScriptResolver>();
             foreach (var kvp in conflictSolver.ResolveByCollection)
             {
@@ -241,11 +243,13 @@ namespace Raven.Server.Documents.Replication
                 {
                     continue;
                 }
+
                 copy[collection] = new ScriptResolver
                 {
                     Script = script
                 };
             }
+
             ScriptConflictResolversCache = copy;
         }
 
@@ -275,7 +279,7 @@ namespace Raven.Server.Documents.Replication
                         AlertType.Replication,
                         NotificationSeverity.Error,
                         "Mismatched Collections On Replication Resolve"
-                        );
+                    );
                     _database.NotificationCenter.Add(differentCollectionNameAlert);
                     return false;
                 }
@@ -285,10 +289,10 @@ namespace Raven.Server.Documents.Replication
         }
 
         public void PutResolvedDocument(
-           DocumentsOperationContext context,
-           DocumentConflict resolved,
-           bool resolvedToLatest,
-           DocumentConflict incoming = null)
+            DocumentsOperationContext context,
+            DocumentConflict resolved,
+            bool resolvedToLatest,
+            DocumentConflict incoming = null)
         {
             resolved.Flags = resolved.Flags.Strip(DocumentFlags.FromClusterTransaction);
 
@@ -299,10 +303,8 @@ namespace Raven.Server.Documents.Replication
             // to avoid feature conflicts on the document due to one-way external replication
             // if this is not the case (resolvedToLatest == false), we should generate a new change vector since it was changed locally.
             // in a cluster this may cause a ping-pong replication which will be settled down by the fact that a conflict with identical content doesn't increase the local etag
-            
-            var changeVector = resolvedToLatest ?
-                context.GetChangeVector(resolved.ChangeVector) :
-                ChangeVector.MergeWithNewDatabaseChangeVector(context, resolved.ChangeVector);
+
+            var changeVector = resolvedToLatest ? context.GetChangeVector(resolved.ChangeVector) : ChangeVector.MergeWithNewDatabaseChangeVector(context, resolved.ChangeVector);
 
             if (resolved.Doc == null)
             {
@@ -426,7 +428,7 @@ namespace Raven.Server.Documents.Replication
 
                 var patch = new PatchConflict(_database, conflicts);
                 updatedConflict = conflicts[0];
-                var patchRequest = new PatchRequest(scriptResolver.Script, PatchRequestType.Conflict);
+                var patchRequest = new ConflictPatchRequest(scriptResolver.Script);
                 if (patch.TryResolveConflict(context, patchRequest, out BlittableJsonReaderObject resolved) == false)
                 {
                     return false;
@@ -455,6 +457,7 @@ namespace Raven.Server.Documents.Replication
 
                 _database.NotificationCenter.Add(alert);
             }
+
             return false;
         }
 
@@ -499,24 +502,24 @@ namespace Raven.Server.Documents.Replication
             {
                 if (group.Count() == 1)
                     continue;
-                
+
                 bool found = false;
                 foreach (var attachment in group)
                 {
                     if (found == false && resolvedAttachmentsMetadata.Any(x =>
-                            x.Name == attachment.Name && 
-                            x.Hash == attachment.Hash && 
+                            x.Name == attachment.Name &&
+                            x.Hash == attachment.Hash &&
                             x.ContentType == attachment.ContentType))
                     {
                         found = true;
-                       // we have to generate a _new_ change vector for the attachment, since it is resolved, to ensure
-                       // all nodes have the same change vector value after replication
-                        var ad = _database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, attachment.DocumentId, 
+                        // we have to generate a _new_ change vector for the attachment, since it is resolved, to ensure
+                        // all nodes have the same change vector value after replication
+                        var ad = _database.DocumentsStorage.AttachmentsStorage.PutAttachment(context, attachment.DocumentId,
                             attachment.Name, attachment.ContentType, attachment.Hash,
-                            stream: null, expectedChangeVector: null,  updateDocument: false);
+                            stream: null, expectedChangeVector: null, updateDocument: false);
                         continue;
                     }
-                    
+
                     if (resolvedToLatest)
                     {
                         // delete duplicates
@@ -532,9 +535,11 @@ namespace Raven.Server.Documents.Replication
                             found = true;
                             continue;
                         }
+
                         // rename duplicates
                         var newName = _database.DocumentsStorage.AttachmentsStorage.ResolveAttachmentName(context, lowerId, attachment.Name);
-                        _database.DocumentsStorage.AttachmentsStorage.MoveAttachment(context, resolved.LowerId, attachment.Name, resolved.LowerId, newName, changeVector: null, attachment.Hash, attachment.ContentType, usePartialKey: false, updateDocument: false, extractCollectionName: false);
+                        _database.DocumentsStorage.AttachmentsStorage.MoveAttachment(context, resolved.LowerId, attachment.Name, resolved.LowerId, newName, changeVector: null, attachment.Hash, attachment.ContentType, usePartialKey: false,
+                            updateDocument: false, extractCollectionName: false);
                     }
                 }
             }

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FastTests;
 using FastTests.Utils;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
@@ -13,12 +14,14 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Replication;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Analyzers;
 using Raven.Server.Documents.Replication;
 using Raven.Server.NotificationCenter;
+using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Tests.Infrastructure;
@@ -1638,6 +1641,84 @@ namespace SlowTests.Server.Replication
             }
         }
 
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(ResolveConflictScriptWithPut)]
+        [InlineData(ResolveConflictScriptWithDel)]
+        [InlineData(ResolveConflictScriptWithLoad)]
+        public async Task ConflictResolutionThrowsMeaningfulExceptionOnUsingForbiddenMethod(string script)
+        {
+            const string id = "users/1";
+            
+            using var store1 = GetDocumentStore(new Options { ModifyDatabaseRecord = ModifyDatabaseRecord });
+            using var store2 = GetDocumentStore(new Options { ModifyDatabaseRecord = ModifyDatabaseRecord });
+            
+            using (var s1 = store1.OpenSession())
+            {
+                s1.Store(new User { Name = "test" }, id);
+                s1.SaveChanges();
+            }
+
+            using (var s2 = store2.OpenSession())
+            {
+                s2.Store(new User { Name = "test2" }, id);
+                s2.SaveChanges();
+            }
+
+            await SetupReplicationAsync(store1, store2);
+
+            GetConflictsResult.Conflict[] waitUntilHasConflict = WaitUntilHasConflict(store2, id);
+
+            DocumentDatabase db = await GetDocumentDatabaseInstanceFor(store2);
+            db.NotificationCenter.GetStored(out var actions);
+                
+            var alerts = actions
+                .Select(item => AlertRaised.FromJson("", item.Json))
+                .ToArray();
+
+            AlertRaised alert = Assert.Single(alerts);
+            
+            Assert.Equal(alert.AlertType, AlertType.Replication);
+            Assert.Equal(alert.Severity, NotificationSeverity.Error);
+            Assert.Equal(alert.Type, NotificationType.AlertRaised);
+
+            void ModifyDatabaseRecord(DatabaseRecord record)
+            {
+                record.ConflictSolverConfig = new ConflictSolver
+                {
+                    ResolveToLatest = false,
+                    ResolveByCollection = new Dictionary<string, ScriptResolver>
+                    {
+                        { "Users", new ScriptResolver { Script = script } }
+                    }
+                };
+            }
+        }
+
+        private const string ResolveConflictScriptWithPut =
+            """
+            put("Conflicts/", {
+              Name: 'Conflict',
+              "@metadata": {
+                "@collection": "Conflicts",
+              }
+            });
+
+            return null;
+            """;
+
+        private const string ResolveConflictScriptWithDel =
+            """
+            del("Conflicts/1");
+            return null;
+            """;
+
+        private const string ResolveConflictScriptWithLoad =
+            """
+            let c = load("Conflicts/1");
+            return null;
+            """;
+
+
         [RavenFact(RavenTestCategory.Replication)]
         public void LocalIsLongerThanRemote()
         {
@@ -1657,6 +1738,7 @@ namespace SlowTests.Server.Replication
 
             Assert.Equal(ConflictStatus.Conflict, ChangeVectorUtils.GetConflictStatus(remote.SerializeVector(), local.SerializeVector()));
         }
+
 
         private class UserIndex : AbstractIndexCreationTask<User>
         {

--- a/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationConflictsTests.cs
@@ -24,6 +24,8 @@ using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Collections;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -1645,19 +1647,21 @@ namespace SlowTests.Server.Replication
         [InlineData(ResolveConflictScriptWithPut)]
         [InlineData(ResolveConflictScriptWithDel)]
         [InlineData(ResolveConflictScriptWithLoad)]
-        public async Task ConflictResolutionThrowsMeaningfulExceptionOnUsingForbiddenMethod(string script)
+        public async Task ConflictResolutionThrowsMeaningfulExceptionOnUsingForbiddenMethod_OnReplication(string script)
         {
             const string id = "users/1";
+
+            Options options = new() { ModifyDatabaseRecord = ConflictsResolutionScriptProvided };
             
-            using var store1 = GetDocumentStore(new Options { ModifyDatabaseRecord = ModifyDatabaseRecord });
-            using var store2 = GetDocumentStore(new Options { ModifyDatabaseRecord = ModifyDatabaseRecord });
+            using var store1 = GetDocumentStore(options);
+            using var store2 = GetDocumentStore(options);
             
             using (var s1 = store1.OpenSession())
             {
                 s1.Store(new User { Name = "test" }, id);
                 s1.SaveChanges();
             }
-
+            
             using (var s2 = store2.OpenSession())
             {
                 s2.Store(new User { Name = "test2" }, id);
@@ -1666,11 +1670,11 @@ namespace SlowTests.Server.Replication
 
             await SetupReplicationAsync(store1, store2);
 
-            GetConflictsResult.Conflict[] waitUntilHasConflict = WaitUntilHasConflict(store2, id);
+            WaitUntilHasConflict(store2, id);
 
             DocumentDatabase db = await GetDocumentDatabaseInstanceFor(store2);
             db.NotificationCenter.GetStored(out var actions);
-                
+
             var alerts = actions
                 .Select(item => AlertRaised.FromJson("", item.Json))
                 .ToArray();
@@ -1681,9 +1685,9 @@ namespace SlowTests.Server.Replication
             Assert.Equal(alert.Severity, NotificationSeverity.Error);
             Assert.Equal(alert.Type, NotificationType.AlertRaised);
 
-            void ModifyDatabaseRecord(DatabaseRecord record)
+            void ConflictsResolutionScriptProvided(DatabaseRecord record)
             {
-                record.ConflictSolverConfig = new ConflictSolver
+                record.ConflictSolverConfig = new()
                 {
                     ResolveToLatest = false,
                     ResolveByCollection = new Dictionary<string, ScriptResolver>
@@ -1693,6 +1697,85 @@ namespace SlowTests.Server.Replication
                 };
             }
         }
+        
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(ResolveConflictScriptWithPut)]
+        [InlineData(ResolveConflictScriptWithDel)]
+        [InlineData(ResolveConflictScriptWithLoad)]
+        public async Task ConflictResolutionThrowsMeaningfulExceptionOnUsingForbiddenMethod_WithScript(string script)
+        {
+            const string id = "users/1";
+
+            Options options = new() { ModifyDatabaseRecord = NoConflictResolutionAtAll };
+            
+            using var store1 = GetDocumentStore(options);
+            using var store2 = GetDocumentStore(options);
+            
+            using (var s1 = store1.OpenSession())
+            {
+                s1.Store(new User { Name = "test" }, id);
+                s1.SaveChanges();
+            }
+            
+            using (var s2 = store2.OpenSession())
+            {
+                s2.Store(new User { Name = "test2" }, id);
+                s2.SaveChanges();
+            }
+
+            await SetupReplicationAsync(store1, store2);
+
+            WaitUntilHasConflict(store2, id);
+
+            var db = await GetDocumentDatabaseInstanceFor(store2);
+            db.NotificationCenter.GetStored(out var actions);
+
+            var alerts = actions
+                .Select(item => AlertRaised.FromJson("", item.Json))
+                .ToArray();
+
+            // Alerts should not be raised now.
+            Assert.Empty(alerts);
+
+            Dictionary<string, ScriptResolver> users = new()
+            {
+                { "Users", new ScriptResolver { Script = script } }
+            };
+            
+            AsyncQueue<DynamicJsonValue> notificationsQueue = new();
+            using (db.NotificationCenter.TrackActions(notificationsQueue, null))
+            {
+                // Update the script to the new one
+                await store2.Maintenance.Server.SendAsync(new ModifyConflictSolverOperation(store2.Database, users, resolveToLatest: false));
+
+                var alert = await notificationsQueue.DequeueUntilAsync(static item =>
+                    {
+                        var alertType = item[nameof(AlertRaised.AlertType)];
+                        var severity = item[nameof(AlertRaised.Severity)];
+                        var message = item[nameof(AlertRaised.Message)];
+
+                        if (alertType == null || severity == null || message == null)
+                        {
+                            return false;
+                        }
+
+                        return alertType.ToString() == nameof(AlertType.Replication) &&
+                               severity.ToString() == nameof(NotificationSeverity.Error) &&
+                               message.ToString().Contains(id);
+                    }
+                );
+            }
+
+            void NoConflictResolutionAtAll(DatabaseRecord record)
+            {
+                record.ConflictSolverConfig = new()
+                {
+                    ResolveToLatest = false,
+                    ResolveByCollection = new Dictionary<string, ScriptResolver>()
+                };
+            }
+        }
+
 
         private const string ResolveConflictScriptWithPut =
             """

--- a/test/Tests.Infrastructure/AsyncQueueExtensions.cs
+++ b/test/Tests.Infrastructure/AsyncQueueExtensions.cs
@@ -10,7 +10,10 @@ public static class AsyncQueueExtensions
     
     public static async Task<T> DequeueUntilAsync<T>(this AsyncQueue<T> queue, Predicate<T> predicate, TimeSpan? maxWaitForDequeue = null)
     {
-        // For the first, wait asynchronously with no timeout
+        // For the first, wait asynchronously with no timeout.
+        // The reason to wait with no timeout here is to wait for some setup that might take more than timeout.
+        // For example notifications, if the setup takes 2s, no item will be found and it will break the test.
+        // The first timeout-less wait ensure that there's always enough of time to set things up.
         T first = await queue.DequeueAsync();
         if (predicate(first))
             return first;

--- a/test/Tests.Infrastructure/AsyncQueueExtensions.cs
+++ b/test/Tests.Infrastructure/AsyncQueueExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading.Tasks;
+using Sparrow.Server.Collections;
+
+namespace Tests.Infrastructure;
+
+public static class AsyncQueueExtensions
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(1);
+    
+    public static async Task<T> DequeueUntilAsync<T>(this AsyncQueue<T> queue, Predicate<T> predicate, TimeSpan? maxWaitForDequeue = null)
+    {
+        // For the first, wait asynchronously with no timeout
+        T first = await queue.DequeueAsync();
+        if (predicate(first))
+            return first;
+        
+        while (true)
+        {
+            (bool success, T item) = await queue.TryDequeueAsync(maxWaitForDequeue ?? DefaultTimeout);
+            if (success)
+            {
+                if (predicate(item))
+                {
+                    return item;
+                }
+            }
+
+            else
+            {
+                throw new Exception("No matching item found");        
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25203/Cant-put-new-documents-in-the-script-resolution-patch

### Additional description

This PR refactors the `ScriptRunnerCache.Key` by introducing an explicit  `ConflictPatchRequest` to handle conflict resolution. To make it work, it provides a new capability to override some of the `ClrFunction` s in the created `Jint` `Engine`. As the engine is instantiated and cached per script, the overrides can be left for future reuse.

The added tests cover all scenarios where:

1. the script resolution is executed by the replication with the write transaction, 
2. the script resolution is executed after the script update with the read transaction

In both cases we assert that the alert is raised properly

Based on https://github.com/ravendb/ravendb/discussions/21599

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

From now on, using functions `put` `load` `delete` and `loadPath` in a conflict resolution script will raise an alert and fail the resolution script. Conflict resolution should be solely based on the content of the document being merged. They should be also side affect free.

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
