### PR TITLE
RavenDB-24536 Fix zindexes for modals and notification center

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Modal.scss
+++ b/src/Raven.Studio/typescript/components/common/Modal.scss
@@ -1,8 +1,8 @@
-@use "Content/scss/variables";
+@use "Content/scss/bs5variables";
 
 @for $i from 1 through 6 {
-    $zIndexBackdrop: #{variables.$zindex-modal + (5 * $i)};
-    $zIndexContent: #{variables.$zindex-modal + (5 * $i) + 2};
+    $zIndexBackdrop: #{bs5variables.$zindex-modal + (5 * $i)};
+    $zIndexContent: #{bs5variables.$zindex-modal + (5 * $i) + 2};
     .modal-backdrop.show:nth-of-type(#{$i}) {
         z-index: $zIndexBackdrop;
     }

--- a/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
+++ b/src/Raven.Studio/wwwroot/Content/css/bootstrap/variables-body.less
@@ -264,6 +264,7 @@
 @zindex-dropdown: var(--zindex-dropdown);
 @zindex-scoped-modal: var(--zindex-scoped-modal);
 @zindex-notification-center: var(--zindex-notification-center);
+@zindex-notification-center-pinned: var(--zindex-notification-center-pinned);
 @zindex-menu-resize: var(--zindex-menu-resize);
 
 @zindex-tooltip: var(--zindex-tooltip);

--- a/src/Raven.Studio/wwwroot/Content/css/root.less
+++ b/src/Raven.Studio/wwwroot/Content/css/root.less
@@ -226,6 +226,7 @@ body {
     &.pin-notifications {
         #notification-center {
             transition: none;
+            z-index: @zindex-notification-center-pinned !important;
         }
     }
 
@@ -251,6 +252,7 @@ body {
                 #notification-center {
                     transform: none;
                     box-shadow: none;
+                    z-index: @zindex-notification-center-pinned !important;
                 }
             }
 

--- a/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
@@ -815,19 +815,20 @@ $zindexes: (
     "dropdown": 1000,
     "sticky": 1020,
     "scoped-modal": 1030,
-    "notification-center": 1035,
     "selection-actions": 1035,
     "menu-resize": 1035,
     "fixed": 1037,
     "offcanvas-backdrop": 1040,
     "topalert": 1083,
-    "modal-backdrop": 1050,
-    "offcanvas": 1055,
-    "popover": 1086,
-    "tooltip": 1086,
-    "modal": 1085,
     "toast": 1090,
     "menu-xs": 1090,
+    "notification-center-pinned": 1100,
+    "popover": 1101,
+    "tooltip": 1101,
+    "notification-center": 1102,
+    "modal-backdrop": 1103,
+    "modal": 1104,
+    "offcanvas": 1111,
     "loading-overlay": 2490,
     "processing-spinner": 2500,
     "ace-fullScreen": 9999,
@@ -840,12 +841,14 @@ $zindex-sticky: map.get($zindexes, "sticky") !default;
 $zindex-fixed: map.get($zindexes, "fixed") !default;
 $zindex-selection-actions: map.get($zindexes, "selection-actions") !default;
 $zindex-offcanvas-backdrop: map.get($zindexes, "backdrop") !default;
-$zindex-modal-backdrop: map.get($zindexes, "modal-dropdown") !default;
+$zindex-modal-backdrop: map.get($zindexes, "modal-backdrop") !default;
 $zindex-offcanvas: map.get($zindexes, "offcanvas") !default;
 $zindex-modal: map.get($zindexes, "modal") !default;
 $zindex-popover: map.get($zindexes, "popover") !default;
 $zindex-tooltip: map.get($zindexes, "tooltip") !default;
 $zindex-toast: map.get($zindexes, "toast") !default;
+$zindex-notification-center: map.get($zindexes, "notification-center") !default;
+$zindex-notification-center-pinned: map.get($zindexes, "notification-center-pinned") !default;
 // scss-docs-end zindex-stack
 
 // scss-docs-start zindex-levels-map


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24536

### Additional description

Fixed zindexes for modals and notification center

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
