### PR TITLE
RavenDB-25225 Ignore license validation for disabled features when re…

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1382,7 +1382,7 @@ namespace Raven.Server.Commercial
 
             foreach (var kvp in indexes)
             {
-                if (HasAdditionalAssembliesFromNuGet(kvp.Value))
+                if (HasAdditionalAssembliesFromNuGet(kvp.Value) && kvp.Value.State != IndexState.Disabled)
                     return true;
             }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -269,7 +269,13 @@ public sealed partial class ClusterStateMachine
     private void AssertStaticIndexesCount(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
         var maxStaticIndexesPerDatabase = licenseStatus.MaxNumberOfStaticIndexesPerDatabase;
-        if (maxStaticIndexesPerDatabase is >= 0 && databaseRecord.Indexes.Count > maxStaticIndexesPerDatabase)
+        if (maxStaticIndexesPerDatabase is null or < 0)
+            return;
+
+        if (databaseRecord.Indexes == null)
+            return;
+
+        if (maxStaticIndexesPerDatabase is >= 0 && databaseRecord.Indexes?.Count > maxStaticIndexesPerDatabase)
         {
             if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
                 return;
@@ -282,7 +288,7 @@ public sealed partial class ClusterStateMachine
         if (maxStaticIndexesPerCluster is null or < 0)
             return;
 
-        var totalStaticIndexesCount = GetTotal(DatabaseRecordElementType.StaticIndex, databaseRecord.DatabaseName, context, items, type) + databaseRecord.Indexes.Count;
+        var totalStaticIndexesCount = GetTotal(DatabaseRecordElementType.StaticIndex, databaseRecord.DatabaseName, context, items, type) + databaseRecord.Indexes?.Count;
         if (totalStaticIndexesCount <= maxStaticIndexesPerCluster)
             return;
 
@@ -295,6 +301,10 @@ public sealed partial class ClusterStateMachine
     private void AssertAutoIndexesCount(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, Table items, string type)
     {
         var maxAutoIndexesPerDatabase = licenseStatus.MaxNumberOfAutoIndexesPerDatabase;
+
+        if (databaseRecord.AutoIndexes == null)
+            return;
+
         if (maxAutoIndexesPerDatabase is >= 0 && databaseRecord.AutoIndexes.Count > maxAutoIndexesPerDatabase)
         {
             if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
@@ -304,17 +314,17 @@ public sealed partial class ClusterStateMachine
         }
 
         var maxAutoIndexesPerCluster = licenseStatus.MaxNumberOfAutoIndexesPerCluster;
-        if (maxAutoIndexesPerCluster is >= 0)
-        {
-            var totalAutoIndexesCount = GetTotal(DatabaseRecordElementType.AutoIndex, databaseRecord.DatabaseName, context, items, type) + databaseRecord.AutoIndexes.Count;
-            if (totalAutoIndexesCount <= maxAutoIndexesPerCluster)
-                return;
+        if (maxAutoIndexesPerCluster is null or < 0)
+            return;
 
-            if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
-                return;
+        var totalAutoIndexesCount = GetTotal(DatabaseRecordElementType.AutoIndex, databaseRecord.DatabaseName, context, items, type) + databaseRecord.AutoIndexes.Count;
+        if (totalAutoIndexesCount <= maxAutoIndexesPerCluster)
+            return;
 
-            throw new LicenseLimitException(LimitType.Indexes, $"The maximum number of auto indexes per cluster cannot exceed the limit of: {maxAutoIndexesPerCluster}");
-        }
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
+            return;
+
+        throw new LicenseLimitException(LimitType.Indexes, $"The maximum number of auto indexes per cluster cannot exceed the limit of: {maxAutoIndexesPerCluster}");
     }
 
     private void AssertRevisionConfiguration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
@@ -789,6 +799,9 @@ public sealed partial class ClusterStateMachine
 
     private void AssertPeriodicBackupLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
     {
+        if (databaseRecord.PeriodicBackups.All(x => x.Disabled))
+            return;
+
         if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60000) == false)
             return;
 
@@ -801,15 +814,15 @@ public sealed partial class ClusterStateMachine
         var backupTypes = LicenseManager.GetBackupTypes(databaseRecord.PeriodicBackups);
 
         if (backupTypes.HasSnapshotBackup)
-            if (licenseStatus.HasSnapshotBackups == false)
+            if (licenseStatus.HasSnapshotBackups == false && databaseRecord.PeriodicBackups.Exists(x => x.Disabled == false && x.BackupType == BackupType.Snapshot))
                 throw new LicenseLimitException(LimitType.SnapshotBackup, "Your license doesn't support adding Snapshot backups feature.");
 
         if (backupTypes.HasCloudBackup)
-            if (licenseStatus.HasCloudBackups == false)
+            if (licenseStatus.HasCloudBackups == false && databaseRecord.PeriodicBackups.Exists(x => x.Disabled == false && x.HasCloudBackup()))
                 throw new LicenseLimitException(LimitType.CloudBackup, "Your license doesn't support adding Cloud backups feature.");
 
         if (backupTypes.HasEncryptedBackup)
-            if (licenseStatus.HasEncryptedBackups == false)
+            if (licenseStatus.HasEncryptedBackups == false && databaseRecord.PeriodicBackups.Exists(x => x.Disabled == false && x.BackupEncryptionSettings != null))
                 throw new LicenseLimitException(LimitType.EncryptedBackup, "Your license doesn't support adding Encrypted backups feature.");
 
         foreach (var configuration in databaseRecord.PeriodicBackups)
@@ -820,7 +833,7 @@ public sealed partial class ClusterStateMachine
                     configuration.HasCloudBackup() == false &&
                     configuration.BackupEncryptionSettings?.Key == null)
                 {
-                    if (AssertPeriodicBackup(licenseStatus) == false)
+                    if (AssertPeriodicBackup(licenseStatus) == false && configuration.Disabled == false)
                         throw new LicenseLimitException(LimitType.PeriodicBackup, "Your license doesn't support adding periodic backups.");
                 }
             }
@@ -838,6 +851,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.SinkPullReplications.Count == 0)
             return;
 
+        if (databaseRecord.SinkPullReplications.All(x => x.Disabled))
+            return;
+
         throw new LicenseLimitException(LimitType.PullReplicationAsSink, "Your license doesn't support adding Sink Replication feature.");
     }
 
@@ -852,6 +868,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.HubPullReplications.Count == 0)
             return;
 
+        if (databaseRecord.HubPullReplications.All(x => x.Disabled))
+            return;
+
         throw new LicenseLimitException(LimitType.PullReplicationAsHub, "Your license doesn't support adding Hub Replication feature.");
     }
 
@@ -861,6 +880,9 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (licenseStatus.HasDelayedExternalReplication)
+            return;
+
+        if (databaseRecord.ExternalReplications.All(x => x.Disabled))
             return;
 
         if (licenseStatus.HasExternalReplication == false)
@@ -904,6 +926,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.RavenEtls.Count == 0)
             return;
 
+        if (databaseRecord.RavenEtls.All(x => x.Disabled))
+            return;
+
         throw new LicenseLimitException(LimitType.RavenEtl, "Your license doesn't support adding Raven ETL feature.");
     }
 
@@ -916,6 +941,9 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (databaseRecord.SqlEtls.Count == 0)
+            return;
+
+        if (databaseRecord.SqlEtls.All(x => x.Disabled))
             return;
 
         throw new LicenseLimitException(LimitType.SqlEtl, "Your license doesn't support adding SQL ETL feature.");
@@ -932,6 +960,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.OlapEtls.Count == 0)
             return;
 
+        if (databaseRecord.OlapEtls.All(x => x.Disabled))
+            return;
+
         throw new LicenseLimitException(LimitType.OlapEtl, "Your license doesn't support adding Olap ETL feature.");
     }
 
@@ -946,6 +977,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.QueueEtls.Count == 0)
             return;
 
+        if (databaseRecord.QueueEtls.All(x => x.Disabled))
+            return;
+
         throw new LicenseLimitException(LimitType.QueueEtl, "Your license doesn't support adding Queue ETL feature.");
     }
 
@@ -958,6 +992,9 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (databaseRecord.ElasticSearchEtls.Count == 0)
+            return;
+
+        if (databaseRecord.ElasticSearchEtls.All(x => x.Disabled))
             return;
 
         throw new LicenseLimitException(LimitType.ElasticSearchEtl, "Your license doesn't support adding Elastic Search ETL feature.");
@@ -991,7 +1028,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.DocumentsCompression == null)
             return;
 
-        if (databaseRecord.DocumentsCompression.CompressAllCollections == false && databaseRecord.DocumentsCompression.CompressRevisions == false)
+        if (databaseRecord.DocumentsCompression.CompressAllCollections == false &&
+            databaseRecord.DocumentsCompression.CompressRevisions == false &&
+            databaseRecord.DocumentsCompression.Collections.Length == 0)
             return;
 
         throw new LicenseLimitException(LimitType.DocumentsCompression, "Your license doesn't support adding Documents Compression feature.");

--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -1,25 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using FastTests;
-using Raven.Client.Documents;
-using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Operations.Replication;
-using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Commercial;
-using Raven.Client.ServerWide;
-using Raven.Client.ServerWide.Operations;
-using Raven.Client.Util;
-using Raven.Server;
-using Raven.Server.Commercial;
-using Raven.Server.ServerWide.Commands;
-using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -28,8 +16,6 @@ namespace SlowTests.Issues
 {
     public class RavenDB_21273 : RavenTestBase
     {
-        private const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
-        private const string RL_PRO = "RAVEN_LICENSE_PROFESSIONAL";
 
         public RavenDB_21273(ITestOutputHelper output) : base(output)
         {
@@ -44,26 +30,18 @@ namespace SlowTests.Issues
             {
                 using (var store = GetDocumentStore())
                 {
-                    var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
-                    dbrecord.DocumentsCompression.CompressRevisions = false;
-                    store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
 
-                    store.Maintenance.Send(new PutIndexesOperation(new[]
-                    {
-                        new IndexDefinition
-                        {
-                            Maps = { "from doc in docs.Images select new { doc.Tags }" },
-                            Name = "test",
-                            AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") }
-                        }
-                    }));
+                    LicenseHelper.PutIndexWithAdditionalAssemblies(store);
+
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
                 }
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
@@ -88,9 +66,9 @@ namespace SlowTests.Issues
                 PeriodicBackupConfiguration config;
                 using (var store = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(Server, store.Database);
-                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
-                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    config = await LicenseHelper.CreatePeriodicBackup(backupPath, store, BackupType.Snapshot);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -98,7 +76,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
@@ -114,8 +92,6 @@ namespace SlowTests.Issues
             {
                 File.Delete(file);
             }
-
-
         }
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
@@ -129,9 +105,8 @@ namespace SlowTests.Issues
                 PeriodicBackupConfiguration config;
                 using (var store = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(Server, store.Database);
-                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot);
-                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    config = await LicenseHelper.CreatePeriodicBackup(backupPath, store, BackupType.Snapshot);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -139,7 +114,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_PRO, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
 
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
@@ -158,12 +133,11 @@ namespace SlowTests.Issues
             }
         }
 
-
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
         public async Task ExceptionWhenImportingExternalReplicationWithCommunityLicense()
         {
             DoNotReuseServer();
-            using (var server = GetNewServer())
+            using (var server1 = GetNewServer())
             using (var server2 = GetNewServer())
             {
                 var file = GetTempFileName();
@@ -172,32 +146,18 @@ namespace SlowTests.Issues
                 try
                 {
                     using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
-                    using (var store2 = GetDocumentStore(new Options() { Server = server }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server1 }))
                     {
-                        var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store2.Database,
-                            RaftIdGenerator.NewId());
-                        await server.ServerStore.SendToLeaderAsync(command);
-                        command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store1.Database,
-                            RaftIdGenerator.NewId());
-                        await server2.ServerStore.SendToLeaderAsync(command);
+                        await LicenseHelper.DisableRevisionCompression(server2, store1);
+                        await LicenseHelper.DisableRevisionCompression(server1, store2);
 
-                        var connectionString = new RavenConnectionString
-                        {
-                            Name = csName,
-                            Database = dbName,
-                            TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
-                        };
-
-                        var result = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
-                        Assert.NotNull(result.RaftCommandIndex);
-
-                        var watcher = new ExternalReplication(dbName, csName);
-                        await store1.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                        ExternalReplication watcher = await LicenseHelper.CreateExternalReplication(csName, dbName, store1);
 
                         var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
-                        await ChangeLicense(server, RL_COMM, store2);
+                        await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store2, LicenseTestBase.RL_COMM);
+
                         var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
                         var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
@@ -219,7 +179,7 @@ namespace SlowTests.Issues
         public async Task ExceptionWhenImportingDelayedExternalReplicationWithProLicense()
         {
             DoNotReuseServer();
-            using (var server = GetNewServer())
+            using (var server1 = GetNewServer())
             using (var server2 = GetNewServer())
             {
                 var file = GetTempFileName();
@@ -228,27 +188,17 @@ namespace SlowTests.Issues
                 try
                 {
                     using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
-                    using (var store2 = GetDocumentStore(new Options() { Server = server }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server1 }))
                     {
-                        var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store2.Database,
-                            RaftIdGenerator.NewId());
-                        await server.ServerStore.SendToLeaderAsync(command);
-                        command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store1.Database,
-                            RaftIdGenerator.NewId());
-                        await server2.ServerStore.SendToLeaderAsync(command);
+                        await LicenseHelper.DisableRevisionCompression(server2, store1);
+                        await LicenseHelper.DisableRevisionCompression(server1, store2);
 
-                        var connectionString = new RavenConnectionString { Name = csName, Database = dbName, TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" } };
-
-                        var result = await store1.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
-                        Assert.NotNull(result.RaftCommandIndex);
-
-                        var watcher = new ExternalReplication(dbName, csName);
-                        await store1.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                        ExternalReplication watcher = await LicenseHelper.CreateExternalReplication(csName, dbName, store1);
 
                         var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                         await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
 
-                        await ChangeLicense(server, RL_COMM, store2);
+                        await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store2, LicenseTestBase.RL_COMM);
 
                         var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                         await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
@@ -278,19 +228,7 @@ namespace SlowTests.Issues
             {
                 using (var store = GetDocumentStore())
                 {
-                    var salesTsConfig = new TimeSeriesCollectionConfiguration
-                    {
-                        Policies = new List<TimeSeriesPolicy>
-                        {
-                            new("DailyRollupForOneYear",
-                                TimeValue.FromDays(1),
-                                TimeValue.FromYears(1))
-                },
-                        RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromDays(7))
-                    };
-                    var databaseTsConfig = new TimeSeriesConfiguration();
-                    databaseTsConfig.Collections["Sales"] = salesTsConfig;
-                    store.Maintenance.Send(new ConfigureTimeSeriesOperation(databaseTsConfig));
+                    LicenseHelper.CreateTsRollupAndRetention(store);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -298,7 +236,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -324,9 +262,7 @@ namespace SlowTests.Issues
             {
                 using (var store = GetDocumentStore())
                 {
-                    var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
-                    dbrecord.DocumentsCompression.CompressAllCollections = true;
-                    store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+                    LicenseHelper.CreateCompressAllCollection(store);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -334,7 +270,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -360,9 +296,7 @@ namespace SlowTests.Issues
             {
                 using (var store = GetDocumentStore())
                 {
-                    var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
-                    dbrecord.DocumentsCompression.CompressAllCollections = true;
-                    store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+                    LicenseHelper.CreateCompressAllCollection(store);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -370,7 +304,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_PRO, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
@@ -400,10 +334,9 @@ namespace SlowTests.Issues
                 PullReplicationAsSink pullAsSink;
                 using (var store = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(Server, store.Database);
-                    pullAsSink = new PullReplicationAsSink(dbName, csName, "hub");
-                    var result = await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(pullAsSink));
-                    Assert.NotNull(result.RaftCommandIndex);
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    pullAsSink = await LicenseHelper.CreatePullReplicationAsSink(dbName, csName, store);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -411,7 +344,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
@@ -440,9 +373,8 @@ namespace SlowTests.Issues
                 PullReplicationDefinition pull;
                 using (var store = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(Server, store.Database);
-                    pull = new PullReplicationDefinition("pull");
-                    store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    pull = LicenseHelper.CraetePullReplicationDefinition(store);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -450,7 +382,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
@@ -479,9 +411,8 @@ namespace SlowTests.Issues
                 PullReplicationDefinition pull;
                 using (var store = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(Server, store.Database);
-                    pull = new PullReplicationDefinition("pull");
-                    store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    pull = LicenseHelper.CraetePullReplicationDefinition(store);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -489,7 +420,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_PRO, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
 
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
@@ -520,23 +451,8 @@ namespace SlowTests.Issues
                 RavenEtlConfiguration etlConfiguration;
                 using (var store = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(Server, store.Database);
-                    etlConfiguration = new RavenEtlConfiguration
-                    {
-                        Name = csName,
-                        ConnectionStringName = csName,
-                        Transforms = { new Transformation { Name = $"ETL : {csName}", ApplyToAllDocuments = true } },
-                        MentorNode = "A",
-                    };
-                    var connectionString = new RavenConnectionString
-                    {
-                        Name = csName,
-                        Database = dbName,
-                        TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" },
-                    };
-
-                    Assert.NotNull(store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString)));
-                    etl = store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    etlConfiguration = LicenseHelper.CreateRavenEtlConfiguration(csName, dbName, store, out etl);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -544,7 +460,7 @@ namespace SlowTests.Issues
 
                 using (var store = GetDocumentStore())
                 {
-                    await ChangeLicense(Server, RL_COMM, store);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store,LicenseTestBase.RL_COMM);
 
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
@@ -562,22 +478,6 @@ namespace SlowTests.Issues
             {
                 File.Delete(file);
             }
-        }
-
-
-        private static async Task ChangeLicense(RavenServer server, string licenseType, DocumentStore store)
-        {
-            var license = Environment.GetEnvironmentVariable(licenseType);
-            LicenseHelper.TryDeserializeLicense(license, out License li);
-            await RavenDB_21427.DisableRevisionCompression(server, store);
-            await server.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
-        }
-
-        internal static async Task DisableRevisionCompression(RavenServer leader, string name)
-        {
-            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, name,
-                RaftIdGenerator.NewId());
-            await leader.ServerStore.SendToLeaderAsync(command);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -36,8 +36,6 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Sharding;
 using Raven.Client.Util;
-using Raven.Server;
-using Raven.Server.Commercial;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Auto;
@@ -59,10 +57,6 @@ namespace SlowTests.Issues
         public RavenDB_21427(ITestOutputHelper output) : base(output)
         {
         }
-
-        private const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
-        private const string RL_DEV = "RAVEN_LICENSE_DEVELOPER";
-        private const string RL_PRO = "RAVEN_LICENSE_PROFESSIONAL";
 
         // ----------------------------------------
         // Tests for Sharding License Limits
@@ -86,9 +80,9 @@ namespace SlowTests.Issues
 
             using (GetDocumentStore(options))
             {
-                await FailToChangeLicense(leader, RL_COMM, LimitType.Sharding);
-                await FailToChangeLicense(leader, RL_DEV, LimitType.Sharding);
-                await FailToChangeLicense(leader, RL_PRO, LimitType.Sharding);
+                await LicenseHelper.FailToChangeLicense(leader, LicenseTestBase.RL_COMM, LimitType.Sharding);
+                await LicenseHelper.FailToChangeLicense(leader, LicenseTestBase.RL_DEV, LimitType.Sharding);
+                await LicenseHelper.FailToChangeLicense(leader, LicenseTestBase.RL_PRO, LimitType.Sharding);
             }
         }
 
@@ -105,9 +99,9 @@ namespace SlowTests.Issues
                 var config = new DataArchivalConfiguration { Disabled = false, ArchiveFrequencyInSec = 100 };
 
                 await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config);
-                await FailToChangeLicense(Server, RL_COMM, LimitType.DataArchival);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.DataArchival);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.DataArchival);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.DataArchival);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -128,7 +122,7 @@ namespace SlowTests.Issues
                         new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + i }
                     }));
                 }
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Indexes);
             }
         }
 
@@ -138,8 +132,7 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 for (int i = 0; i < 12; i++)
                 {
                     store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition { Maps = { "from doc in docs.Images select new { doc.Tags }" }, Name = "test" + i }));
@@ -169,7 +162,7 @@ namespace SlowTests.Issues
                     }
                 }
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Indexes);
             }
             finally
             {
@@ -191,8 +184,7 @@ namespace SlowTests.Issues
                 for (int i = 0; i < 6; i++)
                 {
                     DocumentStore store = GetDocumentStore();
-                    await DisableRevisionCompression(Server, store);
-                    await PutLicense(Server, RL_COMM);
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                     storeList.Add(store);
                     for (int j = 0; j < 10; j++)
                     {
@@ -223,7 +215,7 @@ namespace SlowTests.Issues
                     await database.IndexStore.CreateIndex(new AutoMapIndexDefinition("Users", new[] { new AutoIndexField { Name = "Name" + j } }),
                         Guid.NewGuid().ToString());
                 }
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Indexes);
             }
         }
 
@@ -233,8 +225,7 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 DocumentDatabase database;
                 for (int j = 0; j < 24; j++)
                 {
@@ -268,7 +259,7 @@ namespace SlowTests.Issues
                     }
                 }
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Indexes);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Indexes);
             }
             finally
             {
@@ -291,8 +282,7 @@ namespace SlowTests.Issues
                 for (int i = 0; i < 6; i++)
                 {
                     var store = GetDocumentStore();
-                    await DisableRevisionCompression(Server, store);
-                    await PutLicense(Server, RL_COMM);
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                     storeList.Add(store);
                     for (int j = 0; j < 20; j++)
                     {
@@ -326,11 +316,10 @@ namespace SlowTests.Issues
                     Name = "test",
                     AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") }
                 }));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.AdditionalAssembliesFromNuGet);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.AdditionalAssembliesFromNuGet);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -340,8 +329,7 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var exception = Assert.Throws<LicenseLimitException>(() => store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from doc in docs.Images select new { doc.Tags }" },
@@ -350,7 +338,7 @@ namespace SlowTests.Issues
                 })));
                 Assert.Equal(LimitType.AdditionalAssembliesFromNuGet, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
                 {
                     Maps = { "from doc in docs.Images select new { doc.Tags }" },
@@ -372,14 +360,13 @@ namespace SlowTests.Issues
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.RevisionsConfiguration);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.RevisionsConfiguration);
 
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.RevisionsConfiguration);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.RevisionsConfiguration);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_PRO);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -389,17 +376,16 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration)));
                 Assert.Equal(LimitType.RevisionsConfiguration, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
             }
@@ -411,13 +397,13 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (GetDocumentStore())
             {
-                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_COMM));
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_COMM));
                 Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
 
-                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_PRO));
+                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO));
                 Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -427,20 +413,19 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var configuration = new DocumentsCompressionConfiguration { CompressRevisions = true, Collections = new string[] { } };
 
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await Server.ServerStore.SendToLeaderAsync(new EditDocumentsCompressionCommand(configuration, store.Database, RaftIdGenerator.DontCareId)));
                 Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
 
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await Server.ServerStore.SendToLeaderAsync(new EditDocumentsCompressionCommand(configuration, store.Database, RaftIdGenerator.DontCareId)));
                 Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await Server.ServerStore.SendToLeaderAsync(new EditDocumentsCompressionCommand(configuration, store.Database, RaftIdGenerator.DontCareId));
             }
         }
@@ -451,8 +436,7 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = true, MinimumRevisionsToKeep = 0 } };
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
             }
@@ -470,11 +454,10 @@ namespace SlowTests.Issues
             {
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.PeriodicBackup);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.PeriodicBackup);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_PRO);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -485,15 +468,14 @@ namespace SlowTests.Issues
             var backupPath = NewDataPath(suffix: "BackupFolder");
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *");
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
                 Assert.Equal(LimitType.PeriodicBackup, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
             }
         }
@@ -514,11 +496,10 @@ namespace SlowTests.Issues
                         Key = "OI7Vll7DroXdUORtc6Uo64wdAk1W0Db9ExXXgcg5IUs="
                     });
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.EncryptedBackup);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.EncryptedBackup);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -535,11 +516,10 @@ namespace SlowTests.Issues
                     backupType: BackupType.Snapshot);
 
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.SnapshotBackup);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.SnapshotBackup);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.SnapshotBackup);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.SnapshotBackup);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -549,8 +529,7 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var config = new PeriodicBackupConfiguration
                 {
@@ -566,12 +545,12 @@ namespace SlowTests.Issues
                     await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
                 Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
                 Assert.Equal(LimitType.SnapshotBackup, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
             }
         }
@@ -593,9 +572,9 @@ namespace SlowTests.Issues
                     }
                 };
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.SnapshotBackup);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.SnapshotBackup);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.SnapshotBackup);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.SnapshotBackup);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -605,8 +584,7 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = new PeriodicBackupConfiguration
                 {
                     BackupType = BackupType.Backup,
@@ -623,10 +601,10 @@ namespace SlowTests.Issues
                     await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config)));
                 Assert.Equal(LimitType.CloudBackup, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
             }
         }
@@ -651,11 +629,10 @@ namespace SlowTests.Issues
                     }
                 };
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.CloudBackup);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.CloudBackup);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -666,8 +643,7 @@ namespace SlowTests.Issues
             var backupPath = NewDataPath(suffix: "BackupFolder");
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", disabled: true);
                 await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
             }
@@ -698,11 +674,10 @@ namespace SlowTests.Issues
                        }
             }))
             {
-                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.CustomSorters);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -713,8 +688,7 @@ namespace SlowTests.Issues
             var sorterName = GetDatabaseName();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var sorterCode1 = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName);
                 var sorterCode2 = GetSorter("RavenDB_8355.MySorter.cs", "MySorter", sorterName + "2");
@@ -724,7 +698,7 @@ namespace SlowTests.Issues
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new PutSortersOperation(new SorterDefinition { Name = sorterName + "2", Code = sorterCode2 })));
                 Assert.Equal(LimitType.CustomSorters, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new PutSortersOperation(new SorterDefinition { Name = sorterName + "2", Code = sorterCode2 }));
             }
         }
@@ -751,7 +725,7 @@ namespace SlowTests.Issues
                     });
                     storeList.Add(store);
                 }
-                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomSorters);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.CustomSorters);
             }
             finally
             {
@@ -811,11 +785,10 @@ public class MyAnalyzer2 : Analyzer
                 }
             }))
             {
-                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomAnalyzers);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.CustomAnalyzers);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -854,7 +827,7 @@ public class MyAnalyzer2 : Analyzer
 
                     storeList.Add(store);
                 }
-                await FailToChangeLicense(Server, RL_COMM, LimitType.CustomAnalyzers);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.CustomAnalyzers);
             }
             finally
             {
@@ -871,8 +844,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
                 {
                     Name = "MyAnalyzer2",
@@ -887,7 +859,7 @@ public class MyAnalyzer2 : Analyzer
 
                 Assert.Equal(LimitType.CustomAnalyzers, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 store.Maintenance.Send(new PutAnalyzersOperation(new AnalyzerDefinition
                 {
                     Name = "MyAnalyzer",
@@ -908,7 +880,7 @@ public class MyAnalyzer2 : Analyzer
         }
 
         // ----------------------------------------
-        // Tests for Client Api License Limits
+        // Tests for Client Configuration License Limits
         //  ----------------------------------------
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.ClientApi)]
         public async Task Prevent_License_Downgrade_ClientConfiguration()
@@ -916,11 +888,10 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = r => r.Client = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50 } }))
             {
-                await FailToChangeLicense(Server, RL_COMM, LimitType.ClientConfiguration);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.ClientConfiguration);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -930,8 +901,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var config = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50 };
 
@@ -940,7 +910,7 @@ public class MyAnalyzer2 : Analyzer
                 Assert.Equal(LimitType.ClientConfiguration, exception.LimitType);
 
                 command = new PutDatabaseClientConfigurationCommand(config, store.Database, RaftIdGenerator.NewId());
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await Server.ServerStore.SendToLeaderAsync(command);
             }
         }
@@ -951,8 +921,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var config = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50, Disabled = true };
 
@@ -969,8 +938,7 @@ public class MyAnalyzer2 : Analyzer
             var options = new Options() { Server = server };
             using (var store = GetDocumentStore(options))
             {
-                await DisableRevisionCompression(server, store);
-                await PutLicense(server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(server, store, LicenseTestBase.RL_COMM);
 
                 var config = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50 };
 
@@ -979,7 +947,7 @@ public class MyAnalyzer2 : Analyzer
                 Assert.Equal(LimitType.ClientConfiguration, exception.LimitType);
 
                 command = new PutClientConfigurationCommand(config, RaftIdGenerator.NewId());
-                await PutLicense(server, RL_PRO);
+                await LicenseHelper.PutLicense(server, LicenseTestBase.RL_PRO);
                 await server.ServerStore.SendToLeaderAsync(command);
             }
         }
@@ -998,11 +966,10 @@ public class MyAnalyzer2 : Analyzer
                     RaftIdGenerator.NewId());
                 await Server.ServerStore.SendToLeaderAsync(command);
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.StudioConfiguration);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.StudioConfiguration);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -1012,8 +979,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var command = new PutDatabaseStudioConfigurationCommand(
                     new ServerWideStudioConfiguration { DisableAutoIndexCreation = true },
                     store.Database, RaftIdGenerator.NewId());
@@ -1024,7 +990,7 @@ public class MyAnalyzer2 : Analyzer
                 command = new PutDatabaseStudioConfigurationCommand(
                     new ServerWideStudioConfiguration { DisableAutoIndexCreation = true },
                     store.Database, RaftIdGenerator.NewId());
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await Server.ServerStore.SendToLeaderAsync(command);
             }
         }
@@ -1035,8 +1001,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var command = new PutDatabaseStudioConfigurationCommand(
                     new ServerWideStudioConfiguration { DisableAutoIndexCreation = true, Disabled = true },
                     store.Database, RaftIdGenerator.NewId());
@@ -1058,11 +1023,10 @@ public class MyAnalyzer2 : Analyzer
                 var config = new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 100, };
 
                 await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Expiration);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Expiration);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -1072,13 +1036,12 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = new ExpirationConfiguration { Disabled = false, DeleteFrequencyInSec = 60 };
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config));
                 Assert.Equal(LimitType.Expiration, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
             }
         }
@@ -1089,8 +1052,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = new ExpirationConfiguration { Disabled = true, DeleteFrequencyInSec = 60 };
                 await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
             }
@@ -1108,11 +1070,10 @@ public class MyAnalyzer2 : Analyzer
             {
                 var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = false };
                 await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Refresh);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Refresh);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -1123,15 +1084,14 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = false };
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig)));
 
                 Assert.Equal(LimitType.Refresh, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
             }
         }
@@ -1143,8 +1103,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = true };
                 await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
@@ -1171,11 +1130,10 @@ public class MyAnalyzer2 : Analyzer
                 Path = NewDataPath()
             }))
             {
-                await FailToChangeLicense(Server, RL_COMM, LimitType.Encryption);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.Encryption);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.Encryption);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.Encryption);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1201,7 +1159,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore(options))
             {
-                await WaitForValueAsync(async () =>
+                var res = await WaitForValueAsync(async () =>
                 {
                     var sum = 0;
                     foreach (var node in nodes)
@@ -1220,26 +1178,25 @@ public class MyAnalyzer2 : Analyzer
                             sum++;
                     }
                     return sum;
-                }, 3, timeout: 30_000);
+                }, 3, timeout: 50_000);
 
-
+                Assert.Equal(3, res);
 
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                 {
-                    await PutLicense(leader, RL_COMM);
+                    await LicenseHelper.PutLicense(leader, LicenseTestBase.RL_COMM);
                 });
 
                 Assert.Equal(LimitType.DynamicNodeDistribution, exception.LimitType);
 
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                 {
-                    await PutLicense(leader, RL_PRO);
+                    await LicenseHelper.PutLicense(leader, LicenseTestBase.RL_PRO);
                 });
 
                 Assert.Equal(LimitType.DynamicNodeDistribution, exception.LimitType);
 
-                await DisableRevisionCompression(leader, store);
-                await ChangeLicense(leader, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(leader, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1253,8 +1210,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = new DocumentsCompressionConfiguration
                 {
                     CompressRevisions = true,
@@ -1266,7 +1222,7 @@ public class MyAnalyzer2 : Analyzer
                 );
                 Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await Server.ServerStore.SendToLeaderAsync(
                         new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()))
@@ -1281,8 +1237,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var config = new DocumentsCompressionConfiguration
                 {
@@ -1295,7 +1250,7 @@ public class MyAnalyzer2 : Analyzer
                 );
                 Assert.Equal(LimitType.DocumentsCompression, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await Server.ServerStore.SendToLeaderAsync(
                         new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()))
@@ -1317,9 +1272,9 @@ public class MyAnalyzer2 : Analyzer
                 };
                 await Server.ServerStore.SendToLeaderAsync(
                     new EditDocumentsCompressionCommand(config, store.Database, RaftIdGenerator.NewId()));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.DocumentsCompression);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.DocumentsCompression);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.DocumentsCompression);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.DocumentsCompression);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1329,9 +1284,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
-
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = new DocumentsCompressionConfiguration
                 {
                     CompressAllCollections = false,
@@ -1349,8 +1302,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var config = new DocumentsCompressionConfiguration
                 {
                     CompressRevisions = false,
@@ -1371,8 +1323,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var connectionString = new RavenConnectionString
                 {
                     Name = "RavenConnStr",
@@ -1398,7 +1349,7 @@ public class MyAnalyzer2 : Analyzer
                     await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config)));
                 Assert.Equal(LimitType.RavenEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
             }
         }
@@ -1436,11 +1387,10 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new AddEtlOperation<RavenConnectionString>(config));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.RavenEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.RavenEtl);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_PRO);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -1451,8 +1401,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new SqlConnectionString
                 {
@@ -1483,7 +1432,7 @@ public class MyAnalyzer2 : Analyzer
                     await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config)));
                 Assert.Equal(LimitType.SqlEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
             }
         }
@@ -1495,38 +1444,12 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                var connectionString = new SqlConnectionString
-                {
-                    Name = "SqlConnStr",
-                    FactoryName = "System.Data.SqlClient",
-                    ConnectionString = "Server=localhost;Database=Test;User Id=sa;Password=123456;"
-                };
+                await LicenseHelper.CreateSqlEtlConfiguration(store);
 
-                await store.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(connectionString));
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.SqlEtl);
 
-                var config = new SqlEtlConfiguration
-                {
-                    Name = "SqlEtlTask",
-                    ConnectionStringName = "SqlConnStr",
-                    SqlTables = { new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false } },
-                    Transforms =
-                    {
-                        new Transformation
-                        {
-                            Name = "Script1",
-                            Collections = new List<string> { "Users" },
-                            Script = "loadToUsers(this)"
-                        }
-                    }
-                };
-
-                await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
-
-                await FailToChangeLicense(Server, RL_COMM, LimitType.SqlEtl);
-
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_PRO);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -1537,8 +1460,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new OlapConnectionString
                 {
@@ -1571,13 +1493,13 @@ public class MyAnalyzer2 : Analyzer
 
                 Assert.Equal(LimitType.OlapEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config)));
 
                 Assert.Equal(LimitType.OlapEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config));
             }
         }
@@ -1617,11 +1539,10 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(config));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.OlapEtl);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.OlapEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.OlapEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.OlapEtl);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1632,8 +1553,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new ElasticSearchConnectionString
                 {
@@ -1663,13 +1583,13 @@ public class MyAnalyzer2 : Analyzer
 
                 Assert.Equal(LimitType.ElasticSearchEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config)));
 
                 Assert.Equal(LimitType.ElasticSearchEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config));
             }
         }
@@ -1706,11 +1626,10 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new AddEtlOperation<ElasticSearchConnectionString>(config));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.ElasticSearchEtl);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.ElasticSearchEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.ElasticSearchEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.ElasticSearchEtl);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1721,8 +1640,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new QueueConnectionString
                 {
@@ -1757,12 +1675,12 @@ public class MyAnalyzer2 : Analyzer
 
                 Assert.Equal(LimitType.QueueEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config)));
                 Assert.Equal(LimitType.QueueEtl, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config));
             }
         }
@@ -1804,11 +1722,10 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new AddEtlOperation<QueueConnectionString>(config));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.QueueEtl);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.QueueEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.QueueEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.QueueEtl);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1839,11 +1756,10 @@ public class MyAnalyzer2 : Analyzer
 
                 store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.QueueSink);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.QueueSink);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.QueueSink);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.QueueSink);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -1853,8 +1769,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 store.Maintenance.Send(
                     new PutConnectionStringOperation<QueueConnectionString>(
                         new QueueConnectionString
@@ -1880,12 +1795,12 @@ public class MyAnalyzer2 : Analyzer
                 var exception = Assert.Throws<LicenseLimitException>(() => store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config)));
                 Assert.Equal(LimitType.QueueSink, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = Assert.Throws<LicenseLimitException>(() => store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config)));
 
                 Assert.Equal(LimitType.QueueSink, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(config));
             }
         }
@@ -1896,8 +1811,7 @@ public class MyAnalyzer2 : Analyzer
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
                 var connectionString = new RavenConnectionString
                 {
                     Name = "RavenConnStr",
@@ -1932,8 +1846,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new SqlConnectionString
                 {
@@ -1973,8 +1886,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new OlapConnectionString
                 {
@@ -2015,8 +1927,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new ElasticSearchConnectionString
                 {
@@ -2053,8 +1964,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new QueueConnectionString
                 {
@@ -2158,11 +2068,10 @@ public class MyAnalyzer2 : Analyzer
                     var replicated1 = WaitForDocumentToReplicate<User>(store2, "users/1", 15000);
                     Assert.NotNull(replicated1);
 
-                    await FailToChangeLicense(server1, RL_COMM, LimitType.ExternalReplication);
+                    await LicenseHelper.FailToChangeLicense(server1, LicenseTestBase.RL_COMM, LimitType.ExternalReplication);
 
-                    await DisableRevisionCompression(server1, store1);
-                    await ChangeLicense(server1, RL_DEV);
-                    await ChangeLicense(server1, RL_PRO);
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store1, LicenseTestBase.RL_DEV);
+                    await LicenseHelper.ChangeLicense(server1, LicenseTestBase.RL_PRO);
                 }
             }
         }
@@ -2177,17 +2086,17 @@ public class MyAnalyzer2 : Analyzer
                 using (var store1 = GetDocumentStore(options))
                 using (var store2 = GetDocumentStore())
                 {
-                    await DisableRevisionCompression(server1, store1);
-                    await DisableRevisionCompression(Server, store2);
-                    await PutLicense(server1, RL_COMM);
+                    await LicenseHelper.DisableRevisionCompression(server1, store1);
+                    await LicenseHelper.DisableRevisionCompression(Server, store2);
+                    await LicenseHelper.PutLicense(server1, LicenseTestBase.RL_COMM);
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await SetupReplicationAsync(store1, store2));
                     Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
 
-                    await PutLicense(server1, RL_PRO);
+                    await LicenseHelper.PutLicense(server1, LicenseTestBase.RL_PRO);
                     await SetupReplicationAsync(store1, store2);
 
-                    await PutLicense(server1, RL_DEV);
+                    await LicenseHelper.PutLicense(server1, LicenseTestBase.RL_DEV);
                     await SetupReplicationAsync(store1, store2);
                 }
             }
@@ -2200,12 +2109,11 @@ public class MyAnalyzer2 : Analyzer
             using (var store = GetDocumentStore())
             {
                 await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutPullReplicationAsHubOperation("test"));
-                await FailToChangeLicense(Server, RL_COMM, LimitType.PullReplicationAsHub);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.PullReplicationAsHub);
 
-                await FailToChangeLicense(Server, RL_PRO, LimitType.PullReplicationAsHub);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.PullReplicationAsHub);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -2216,13 +2124,12 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutPullReplicationAsHubOperation("test")));
                 Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.ForDatabase(store.Database).SendAsync(new PutPullReplicationAsHubOperation("test")));
                 Assert.Equal(LimitType.PullReplicationAsHub, exception.LimitType);
             }
@@ -2234,8 +2141,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var connectionString = new RavenConnectionString
                 {
@@ -2256,8 +2162,8 @@ public class MyAnalyzer2 : Analyzer
 
                 Assert.Equal(LimitType.PullReplicationAsSink, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -2284,11 +2190,10 @@ public class MyAnalyzer2 : Analyzer
                 await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
                 await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(config));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.PullReplicationAsSink);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.PullReplicationAsSink);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_PRO);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -2299,8 +2204,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var delayed = new ExternalReplication("otherDb", "DelayedReplication")
                 {
@@ -2310,12 +2214,12 @@ public class MyAnalyzer2 : Analyzer
                     await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed)));
                 Assert.Equal(LimitType.ExternalReplication, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed)));
                 Assert.Equal(LimitType.DelayedExternalReplication, exception.LimitType);
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed));
             }
         }
@@ -2334,11 +2238,10 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(delayed));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.DelayedExternalReplication);
-                await FailToChangeLicense(Server, RL_PRO, LimitType.DelayedExternalReplication);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.DelayedExternalReplication);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.DelayedExternalReplication);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
             }
         }
 
@@ -2354,9 +2257,9 @@ public class MyAnalyzer2 : Analyzer
 
             using (GetDocumentStore())
             {
-                await FailToChangeLicense(leader, RL_COMM, LimitType.ClusterSize);
-                await FailToChangeLicense(leader, RL_DEV, LimitType.ClusterSize);
-                await FailToChangeLicense(leader, RL_PRO, LimitType.ClusterSize);
+                await LicenseHelper.FailToChangeLicense(leader, LicenseTestBase.RL_COMM, LimitType.ClusterSize);
+                await LicenseHelper.FailToChangeLicense(leader, LicenseTestBase.RL_DEV, LimitType.ClusterSize);
+                await LicenseHelper.FailToChangeLicense(leader, LicenseTestBase.RL_PRO, LimitType.ClusterSize);
             }
         }
 
@@ -2369,7 +2272,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (GetDocumentStore())
             {
-                await PutLicense(leader, RL_COMM);
+                await LicenseHelper.PutLicense(leader, LicenseTestBase.RL_COMM);
                 using (var server = GetNewServer(new ServerCreationOptions()))
                 using (var server2 = GetNewServer(new ServerCreationOptions()))
                 using (var server3 = GetNewServer(new ServerCreationOptions()))
@@ -2381,11 +2284,11 @@ public class MyAnalyzer2 : Analyzer
                         var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await requestExecutor.ExecuteAsync(command, context));
                         Assert.Equal(LimitType.ClusterSize, exception.LimitType);
 
-                        await PutLicense(leader, RL_DEV);
+                        await LicenseHelper.PutLicense(leader, LicenseTestBase.RL_DEV);
                         exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await requestExecutor.ExecuteAsync(command, context));
                         Assert.Equal(LimitType.ClusterSize, exception.LimitType);
 
-                        await PutLicense(leader, RL_PRO);
+                        await LicenseHelper.PutLicense(leader, LicenseTestBase.RL_PRO);
                         await requestExecutor.ExecuteAsync(command, context); // cluster size = 4, which is allowed by PRO license
                         command = new AddClusterNodeCommand(server2.WebUrl);
                         await requestExecutor.ExecuteAsync(command, context); // cluster size = 5, which is allowed by PRO license
@@ -2408,8 +2311,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var timeSeriesConfig = new TimeSeriesConfiguration
                 {
@@ -2434,10 +2336,10 @@ public class MyAnalyzer2 : Analyzer
 
                 Assert.Equal(LimitType.TimeSeriesRollupsAndRetention, exception.LimitType);
 
-                await PutLicense(Server, RL_PRO);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_PRO);
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
 
-                await PutLicense(Server, RL_DEV);
+                await LicenseHelper.PutLicense(Server, LicenseTestBase.RL_DEV);
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
             }
         }
@@ -2469,11 +2371,10 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
 
-                await FailToChangeLicense(Server, RL_COMM, LimitType.TimeSeriesRollupsAndRetention);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.TimeSeriesRollupsAndRetention);
 
-                await DisableRevisionCompression(Server, store);
-                await ChangeLicense(Server, RL_DEV);
-                await ChangeLicense(Server, RL_PRO);
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_DEV);
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_PRO);
             }
         }
 
@@ -2484,8 +2385,7 @@ public class MyAnalyzer2 : Analyzer
 
             using (var store = GetDocumentStore())
             {
-                await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
                 var timeSeriesConfig = new TimeSeriesConfiguration
                 {
@@ -2509,38 +2409,6 @@ public class MyAnalyzer2 : Analyzer
 
                 await store.Maintenance.SendAsync(new ConfigureTimeSeriesOperation(timeSeriesConfig));
             }
-        }
-        private static async Task FailToChangeLicense(RavenServer leader, string licenseType, LimitType limitType)
-        {
-            var license = Environment.GetEnvironmentVariable(licenseType);
-            LicenseHelper.TryDeserializeLicense(license, out License li);
-
-            var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId()));
-
-            Assert.Equal(limitType, exception.LimitType);
-        }
-
-        private static async Task ChangeLicense(RavenServer leader, string licenseType)
-        {
-            var license = Environment.GetEnvironmentVariable(licenseType);
-            LicenseHelper.TryDeserializeLicense(license, out License li);
-
-            await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
-        }
-
-        private static async Task PutLicense(RavenServer leader, string licenseType)
-        {
-            var license = Environment.GetEnvironmentVariable(licenseType);
-            LicenseHelper.TryDeserializeLicense(license, out License li);
-
-             await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
-        }
-
-        internal static async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
-        {
-            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
-                RaftIdGenerator.NewId());
-            await leader.ServerStore.SendToLeaderAsync(command);
         }
 
         private static string GetSorter(string resourceName, string originalSorterName, string sorterName)

--- a/test/SlowTests/Issues/RavenDB-24118.cs
+++ b/test/SlowTests/Issues/RavenDB-24118.cs
@@ -20,7 +20,6 @@ namespace SlowTests.Issues
         public RavenDB_24118(ITestOutputHelper output) : base(output)
         {
         }
-        private const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
 
         [RavenFact(RavenTestCategory.Licensing)]
         public async Task Prevent_Put_Revision()
@@ -30,12 +29,11 @@ namespace SlowTests.Issues
             using (var store = GetDocumentStore())
             {
                 await DisableRevisionCompression(Server, store);
-                await PutLicense(Server, RL_COMM);
+                await PutLicense(Server, LicenseTestBase.RL_COMM);
 
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration)));
                 Assert.Equal(LimitType.RevisionsConfiguration, exception.LimitType);
-
             }
         }
 
@@ -50,7 +48,7 @@ namespace SlowTests.Issues
                 var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = false, MinimumRevisionsToKeep = 0 } };
                 await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
 
-                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, RL_COMM));
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await PutLicense(Server, LicenseTestBase.RL_COMM));
                 Assert.Equal(LimitType.RevisionsConfiguration, exception.LimitType);
             }
         }
@@ -58,7 +56,7 @@ namespace SlowTests.Issues
         private static async Task PutLicense(RavenServer leader, string licenseType)
         {
             var license = Environment.GetEnvironmentVariable(licenseType);
-            LicenseHelper.TryDeserializeLicense(license, out License li);
+            Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
 
             await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
         }

--- a/test/SlowTests/Issues/RavenDB-25225.cs
+++ b/test/SlowTests/Issues/RavenDB-25225.cs
@@ -1,0 +1,1347 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Configuration;
+using Raven.Client.Documents.Operations.DataArchival;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Expiration;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.Refresh;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide.Operations.Configuration;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Commands;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using BackupConfiguration = Raven.Client.Documents.Operations.Backups.BackupConfiguration;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25225 : RavenTestBase
+    {
+        public RavenDB_25225(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        // ----------------------------------------
+        // Tests for Data Archival License Limits
+        // ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledDataArchivalCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var config = new DataArchivalConfiguration { Disabled = true, ArchiveFrequencyInSec = 100 };
+                    await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDataArchivalCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var config = new DataArchivalConfiguration { Disabled = false, ArchiveFrequencyInSec = 100 };
+                    await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledDataArchivalCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var config = new DataArchivalConfiguration { Disabled = true, ArchiveFrequencyInSec = 100 };
+                    await DataArchivalHelper.SetupDataArchival(store, Server.ServerStore, config);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Indexes License Limits
+        // ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport | RavenTestCategory.Indexes)]
+        public async Task ImportingDisabledAdditionalAssembliesWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    LicenseHelper.PutIndexWithAdditionalAssemblies(store, IndexState.Disabled);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    var index = store.Maintenance.Send(new GetIndexOperation("test"));
+                    Assert.Null(index);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport | RavenTestCategory.Indexes)]
+        public async Task RestoreDisabledAdditionalAssembliesWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    LicenseHelper.PutIndexWithAdditionalAssemblies(store, IndexState.Disabled);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Revision License Limits
+        // ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledRevisionCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = true, MinimumRevisionsToKeep = 0 } };
+                    await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledRevisionCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var configuration = new RevisionsConfiguration { Default = new RevisionsCollectionConfiguration { Disabled = true, MinimumRevisionsToKeep = 0 } };
+                    await store.Maintenance.SendAsync(new ConfigureRevisionsOperation(configuration));
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                    WaitForUserToContinueTheTest(store);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Backup License Limits
+        // ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledSnapshotWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var file = GetTempFileName();
+            try
+            {
+                PeriodicBackupConfiguration config;
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot, disabled: true);
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledSnapshotWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                PeriodicBackupConfiguration config;
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Snapshot, disabled: true);
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledSnapshotWithProLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.CreatePeriodicBackup(backupPath, store, BackupType.Snapshot, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledSnapshotWithProLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.CreatePeriodicBackup(backupPath, store, BackupType.Snapshot, true);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledBackupWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var file = GetTempFileName();
+            try
+            {
+                PeriodicBackupConfiguration config;
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Backup, disabled: true);
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledBackupWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                PeriodicBackupConfiguration config;
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    config = Backup.CreateBackupConfiguration(backupPath, fullBackupFrequency: "* */1 * * *", incrementalBackupFrequency: "* */2 * * *", backupType: BackupType.Backup, disabled: true);
+                    await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledBackupWithProLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.CreatePeriodicBackup(backupPath, store, BackupType.Backup, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledBackupWithProLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.CreatePeriodicBackup(backupPath, store, BackupType.Backup, true);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Client Configuration License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledClientConfigurationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = r => r.Client = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50, Disabled = true} }))
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingClientConfigurationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = r => r.Client = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50, Disabled = false } }))
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    });
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledClientConfigurationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore(new Options { ModifyDatabaseRecord = r => r.Client = new ClientConfiguration { MaxNumberOfRequestsPerSession = 50, Disabled = true } }))
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Studio Configuration License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledStudioConfigurationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    var command = new PutDatabaseStudioConfigurationCommand(new StudioConfiguration() { DisableAutoIndexCreation = true, Disabled = true }, store.Database,
+                        RaftIdGenerator.NewId());
+                    await Server.ServerStore.SendToLeaderAsync(command);
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledStudioConfigurationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    var command = new PutDatabaseStudioConfigurationCommand(new ServerWideStudioConfiguration() { DisableAutoIndexCreation = true, Disabled = true}, store.Database,
+                        RaftIdGenerator.NewId());
+                    await Server.ServerStore.SendToLeaderAsync(command);
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Expiration License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledExpirationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var config = new ExpirationConfiguration { Disabled = true, DeleteFrequencyInSec = 100, };
+                    await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledExpirationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var config = new ExpirationConfiguration { Disabled = true, DeleteFrequencyInSec = 100, };
+                    await ExpirationHelper.SetupExpiration(store, Server.ServerStore, config);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Refresh License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledRefreshWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = true };
+                    await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledRefreshWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    var refConfig = new RefreshConfiguration { RefreshFrequencyInSec = 33, Disabled = true };
+                    await store.Maintenance.SendAsync(new ConfigureRefreshOperation(refConfig));
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for ETL License Limits
+        //  ---------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task ImportingDisabledRavenEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CreateRavenEtlConfiguration(csName, dbName, store, out AddEtlOperationResult _, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task RestoreDisabledRavenEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CreateRavenEtlConfiguration(csName, dbName, store, out AddEtlOperationResult _, true);
+                    WaitForUserToContinueTheTest(store);
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task ImportingDisabledSqlEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.CreateSqlEtlConfiguration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task RestoreDisabledSqlEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.CreateSqlEtlConfiguration(store, true);
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Replication License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task ImportingDisabledExternalReplicationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var server1 = GetNewServer())
+            using (var server2 = GetNewServer())
+            {
+                var file = GetTempFileName();
+                var dbName = $"db/{Guid.NewGuid()}";
+                var csName = $"cs/{Guid.NewGuid()}";
+                try
+                {
+                    using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server1 }))
+                    {
+                        await LicenseHelper.DisableRevisionCompression(server2, store1);
+                        await LicenseHelper.DisableRevisionCompression(server1, store2);
+
+                        await LicenseHelper.CreateExternalReplication(csName, dbName, store1, true);
+
+                        var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                        await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                        await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store2, LicenseTestBase.RL_COMM);
+
+                        var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    }
+                }
+                finally
+                {
+                    File.Delete(file);
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task RestoreDisabledExternalReplicationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var server1 = GetNewServer())
+            using (var server2 = GetNewServer())
+            {
+                var dbName = $"db/{Guid.NewGuid()}";
+                var csName = $"cs/{Guid.NewGuid()}";
+                try
+                {
+                    using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server1 }))
+                    {
+                        await LicenseHelper.DisableRevisionCompression(server2, store1);
+                        await LicenseHelper.DisableRevisionCompression(server1, store2);
+
+                        await LicenseHelper.CreateExternalReplication(csName, dbName, store1, true);
+
+                        await RunBackup(store1, backupPath);
+
+                        await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store2, LicenseTestBase.RL_COMM);
+
+                        runRestore(store2, backupPath);
+                    }
+                }
+                finally
+                {
+                    Directory.Delete(backupPath, true);
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task ImportingDisabledDelayedExternalReplicationWithProLicense()
+        {
+            DoNotReuseServer();
+            using (var server1 = GetNewServer())
+            using (var server2 = GetNewServer())
+            {
+                var file = GetTempFileName();
+                var dbName = $"cs/{Guid.NewGuid()}";
+                var csName = $"cs/{Guid.NewGuid()}";
+                try
+                {
+                    using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server1 }))
+                    {
+                        await LicenseHelper.DisableRevisionCompression(server2, store1);
+                        await LicenseHelper.DisableRevisionCompression(server1, store2);
+
+                        await LicenseHelper.CreateExternalReplication(csName, dbName, store1, true);
+
+                        var operation = await store1.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                        await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+
+                        await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store2, LicenseTestBase.RL_COMM);
+
+                        var importOperation = await store2.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                        await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                    }
+                }
+                finally
+                {
+                    File.Delete(file);
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task RestoreDisabledDelayedExternalReplicationWithProLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using (var server1 = GetNewServer())
+            using (var server2 = GetNewServer())
+            {
+                var dbName = $"cs/{Guid.NewGuid()}";
+                var csName = $"cs/{Guid.NewGuid()}";
+                try
+                {
+                    using (var store1 = GetDocumentStore(new Options() { Server = server2 }))
+                    using (var store2 = GetDocumentStore(new Options() { Server = server1 }))
+                    {
+                        await LicenseHelper.DisableRevisionCompression(server2, store1);
+                        await LicenseHelper.DisableRevisionCompression(server1, store2);
+
+                        await LicenseHelper.CreateExternalReplication(csName, dbName, store1, true);
+
+                        await RunBackup(store1, backupPath);
+
+                        await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(server1, store2, LicenseTestBase.RL_COMM);
+
+                        runRestore(store2, backupPath);
+                    }
+                }
+                finally
+                {
+                    Directory.Delete(backupPath, true);
+                }
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task ImportingDisabledPullReplicationAsSinkWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await LicenseHelper.CreatePullReplicationAsSink(dbName, csName, store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task RestoreDisabledPullReplicationAsSinkWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            var dbName = $"db/{Guid.NewGuid()}";
+            var csName = $"cs/{Guid.NewGuid()}";
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await LicenseHelper.CreatePullReplicationAsSink(dbName, csName, store, true);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task ImportingDisabledPullReplicationAsHubWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CraetePullReplicationDefinition(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task RestoreDisabledPullReplicationAsHubWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CraetePullReplicationDefinition(store, true);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task ImportingDisabledPullReplicationAsHubWithProLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CraetePullReplicationDefinition(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+        public async Task RestoreDisabledPullReplicationAsHubWithProLicense()
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CraetePullReplicationDefinition(store, true);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        // ----------------------------------------
+        // Tests for Time Series Configuration License Limits
+        //  ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.TimeSeries)]
+        public async Task ImportingDisabledTsRollupAndRetentionWithCommunityLicense()
+        {
+            DoNotReuseServer();
+
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CreateTsRollupAndRetention(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.TimeSeries)]
+        public async Task RestoreDisabledTsRollupAndRetentionWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    LicenseHelper.CreateTsRollupAndRetention(store, true);
+
+                    await RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    runRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        private void runRestore(DocumentStore store, string backupPath)
+        {
+            var configuration = new RestoreBackupConfiguration { DatabaseName = store.Database + "1" };
+            configuration.BackupLocation = Directory.GetDirectories(backupPath).First();
+           Backup.RestoreDatabase(store, configuration);
+        }
+
+        private static async Task RunBackup(DocumentStore store, string backupPath)
+        {
+            var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+            {
+                BackupType = BackupType.Backup,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = backupPath
+                }
+            }));
+
+            _ = (BackupResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.License.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.License.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Server.Commercial;
+using Raven.Server.ServerWide.Commands;
+using Sparrow;
+using Xunit;
+
+namespace FastTests
+{
+    public abstract partial class RavenTestBase
+    {
+        public readonly LicenseTestBase LicenseHelper;
+
+        public class LicenseTestBase
+        {
+            private readonly RavenTestBase _parent;
+
+            public LicenseTestBase(RavenTestBase parent)
+            {
+                _parent = parent ?? throw new ArgumentNullException(nameof(parent));
+            }
+
+            internal const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
+            internal const string RL_PRO = "RAVEN_LICENSE_PROFESSIONAL";
+            internal const string RL_DEV = "RAVEN_LICENSE_DEVELOPER";
+
+            internal async Task FailToChangeLicense(RavenServer leader, string licenseType, LimitType limitType)
+            {
+                var license = Environment.GetEnvironmentVariable(licenseType);
+                Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () => await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId()));
+
+                Assert.Equal(limitType, exception.LimitType);
+            }
+
+            internal async Task ChangeLicense(RavenServer leader, string licenseType)
+            {
+                var license = Environment.GetEnvironmentVariable(licenseType);
+                Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
+
+                await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+            }
+
+            internal async Task PutLicense(RavenServer leader, string licenseType)
+            {
+                var license = Environment.GetEnvironmentVariable(licenseType);
+                Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
+
+                await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+            }
+
+            internal async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
+            {
+                var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
+                    RaftIdGenerator.NewId());
+                await leader.ServerStore.SendToLeaderAsync(command);
+            }
+
+            internal async Task PutLicenseAndDisableRevisionCompression(RavenServer server, DocumentStore store, string licenseType)
+            {
+                await DisableRevisionCompression(server, store);
+                await PutLicense(server, licenseType);
+            }
+
+            internal async Task ChangeLicenseAndDisableRevisionCompression(RavenServer server, DocumentStore store, string licenseType)
+            {
+                await DisableRevisionCompression(server, store);
+                await ChangeLicense(server, licenseType);
+            }
+
+            internal void PutIndexWithAdditionalAssemblies(DocumentStore store, IndexState indexState = IndexState.Normal)
+            {
+                store.Maintenance.Send(new PutIndexesOperation(new[]
+                {
+                    new IndexDefinition
+                    {
+                        Maps = { "from doc in docs.Images select new { doc.Tags }" },
+                        Name = "test",
+                        AdditionalAssemblies = { AdditionalAssembly.FromNuGet("System.Drawing.Common", "4.7.0") },
+                        State = indexState
+                    }
+                }));
+            }
+
+            internal async Task<PeriodicBackupConfiguration> CreatePeriodicBackup(string backupPath, DocumentStore store ,BackupType type, bool disabled = false)
+            {
+                PeriodicBackupConfiguration config = new PeriodicBackupConfiguration()
+                {
+                    BackupType = type,
+                    FullBackupFrequency = "* */1 * * *",
+                    Disabled = disabled,
+                    BackupUploadMode = BackupUploadMode.Default,
+                    PinToMentorNode = false,
+                    LocalSettings = new LocalSettings { FolderPath = backupPath }
+                };
+                await store.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config));
+                return config;
+            }
+
+            internal async Task<ExternalReplication> CreateExternalReplication(string csName, string dbName, DocumentStore store, bool disabled = false)
+            {
+                var connectionString = new RavenConnectionString
+                {
+                    Name = csName,
+                    Database = dbName,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" }
+                };
+
+                var result = await store.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+                Assert.NotNull(result.RaftCommandIndex);
+
+                var watcher = new ExternalReplication(dbName, csName);
+                watcher.Disabled = disabled;
+                await store.Maintenance.SendAsync(new UpdateExternalReplicationOperation(watcher));
+                return watcher;
+            }
+
+            internal void CreateTsRollupAndRetention(DocumentStore store, bool disabled = false)
+            {
+                var salesTsConfig = new TimeSeriesCollectionConfiguration
+                {
+                    Policies = new List<TimeSeriesPolicy>
+                    {
+                        new("DailyRollupForOneYear",
+                            TimeValue.FromDays(1),
+                            TimeValue.FromYears(1))
+                    },
+                    RawPolicy = new RawTimeSeriesPolicy(TimeValue.FromDays(7))
+                };
+                var databaseTsConfig = new TimeSeriesConfiguration();
+                salesTsConfig.Disabled = disabled;
+                databaseTsConfig.Collections["Sales"] = salesTsConfig;
+                store.Maintenance.Send(new ConfigureTimeSeriesOperation(databaseTsConfig));
+            }
+
+            internal void CreateCompressAllCollection(DocumentStore store)
+            {
+                var dbrecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+                dbrecord.DocumentsCompression.CompressAllCollections = true;
+                store.Maintenance.Server.Send(new UpdateDatabaseOperation(dbrecord, dbrecord.Etag));
+            }
+
+            internal async Task<PullReplicationAsSink> CreatePullReplicationAsSink(string dbName, string csName, DocumentStore store, bool disabled = false)
+            {
+                PullReplicationAsSink pullAsSink;
+                pullAsSink = new PullReplicationAsSink(dbName, csName, "hub");
+                pullAsSink.Disabled = disabled;
+                var result = await store.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(pullAsSink));
+                Assert.NotNull(result.RaftCommandIndex);
+                return pullAsSink;
+            }
+
+            internal  PullReplicationDefinition CraetePullReplicationDefinition(DocumentStore store, bool disabled = false)
+            {
+                PullReplicationDefinition pull;
+                pull = new PullReplicationDefinition("pull");
+                pull.Disabled = disabled;
+                store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
+                return pull;
+            }
+
+            internal RavenEtlConfiguration CreateRavenEtlConfiguration(string csName, string dbName, DocumentStore store, out AddEtlOperationResult etl, bool disabled = false)
+            {
+                RavenEtlConfiguration etlConfiguration;
+                etlConfiguration = new RavenEtlConfiguration
+                {
+                    Name = csName,
+                    ConnectionStringName = csName,
+                    Transforms = { new Transformation { Name = $"ETL : {csName}", ApplyToAllDocuments = true } },
+                    MentorNode = "A",
+                    Disabled = disabled
+                };
+                var connectionString = new RavenConnectionString
+                {
+                    Name = csName,
+                    Database = dbName,
+                    TopologyDiscoveryUrls = new[] { "http://127.0.0.1:12345" },
+                };
+
+                Assert.NotNull(store.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString)));
+                etl = store.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(etlConfiguration));
+                return etlConfiguration;
+            }
+
+            internal async Task CreateSqlEtlConfiguration(DocumentStore store, bool disabled = false)
+            {
+                var connectionString = new SqlConnectionString
+                {
+                    Name = "SqlConnStr",
+                    FactoryName = "System.Data.SqlClient",
+                    ConnectionString = "Server=localhost;Database=Test;User Id=sa;Password=123456;"
+                };
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<SqlConnectionString>(connectionString));
+
+                var config = new SqlEtlConfiguration
+                {
+                    Name = "SqlEtlTask",
+                    ConnectionStringName = "SqlConnStr",
+                    SqlTables = { new SqlEtlTable { TableName = "Users", DocumentIdColumn = "Id", InsertOnlyMode = false } },
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = "Script1",
+                            Collections = new List<string> { "Users" },
+                            Script = "loadToUsers(this)"
+                        }
+                    },
+                    Disabled = disabled
+                };
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -23,13 +23,12 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
-using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents;
-using Raven.Server.ServerWide;
 using Raven.Server.Documents.Handlers;
 using Raven.Server.Exceptions;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Collections;
@@ -61,6 +60,7 @@ namespace FastTests
             Replication = new ReplicationTestBase2(this);
             Databases = new DatabasesTestBase(this);
             Etl = new EtlTestBase(this);
+            LicenseHelper = new LicenseTestBase(this);
         }
 
         public async ValueTask<DatabaseRecord> GetDatabaseRecordAsync(IDocumentStore store, string database = null)


### PR DESCRIPTION
…storing a database

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25225

### Additional description

* Ignore license validation for disabled features when restoring a database

* Added RavenTestBase.License.cs , helper for the license tests

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
