### PR TITLE
RavenDB-23470 VectorSearch: results must be sorted and deduplicated in `SortingMatch`.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -85,7 +85,7 @@ public static partial class CoraxQueryBuilder
             AllEntries = IndexSearcher.Memoize(IndexSearcher.AllEntries());
             Metadata = query.Metadata;
             HasDynamics = index.Definition.HasDynamicFields;
-            IsVectorSingleClause = Metadata.Query.Where is MethodExpression me && QueryMethod.GetMethodType(me.Name.Value) == MethodType.Vector_Search;
+            IsVectorSingleClause = Metadata.Query.Where is MethodExpression me && QueryMethod.GetMethodType(me.Name.Value) == MethodType.Vector_Search && Metadata.Query.OrderBy is null or {Count: 0};
             DynamicFields = HasDynamics
                 ? new Lazy<List<string>>(() => IndexSearcher.GetFields())
                 : null;

--- a/test/SlowTests/Issues/RavenDB-23470.cs
+++ b/test/SlowTests/Issues/RavenDB-23470.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23470(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    public void AddingOrderByScoreClauseDoesNotChangeNumberOfResults()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var session = store.OpenSession();
+        session.Store(new TestDocument()
+        {
+            Name = "First",
+            Vector = [[0.1f, 0.1f], [0.15f, 0.15f]]
+        });
+
+        session.Store(new TestDocument()
+        {
+            Name = "Second",
+            Vector = [[0.25f, 0.2f], [0.25f, 0.2f]]
+        });
+
+        session.SaveChanges();
+
+
+        var queryWithoutOrderBy = session.Query<TestDocument>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(s => s.Vector),
+                v => v.ByEmbedding([0.1f, 0.1f]), minimumSimilarity: 0.001f)
+            .ToList();
+
+        var queryWithOrderBy = session.Query<TestDocument>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .VectorSearch(f => f.WithEmbedding(s => s.Vector),
+                v => v.ByEmbedding([0.1f, 0.1f]), minimumSimilarity: 0.001f)
+            .OrderByScore()
+            .ToList();
+
+        Assert.Equal(queryWithOrderBy.Count, queryWithoutOrderBy.Count);
+        Assert.Equal(2, queryWithOrderBy.Count);
+        Assert.Equal(queryWithOrderBy.Select(x => x.Name), queryWithoutOrderBy.Select(x => x.Name));
+        Assert.Equal("First", queryWithoutOrderBy[0].Name);
+        Assert.Equal("Second", queryWithoutOrderBy[1].Name);
+    }
+
+    private class TestDocument
+    {
+        public float[][] Vector { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23470
### Additional description

Changing the `SkipSortingResults` flag resulted in duplicates not being removed during sorting. This fix adds a condition to change streaming into normal query when performing a vector search with order by.
This will likely be changed in https://issues.hibernatingrhinos.com/issue/RavenDB-23453 into a streaming optimization.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
