### PR TITLE
RavenDB-25245 Update validation of embeddings generation task configuration

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -25,22 +25,20 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
         };
     }
 
-    public bool Validate(string path, List<string> errors)
+    public void Validate(string source, List<string> errors)
     {
         if (MaxTokensPerChunk <= 0)
-            errors.Add($"Path '{path}': {nameof(MaxTokensPerChunk)} value has to be greater than 0.");
+            errors.Add($"'{source}': {nameof(MaxTokensPerChunk)} value has to be greater than 0.");
         
         if (OverlapTokens < 0)
-            errors.Add($"Path '{path}': {nameof(OverlapTokens)} value cannot be negative.");
+            errors.Add($"'{source}': {nameof(OverlapTokens)} value cannot be negative.");
         
         if (OverlapTokens > MaxTokensPerChunk)
-            errors.Add($"Path '{path}': {nameof(OverlapTokens)} cannot be greater than {nameof(MaxTokensPerChunk)}.");
+            errors.Add($"'{source}': {nameof(OverlapTokens)} cannot be greater than {nameof(MaxTokensPerChunk)}.");
         
         if (OverlapTokens > 0 &&
             MethodsSupportingOverlapTokens.Contains(ChunkingMethod) == false)
-            errors.Add($"Path '{path}': {nameof(OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", MethodsSupportingOverlapTokens)}.");
-        
-        return true;
+            errors.Add($"'{source}': {nameof(OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", MethodsSupportingOverlapTokens)}.");
     }
 }
 

--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -25,7 +25,7 @@ public class ChunkingOptions : IDynamicJsonValueConvertible
         };
     }
 
-    public void Validate(string source, List<string> errors)
+    internal void Validate(string source, List<string> errors)
     {
         if (MaxTokensPerChunk <= 0)
             errors.Add($"'{source}': {nameof(MaxTokensPerChunk)} value has to be greater than 0.");

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -111,9 +111,8 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             foreach (var pathConfiguration in EmbeddingsPathConfigurations)
                 pathConfiguration.ChunkingOptions.Validate(pathConfiguration.Path, errors);
         }
-        
-        if (EmbeddingsTransformation?.ValidateScript() == false)
-            errors.Add($"Transformation script must use {EmbeddingsTransformation.GenerateEmbeddingsFunctionName} method.");
+
+        EmbeddingsTransformation?.Validate(errors);
         
         if (Quantization == VectorEmbeddingType.Text)
             errors.Add($"{nameof(Quantization)} cannot be {nameof(VectorEmbeddingType.Text)}");

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Raven.Client.Documents.Operations.AI;
 
@@ -12,10 +13,18 @@ public class EmbeddingsTransformation
 
     public ChunkingOptions ChunkingOptions { get; set; } = new() { ChunkingMethod = ChunkingMethod.PlainTextSplit, MaxTokensPerChunk = 256 };
 
-    public bool ValidateScript()
+    public void Validate(List<string> errors)
+    {
+        ValidateScript(errors);
+        
+        ChunkingOptions.Validate(GenerateEmbeddingsFunctionName, errors);
+    }
+
+    private void ValidateScript(List<string> errors)
     {
         var match = EmbeddingsGenerateRegex.Match(Script);
-
-        return match.Length > 0;
+        
+        if (match.Length == 0)
+            errors.Add($"Transformation script must use {GenerateEmbeddingsFunctionName} method.");
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
@@ -13,7 +13,7 @@ public class EmbeddingsTransformation
 
     public ChunkingOptions ChunkingOptions { get; set; } = new() { ChunkingMethod = ChunkingMethod.PlainTextSplit, MaxTokensPerChunk = 256 };
 
-    public void Validate(List<string> errors)
+    internal void Validate(List<string> errors)
     {
         ValidateScript(errors);
         

--- a/test/SlowTests.Issues/Issues/RavenDB-23909.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23909.cs
@@ -21,8 +21,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         using (var store = GetDocumentStore(options))
         {
             var (configuration, _) = AddEmbeddingsGenerationTask(store);
-
-
+            
             using (var session = store.OpenSession())
             {
                 var aiTaskDone = Etl.WaitForEtlToComplete(store);

--- a/test/SlowTests.Issues/Issues/RavenDB-24816.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24816.cs
@@ -198,7 +198,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
                     }
                 ]));
 
-            Assert.Contains("Path 'Name': OverlapTokens option is only supported for the following chunking methods: MarkDownSplitParagraphs, PlainTextSplitParagraphs.", exception.Message);
+            Assert.Contains("'Name': OverlapTokens option is only supported for the following chunking methods: MarkDownSplitParagraphs, PlainTextSplitParagraphs.", exception.Message);
         }
     }
     

--- a/test/SlowTests.Issues/Issues/RavenDB-25245.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25245.cs
@@ -1,0 +1,36 @@
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25245(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Ai)]
+    public void ValidationOfEmbeddingsTransformationShouldThrow()
+    {
+        using (var store = GetDocumentStore())
+        {
+            const string script = """
+                                  embeddings.generate({
+                                                // No chunking method is specified here
+                                                Name: this.Name,
+                                                Description: this.Description
+                                            });
+                                  """;
+
+            var chunkingOptions = new ChunkingOptions()
+            {
+                ChunkingMethod = ChunkingMethod.PlainTextSplitLines,
+                MaxTokensPerChunk = 2048,
+                OverlapTokens = 128 // unsupported for this method
+            };
+
+            var exception = Assert.Throws<RavenException>(() => AddEmbeddingsGenerationTask(store, script: script, chunkingOptionsForScript: chunkingOptions));
+            
+            Assert.Contains("'embeddings.generate': OverlapTokens option is only supported for the following chunking methods: MarkDownSplitParagraphs, PlainTextSplitParagraphs.", exception.Message);
+        }
+    }
+}

--- a/test/Tests.Infrastructure/EmbeddingsGenerationTestBase.cs
+++ b/test/Tests.Infrastructure/EmbeddingsGenerationTestBase.cs
@@ -59,7 +59,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
             EmbeddingsTransformation = string.IsNullOrEmpty(script) == false ? new EmbeddingsTransformation
             {
                 Script = script,
-                ChunkingOptions = chunkingOptionsForScript
+                ChunkingOptions = chunkingOptionsForScript ?? DefaultChunkingOptions
             }
             : null,
             Quantization = targetQuantization,

--- a/test/Tests.Infrastructure/EmbeddingsGenerationTestBase.cs
+++ b/test/Tests.Infrastructure/EmbeddingsGenerationTestBase.cs
@@ -45,6 +45,7 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
         string connectionStringName = DefaultConnectionStringName,
         List<EmbeddingPathConfiguration> embeddingsPaths = null,
         string script = null,
+        ChunkingOptions chunkingOptionsForScript = null,
         string collectionName = null,
         VectorEmbeddingType targetQuantization = VectorEmbeddingType.Single,
         ChunkingOptions chunkingOptionsForQuerying = null)
@@ -57,7 +58,8 @@ public abstract class EmbeddingsGenerationTestBase(ITestOutputHelper output) : R
             Collection = collectionName ?? "Dtos",
             EmbeddingsTransformation = string.IsNullOrEmpty(script) == false ? new EmbeddingsTransformation
             {
-                Script = script
+                Script = script,
+                ChunkingOptions = chunkingOptionsForScript
             }
             : null,
             Quantization = targetQuantization,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25245/Embedding-Generation-Task-Should-throw-if-OverlapTokens-is-set-with-an-unsupported-chunking-method-in-EmbeddingTransformation

### Additional description

Using non-zero `OverlapTokens` value with unsupported chunking method for default chunking settings in embeddings generation task transformation script configuration should throw a relevant exception

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
