### PR TITLE
RavenDB-25290 Bugfix of vectorized version in DistanceToScore.

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -53,7 +53,7 @@ public partial class Hnsw
         ref float bufferRef = ref MemoryMarshal.GetReference(scores);
         int N = 0;
 
-        if (AdvInstructionSet.IsAcceleratedVector512 && scores.Length <= Vector512<float>.Count)
+        if (AdvInstructionSet.IsAcceleratedVector512 && scores.Length >= Vector512<float>.Count)
         {
             var divisor = Vector512.Create(8f * vectorSizeInBytes);
             N = Vector512<float>.Count;
@@ -63,12 +63,11 @@ public partial class Hnsw
                 var currentScores = Vector512.LoadUnsafe(ref currentPos);
                 var divide = Vector512.Divide(currentScores, divisor);
                 var result = Vector512.Subtract(Vector512.Create(1F), divide);
-                result = Vector512.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector256 && scores.Length - pos <= Vector256<float>.Count)
+        if (AdvInstructionSet.IsAcceleratedVector256 && scores.Length - pos >= Vector256<float>.Count)
         {
             var divisor = Vector256.Create(8f * vectorSizeInBytes);
             N = Vector256<float>.Count;
@@ -78,12 +77,11 @@ public partial class Hnsw
                 var currentScores = Vector256.LoadUnsafe(ref currentPos);
                 var divide = Vector256.Divide(currentScores, divisor);
                 var result = Vector256.Subtract(Vector256.Create(1F), divide);
-                result = Vector256.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector128 && scores.Length - pos <= Vector128<float>.Count)
+        if (AdvInstructionSet.IsAcceleratedVector128 && scores.Length - pos >= Vector128<float>.Count)
         {
             var divisor = Vector128.Create(8f * vectorSizeInBytes);
             N = Vector128<float>.Count;
@@ -93,7 +91,6 @@ public partial class Hnsw
                 var currentScores = Vector128.LoadUnsafe(ref currentPos);
                 var divide = Vector128.Divide(currentScores, divisor);
                 var result = Vector128.Subtract(Vector128.Create(1F), divide);
-                result = Vector128.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
@@ -108,7 +105,7 @@ public partial class Hnsw
         ref float bufferRef = ref MemoryMarshal.GetReference(scores);
         int N = 0;
 
-        if (AdvInstructionSet.IsAcceleratedVector512  && scores.Length <= Vector512<float>.Count)
+        if (AdvInstructionSet.IsAcceleratedVector512  && scores.Length >= Vector512<float>.Count)
         {
             N = Vector512<float>.Count;
             for (; pos + N < scores.Length; pos += N)
@@ -116,12 +113,11 @@ public partial class Hnsw
                 ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
                 var currentScores = Vector512.LoadUnsafe(ref currentPos);
                 var result = Vector512.Subtract(Vector512.Create(1F), currentScores);
-                result = Vector512.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector256 && scores.Length - pos <= Vector256<float>.Count)
+        if (AdvInstructionSet.IsAcceleratedVector256 && scores.Length - pos >= Vector256<float>.Count)
         {
             N = Vector256<float>.Count;
             for (; pos + N < scores.Length; pos += N)
@@ -129,12 +125,11 @@ public partial class Hnsw
                 ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
                 var currentScores = Vector256.LoadUnsafe(ref currentPos);
                 var result = Vector256.Subtract(Vector256.Create(1F), currentScores);
-                result = Vector256.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }
 
-        if (AdvInstructionSet.IsAcceleratedVector128 && scores.Length - pos <= Vector128<float>.Count)
+        if (AdvInstructionSet.IsAcceleratedVector128 && scores.Length - pos >= Vector128<float>.Count)
         {
             N = Vector128<float>.Count;
             for (; pos + Vector128<float>.Count < scores.Length; pos += N)
@@ -142,7 +137,6 @@ public partial class Hnsw
                 ref var currentPos = ref Unsafe.Add(ref bufferRef, pos);
                 var currentScores = Vector128.LoadUnsafe(ref currentPos);
                 var result = Vector128.Subtract(Vector128.Create(1F), currentScores);
-                result = Vector128.Add(result, currentScores);
                 result.StoreUnsafe(ref currentPos);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25290

### Additional description

Fixing wrong vectorized code. This is fixing the scoring values we expose in query.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
