### PR TITLE
RavenDB-25252 Humanize IO throughput value in Advanced/Threads view

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -12,7 +12,7 @@ import threadsInfoWebSocketClient = require("common/threadsInfoWebSocketClient")
 import eventsCollector = require("common/eventsCollector");
 import awesomeMultiselect = require("common/awesomeMultiselect");
 
-type Unit = "" | "%" | "KB" | "KB/s";
+type Unit = "" | "%" | "B" | "KB" | "KB/s";
 type ThreadInfo = Raven.Server.Dashboard.ThreadInfo;
 
 class debugAdvancedThreadsRuntime extends viewModelBase {
@@ -129,24 +129,28 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         return item.Name.toLocaleLowerCase().includes(filterLowered) ||
                item.Id.toString().includes(filterLowered);
     }
-
-    private getUnitSeparator(unit: Unit): string {
-        if (unit === "KB" || unit === "KB/s") {
-            return " ";
-        }
-
-        return "";
-    }
     
-    private getStringValue(value: number, fractionDigits: number, unit: Unit = ""): string {
+    private getStringValue(value: number, defaultFractionDigits: number, originalUnit: Unit = ""): string {
         if (value == null) {
             return "N/A";
         }
 
-        const unitSeparator = this.getUnitSeparator(unit);
-        const fractionDigitsToUse = value === 0 ? 0 : fractionDigits;
+        const fractionDigits = value === 0 ? 0 : defaultFractionDigits;
 
-        return generalUtils.formatNumberToStringFixed(value, fractionDigitsToUse) + unitSeparator + unit;
+        switch (originalUnit) {
+            case "":
+                return generalUtils.formatNumberToStringFixed(value, fractionDigits);
+            case "%":
+                return generalUtils.formatNumberToStringFixed(value, fractionDigits) + "%";
+            case "B":
+                return generalUtils.formatBytesToSize(value, fractionDigits);
+            case "KB":
+                return generalUtils.formatBytesToSize(value * 1024, fractionDigits);
+            case "KB/s":
+                return generalUtils.formatBytesToSize(value * 1024, fractionDigits) + "/s";
+            default:
+                generalUtils.assertUnreachable(originalUnit);
+        }
     }
 
     private getSortableValue(value: number | string): number | string {
@@ -185,7 +189,7 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                         defaultSortOrder: "desc",
                         headerTitle: "Current CPU usage percentage",
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.UnmanagedAllocationsInBytes, 2, "KB"), "Unmanaged Alloc.", "7%", {
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.UnmanagedAllocationsInBytes, 2, "B"), "Unmanaged Alloc.", "7%", {
                         sortable: x => this.getSortableValue(x.UnmanagedAllocationsInBytes),
                         headerTitle: "Unmanaged allocations in bytes",
                     }),


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25252/Humanize-IO-throughput-value-in-Advanced-Threads-view

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
