### PR TITLE
RavenDB-25186 : Add `SendToModel` in AiAgentParameter

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
@@ -22,12 +22,22 @@ public class AiAgentParameter : IDynamicJson
         Description = description;
     }
 
-    public AiAgentParameter(string name, string description, bool? sendToModel = null) : this(name)
+    /// <summary>
+    /// Initializes a new agent parameter and controls whether its value should be sent to the LLM.
+    /// Use this overload when you need to explicitly hide sensitive values (e.g. userId/tenant/company) from the model.
+    /// </summary>
+    /// <param name="name">The parameter name. Cannot be null or empty.</param>
+    /// <param name="description">
+    /// A human-readable description. May be null or empty when using this overload.
+    /// </param>
+    /// <param name="sendToModel">
+    /// When <c>false</c>, the parameter is hidden from the model (it will not be included in prompts/echo messages).
+    /// When <c>true</c>, the parameter is exposed to the model.
+    /// If you do not call this overload, the default is <see langword="null"/> (treated as exposed).
+    /// </param>
+    public AiAgentParameter(string name, string description, bool sendToModel) : this(name)
     {
-        if (string.IsNullOrEmpty(description) == false)
-        {
-            Description = description;
-        }
+        Description = description;
         SendToModel = sendToModel;
     }
 

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
@@ -22,6 +22,16 @@ public class AiAgentParameter : IDynamicJson
         Description = description;
     }
 
+    public AiAgentParameter(string name, string description, bool? sendToModel = null) : this(name)
+    {
+        if (string.IsNullOrEmpty(description) == false)
+        {
+            Description = description;
+        }
+        SendToModel = sendToModel;
+    }
+
+    public bool? SendToModel { get; set; }
     public string Name { get; set; }
     public string Description { get; set; }
     public DynamicJsonValue ToJson()
@@ -29,7 +39,8 @@ public class AiAgentParameter : IDynamicJson
         return new DynamicJsonValue
         {
             [nameof(Name)] = Name,
-            [nameof(Description)] = Description
+            [nameof(Description)] = Description,
+            [nameof(SendToModel)] = SendToModel
         };
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -39,14 +39,16 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (Messages.Count > 0)
             throw new InvalidOperationException("conversation document is already initialized. Cannot re-initialize.");
 
-        foreach (var parameter in configuration.Parameters)
+        var relevantParameters = configuration.Parameters.Where(p => p.SendToModel != false).ToList();
+
+        foreach (var parameter in relevantParameters)
         {
             if (Parameters == null || Parameters.TryGet(parameter.Name, out object _) == false)
                 throw new ArgumentException($"Parameter '{parameter.Name}' is missing.");
         }
 
         var promptMessage = configuration.SystemPrompt;
-        if (TryCreateParameterDescriptionMessage(configuration, out string message))
+        if (TryCreateParameterDescriptionMessage(relevantParameters, out string message))
         {
             promptMessage += "\n" + message;
         }
@@ -57,12 +59,12 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [ChatCompletionClient.Constants.RequestFields.Content] = promptMessage
         }, "system/msg"), usage: null);
 
-        if (configuration.Parameters.Count > 0)
+        if (relevantParameters.Count > 0)
         {
             AddMessage(context, context.ReadObject(new DynamicJsonValue
             {
                 [ChatCompletionClient.Constants.RequestFields.Role] = ChatCompletionClient.Constants.RequestFields.RoleUserValue,
-                [ChatCompletionClient.Constants.RequestFields.Content] = ParametersToString(configuration)
+                [ChatCompletionClient.Constants.RequestFields.Content] = ParametersToString(relevantParameters)
             }, "system/msg"), usage: null);
         }
 
@@ -122,10 +124,10 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         }
     }
 
-    private string ParametersToString(AiAgentConfiguration configuration)
+    private string ParametersToString(List<AiAgentParameter> parameters)
     {
         var sb = new StringBuilder("AI Agent Parameters:\n");
-        foreach (var parameter in configuration.Parameters)
+        foreach (var parameter in parameters)
         {
             var value = Parameters[parameter.Name];
             sb.AppendLine($"{parameter.Name} = {value.ToString()}");
@@ -313,12 +315,12 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         }
     }
 
-    private static bool TryCreateParameterDescriptionMessage(AiAgentConfiguration configuration, out string message)
+    private static bool TryCreateParameterDescriptionMessage(List<AiAgentParameter> parameters, out string message)
     {
         var hasDescription = false;
         var sb = new StringBuilder();
         sb.AppendLine("\nThe parameters for this conversation are described as follows:");
-        foreach (var parameter in configuration.Parameters)
+        foreach (var parameter in parameters)
         {
             if (string.IsNullOrEmpty(parameter.Description))
                 continue;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -39,7 +39,18 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (Messages.Count > 0)
             throw new InvalidOperationException("conversation document is already initialized. Cannot re-initialize.");
 
-        var relevantParameters = configuration.Parameters.Where(p => p.SendToModel != false).ToList();
+        List<AiAgentParameter> relevantParameters = [];
+        var parameters = configuration.Parameters;
+
+        if (parameters != null)
+        {
+            for (int i = 0; i < parameters.Count; i++)
+            {
+                var p = parameters[i];
+                if (p.SendToModel != false)
+                    relevantParameters.Add(p);
+            }
+        }
 
         foreach (var parameter in relevantParameters)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
@@ -123,7 +123,11 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var agent = new AiAgentConfiguration("shopping assistant", csName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
 
-            agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id", exposed));
+            if (exposed.HasValue == false)
+                agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id"));
+            else
+                agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id", exposed.Value));
+
 
             agent.Queries =
             [

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
@@ -1,0 +1,141 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25186 : RavenTestBase
+    {
+        public RavenDB_25186(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true, true])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false, false])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null, true, true])]
+        public async Task SendToModelVariants(Options options, GenAiConfiguration configuration, bool? exposed, bool expectEcho, bool expectRaw)
+        {
+            using var store = GetDocumentStore(options);
+            await PutConn(store, configuration);
+
+            var agent = CreateShoppingAssistant(configuration.ConnectionStringName, exposed);
+            var agentId = (await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/",
+                new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
+
+            chat.SetUserPrompt("hello");
+            var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+            Assert.Equal(AiConversationResult.Done, result.Status);
+
+            await AssertConversationAsync(store, chat.Id,
+                expectEcho: expectEcho,
+                expectRawValueLeak: expectRaw,
+                expectParamStored: true);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task MixedParametersOnlyExposedParametersAreInTheContent(Options options, GenAiConfiguration configuration)
+        {
+            using var store = GetDocumentStore(options);
+            await PutConn(store, configuration);
+
+            var agent = CreateShoppingAssistant(configuration.ConnectionStringName, true);
+            agent.Parameters.Add(new AiAgentParameter("userId", "Authenticated user identifier", sendToModel: false));
+            var agentId = (await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(agentId, "chats/",
+                new AiConversationCreationOptions()
+                    .AddParameter("company", "companies/90-A")
+                    .AddParameter("userId", "users/1-A"));
+
+            chat.SetUserPrompt("hello");
+            var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+            Assert.Equal(AiConversationResult.Done, result.Status);
+
+            using var s = store.OpenAsyncSession();
+            var conv = await s.LoadAsync<BlittableJsonReaderObject>(chat.Id);
+
+            Assert.True(conv.TryGet(nameof(ConversationDocument.Parameters), out BlittableJsonReaderObject p));
+            Assert.True(p.TryGet("company", out string company));
+            Assert.True(p.TryGet("userId", out string userId));
+            Assert.Equal("companies/90-A", company);
+            Assert.Equal("users/1-A", userId);
+
+            Assert.True(conv.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray msgs));
+            var content = string.Join("\n", msgs.Items.Select(i =>
+            {
+                var o = (BlittableJsonReaderObject)i;
+                return o.TryGet("content", out string c) ? c : null;
+            }).Where(x => x != null));
+
+            Assert.Contains("AI Agent Parameters:", content);
+            Assert.Contains("company = companies/90-A", content);
+            Assert.DoesNotContain("userId =", content);
+            Assert.DoesNotContain("users/1-A", content);
+        }
+
+        private static async Task PutConn(IDocumentStore store, GenAiConfiguration cfg) =>
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(cfg.Connection));
+
+        private static async Task AssertConversationAsync(IDocumentStore store, string id,
+            bool expectEcho, bool expectRawValueLeak, bool expectParamStored)
+        {
+            using var s = store.OpenAsyncSession();
+            var conv = await s.LoadAsync<BlittableJsonReaderObject>(id);
+            Assert.NotNull(conv);
+
+            Assert.True(conv.TryGet(nameof(ConversationDocument.Parameters), out BlittableJsonReaderObject convParams));
+            var hasParam = convParams.TryGet("company", out string companyValue);
+            Assert.Equal(expectParamStored, hasParam);
+            if (expectParamStored)
+                Assert.Equal("companies/90-A", companyValue);
+
+            Assert.True(conv.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray msgs));
+            var content = string.Join("\n", msgs.Items.Select(i =>
+            {
+                var o = (BlittableJsonReaderObject)i;
+                return o.TryGet("content", out string c) ? c : null;
+            }).Where(x => x != null));
+
+            var echoed = content.Contains("AI Agent Parameters:");
+            var leaked = content.Contains("companies/90-A");
+
+            Assert.Equal(expectEcho, echoed);
+            Assert.Equal(expectRawValueLeak, leaked);
+        }
+
+        private static AiAgentConfiguration CreateShoppingAssistant(string csName, bool? exposed)
+        {
+            var agent = new AiAgentConfiguration("shopping assistant", csName,
+                "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+
+            agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id", exposed));
+
+            agent.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "RecentOrder",
+                    Description = "Get the recent orders of the current user",
+                    Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                    ParametersSampleObject = "{}"
+                }
+            ];
+            return agent;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25186/Add-SendToModel-in-AiAgentParameter

### Additional description

Introduced bool? SendToModel on AiAgentParameter.

null or true ⇒ parameter is exposed to the LLM.

false ⇒ parameter is hidden from the LLM.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
