### PR TITLE
RavenDB-21861 syscr and syscw represent number of r/w syscalls, not IOPS

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -72,21 +72,21 @@ namespace Raven.Server.Dashboard
     {
         // Per-thread IO metrics (Linux only, populated when available)
         // Last measured I/O operations per second (syscr + syscw delta / interval)
-        public double? IoOpsPerSecLast { get; set; }
+        public double? IoSyscallsPerSecLast { get; set; }
         // Last measured throughput in KB/s based on read_bytes+write_bytes delta
         public double? ThroughputKbPerSecLast { get; set; }
         // Total number of I/O operations since metering started
-        public long? IoOpsTotal { get; set; }
+        public long? IoSyscallsTotal { get; set; }
         // Total data volume in KB since metering started
         public double? ThroughputKbTotal { get; set; }
 
         // Split read/write metrics
-        public double? ReadIoOpsPerSecLast { get; set; }
-        public double? WriteIoOpsPerSecLast { get; set; }
+        public double? ReadIoSyscallsPerSecLast { get; set; }
+        public double? WriteIoSyscallsPerSecLast { get; set; }
         public double? ReadThroughputKbPerSecLast { get; set; }
         public double? WriteThroughputKbPerSecLast { get; set; }
-        public long? ReadIoOpsTotal { get; set; }
-        public long? WriteIoOpsTotal { get; set; }
+        public long? ReadIoSyscallsTotal { get; set; }
+        public long? WriteIoSyscallsTotal { get; set; }
         public double? ReadThroughputKbTotal { get; set; }
         public double? WriteThroughputKbTotal { get; set; }
 
@@ -94,16 +94,16 @@ namespace Raven.Server.Dashboard
         {
             return new DynamicJsonValue
             {
-                [nameof(IoOpsPerSecLast)] = IoOpsPerSecLast,
+                [nameof(IoSyscallsPerSecLast)] = IoSyscallsPerSecLast,
                 [nameof(ThroughputKbPerSecLast)] = ThroughputKbPerSecLast,
-                [nameof(IoOpsTotal)] = IoOpsTotal,
+                [nameof(IoSyscallsTotal)] = IoSyscallsTotal,
                 [nameof(ThroughputKbTotal)] = ThroughputKbTotal,
-                [nameof(ReadIoOpsPerSecLast)] = ReadIoOpsPerSecLast,
-                [nameof(WriteIoOpsPerSecLast)] = WriteIoOpsPerSecLast,
+                [nameof(ReadIoSyscallsPerSecLast)] = ReadIoSyscallsPerSecLast,
+                [nameof(WriteIoSyscallsPerSecLast)] = WriteIoSyscallsPerSecLast,
                 [nameof(ReadThroughputKbPerSecLast)] = ReadThroughputKbPerSecLast,
                 [nameof(WriteThroughputKbPerSecLast)] = WriteThroughputKbPerSecLast,
-                [nameof(ReadIoOpsTotal)] = ReadIoOpsTotal,
-                [nameof(WriteIoOpsTotal)] = WriteIoOpsTotal,
+                [nameof(ReadIoSyscallsTotal)] = ReadIoSyscallsTotal,
+                [nameof(WriteIoSyscallsTotal)] = WriteIoSyscallsTotal,
                 [nameof(ReadThroughputKbTotal)] = ReadThroughputKbTotal,
                 [nameof(WriteThroughputKbTotal)] = WriteThroughputKbTotal
             };

--- a/src/Raven.Server/Utils/ThreadIoStatsReader.cs
+++ b/src/Raven.Server/Utils/ThreadIoStatsReader.cs
@@ -19,18 +19,18 @@ namespace Raven.Server.Utils
 
         public sealed class Stats
         {
-            public double OpsPerSecLast;
+            public double IoSyscallsPerSecLast;
             public double KbPerSecLast;
-            public long OpsTotal;
+            public long IoSyscallsTotal;
             public double KbTotal;
 
             // Split metrics when available
-            public double? ReadOpsPerSecLast;
-            public double? WriteOpsPerSecLast;
+            public double? ReadIoSyscallsPerSecLast;
+            public double? WriteIoSyscallsPerSecLast;
             public double? ReadKbPerSecLast;
             public double? WriteKbPerSecLast;
-            public long? ReadOpsTotal;
-            public long? WriteOpsTotal;
+            public long? ReadSyscallsTotal;
+            public long? WriteSyscallsTotal;
             public double? ReadKbTotal;
             public double? WriteKbTotal;
         }
@@ -220,30 +220,30 @@ namespace Raven.Server.Utils
 
                         _stats.AddOrUpdate(tid, new Stats
                         {
-                            OpsPerSecLast = readOpsPerSec + writeOpsPerSec,
+                            IoSyscallsPerSecLast = readOpsPerSec + writeOpsPerSec,
                             KbPerSecLast = readKbPerSec + writeKbPerSec,
-                            OpsTotal = opsTotal,
+                            IoSyscallsTotal = opsTotal,
                             KbTotal = kbTotal,
-                            ReadOpsPerSecLast = readOpsPerSec,
-                            WriteOpsPerSecLast = writeOpsPerSec,
+                            ReadIoSyscallsPerSecLast = readOpsPerSec,
+                            WriteIoSyscallsPerSecLast = writeOpsPerSec,
                             ReadKbPerSecLast = readKbPerSec,
                             WriteKbPerSecLast = writeKbPerSec,
-                            ReadOpsTotal = syscr,
-                            WriteOpsTotal = syscw,
+                            ReadSyscallsTotal = syscr,
+                            WriteSyscallsTotal = syscw,
                             ReadKbTotal = readBytes / Kb,
                             WriteKbTotal = writeBytes / Kb
                         }, (kk, s) =>
                         {
-                            s.OpsPerSecLast = readOpsPerSec + writeOpsPerSec;
+                            s.IoSyscallsPerSecLast = readOpsPerSec + writeOpsPerSec;
                             s.KbPerSecLast = readKbPerSec + writeKbPerSec;
-                            s.OpsTotal = opsTotal;
+                            s.IoSyscallsTotal = opsTotal;
                             s.KbTotal = kbTotal;
-                            s.ReadOpsPerSecLast = readOpsPerSec;
-                            s.WriteOpsPerSecLast = writeOpsPerSec;
+                            s.ReadIoSyscallsPerSecLast = readOpsPerSec;
+                            s.WriteIoSyscallsPerSecLast = writeOpsPerSec;
                             s.ReadKbPerSecLast = readKbPerSec;
                             s.WriteKbPerSecLast = writeKbPerSec;
-                            s.ReadOpsTotal = syscr;
-                            s.WriteOpsTotal = syscw;
+                            s.ReadSyscallsTotal = syscr;
+                            s.WriteSyscallsTotal = syscw;
                             s.ReadKbTotal = readBytes / Kb;
                             s.WriteKbTotal = writeBytes / Kb;
                             return s;

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -150,17 +150,17 @@ namespace Raven.Server.Utils
                                     {
                                         ti.IoStats = new IoStats
                                         {
-                                            IoOpsPerSecLast = io.OpsPerSecLast,
+                                            IoSyscallsPerSecLast = io.IoSyscallsPerSecLast,
                                             ThroughputKbPerSecLast = io.KbPerSecLast,
-                                            IoOpsTotal = io.OpsTotal,
+                                            IoSyscallsTotal = io.IoSyscallsTotal,
                                             ThroughputKbTotal = io.KbTotal,
 
-                                            ReadIoOpsPerSecLast = io.ReadOpsPerSecLast,
-                                            WriteIoOpsPerSecLast = io.WriteOpsPerSecLast,
+                                            ReadIoSyscallsPerSecLast = io.ReadIoSyscallsPerSecLast,
+                                            WriteIoSyscallsPerSecLast = io.WriteIoSyscallsPerSecLast,
                                             ReadThroughputKbPerSecLast = io.ReadKbPerSecLast,
                                             WriteThroughputKbPerSecLast = io.WriteKbPerSecLast,
-                                            ReadIoOpsTotal = io.ReadOpsTotal,
-                                            WriteIoOpsTotal = io.WriteOpsTotal,
+                                            ReadIoSyscallsTotal = io.ReadSyscallsTotal,
+                                            WriteIoSyscallsTotal = io.WriteSyscallsTotal,
                                             ReadThroughputKbTotal = io.ReadKbTotal,
                                             WriteThroughputKbTotal = io.WriteKbTotal
                                         };

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -41,15 +41,15 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         "Name",
         "CPU%",
         "Unmanaged Alloc.",
-        "IOPS",
-        "IOPS Read",
-        "IOPS Write",
+        "IO SysCalls",
+        "IO SysCalls Read",
+        "IO SysCalls Write",
         "IO Throughput",
         "IO Throughput Read",
         "IO Throughput Write",
-        "Total IOPS",
-        "Total IOPS Read",
-        "Total IOPS Write",
+        "Total IO SysCalls",
+        "Total IO SysCalls Read",
+        "Total IO SysCalls Write",
         "Total IO Throughput",
         "Total IO Throughput Read",
         "Total IO Throughput Write",
@@ -65,9 +65,9 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         "Name",
         "CPU%",
         "Unmanaged Alloc.",
-        "IOPS",
+        "IO SysCalls",
         "IO Throughput",
-        "Total IOPS",
+        "Total IO SysCalls",
         "Total IO Throughput",
         "Total CPU Time",
         "Thread ID",
@@ -193,14 +193,14 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                         sortable: x => this.getSortableValue(x.UnmanagedAllocationsInBytes),
                         headerTitle: "Unmanaged allocations in bytes",
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoOpsPerSecLast, 0), "IOPS", "7%", {
-                        sortable: x => this.getSortableValue(x.IoStats?.IoOpsPerSecLast),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoSyscallsPerSecLast, 0), "IO SysCalls", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.IoSyscallsPerSecLast),
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoOpsPerSecLast, 0), "IOPS Read", "7%", {
-                        sortable: x => this.getSortableValue(x.IoStats?.ReadIoOpsPerSecLast),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoSyscallsPerSecLast, 0), "IO SysCalls Read", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ReadIoSyscallsPerSecLast),
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoOpsPerSecLast, 0), "IOPS Write", "7%", {
-                        sortable: x => this.getSortableValue(x.IoStats?.WriteIoOpsPerSecLast),
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoSyscallsPerSecLast, 0), "IO SysCalls Write", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.WriteIoSyscallsPerSecLast),
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ThroughputKbPerSecLast, 2, "KB/s"), "IO Throughput", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.ThroughputKbPerSecLast),
@@ -211,17 +211,17 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteThroughputKbPerSecLast, 2, "KB/s"), "IO Throughput Write", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.WriteThroughputKbPerSecLast),
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoOpsTotal, 0), "Total IOPS", "7%", {
-                        sortable: x => this.getSortableValue(x.IoStats?.IoOpsTotal),
-                        headerTitle: "Total IOPS aggregated since this view was open",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoSyscallsTotal, 0), "Total IO SysCalls", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.IoSyscallsTotal),
+                        headerTitle: "Total IO SysCalls aggregated since this view was open",
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoOpsTotal, 0), "Total IOPS Read", "7%", {
-                        sortable: x => this.getSortableValue(x.IoStats?.ReadIoOpsTotal),
-                        headerTitle: "Total IOPS Read aggregated since this view was open",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoSyscallsTotal, 0), "Total IO SysCalls Read", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.ReadIoSyscallsTotal),
+                        headerTitle: "Total IO SysCalls Read aggregated since this view was open",
                     }),
-                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoOpsTotal, 0), "Total IOPS Write", "7%", {
-                        sortable: x => this.getSortableValue(x.IoStats?.WriteIoOpsTotal),
-                        headerTitle: "Total IOPS Write aggregated since this view was open",
+                    new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoSyscallsTotal, 0), "Total IO SysCalls Write", "7%", {
+                        sortable: x => this.getSortableValue(x.IoStats?.WriteIoSyscallsTotal),
+                        headerTitle: "Total IO SysCalls aggregated since this view was open",
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ThroughputKbTotal, 2, "KB"), "Total IO Throughput", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.ThroughputKbTotal),


### PR DESCRIPTION
- adjust how we display information

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21861

### Additional description

- fields and column names adjustment in the studio

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
