### PR TITLE
RavenDB-25172 Remove ECB from des provider

### DIFF
--- a/src/Raven.Server/Monitoring/Snmp/Providers/DotnetDESPrivacyProvider.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Providers/DotnetDESPrivacyProvider.cs
@@ -52,10 +52,6 @@ public sealed class DotnetDESPrivacyProvider : IPrivacyProvider
     /// </summary>
     public static bool UseLegacy { get; set; }
 #endif
-    /// <summary>
-    /// Flag to force using old ECB cipher mode encryption.
-    /// </summary>
-    public static bool UseEcbEncryption { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="phrase"/> class.
@@ -134,11 +130,6 @@ public sealed class DotnetDESPrivacyProvider : IPrivacyProvider
         // DES uses 8 byte keys but we need 16 to encrypt ScopedPdu. Get first 8 bytes and use them as encryption key
         var outKey = GetKey(key);
 
-        if (UseEcbEncryption)
-        {
-            return EcbEncrypt(outKey, iv, unencryptedData);
-        }
-
         if ((unencryptedData.Length % 8) != 0)
         {
             byte[] tmpBuffer = new byte[8 * ((unencryptedData.Length / 8) + 1)];
@@ -169,49 +160,6 @@ public sealed class DotnetDESPrivacyProvider : IPrivacyProvider
 
         using var transform = des.CreateEncryptor(key, iv);
         return transform.TransformFinalBlock(unencryptedData, 0, unencryptedData.Length);
-    }
-
-    internal static byte[] EcbEncrypt(byte[] key, byte[] iv, byte[] unencryptedData)
-    {
-        var div = (int)Math.Floor(unencryptedData.Length / 8.0);
-        if ((unencryptedData.Length % 8) != 0)
-        {
-            div += 1;
-        }
-
-        var newLength = div * 8;
-        var result = new byte[newLength];
-        var buffer = new byte[newLength];
-
-        var inBuffer = new byte[8];
-        var cipherText = iv;
-        var posIn = 0;
-        var posResult = 0;
-        Buffer.BlockCopy(unencryptedData, 0, buffer, 0, unencryptedData.Length);
-
-        using DES des = DES.Create();
-        des.Mode = CipherMode.ECB;
-        des.Padding = PaddingMode.None;
-
-        using (var transform = des.CreateEncryptor(key, null))
-        {
-            for (var b = 0; b < div; b++)
-            {
-                for (var i = 0; i < 8; i++)
-                {
-                    inBuffer[i] = (byte)(buffer[posIn] ^ cipherText[i]);
-                    posIn++;
-                }
-
-                transform.TransformBlock(inBuffer, 0, inBuffer.Length, cipherText, 0);
-                Buffer.BlockCopy(cipherText, 0, result, posResult, cipherText.Length);
-                posResult += cipherText.Length;
-            }
-        }
-
-        des.Clear();
-
-        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25172

### Additional description

Removed unused ECB from des privacy provider for snmp.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
