### PR TITLE
RavenDB-25280 - Add a special error if `ChunkingOptions` are not provided for `EmbeddingsPathConfiguration` when creating `EmbeddingsGenerationConfiguration`

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -109,7 +109,12 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
         if (EmbeddingsPathConfigurations is not null)
         {
             foreach (var pathConfiguration in EmbeddingsPathConfigurations)
-                pathConfiguration.ChunkingOptions.Validate(pathConfiguration.Path, errors);
+            {
+                if (pathConfiguration.ChunkingOptions is not null)
+                    pathConfiguration.ChunkingOptions.Validate(pathConfiguration.Path, errors);
+                else
+                    errors.Add($"Path '{pathConfiguration.Path}': {nameof(ChunkingOptions)} must be provided.");
+            }
         }
         
         if (EmbeddingsTransformation?.ValidateScript() == false)

--- a/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
@@ -1,7 +1,9 @@
-﻿using FastTests;
+﻿using System;
+using FastTests;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -77,5 +79,31 @@ public class TasksManagementTests : RavenTestBase
         var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(update.TaskId, OngoingTaskType.EmbeddingsGeneration));
 
         Assert.Equal(OngoingTaskState.Disabled, ongoingTask.TaskState);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public void EmbeddingsGenerationConfiguration_WithoutChunkingOptions_ShouldProvideMeaningfulError()
+    {
+        using var store = GetDocumentStore();
+
+        var configuration = new EmbeddingsGenerationConfiguration
+        {
+            Name = "ai-task-testing",
+            ConnectionStringName = "ai-service-connection",
+            EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration { Path = "PostContent" }],
+            Collection = "Posts",
+            ChunkingOptionsForQuerying = DefaultChunkingOptions
+        };
+
+        var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, EmbeddedSettings = new EmbeddedSettings() };
+
+        var putAiConnectionStringResult = store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+        Assert.NotNull(putAiConnectionStringResult.RaftCommandIndex);
+
+        var exception = Record.Exception(() => store.Maintenance.Send(new AddEmbeddingsGenerationOperation(configuration)));
+        Assert.NotNull(exception);
+        Assert.IsType<RavenException>(exception);
+        Assert.True(exception.Message.Contains("Path 'PostContent': ChunkingOptions must be provided"),
+            $"The exception must include a description of the problem regarding the missing ChunkingOptions, but it didn't:{Environment.NewLine}`{exception.Message}`");
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25280

### Additional description

This pull request clarifies the problem that arises when a user creates an `EmbeddingsGenerationConfiguration` that doesn't provide `ChunkingOptions` for one or more `EmbeddingsPathConfiguration`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed