### PR TITLE
RavenDB-24955 - String escaping issues with property names

### DIFF
--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -170,7 +170,7 @@ namespace Sparrow.Json
 
         private readonly FastList<PropertyName> _docPropNames = new FastList<PropertyName>();
         private readonly SortedDictionary<PropertyName, object> _propertiesSortOrder = new SortedDictionary<PropertyName, object>();
-        private readonly Dictionary<LazyStringValue, PropertyName> _propertyNameToId = new Dictionary<LazyStringValue, PropertyName>(default(LazyStringValueStructComparer));
+        private readonly Dictionary<LazyStringValue, PropertyName> _propertyNameToId = new Dictionary<LazyStringValue, PropertyName>(LazyStringValueComparer.Instance);
         private bool _propertiesNeedSorting;
 
         public int PropertiesDiscovered;

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -492,8 +492,12 @@ namespace Sparrow.Json
             {
 #endif
                 EnsureNotDisposed();
-                var memory = GetLongLivedMemory(key.Size);
+                var memory = GetLongLivedMemory(key.Size + 1);
                 Memory.Copy(memory.Address, key.Buffer, key.Size);
+                // This is a marker for the numberOfEscapeSequences that follows _after_ the lazy string
+                // The GetLazyStringForFieldWithCachingUnlikely(LazyStringValue) overload is used to process values read directly 
+				// from the parser, without the escapes, and we aren't writing directly from it anyway
+                memory.Address[key.Size] = 0;
                 string keyStr = key;
                 var str = new LazyStringValue(keyStr, memory.Address, key.Size, this)
                 {

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -448,6 +448,7 @@ namespace Sparrow.Json
                 Debug.Assert(value.IsDisposed == false);
                 return value;
             }
+
             return GetLazyStringForFieldWithCachingUnlikely(field);
         }
 
@@ -471,20 +472,20 @@ namespace Sparrow.Json
             using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
             {
 #endif
-            EnsureNotDisposed();
-            LazyStringValue value = GetLazyString(key, longLived: true);
-            _fieldNames[key.Value] = value;
-            _fieldNamesLazyStrings[value] = value;
+                EnsureNotDisposed();
+                LazyStringValue value = GetLazyString(key, longLived: true);
+                _fieldNames[key.Value] = value;
+                _fieldNamesLazyStrings[value] = value;
 
-            //sanity check, in case the 'value' is manually disposed outside of this function
-            Debug.Assert(value.IsDisposed == false);
-            return value;
+                //sanity check, in case the 'value' is manually disposed outside of this function
+                Debug.Assert(value.IsDisposed == false);
+                return value;
 #if DEBUG || VALIDATE
             }
 #endif
         }
-        
-        
+
+
         private unsafe LazyStringValue GetLazyStringForFieldWithCachingUnlikely(LazyStringValue key)
         {
 #if DEBUG || VALIDATE
@@ -496,7 +497,7 @@ namespace Sparrow.Json
                 Memory.Copy(memory.Address, key.Buffer, key.Size);
                 // This is a marker for the numberOfEscapeSequences that follows _after_ the lazy string
                 // The GetLazyStringForFieldWithCachingUnlikely(LazyStringValue) overload is used to process values read directly 
-				// from the parser, without the escapes, and we aren't writing directly from it anyway
+                // from the parser, without the escapes, and we aren't writing directly from it anyway
                 memory.Address[key.Size] = 0;
                 string keyStr = key;
                 var str = new LazyStringValue(keyStr, memory.Address, key.Size, this)
@@ -548,6 +549,7 @@ namespace Sparrow.Json
                 {
                     result.EscapePositions = state.EscapePositions.ToArray();
                 }
+
                 return result;
             }
         }
@@ -576,6 +578,7 @@ namespace Sparrow.Json
             {
                 result.EscapePositions = state.EscapePositions.ToArray();
             }
+
             return result;
         }
 
@@ -681,6 +684,7 @@ namespace Sparrow.Json
                         bytes.Used = 0;
                         parser.SetBuffer(bytes);
                     }
+
                     builder.FinalizeDocument();
                     return builder.CreateReader();
                 }
@@ -746,6 +750,7 @@ namespace Sparrow.Json
                     parser.SetBuffer(buffer, 0, length);
                     lastReadResult = builder.Read();
                 }
+
                 if (lastReadResult == false)
                     throw new EndOfStreamException("Buffer ended without reaching end of json content");
 
@@ -788,12 +793,14 @@ namespace Sparrow.Json
                         bytes.Valid = read.Count;
                         bytes.Used = 0;
                     }
+
                     parser.SetBuffer(bytes);
                     var result = builder.Read();
                     bytes.Used += parser.BufferOffset;
                     if (result)
                         break;
                 }
+
                 builder.FinalizeDocument();
 
                 var reader = builder.CreateReader();
@@ -860,6 +867,7 @@ namespace Sparrow.Json
                     if (result)
                         break;
                 }
+
                 builder.FinalizeDocument();
 
                 var reader = builder.CreateReader();
@@ -1019,7 +1027,7 @@ namespace Sparrow.Json
             await using (var writer = new AsyncBlittableJsonTextWriter(this, stream))
             {
                 writer.WriteObject(json);
-                
+
                 // PERF: Check if flush completed synchronously to avoid async state machine
                 var flushTask = writer.FlushAsync(token);
                 if (flushTask.IsCompletedSuccessfully == false)
@@ -1104,12 +1112,13 @@ namespace Sparrow.Json
 
                 WriteValue(writer, state, parser);
             }
+
             writer.WriteEndObject();
         }
 
 
         private void WriteValue<TWriter>(TWriter writer, JsonParserState state, ObjectJsonParser parser)
-            where TWriter: IBlittableJsonTextWriter
+            where TWriter : IBlittableJsonTextWriter
         {
             switch (state.CurrentTokenType)
             {
@@ -1146,6 +1155,7 @@ namespace Sparrow.Json
 
                         writer.WriteString(lazyStringValue);
                     }
+
                     break;
 
                 case JsonParserToken.Float:
@@ -1175,7 +1185,7 @@ namespace Sparrow.Json
             }
         }
 
-        public void WriteArray<TWriter>( TWriter writer, JsonParserState state, ObjectJsonParser parser)
+        public void WriteArray<TWriter>(TWriter writer, JsonParserState state, ObjectJsonParser parser)
             where TWriter : IBlittableJsonTextWriter
         {
             EnsureNotDisposed();
@@ -1198,6 +1208,7 @@ namespace Sparrow.Json
 
                 WriteValue(writer, state, parser);
             }
+
             writer.WriteEndArray();
         }
 

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -38,6 +38,7 @@ namespace Sparrow.Json
         private AllocatedMemoryData _tempBuffer;
 
         private readonly Dictionary<StringSegment, LazyStringValue> _fieldNames = new Dictionary<StringSegment, LazyStringValue>(StringSegmentEqualityStructComparer.BoxedInstance);
+        private readonly Dictionary<LazyStringValue, LazyStringValue> _fieldNamesLazyStrings = new Dictionary<LazyStringValue, LazyStringValue>(LazyStringValueComparer.Instance);
 
         private static readonly PerCoreContainer<PathCache> _perCorePathCache = new PerCoreContainer<PathCache>();
         private PathCache _activeAllocatePathCaches;
@@ -438,6 +439,19 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LazyStringValue GetLazyStringForFieldWithCaching(LazyStringValue field)
+        {
+            EnsureNotDisposed();
+            if (_fieldNamesLazyStrings.TryGetValue(field, out LazyStringValue value))
+            {
+                // PERF: This is usually the most common scenario, so actually being contiguous improves the behavior.
+                Debug.Assert(value.IsDisposed == false);
+                return value;
+            }
+            return GetLazyStringForFieldWithCachingUnlikely(field);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue GetLazyStringForFieldWithCaching(string field)
         {
             EnsureNotDisposed();
@@ -460,10 +474,36 @@ namespace Sparrow.Json
             EnsureNotDisposed();
             LazyStringValue value = GetLazyString(key, longLived: true);
             _fieldNames[key.Value] = value;
+            _fieldNamesLazyStrings[value] = value;
 
             //sanity check, in case the 'value' is manually disposed outside of this function
             Debug.Assert(value.IsDisposed == false);
             return value;
+#if DEBUG || VALIDATE
+            }
+#endif
+        }
+        
+        
+        private unsafe LazyStringValue GetLazyStringForFieldWithCachingUnlikely(LazyStringValue key)
+        {
+#if DEBUG || VALIDATE
+            using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
+            {
+#endif
+                EnsureNotDisposed();
+                var memory = GetLongLivedMemory(key.Size);
+                Memory.Copy(memory.Address, key.Buffer, key.Size);
+                string keyStr = key;
+                var str = new LazyStringValue(keyStr, memory.Address, key.Size, this)
+                {
+                    EscapePositions = key.EscapePositions,
+                    AllocatedMemoryData = memory,
+                };
+                _fieldNames[keyStr] = str;
+                _fieldNamesLazyStrings[str] = str;
+
+                return str;
 #if DEBUG || VALIDATE
             }
 #endif
@@ -913,6 +953,7 @@ namespace Sparrow.Json
                 allocatorForLongLivedValues.Dispose();
 
                 _fieldNames.Clear();
+                _fieldNamesLazyStrings.Clear(); // no need to dispose the data here, same instances as in _fieldNames 
             }
 
             if (_allocateStringValues != null)

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -18,7 +18,7 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(LazyStringValue x, LazyStringValue y)
         {
-            if (x == y)
+            if (ReferenceEquals(x,y))
                 return true;
             if (x == null || y == null)
                 return false;
@@ -29,31 +29,6 @@ namespace Sparrow.Json
         public int GetHashCode(LazyStringValue obj)
         {
             return obj.GetHashCode();
-        }
-    }
-
-    internal struct LazyStringValueStructComparer : IEqualityComparer<LazyStringValue>
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Equals(LazyStringValue x, LazyStringValue y)
-        {
-            if (x == y)
-                return true;
-            if (x == null || y == null)
-                return false;
-            return x.CompareTo(y) == 0;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetHashCode(LazyStringValue obj)
-        {
-            unsafe
-            {
-                //PERF: JIT will remove the corresponding line based on the target architecture using dead code removal.
-                if (IntPtr.Size == 4)
-                    return (int)Hashing.XXHash32.CalculateInline(obj.Buffer, obj.Size);
-                return (int)Hashing.XXHash64.CalculateInline(obj.Buffer, (ulong)obj.Size);
-            }
         }
     }
 
@@ -166,8 +141,6 @@ namespace Sparrow.Json
 
             return _context.GetLazyString(_buffer, _size, longLived: false);
         }
-
-        public bool HasStringValue => _string != null;
 
         [ThreadStatic]
         private static char[] _lazyStringTempBuffer;

--- a/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
+++ b/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
@@ -18,7 +18,7 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
     public async Task PropertyNameWithControlCharacter_WhenTryToAddUserLevelEscapedVersion_ShouldTreatThemAsDifferentValues()
     {
         using var context = JsonOperationContext.ShortTermSingleUse();
-        
+
         using var memoryStream = new MemoryStream();
 
         using (var withControlCharacter = context.GetLazyString("a\0a"))
@@ -31,13 +31,13 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
             {
                 writer.WritePropertyName(withControlCharacter);
                 writer.WriteString("someValue1");
-                
+
                 writer.WritePropertyName(withControlCharacterButEscapedInUserLevel);
                 writer.WriteString("someValue2");
-                
+
                 writer.WritePropertyName(withNewLineAndBack);
                 writer.WriteString("someValue3");
-                
+
                 writer.WritePropertyName(withNewLineAndBackEscaped);
                 writer.WriteString("someValue4");
             }
@@ -56,7 +56,7 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
     public async Task PropertyNameWithControlCharacter_WhenCache_ShouldNotCacheTwice()
     {
         using var context = JsonOperationContext.ShortTermSingleUse();
-        
+
         using var memoryStream = new MemoryStream();
 
         using (var propNameWithNull = context.GetLazyString("\na\0"))
@@ -74,14 +74,14 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
         using (var _ = await context.ReadForMemoryAsync(memoryStream, "result"))
         {
         }
-    
+
         memoryStream.Seek(0, SeekOrigin.Begin);
         //Fails here while reading.
         using (var _ = await context.ReadForMemoryAsync(memoryStream, "result"))
         {
         }
     }
-    
+
     [RavenFact(RavenTestCategory.Core)]
     public void PropertyNameWithControlCharacter_LoadingDictionaryKeyWithNullChar_ShouldNotThrowException()
     {
@@ -92,6 +92,7 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
                 session.Store(new Doc { Id = "doc-1", StrDict = new Dictionary<string, string> { { "nullChar\0", "value" } } });
                 session.SaveChanges();
             }
+
             using (var session = store.OpenSession())
             {
                 var doc = session.Load<Doc>("doc-1");

--- a/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
+++ b/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Blittable;
+
+public class PropertyNamesWithEscapedCharsTests : RavenTestBase
+{
+    public PropertyNamesWithEscapedCharsTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public async Task PropertyNameWithControlCharacter_WhenTryToAddUserLevelEscapedVersion_ShouldTreatThemAsDifferentValues()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        
+        using var memoryStream = new MemoryStream();
+
+        using (var withControlCharacter = context.GetLazyString("a\0a"))
+        using (var withControlCharacterButEscapedInUserLevel = context.GetLazyString("a\\u0000a"))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+        {
+            writer.WriteStartObject();
+            {
+                writer.WritePropertyName(withControlCharacter);
+                writer.WriteString("someValue1");
+                
+                writer.WritePropertyName(withControlCharacterButEscapedInUserLevel);
+                writer.WriteString("someValue2");
+            }
+            writer.WriteEndObject();
+        }
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using (var json = await context.ReadForMemoryAsync(memoryStream, "result"))
+        {
+            Assert.Equal(2, json.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public async Task PropertyNameWithControlCharacter_WhenCache_ShouldNotCacheTwice()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        
+        using var memoryStream = new MemoryStream();
+
+        using (var propNameWithNull = context.GetLazyString("\na\0"))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
+        {
+            writer.WriteStartObject();
+            {
+                writer.WritePropertyName(propNameWithNull);
+                writer.WriteString("a\nc");
+            }
+            writer.WriteEndObject();
+        }
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        using (var _ = await context.ReadForMemoryAsync(memoryStream, "result"))
+        {
+        }
+    
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        //Fails here while reading.
+        using (var _ = await context.ReadForMemoryAsync(memoryStream, "result"))
+        {
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void PropertyNameWithControlCharacter_LoadingDictionaryKeyWithNullChar_ShouldNotThrowException()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Doc { Id = "doc-1", StrDict = new Dictionary<string, string> { { "nullChar\0", "value" } } });
+                session.SaveChanges();
+            }
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Doc>("doc-1");
+                Assert.Equal("value", doc.StrDict["nullChar\0"]);
+            }
+        }
+    }
+
+    public class Doc
+    {
+        public string Id { get; set; }
+        public string StrVal { get; set; }
+        public Dictionary<string, string> StrDict { get; set; }
+    }
+}

--- a/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
+++ b/test/FastTests/Blittable/PropertyNamesWithEscapedCharsTests.cs
@@ -23,6 +23,8 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
 
         using (var withControlCharacter = context.GetLazyString("a\0a"))
         using (var withControlCharacterButEscapedInUserLevel = context.GetLazyString("a\\u0000a"))
+        using (var withNewLineAndBack = context.GetLazyString("a\n\bb"))
+        using (var withNewLineAndBackEscaped = context.GetLazyString("a\\n\\bb"))
         await using (var writer = new AsyncBlittableJsonTextWriter(context, memoryStream))
         {
             writer.WriteStartObject();
@@ -32,6 +34,12 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
                 
                 writer.WritePropertyName(withControlCharacterButEscapedInUserLevel);
                 writer.WriteString("someValue2");
+                
+                writer.WritePropertyName(withNewLineAndBack);
+                writer.WriteString("someValue3");
+                
+                writer.WritePropertyName(withNewLineAndBackEscaped);
+                writer.WriteString("someValue4");
             }
             writer.WriteEndObject();
         }
@@ -39,7 +47,8 @@ public class PropertyNamesWithEscapedCharsTests : RavenTestBase
         memoryStream.Seek(0, SeekOrigin.Begin);
         using (var json = await context.ReadForMemoryAsync(memoryStream, "result"))
         {
-            Assert.Equal(2, json.Count);
+            Assert.Equal(4, json.Count);
+            Assert.Equal("{\"a\\u0000a\":\"someValue1\",\"a\\\\u0000a\":\"someValue2\",\"a\\n\\bb\":\"someValue3\",\"a\\\\n\\\\bb\":\"someValue4\"}", json.ToString());
         }
     }
 


### PR DESCRIPTION
`LazyStringValue` represents a sequence of bytes containing the UTF-8 value of the string.  
After the content, there is additional metadata marking which characters should be escaped.  
Characters such as `\b`, `\t`, `\r`, `\n`, `\f`, `"`, and `\\` are not actually escaped, only marked as such.  
Other control characters are using the notation `\\u0000`, since they have no escape sequence.  We encode that already escaped in the string, to avoid needing to add the `\` when writing it out to the network.

However, internally, `GetLazyStringForFieldWithCaching(string)` was used, and the _implicit operator_ was used to get the field name.
When that happened `a\0b` and `a\\u0000b` would end up being encoded in the same manner, which is _not_ what we want.
The used explicitly escaped the `\\`, but we messed that up. This fixes this.

- Don't round trip LazyStringValue -> str -> LazyStringValue when calling GetLazyStringForFieldWithCaching()
- Introduced a separate dictionary to allow direct lookups by LazyStringValue
- Removing LazyStringValueStructComparer, because that is no longer a perf boost
- Avoid calling Equals() twice in LazyStringValueComparer (in the == when we meant to do ReferenceEquals)

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24955

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Moderate 

### Backward compatibility

- [x] Non breaking change

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). 

Added a new dictionary to a context, may affect allocation patterns.
On the other hand, reduced number of comparisons we make in this case as well. 