### PR TITLE
RavenDB-24495 Replace X509Certificate2 instantiations with CertificateLoaderUtil or CertificateHelper methods where applicable

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptCertificateUtil.cs
@@ -39,7 +39,7 @@ public sealed class LetsEncryptCertificateUtil
 
     public static async Task WriteCertificateAsPemToZipArchiveAsync(string name, byte[] rawBytes, string exportPassword, ZipArchive archive)
     {
-        var cert = new X509Certificate2(rawBytes, exportPassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet);
+        var cert = CertificateHelper.CreateCertificateFromPfx(rawBytes, exportPassword, X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet);
     
         // Export the certificate to PEM
         var certPem = cert.ExportCertificatePem();

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -273,7 +273,7 @@ namespace Raven.Server.Utils
             var pfxCollection = new X509Certificate2Collection();
 
             // Import the existing PFX file (client certificate) into the collection
-            pfxCollection.Import(certBytes, null, CertificateLoaderUtil.FlagsForExport);
+            CertificateLoaderUtil.ImportPfx(pfxCollection, certBytes, null, CertificateLoaderUtil.FlagsForExport);
 
             // Add the server certificate to the collection
             pfxCollection.Add(CertificateLoaderUtil.CreateCertificateFromAny(serverCertBytes, flags: CertificateLoaderUtil.FlagsForExport));
@@ -564,7 +564,7 @@ namespace Raven.Server.Utils
                             // Try to create a certificate from this position
                             var certBytes = new byte[rawData.Length - i];
                             Array.Copy(rawData, i, certBytes, 0, certBytes.Length);
-                            serverCertificateFromExtension = new X509Certificate2(certBytes);
+                            serverCertificateFromExtension = CertificateHelper.CreateCertificateFromCert(certBytes);
                             break;
                         }
                         catch

--- a/test/SlowTests.Issues/Issues/RavenDB-21535.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21535.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
+using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Utils;
@@ -31,7 +32,7 @@ namespace SlowTests.Issues
                 notAfter: DateTime.UtcNow.Date.AddMonths(1),
                 certBytes: out var clientCertBytes);
 
-            var client = new X509Certificate2(clientCertBytes);
+            var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientCertBytes);
 
             var server = GetNewServer(new ServerCreationOptions
             {
@@ -68,7 +69,7 @@ namespace SlowTests.Issues
                 certBytes: out var clientCertBytes,
                 sans: new[] { san });
 
-            var client = new X509Certificate2(clientCertBytes);
+            var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientCertBytes);
 
             var server = GetNewServer(new ServerCreationOptions
             {
@@ -105,7 +106,7 @@ namespace SlowTests.Issues
                 certBytes: out var clientCertBytes,
                 sans: new[] { san });
 
-            var client = new X509Certificate2(clientCertBytes);
+            var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientCertBytes);
 
             var server = GetNewServer(new ServerCreationOptions
             {
@@ -137,7 +138,7 @@ namespace SlowTests.Issues
                 certBytes: out var clientCertBytes,
                 sans: new[] { LocalDomainName });
 
-            var client = new X509Certificate2(clientCertBytes);
+            var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientCertBytes);
 
             var server = GetNewServer(new ServerCreationOptions
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-22210.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22210.cs
@@ -10,6 +10,7 @@ using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using System.Security.Cryptography;
+using Raven.Client.Util;
 
 namespace SlowTests.Issues;
 
@@ -126,7 +127,7 @@ public class RavenDB_22210 : RavenTestBase
             isCaCertificate: true,
             notAfter: DateTime.UtcNow.Date.AddYears(2),
             certBytes: out var intermediateBytes);
-        var intermediate = new X509Certificate2(intermediateBytes);
+        var intermediate = CertificateLoaderUtil.CreateCertificateFromPfx(intermediateBytes);
 
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
             commonNameValue: $"{IntermediateName}-{suffix}-2",
@@ -136,7 +137,7 @@ public class RavenDB_22210 : RavenTestBase
             isCaCertificate: true,
             notAfter: DateTime.UtcNow.Date.AddYears(2),
             certBytes: out var intermediate2Bytes);
-        var intermediate2 = new X509Certificate2(intermediate2Bytes);
+        var intermediate2 = CertificateLoaderUtil.CreateCertificateFromPfx(intermediate2Bytes);
 
         var clientKp = RSA.Create(2048);
 
@@ -149,7 +150,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var clientBytes,
             subjectPrivateKey: clientKp);
-        var client = new X509Certificate2(clientBytes);
+        var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientBytes);
 
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
             commonNameValue: $"{ClientRenewedName}-{suffix}",
@@ -160,7 +161,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var client2Bytes,
             subjectPrivateKey: clientKp);
-        var client2 = new X509Certificate2(client2Bytes);
+        var client2 = CertificateLoaderUtil.CreateCertificateFromPfx(client2Bytes);
 
         return (ca, intermediate, intermediate2, client, client2);
     }
@@ -181,7 +182,7 @@ public class RavenDB_22210 : RavenTestBase
             isCaCertificate: true,
             notAfter: DateTime.UtcNow.Date.AddYears(2),
             certBytes: out var intermediateBytes);
-        var intermediate = new X509Certificate2(intermediateBytes);
+        var intermediate = CertificateLoaderUtil.CreateCertificateFromPfx(intermediateBytes);
 
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
             commonNameValue: $"{IntermediateName}-{suffix}-2",
@@ -191,7 +192,7 @@ public class RavenDB_22210 : RavenTestBase
             isCaCertificate: true,
             notAfter: DateTime.UtcNow.Date.AddYears(2),
             certBytes: out var intermediate2Bytes);
-        var intermediate2 = new X509Certificate2(intermediate2Bytes);
+        var intermediate2 = CertificateLoaderUtil.CreateCertificateFromPfx(intermediate2Bytes);
 
         var clientKp = RSA.Create(2048);
 
@@ -204,7 +205,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var clientBytes,
             subjectPrivateKey: clientKp);
-        var client = new X509Certificate2(clientBytes);
+        var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientBytes);
 
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
             commonNameValue: $"{ClientRenewedName}-{suffix}",
@@ -215,7 +216,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var client2Bytes,
             subjectPrivateKey: clientKp);
-        var client2 = new X509Certificate2(client2Bytes);
+        var client2 = CertificateLoaderUtil.CreateCertificateFromPfx(client2Bytes);
 
         return (ca, ca2, intermediate, intermediate2, client, client2);
     }
@@ -233,7 +234,7 @@ public class RavenDB_22210 : RavenTestBase
             isCaCertificate: true,
             notAfter: DateTime.UtcNow.Date.AddYears(2),
             certBytes: out var intermediateBytes);
-        var intermediate = new X509Certificate2(intermediateBytes);
+        var intermediate = CertificateLoaderUtil.CreateCertificateFromPfx(intermediateBytes);
 
         var clientKp = RSA.Create(2048);
 
@@ -246,7 +247,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var clientBytes,
             subjectPrivateKey: clientKp);
-        var client = new X509Certificate2(clientBytes);
+        var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientBytes);
 
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
             commonNameValue: $"{ClientRenewedName}-{suffix}",
@@ -257,7 +258,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var client2Bytes,
             subjectPrivateKey: clientKp);
-        var client2 = new X509Certificate2(client2Bytes);
+        var client2 = CertificateLoaderUtil.CreateCertificateFromPfx(client2Bytes);
 
         return (ca, intermediate, client, client2);
     }
@@ -276,7 +277,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var clientBytes,
             subjectPrivateKey: clientKp);
-        var client = new X509Certificate2(clientBytes);
+        var client = CertificateLoaderUtil.CreateCertificateFromPfx(clientBytes);
 
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
             commonNameValue: $"{ClientRenewedName}-{suffix}",
@@ -287,7 +288,7 @@ public class RavenDB_22210 : RavenTestBase
             notAfter: DateTime.UtcNow.Date.AddYears(1),
             certBytes: out var client2Bytes,
             subjectPrivateKey: clientKp);
-        var client2 = new X509Certificate2(client2Bytes);
+        var client2 = CertificateLoaderUtil.CreateCertificateFromPfx(client2Bytes);
 
         return (client, client2);
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-24495.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24495.cs
@@ -92,8 +92,8 @@ public class RavenDB_24495 : ClusterTestBase
         var bcBytes = BouncyCastleCertificateUtils.CreateSelfSignedTestCertificate(cn, issuerName: null, with2Eku: true);
         var dotnetBytes = CertificateUtils.CreateSelfSignedTestCertificate(cn, issuerName: null, with2Eku: true);
 
-        using var bcCert = new X509Certificate2(bcBytes);
-        using var dnCert = new X509Certificate2(dotnetBytes);
+        using var bcCert = CertificateLoaderUtil.CreateCertificateFromPfx(bcBytes);
+        using var dnCert = CertificateLoaderUtil.CreateCertificateFromPfx(dotnetBytes);
 
         // Assert basic equivalence
         Assert.Equal($"CN={cn}", GetSubjectCN(bcCert));

--- a/test/Tests.Infrastructure/Utils/BouncyCastleCertificateUtil.cs
+++ b/test/Tests.Infrastructure/Utils/BouncyCastleCertificateUtil.cs
@@ -522,7 +522,7 @@ namespace Tests.Infrastructure.Utils
             var stream = new MemoryStream();
             store.Save(stream, Array.Empty<char>(), random);
 
-            return new X509Certificate2(stream.ToArray());
+            return CertificateLoaderUtil.CreateCertificateFromPfx(stream.ToArray());
         }
 
         public static X509Certificate2 CreateClientCertificateFromServerCertificate(X509Certificate2 serverCertificate, out byte[] clientCertBytes)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24495

### Additional description

To avoid `Warning SYSLIB0057: 'X509Certificate2.X509Certificate2(byte[])' is obsolete`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
