### PR TITLE
RavenDB-25140 Avoid cloning a nested blittable inside BlittableJsonReaderArray.Clone

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -410,7 +410,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         using (var reqsBlittable = context.ReadObject(new DynamicJsonValue { ["Requests"] = reqs }, "ai-agent/multi-query"))
         using (var handler = new MultiGetHandlerProcessorForPost(multiGetHandler))
         using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
-        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext clone))
         {
             await handler.ExecuteMultiGetAsync(context, reqsBlittable, memoryStream);
             memoryStream.Position = 0;
@@ -439,7 +438,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                     {
                         ["tool_call_id"] = toolCallsIds[i],
                         ["role"] = "tool",
-                        ["content"] = queryResult.Clone(clone).ToString()
+                        ["content"] = queryResult.Clone().ToString()
                     }, "tool-call/response"), usage: null);
             }
         }

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -776,7 +776,7 @@ namespace Sparrow.Json
 
             var reader = CreateReader();
             reader.NoCache = noCache;
-            if (reader.TryGet("_", out BlittableJsonReaderArray array))
+            if (reader.TryGet(BlittableJsonReaderArray.RootArrayHolderPropertyNameSegment, out BlittableJsonReaderArray array))
             {
                 array.ArrayIsRoot();
                 return array;

--- a/src/Sparrow/Json/BlittableJsonReaderArray.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderArray.cs
@@ -10,7 +10,9 @@ namespace Sparrow.Json
 {
     public sealed unsafe class BlittableJsonReaderArray : BlittableJsonReaderBase, IEnumerable<object>, IDisposable
     {
-        private bool _disposeParent;
+        private const string RootArrayHolderPropertyName = "_";
+        internal static readonly StringSegment RootArrayHolderPropertyNameSegment = RootArrayHolderPropertyName;
+
         private readonly int _count;
         private readonly byte* _metadataPtr;
         private readonly byte* _dataStart;
@@ -21,7 +23,8 @@ namespace Sparrow.Json
 
         public BlittableJsonReaderObject Parent => _parent;
 
-        internal void ArrayIsRoot() => _disposeParent = true;
+        internal void ArrayIsRoot() => IsRoot = true;
+        internal bool IsRoot { get; private set; }
 
         public BlittableJsonReaderArray(int pos, BlittableJsonReaderObject parent, BlittableJsonToken type)
             : base(parent._context)
@@ -71,52 +74,24 @@ namespace Sparrow.Json
             _parent?.BlittableValidation();
         }
 
-        //Todo Fixing the clone implementation to support this situation or throw clear error
+        public BlittableJsonReaderArray Clone(BlittableJsonDocumentBuilder.UsageMode usageMode = BlittableJsonDocumentBuilder.UsageMode.None)
+        {
+            return Clone(_context, usageMode);
+        }
+        
         public BlittableJsonReaderArray Clone(JsonOperationContext context, BlittableJsonDocumentBuilder.UsageMode usageMode = BlittableJsonDocumentBuilder.UsageMode.None)
         {
             AssertContextNotDisposed();
-            using (var builder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context))
-            {
-                builder.Reset(usageMode);
-                builder.StartArrayDocument();
-                builder.StartWriteArray();
-                using (var itr = new BlittableJsonArrayEnumerator(this))
-                {
-                    while (itr.MoveNext())
-                    {
-                        switch (itr.Current)
-                        {
-                            case BlittableJsonReaderObject item:
-                                var clone = item.CloneOnTheSameContext();
-                                builder.WriteEmbeddedBlittableDocument(clone.BasePointer, clone.Size);
-                                break;
 
-                            case LazyStringValue item:
-                                builder.WriteValue(item);
-                                break;
-
-                            case long item:
-                                builder.WriteValue(item);
-                                break;
-
-                            case LazyNumberValue item:
-                                builder.WriteValue(item);
-                                break;
-
-                            case LazyCompressedStringValue item:
-                                builder.WriteValue(item);
-                                break;
-
-                            default:
-                                throw new InvalidDataException($"Actual value type is {itr.Current.GetType()}. Should be known serialized type and should not happen. ");
-                        }
-                    }
-                }
-                builder.WriteArrayEnd();
-                builder.FinalizeDocument();
-
-                return builder.CreateArrayReader();
-            }
+            var arrayHolder = IsRoot && Modifications == null
+                ? _parent.Clone(context) 
+                : context.ReadObject(new DynamicJsonValue { [RootArrayHolderPropertyName] = this }, "array holder", usageMode);
+            
+            if(arrayHolder.TryGet(RootArrayHolderPropertyNameSegment, out BlittableJsonReaderArray array) == false)
+                throw new InvalidOperationException("Couldn't find array");
+                
+            array.ArrayIsRoot();
+            return array;
         }
 
         public void Dispose()
@@ -125,7 +100,7 @@ namespace Sparrow.Json
 
             // this is required only in cases that we get a BlittableJsonReaderArray, which is an only child of an BlittableJsonReaderObject and we lose track of it's parent,
             // like in BlittableJsonDocumentBuilder.CreateArrayReader.
-            if (_disposeParent)
+            if (IsRoot)
                 _parent?.Dispose();
         }
 

--- a/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/ManualBlittableJsonDocumentBuilder.cs
@@ -12,8 +12,6 @@ namespace Sparrow.Json
         private UsageMode _mode;
         private WriteToken _writeToken;
 
-        private static readonly StringSegment UnderscoreSegment = new StringSegment("_");
-
         /// <summary>
         /// Allows incrementally building json document
         /// </summary>
@@ -42,7 +40,7 @@ namespace Sparrow.Json
                 State = ContinuationState.ReadArrayDocument,
             };
 
-            var fakeFieldName = _context.GetLazyStringForFieldWithCaching(UnderscoreSegment);
+            var fakeFieldName = _context.GetLazyStringForFieldWithCaching(BlittableJsonReaderArray.RootArrayHolderPropertyNameSegment);
             var prop = _writer.CachedProperties.GetProperty(fakeFieldName);
             currentState.CurrentProperty = prop;
             currentState.MaxPropertyId = prop.PropertyId;
@@ -655,8 +653,7 @@ namespace Sparrow.Json
         public BlittableJsonReaderArray CreateArrayReader()
         {
             var reader = CreateReader();
-            BlittableJsonReaderArray array;
-            if (reader.TryGet("_", out array))
+            if (reader.TryGet(BlittableJsonReaderArray.RootArrayHolderPropertyNameSegment, out BlittableJsonReaderArray array))
                 return array;
             throw new InvalidOperationException("Couldn't find array");
         }
@@ -666,6 +663,5 @@ namespace Sparrow.Json
             _writer.Dispose();
             base.Dispose();
         }
-
     }
 }

--- a/test/SlowTests/Blittable/BlittableJsonReaderObjectTest.cs
+++ b/test/SlowTests/Blittable/BlittableJsonReaderObjectTest.cs
@@ -67,26 +67,23 @@ namespace SlowTests.Blittable
             }
         }
 
-        //Todo Fixing the clone implementation to support this situation or throw clear error
-        [RavenFact(RavenTestCategory.Core, Skip = "Should fixing the clone implementation to support this situation or throw clear error")]
+        [RavenFact(RavenTestCategory.Core)]
         public void Clone_WhenContainItemsOfObjects_AndOriginAndCloneOnSameContext_ShouldBeEqualToOrigin()
         {
             //Arrange
-            using (Server.ServerStore.ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            using var context = JsonOperationContext.ShortTermSingleUse();
+            var data = new
             {
-                var data = new
-                {
-                    Property = new[] { new { Prop = "Value1" }, new { Prop = "Value2" } }
-                };
-                var readerObject = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(data, context);
-                readerObject.TryGet(nameof(data.Property), out BlittableJsonReaderArray expected);
+                Property = new object[] { new { Prop1 = "Value1" }, new { Prop2 = "Value2" } }
+            };
+            var readerObject = DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(data, context);
+            readerObject.TryGet(nameof(data.Property), out BlittableJsonReaderArray expected);
 
-                //Action
-                var actual = expected.Clone(context);
+            //Action
+            var actual = expected.Clone(context);
 
-                //Assert
-                Assert.Equal(expected, actual);
-            }
+            //Assert
+            Assert.Equal(expected, actual);
         }
 
         [RavenFact(RavenTestCategory.Core)]


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25140

### Additional description
The main issue was the usage of BlittableJsonReaderObject.Clone for nested BlittableJsonReaderObject.
We can't use the same context to build two BlittableJsonReaderObject at the same time.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
