### PR TITLE
RavenDB-25228 : Provide a way to pass agent parameters to GenAi

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -36,7 +36,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
     public bool EnableTracing { get; set; }
 
-    public int? ExpirationInSeconds { get; set; }
+    public int? ExpirationInSec { get; set; }
 
     private List<Transformation> _transforms;
 
@@ -125,7 +125,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(MaxConcurrency)] = MaxConcurrency;
         json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
         json[nameof(EnableTracing)] = EnableTracing;
-        json[nameof(ExpirationInSeconds)] = ExpirationInSeconds;
+        json[nameof(ExpirationInSec)] = ExpirationInSec;
 
         return json;
     }

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ETL;
@@ -31,6 +32,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
     public string UpdateScript { get; set; }
 
     public int MaxConcurrency { get; set; } = DefaultMaxConcurrency;
+
+    public List<AiAgentParameter> Parameters { get; set; } = new();
 
     public List<AiAgentToolQuery> Queries { get; set; } = [];
 
@@ -123,8 +126,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(UpdateScript)] = UpdateScript;
         json[nameof(GenAiTransformation)] = GenAiTransformation.ToJson();
         json[nameof(MaxConcurrency)] = MaxConcurrency;
-        json[nameof(MaxConcurrency)] = MaxConcurrency;
         json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
+        json[nameof(Parameters)] = Parameters != null ? new DynamicJsonArray(Parameters) : null;
         json[nameof(EnableTracing)] = EnableTracing;
         json[nameof(ExpirationInSeconds)] = ExpirationInSeconds;
 
@@ -141,7 +144,9 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             UpdateScript != other.UpdateScript ||
             JsonSchema != other.JsonSchema ||
             SampleObject != other.SampleObject ||
-            MaxConcurrency != other.MaxConcurrency)
+            MaxConcurrency != other.MaxConcurrency ||
+            Queries?.SequenceEqual(other.Queries) == false ||
+            Parameters?.SequenceEqual(other.Parameters) == false)
             differences |= EtlConfigurationCompareDifferences.Other;
 
         return differences;

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ETL;
@@ -32,8 +31,6 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
     public string UpdateScript { get; set; }
 
     public int MaxConcurrency { get; set; } = DefaultMaxConcurrency;
-
-    public List<AiAgentParameter> Parameters { get; set; } = new();
 
     public List<AiAgentToolQuery> Queries { get; set; } = [];
 
@@ -127,7 +124,6 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(GenAiTransformation)] = GenAiTransformation.ToJson();
         json[nameof(MaxConcurrency)] = MaxConcurrency;
         json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
-        json[nameof(Parameters)] = Parameters != null ? new DynamicJsonArray(Parameters) : null;
         json[nameof(EnableTracing)] = EnableTracing;
         json[nameof(ExpirationInSeconds)] = ExpirationInSeconds;
 
@@ -144,9 +140,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             UpdateScript != other.UpdateScript ||
             JsonSchema != other.JsonSchema ||
             SampleObject != other.SampleObject ||
-            MaxConcurrency != other.MaxConcurrency ||
-            Queries?.SequenceEqual(other.Queries) == false ||
-            Parameters?.SequenceEqual(other.Parameters) == false)
+            MaxConcurrency != other.MaxConcurrency)
             differences |= EtlConfigurationCompareDifferences.Other;
 
         return differences;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -23,6 +23,7 @@ using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Commands.AI;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
@@ -196,28 +197,14 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 string json = item.ContextOutput.Context.ToString();
                 Task<GenAiHandlerResult> task;
 
+                var agentConfiguration = CreateAgentConfiguration(context, item);
                 var handler = new GenAiConversationHandler(Database.ServerStore, Database, Configuration)
                 {
                     // GenAI task uses full access
                     Authentication = Database.ServerStore.Server.AuthenticateConnectionCertificate(Database.ServerStore.Server.Certificate.ClientCertificate, $"GenAI access for '{Name}'")
                 };
 
-                var agentParameters = new List<AiAgentParameter>();
-                var contextObjPropNames = item.ContextOutput.Context.GetPropertyNames();
-                foreach (var name in contextObjPropNames)
-                {
-                    agentParameters.Add(new AiAgentParameter(name));
-                }
-
-                var agent = new AiAgentConfiguration("GenAiAgent", Configuration.ConnectionStringName, Configuration.Prompt)
-                {
-                    OutputSchema = Configuration.JsonSchema,
-                    SampleObject = Configuration.SampleObject,
-                    Queries = Configuration.Queries,
-                    Parameters = agentParameters
-                };
-
-                handler.Initialize(Agent, $"{Configuration.Identifier}/{item.DocumentId}/", new RequestBody
+                handler.Initialize(agentConfiguration, $"GenAI/{item.DocumentId}", new RequestBody
                 {
                     Parameters = item.ContextOutput.Context,
                     CreationOptions = new AiConversationCreationOptions
@@ -259,7 +246,29 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         }
     }
 
-    private List<Exception> ProcessModelResults(List<GenAiResultItem> items, DocumentsOperationContext context, List<Task<GenAiHandlerResult>> tasks, GenAiStatsScope statsScope)
+    private AiAgentConfiguration CreateAgentConfiguration(DocumentsOperationContext context, GenAiResultItem item)
+    {
+        var agentParameters = new List<AiAgentParameter>();
+        var contextObjPropNames = item.ContextOutput.Context.GetPropertyNames();
+        foreach (var name in contextObjPropNames)
+        {
+            agentParameters.Add(new AiAgentParameter(name));
+        }
+
+        var agentConfiguration = new AiAgentConfiguration("GenAiAgent", Configuration.ConnectionStringName, Configuration.Prompt)
+        {
+            OutputSchema = Configuration.JsonSchema,
+            SampleObject = Configuration.SampleObject,
+            Queries = Configuration.Queries,
+            Parameters = agentParameters,
+            ChatTrimming = null
+        };
+
+        AddOrUpdateAiAgentCommand.ValidateConfiguration(context, agentConfiguration);
+        return agentConfiguration;
+    }
+
+    private List<Exception> ProcessModelResults(List<GenAiResultItem> items, DocumentsOperationContext context, List<Task<(string Result, AiUsage Usage)>> tasks, GenAiStatsScope statsScope)
     {
         List<Exception> exceptions = null;
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -168,16 +168,6 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         return results.Count;
     }
 
-    private AiAgentConfiguration _agent;
-
-    private AiAgentConfiguration Agent => _agent ??= new AiAgentConfiguration("GenAiAgent", Configuration.ConnectionStringName, Configuration.Prompt)
-    {
-        OutputSchema = Configuration.JsonSchema,
-        SampleObject = Configuration.SampleObject,
-        Queries = Configuration.Queries,
-        Parameters = Configuration.Parameters
-    };
-
     private List<Exception> SendToModel(List<GenAiResultItem> items, DocumentsOperationContext context, GenAiStatsScope scope)
     {
         using (var statsScope = scope.For(GenAiOperations.LoadToModel))
@@ -211,6 +201,22 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     // GenAI task uses full access
                     Authentication = Database.ServerStore.Server.AuthenticateConnectionCertificate(Database.ServerStore.Server.Certificate.ClientCertificate, $"GenAI access for '{Name}'")
                 };
+
+                var agentParameters = new List<AiAgentParameter>();
+                var contextObjPropNames = item.ContextOutput.Context.GetPropertyNames();
+                foreach (var name in contextObjPropNames)
+                {
+                    agentParameters.Add(new AiAgentParameter(name));
+                }
+
+                var agent = new AiAgentConfiguration("GenAiAgent", Configuration.ConnectionStringName, Configuration.Prompt)
+                {
+                    OutputSchema = Configuration.JsonSchema,
+                    SampleObject = Configuration.SampleObject,
+                    Queries = Configuration.Queries,
+                    Parameters = agentParameters
+                };
+
                 handler.Initialize(Agent, $"{Configuration.Identifier}/{item.DocumentId}/", new RequestBody
                 {
                     Parameters = item.ContextOutput.Context,

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -174,7 +174,8 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
     {
         OutputSchema = Configuration.JsonSchema,
         SampleObject = Configuration.SampleObject,
-        Queries = Configuration.Queries
+        Queries = Configuration.Queries,
+        Parameters = Configuration.Parameters
     };
 
     private List<Exception> SendToModel(List<GenAiResultItem> items, DocumentsOperationContext context, GenAiStatsScope scope)
@@ -212,6 +213,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 };
                 handler.Initialize(Agent, $"{Configuration.Identifier}/{item.DocumentId}/", new RequestBody
                 {
+                    Parameters = item.ContextOutput.Context,
                     CreationOptions = new AiConversationCreationOptions
                     {
                         ExpirationInSec = Configuration.ExpirationInSeconds

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -209,7 +209,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     Parameters = item.ContextOutput.Context,
                     CreationOptions = new AiConversationCreationOptions
                     {
-                        ExpirationInSec = Configuration.ExpirationInSeconds
+                        ExpirationInSec = Configuration.ExpirationInSec
                     },
                     UserPrompt = json,
                     Attachments = item.ContextOutput.Attachments

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -204,7 +204,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     Authentication = Database.ServerStore.Server.AuthenticateConnectionCertificate(Database.ServerStore.Server.Certificate.ClientCertificate, $"GenAI access for '{Name}'")
                 };
 
-                handler.Initialize(agentConfiguration, $"GenAI/{item.DocumentId}", new RequestBody
+                handler.Initialize(agentConfiguration, $"{Configuration.Identifier}/{item.DocumentId}/", new RequestBody
                 {
                     Parameters = item.ContextOutput.Context,
                     CreationOptions = new AiConversationCreationOptions
@@ -268,7 +268,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         return agentConfiguration;
     }
 
-    private List<Exception> ProcessModelResults(List<GenAiResultItem> items, DocumentsOperationContext context, List<Task<(string Result, AiUsage Usage)>> tasks, GenAiStatsScope statsScope)
+    private List<Exception> ProcessModelResults(List<GenAiResultItem> items, DocumentsOperationContext context, List<Task<GenAiHandlerResult>> tasks, GenAiStatsScope statsScope)
     {
         List<Exception> exceptions = null;
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/utils/editGenAiTaskUtils.ts
@@ -89,7 +89,7 @@ const mapToDto = (
         //temporary until UI supports queries
         Queries: null,
         EnableTracing: false,
-        ExpirationInSeconds: null,
+        ExpirationInSec: null,
     };
 };
 

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -353,7 +353,7 @@ export class TasksStubs {
                 // temporary until UI supports queries
                 Queries: null,
                 EnableTracing: false,
-                ExpirationInSeconds: null,
+                ExpirationInSec: null,
             },
             ChangeVector: null,
         };

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
@@ -324,7 +324,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;";
         var chatCompletionClient = etlProcess.GetChatCompletionClient();
         chatCompletionClient.ForTestingPurposesOnly().SimulateFailureAsync = (ctx) =>
         {
-            if (ctx.Contains(config.Prompt))
+            if (ctx.Contains(config.Prompt) || ctx.Contains("AI Agent Parameters:"))
                 return Task.CompletedTask;
 
             if (Interlocked.Decrement(ref triggerOn) <= 0)

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24973.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24973.cs
@@ -81,19 +81,23 @@ for(const comment of this.Comments)
 
             foreach (var doc in docs)
             {
-                Assert.Equal(3, doc.Messages.Count); // prompt, context, model response
+                Assert.Equal(4, doc.Messages.Count); // prompt, agent parameters, context, model response
 
                 Assert.Equal(config.Prompt, doc.Messages[0].Content.ToString());
                 Assert.Equal("system", doc.Messages[0].Role);
 
-                var ctx = doc.Messages[1].Content.ToString();
+                var paramsMsg = doc.Messages[1].Content.ToString();
+                Assert.Contains("AI Agent Parameters", paramsMsg);
+                Assert.Equal("user", doc.Messages[1].Role);
+
+                var ctx = doc.Messages[2].Content.ToString();
                 Assert.True(comments.Any(c => ctx.Contains($"\"Text\":\"{c.Text}\",\"Author\":\"{c.Author}\",\"Id\":\"{c.Id}\"")));
                 Assert.Equal("user", doc.Messages[1].Role);
 
-                var response = doc.Messages[2].Content.ToString();
+                var response = doc.Messages[3].Content.ToString();
                 Assert.True(response.Contains("\"Blocked\":"));
                 Assert.True(response.Contains("\"Reason\":"));
-                Assert.Equal("assistant", doc.Messages[2].Role);
+                Assert.Equal("assistant", doc.Messages[3].Role);
 
                 // verify document has expiration set up 
                 var metadata = session.Advanced.GetMetadataFor(doc);
@@ -193,7 +197,7 @@ if($output.Blocked)
                     Assert.NotNull(doc);
 
                     Assert.True(doc.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages));
-                    Assert.Equal(3, messages.Length);
+                    Assert.Equal(4, messages.Length);
 
                     // prompt message
                     var msgAsObj = messages[0] as BlittableJsonReaderObject;
@@ -204,8 +208,17 @@ if($output.Blocked)
                     Assert.True(msgAsObj.TryGet("role", out string role));
                     Assert.Equal("system", role);
 
-                    // context object message
+                    // agent parameters message
                     msgAsObj = messages[1] as BlittableJsonReaderObject;
+                    Assert.NotNull(msgAsObj);
+                    Assert.True(msgAsObj.TryGet("content", out content));
+                    Assert.Contains("AI Agent Parameters", content);
+
+                    Assert.True(msgAsObj.TryGet("role", out role));
+                    Assert.Equal("user", role);
+
+                    // context object message
+                    msgAsObj = messages[2] as BlittableJsonReaderObject;
                     Assert.NotNull(msgAsObj);
                     Assert.True(msgAsObj.TryGet("content", out content));
                     Assert.True(comments.Any(c => content.Contains($"\"Text\":\"{c.Text}\",\"Author\":\"{c.Author}\",\"Id\":\"{c.Id}\"")));
@@ -214,7 +227,7 @@ if($output.Blocked)
                     Assert.Equal("user", role);
 
                     // model response message
-                    msgAsObj = messages[2] as BlittableJsonReaderObject;
+                    msgAsObj = messages[3] as BlittableJsonReaderObject;
                     Assert.NotNull(msgAsObj);
                     Assert.True(msgAsObj.TryGet("content", out content));
                    

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24973.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24973.cs
@@ -52,7 +52,7 @@ for(const comment of this.Comments)
 
         // set up conversation tracing and expiration
         config.EnableTracing = true;
-        config.ExpirationInSeconds = 60 * 60 * 24;
+        config.ExpirationInSec = 60 * 60 * 24;
 
         store.Maintenance.Send(new AddGenAiOperation(config));
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
@@ -217,7 +217,83 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
 
             Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
             Assert.NotNull(error);
-            Assert.True(error.Error.Contains("Value of parameter 'customerId' was not provided"));
+            Assert.True(error.Error.Contains("Tool query 'recent-orders-for-customer' contains parameters that are not defined in the agent configuration: 'customerId'"));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldThrowWhenParameterIsDefinedInQueryToolSchemaAndPassedInContext(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore();
+
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Name = "GenAi-ShoppingCart-Suggestions";
+            config.Identifier = "shopping-cart-suggestions";
+            config.Collection = "ShoppingCarts";
+
+            config.Prompt =
+                "Use the tool 'recent-orders-for-customer' to fetch items from the customer's recent orders. " +
+                "From that list, suggest items to add to the shopping cart. " +
+                "Make sure that the items you suggest are NOT already in 'cartItems'. ";
+
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
+
+            // customerId is part of the context object that we send to the model 
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script =
+                    "ai.genContext({ " +
+                    "  customerId: this.CustomerId, " +
+                    "  cartItems: this.Items " +
+                    "});"
+            };
+
+            // but customerId also appears as a parameter in ParametersSampleObject
+            config.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "recent-orders-for-customer",
+                    Description = "Return item names from recent orders",
+                    Query =
+                        "from Orders " +
+                        "where CustomerId = $customerId " +
+                        "select Items",
+                    ParametersSampleObject = "{\"customerId\":\"customers/1-A\"}",
+                }
+            ];
+
+            config.UpdateScript = "this.SuggestedItems = $output.Suggestions;";
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Order
+                {
+                    Id = "orders/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = new[] { "milk", "bread" }
+                });
+                session.Store(new ShoppingCart
+                {
+                    Id = "carts/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = new[] { "bread", "apples" }
+                });
+                session.SaveChanges();
+            }
+
+            EtlErrorInfo error = null;
+            var value = await WaitForValueAsync(async () =>
+            {
+                error = await Etl.TryGetLoadErrorAsync(store.Database, config);
+                return error != null;
+            }, true, timeout: 60_000);
+
+            Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+            Assert.NotNull(error);
+            Assert.True(error.Error.Contains("Parameter customerId is defined on both the agent level and the query level for recent-orders-for-customer"));
         }
 
         private class Order

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDB_25228(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanPassAgentParametersIntoGenAiTools(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore();
+
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            // --- GenAI task config ---
+            config.Name = "GenAi-ShoppingCart-Suggestions";
+            config.Identifier = "shopping-cart-suggestions";
+            config.Collection = "ShoppingCarts";
+
+            config.Prompt =
+                "Use the tool 'recent-orders-for-customer' to fetch items from the customer's recent orders. " +
+                "From that list, suggest items to add to the shopping cart. " +
+                "Make sure that the items you suggest are NOT already in 'cartItems'. ";
+
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
+
+            // Set agent parameters 
+            config.Parameters = [new AiAgentParameter("customerId")];
+
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script =
+                    "ai.genContext({ " +
+                    "  customerId: this.CustomerId, " +
+                    "  cartItems: this.Items " +
+                    "});"
+            };
+
+            config.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "recent-orders-for-customer",
+                    Description = "Return item names from recent orders",
+                    Query =
+                        "from Orders " +
+                        "where CustomerId = $customerId " +
+                        "select Items",
+                    ParametersSampleObject = "{}",
+                }
+            ];
+
+            // Update the ShoppingCart with the model's Suggestions
+            config.UpdateScript = "this.SuggestedItems = $output.Suggestions;";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            var etlDone = Etl.WaitForEtlToComplete(store);
+
+            // --- Seed data ---
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Order
+                {
+                    Id = "orders/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = ["milk", "bread"]
+                });
+                session.Store(new Order
+                {
+                    Id = "orders/2-A",
+                    CustomerId = "customers/1-A",
+                    Items = ["eggs"]
+                });
+                session.Store(new Order
+                {
+                    Id = "orders/3-A",
+                    CustomerId = "customers/1-A",
+                    Items = ["wine"]
+                });
+
+                session.Store(new Order
+                {
+                    Id = "orders/4-A",
+                    CustomerId = "customers/2-A",
+                    Items = ["apples"]
+                });
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new ShoppingCart
+                {
+                    Id = "carts/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = ["bread", "apples"]
+                });
+
+                session.Store(new ShoppingCart
+                {
+                    Id = "carts/2-A",
+                    CustomerId = "customers/2-A",
+                    Items = []
+                });
+
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+            using (var session = store.OpenSession())
+            {
+                var cart1 = session.Load<ShoppingCart>("carts/1-A");
+                var cart2 = session.Load<ShoppingCart>("carts/2-A");
+
+                Assert.NotNull(cart1);
+                Assert.NotNull(cart2);
+
+                // For customers/1-A:
+                // recent items: milk, bread, eggs, wine
+                // cart already has bread, apples → suggestions should be [milk, eggs, wine]
+                Assert.NotNull(cart1.SuggestedItems);
+                Assert.Equal(3, cart1.SuggestedItems.Length);
+                Assert.DoesNotContain("bread", cart1.SuggestedItems);
+                Assert.Contains("milk", cart1.SuggestedItems);
+                Assert.Contains("eggs", cart1.SuggestedItems);
+                Assert.Contains("wine", cart1.SuggestedItems);
+
+                // For customers/2-A:
+                // recent items: apples; empty cart → suggestions should be [apples]
+                Assert.NotNull(cart2.SuggestedItems);
+                Assert.Single(cart2.SuggestedItems);
+                Assert.Equal("apples", cart2.SuggestedItems[0]);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldThrowWhenRequiredParametersAreNotPassedInContext(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore();
+
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Name = "GenAi-ShoppingCart-Suggestions";
+            config.Identifier = "shopping-cart-suggestions";
+            config.Collection = "ShoppingCarts";
+
+            config.Prompt =
+                "Use the tool 'recent-orders-for-customer' to fetch items from the customer's recent orders. " +
+                "From that list, suggest items to add to the shopping cart. " +
+                "Make sure that the items you suggest are NOT already in 'cartItems'. ";
+
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
+
+            // Set agent parameters 
+            config.Parameters = [new AiAgentParameter("customerId")];
+
+            // customerId is not part of the context object that we send to the model 
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script =
+                    "ai.genContext({ " +
+                    "  cartItems: this.Items " +
+                    "});"
+            };
+
+            config.Queries =
+            [
+                new AiAgentToolQuery
+                {
+                    Name = "recent-orders-for-customer",
+                    Description = "Return item names from recent orders",
+                    Query =
+                        "from Orders " +
+                        "where CustomerId = $customerId " +
+                        "select Items",
+                    ParametersSampleObject = "{}",
+                }
+            ];
+
+            // Update the ShoppingCart with the model's deterministic Suggestions
+            config.UpdateScript = "this.SuggestedItems = $output.Suggestions;";
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            const string docId = "carts/1";
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Order
+                {
+                    Id = "orders/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = new[] { "milk", "bread" }
+                });
+                session.Store(new ShoppingCart
+                {
+                    Id = "carts/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = new[] { "bread", "apples" }
+                }, docId);
+                session.SaveChanges();
+            }
+
+            EtlErrorInfo error = null;
+            var value = await WaitForValueAsync(async () =>
+            {
+                error = await Etl.TryGetLoadErrorAsync(store.Database, config);
+                return error != null;
+            }, true, timeout: 60_000);
+
+            Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+            Assert.NotNull(error);
+            Assert.True(error.Error.Contains("Parameter 'customerId' is missing"));
+        }
+
+        private class Order
+        {
+            public string Id { get; set; }
+            public string CustomerId { get; set; }
+            public string[] Items { get; set; }
+        }
+
+        private class ShoppingCart
+        {
+            public string Id { get; set; }
+            public string CustomerId { get; set; }
+            public string[] Items { get; set; }
+            public string[] SuggestedItems { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
@@ -35,9 +35,6 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
 
             config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
 
-            // Set agent parameters 
-            config.Parameters = [new AiAgentParameter("customerId")];
-
             config.GenAiTransformation = new GenAiTransformation
             {
                 Script =
@@ -149,7 +146,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
 
         [RavenTheory(RavenTestCategory.Ai)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task ShouldThrowWhenRequiredParametersAreNotPassedInContext(Options options, GenAiConfiguration config)
+        public async Task ShouldThrowWhenParametersInQueryToolAreNotPassedInContext(Options options, GenAiConfiguration config)
         {
             using var store = GetDocumentStore();
 
@@ -165,9 +162,6 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
                 "Make sure that the items you suggest are NOT already in 'cartItems'. ";
 
             config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
-
-            // Set agent parameters 
-            config.Parameters = [new AiAgentParameter("customerId")];
 
             // customerId is not part of the context object that we send to the model 
             config.GenAiTransformation = new GenAiTransformation
@@ -197,7 +191,6 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
 
             store.Maintenance.Send(new AddGenAiOperation(config));
 
-            const string docId = "carts/1";
             using (var session = store.OpenSession())
             {
                 session.Store(new Order
@@ -211,7 +204,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
                     Id = "carts/1-A",
                     CustomerId = "customers/1-A",
                     Items = new[] { "bread", "apples" }
-                }, docId);
+                });
                 session.SaveChanges();
             }
 
@@ -224,7 +217,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
 
             Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
             Assert.NotNull(error);
-            Assert.True(error.Error.Contains("Parameter 'customerId' is missing"));
+            Assert.True(error.Error.Contains("Value of parameter 'customerId' was not provided"));
         }
 
         private class Order


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25228/Provide-a-way-to-pass-agent-parameters-to-GenAi

### Additional description

Add support for passing agent parameters to GenAI configurations.
Agent parameters can now be defined per GenAI task and accessed from query tools.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
