### PR TITLE
RavenDB-25274 Pass correct cert in admin handler

### DIFF
--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -140,7 +140,7 @@ namespace Raven.Server.Web.Authentication
 
             // this creates a client certificate which is signed by the current server certificate
             var selfSignedCertificate = CertificateUtils.CreateSelfSignedClientCertificate(certificate.Name, serverStore.Server.Certificate.ServerCertificate,
-                serverStore.Server.Certificate.PrivateKey, out var clientCertBytes,
+                serverStore.Server.Certificate.PrivateKey, out _,
                 certificate.NotAfter ?? DateTime.UtcNow.Date.AddYears(5));
 
             var newCertDef = new CertificateDefinition
@@ -176,7 +176,7 @@ namespace Raven.Server.Web.Authentication
                 await using (var s = entry.Open())
                     await s.WriteAsync(certBytes, 0, certBytes.Length);
 
-                await LetsEncryptCertificateUtil.WriteCertificateAsPemToZipArchiveAsync(certificate.Name, clientCertBytes, certificate.Password, archive);
+                await LetsEncryptCertificateUtil.WriteCertificateAsPemToZipArchiveAsync(certificate.Name, certBytes, certificate.Password, archive);
             }
 
             return ms.ToArray();

--- a/test/SlowTests/Issues/RavenDB-25274.cs
+++ b/test/SlowTests/Issues/RavenDB-25274.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
+using Raven.Server.Web.Authentication;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25274 : RavenTestBase
+{
+    public RavenDB_25274(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Certificates | RavenTestCategory.Security)]
+    [InlineData(null)]
+    [InlineData("sec3tp@ssw0rd")]
+    public async Task CanGenerateCertificate(string password)
+    {
+        var certificates = Certificates.SetupServerAuthentication();
+        using var store = GetDocumentStore(new Options
+        {
+            CreateDatabase = true,
+            AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+            ClientCertificate = certificates.ServerCertificateForCommunication.Value
+        });
+
+        var notAfter = DateTime.UtcNow.AddDays(7);
+        const string name = "test-cert";
+        var zip = await AdminCertificatesHandler.GenerateCertificateInternal(new CertificateDefinition
+            {
+                Password = password,
+                Name = name,
+                NotAfter = notAfter
+            },
+            Server.ServerStore,
+            null,
+            RaftIdGenerator.NewId());
+
+        using var ms = new MemoryStream(zip);
+        using var archive = new ZipArchive(ms);
+        var entry = archive.GetEntry($"{name}.pfx");
+        Assert.NotNull(entry);
+
+        byte[] certificateBytes;
+        using (var entryStream = entry.Open())
+        using (var ms2 = new MemoryStream())
+        {
+            await entryStream.CopyToAsync(ms2);
+            certificateBytes = ms2.ToArray();
+        }
+
+        var certificate = new X509Certificate2(certificateBytes, password);
+        Assert.Equal(notAfter.Date, certificate.NotAfter.ToUniversalTime().Date);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25274 

### Additional description

Pass correct cert bytes when generating new certificate in admin handler.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
