### PR TITLE
RavenDB-25255 pass authentication to the query tool execution

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -205,7 +205,11 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 string json = item.ContextOutput.Context.ToString();
                 Task<(string Result, AiUsage Usage)> task;
 
-                var handler = new GenAiConversationHandler(Database.ServerStore, Database);
+                var handler = new GenAiConversationHandler(Database.ServerStore, Database)
+                {
+                    // GenAI task uses full access
+                    Authentication = Database.ServerStore.Server.AuthenticateConnectionCertificate(Database.ServerStore.Server.Certificate.ClientCertificate, $"GenAI access for '{Name}'")
+                };
                 handler.Initialize(Agent, $"GenAI/{item.DocumentId}", new RequestBody
                 {
                     CreationOptions = new AiConversationCreationOptions(),

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -31,7 +32,10 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             using var _ = ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
             var body = await ReadRequestBodyAsync(context, token.Token);
-            var handler = new ConversationHandler(RequestHandler.ServerStore, RequestHandler.Database);
+            var handler = new ConversationHandler(RequestHandler.ServerStore, RequestHandler.Database)
+            {
+                Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
+            };
 
             await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, token);
         }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
@@ -32,7 +33,10 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         AiAgentHelpers.AddDefaultValues(body.Configuration, RequestHandler.Configuration.Ai);
         AddOrUpdateAiAgentCommand.ValidateConfiguration(context, body.Configuration);
 
-        var handler = new TestConversationHandler(ServerStore, RequestHandler.Database, body);
+        var handler = new TestConversationHandler(ServerStore, RequestHandler.Database, body)
+        {
+            Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
+        };
         await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, token: token);
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features.Authentication;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Commands.MultiGet;
 using Raven.Client.Documents.Operations.AI;
@@ -41,6 +42,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
     private string _raftId;
     private int _maxModelIterationsPerCall;
 
+    public required RavenServer.AuthenticateConnection Authentication;
     public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null)
     {
         _conversationId = conversationId;
@@ -402,6 +404,8 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             RavenServer = server.Server,
             HttpContext = new DefaultHttpContext()
         });
+
+        multiGetHandler.HttpContext.Features.Set<IHttpAuthenticationFeature>(Authentication);
 
         using (var reqsBlittable = context.ReadObject(new DynamicJsonValue { ["Requests"] = reqs }, "ai-agent/multi-query"))
         using (var handler = new MultiGetHandlerProcessorForPost(multiGetHandler))

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
@@ -88,8 +88,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 var creation = new AiConversationCreationOptions().AddParameter("company", "companies/1-A");
                 var blittable = context.ReadObject(creation.ToJson(), "fake-params");
                 blittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
-              
-                var x = new EvilLmHandler(Server.ServerStore, database);
+
+                var x = new EvilLmHandler(Server.ServerStore, database)
+                {
+                    Authentication = null
+                };
                 x.Initialize(agent, "Dummy", new RequestBody
                 {
                     Parameters = parameters,

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Documents.AI;
+using SlowTests.Server.Documents.AI.GenAi;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using static SlowTests.Server.Documents.AI.AiAgent.AiAgentClientApiBasics;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25255 : RavenTestBase
+    {
+        public RavenDB_25255(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanUseQueryToolWithSecuredServer(Options options, GenAiConfiguration config)
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            var adminCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+            var clientCertificate = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate2.Value, new Dictionary<string, DatabaseAccess>
+            {
+                [dbName] = DatabaseAccess.Admin
+            });
+
+            using var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCertificate,
+                ClientCertificate = clientCertificate,
+                ModifyDatabaseName = s => dbName
+            });
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            using var session = store.OpenAsyncSession();
+
+            var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Parameters.Add(new AiAgentParameter("company"));
+            agent.Queries =
+            [
+                new AiAgentToolQuery
+            {
+                Name = "ProductSearch",
+                Description =  "semantic search the store product catalog",
+                Query = "from Products where vector.search(embedding.text(Name), $query)",
+                ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            }
+            ,
+            new AiAgentToolQuery
+            {
+                Name = "RecentOrder",
+                Description = "Get the recent orders of the current user",
+                Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                ParametersSampleObject = "{}"
+            }
+            ];
+
+            var identifier = (await store.AI.CreateAgentAsync(agent, AnswerSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(identifier, "chats/",
+                new AiConversationCreationOptions()
+                    .AddParameter("company", "companies/90-A"));
+
+            chat.SetUserPrompt("what goes well with my cheese?");
+            var r = await chat.RunAsync<AnswerSchema>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
+
+            Assert.NotNull(r.Answer);
+            Assert.NotNull(chat.Id);
+
+            chat.SetUserPrompt("what goes well with my cheese?");
+            r = await chat.RunAsync<AnswerSchema>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
+
+            Assert.NotNull(r.Answer);
+
+            chat.SetUserPrompt("what cheese goes well with italian food?");
+            r = await chat.RunAsync<AnswerSchema>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanUseQueryToolsInGenAiTaskSecured(Options options, GenAiConfiguration config)
+        {
+            var dbName = GetDatabaseName();
+            var certificates = Certificates.SetupServerAuthentication();
+            var cert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates.ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var store = GetDocumentStore(new Options
+            {
+                AdminCertificate = cert,
+                ClientCertificate = cert,
+                ModifyDatabaseName = s => dbName
+            });
+
+            await new ProductsByCategory().ExecuteAsync(store);
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Name = "GenAi-With-QueryTool";
+            config.Identifier = "products-category-counter";
+            config.Collection = "Products";
+            config.Prompt = "Figure out if the provided products' category is popular or not. " +
+                            "'Popular' is if there are at least 3 Product records of this Category in the dataset. " +
+                            "If less than 3, then it isn't considered a popular category." +
+                            "Use provided tools.";
+
+            var sampleObject = JsonConvert.SerializeObject(new { IsPopular = true });
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(sampleObject);
+
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = "ai.genContext({ Category: this.Category });"
+            };
+
+            config.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "products-by-category",
+                    Description = "Return count of products filtered by category",
+                    Query = "from index 'ProductsByCategory' where Category = $category select Count",
+                    ParametersSampleObject = "{\"category\":\"Vegetables\"}",
+                }
+            ];
+
+            config.UpdateScript = "this.Popular = $output.IsPopular;";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            var etlDone = Etl.WaitForEtlToComplete(store);
+
+            using (var session = store.OpenSession())
+            {
+                // fruit 
+                session.Store(new Product
+                {
+                    Name = "apple",
+                    Category = "fruit"
+                });
+
+                // grains
+                session.Store(new Product
+                {
+                    Name = "rice",
+                    Category = "grains"
+                });
+                session.Store(new Product
+                {
+                    Name = "rye",
+                    Category = "grains"
+                });
+
+                // alcohol
+                session.Store(new Product
+                {
+                    Name = "beer",
+                    Category = "alcohol"
+                });
+                session.Store(new Product
+                {
+                    Name = "wine",
+                    Category = "alcohol"
+                });
+                session.Store(new Product
+                {
+                    Name = "gin",
+                    Category = "alcohol"
+                });
+                session.Store(new Product
+                {
+                    Name = "vodka",
+                    Category = "alcohol"
+                });
+
+
+                session.Advanced.WaitForIndexesAfterSaveChanges();
+                session.SaveChanges();
+            }
+
+            await Etl.AssertEtlDoneAsync(etlDone, TimeSpan.FromSeconds(60), store.Database, config);
+
+            using (var session = store.OpenSession())
+            {
+                var allProducts = session.Query<Product>().ToList();
+                Assert.Equal(7, allProducts.Count);
+
+                foreach (var p in allProducts)
+                {
+                    // only "alcohol" category is popular (4 products)
+                    Assert.Equal(p.Category == "alcohol", p.Popular);
+                }
+            }
+        }
+
+        private class Product
+        {
+            public string Name { get; set; }
+            public string Category { get; set; }
+            public bool Popular { get; set; }
+        }
+
+        private class ProductsByCategory : AbstractIndexCreationTask<Product, ProductsByCategory.Result>
+        {
+            public class Result
+            {
+                public string Category { get; set; }
+                public int Count { get; set; }
+            }
+
+            public ProductsByCategory()
+            {
+                Map = products => from p in products
+                                  select new { p.Category, Count = 1 };
+
+                Reduce = results => from r in results
+                                    group r by r.Category
+                    into g
+                                    select new
+                                    {
+                                        Category = g.Key,
+                                        Count = g.Sum(x => x.Count)
+                                    };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/ElasticSearchEtlTestBase.cs
@@ -142,15 +142,6 @@ loadToOrders" + IndexSuffix + @"(orderData);";
             }
         }
 
-        protected async Task AssertEtlDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config)
-        {
-            if (await etlDone.WaitAsync(timeout) == false)
-            {
-                var loadError = await Etl.TryGetLoadErrorAsync(databaseName, config);
-                var transformationError = await Etl.TryGetTransformationErrorAsync(databaseName, config);
-
-                Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
-            }
-        }
+        protected Task AssertEtlDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, ElasticSearchEtlConfiguration config) => Etl.AssertEtlDoneAsync(etlDone, timeout, databaseName, config);
     }
 }

--- a/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/QueueEtlTestBase.cs
@@ -16,15 +16,5 @@ public abstract class QueueEtlTestBase : RavenTestBase
     {
     }
 
-    protected async Task AssertEtlDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config)
-    {
-        if (await etlDone.WaitAsync(timeout) == false)
-        {
-            var loadError = await Etl.TryGetLoadErrorAsync(databaseName, config);
-            var transformationError = await Etl.TryGetTransformationErrorAsync(databaseName, config);
-
-            Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
-        }
-    }
-
+    protected Task AssertEtlDoneAsync(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, QueueEtlConfiguration config) => Etl.AssertEtlDoneAsync(etlDone, timeout, databaseName, config);
 }

--- a/test/Tests.Infrastructure/RavenTestBase.Etl.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Etl.cs
@@ -348,6 +348,16 @@ namespace FastTests
                 return string.Join(Environment.NewLine, stats.Select(JsonConvert.SerializeObject));
             }
 
+            public async Task AssertEtlDoneAsync<T>(AsyncManualResetEvent etlDone, TimeSpan timeout, string databaseName, EtlConfiguration<T> config) where T : ConnectionString
+            {
+                if (await etlDone.WaitAsync(timeout) == false)
+                {
+                    var loadError = await TryGetLoadErrorAsync(databaseName, config);
+                    var transformationError = await TryGetTransformationErrorAsync(databaseName, config);
+
+                    Assert.Fail($"ETL wasn't done. Load error: {loadError?.Error}. Transformation error: {transformationError?.Error}");
+                }
+            }
             public void Dispose()
             {
                 try


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25255

### Additional description

Secured server requires authentication, which was not set properly when creating a new `HttpContext` for the query tool `MultiGet` call

### Type of change

- [ ] Bug fix
- [x] Regression bug fix (https://github.com/ravendb/ravendb/pull/21411)
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
