### PR TITLE
RavenDB-25267 Do not try to open @SharedJournals env as a regular index during a database restore so it won't cause CatastrophicFailure to be thrown under the covers

### DIFF
--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -696,6 +696,12 @@ namespace Raven.Server.Config.Categories
             DefaultSearchAnalyzerType = new Lazy<AnalyzerFactory>(() => LuceneIndexingExtensions.GetAnalyzerType("@default", DefaultSearchAnalyzer, resourceName));
         }
 
+        public bool IsSharedJournalsPath(string path)
+        {
+            var pathSetting = new PathSetting(path);
+            return SharedJournalsPath.Equals(pathSetting);
+        }
+
         public enum ErrorIndexStartupBehaviorType
         {
             Default,

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -377,6 +377,9 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 Index index = null;
                 try
                 {
+                    if (database.Configuration.Indexing.IsSharedJournalsPath(indexPath))
+                        continue;
+
                     index = Index.Open(indexPath, database, generateNewDatabaseId: true, out _);
                 }
                 catch (Exception e)

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -391,8 +391,7 @@ namespace Raven.Server.Web.System
 
                 foreach (var indexPath in Directory.GetDirectories(indexesPath))
                 {
-                    var pathSetting = new PathSetting(indexPath);
-                    if (databaseConfiguration.Indexing.SharedJournalsPath.Equals(pathSetting))
+                    if (databaseConfiguration.Indexing.IsSharedJournalsPath(indexPath))
                         continue;
 
                     Index index = null;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25267/SlowTests.Issues.RavenDB25136.CoraxCanSortReduceResultsWithPagingAndTermsReader

### Additional description

It was failing occasionally as it's happening in the background.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior - in particular `SlowTests.Issues.RavenDB_25136.CoraxCanSortReduceResultsWithPagingAndTermsReader`

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
