### PR TITLE
[v5.4] RavenDB-25296 visible input for entering the ID in creating new document, as we are in full-screen mode for aceEditor

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -172,6 +172,7 @@ class editDocument extends viewModelBase {
     canViewRelated: KnockoutComputed<boolean>;
     canViewCSharpClass: KnockoutComputed<boolean>;
 
+    isFullScreenEditor = ko.observable(false);
     collapseDocsWhenOpening = ko.observable<boolean>(false);
     isDocumentCollapsed = ko.observable<boolean>(false);
     forceFold = false;
@@ -260,11 +261,41 @@ class editDocument extends viewModelBase {
 
         this.setupDisableReasons();
         this.focusOnEditor();
+        this.watchFullScreenCommand();
     }
     
     detached() {
         super.detached();
         this.connectedDocuments.dispose();
+    }
+
+    private watchFullScreenCommand() {
+        if (!this.docEditor?.commands) {
+            return;
+        }
+
+        this.wrapAceEditorCommand("Toggle Fullscreen", () => {
+            this.isFullScreenEditor(!this.isFullScreenEditor());
+        });
+
+        this.wrapAceEditorCommand("Exit FullScreen", () => {
+            this.isFullScreenEditor(false);
+        });
+    }
+
+    private wrapAceEditorCommand(commandName: string, callback: () => void) {
+        const command = this.docEditor.commands.byName[commandName];
+        if (!command) {
+            console.error(`Ace editor command '${commandName}' not found`);
+            return;
+        }
+
+        const originalExec = command.exec;
+
+        command.exec = (editor: AceAjax.Editor, args?: unknown) => {
+            originalExec(editor, args);
+            callback();
+        };
     }
 
     private activateById(id: string) {

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -1,10 +1,10 @@
 <form data-bind="submit: saveDocument, css: { 'diff': inDiffMode }" class="edit-document" autocomplete="off">
-    <div class="docEditor flex-window flex-grow content-margin">
+    <div class="docEditor flex-window flex-grow content-margin" data-bind="style: { 'z-index': isFullScreenEditor() ? 1050 : undefined }">
         <div class="flex-window-head">
             <div class="flex-horizontal copy-area">
                 <div class="flex-grow">
                     <div class="documentId">
-                        <div data-bind="if: isCreatingNewDocument()">
+                        <div data-bind="if: isCreatingNewDocument() && !isFullScreenEditor()">
                             <div class="input-group" data-bind="validationElement: userSpecifiedId">
                                 <div class="input-group-addon">ID</div>
                                 <input class="form-control"

--- a/src/Raven.Studio/wwwroot/Content/css/pages/documents-edit.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/documents-edit.less
@@ -13,7 +13,6 @@
 
     .docEditor {
         flex-grow: 1;
-        z-index: 1050;
     }
 
     .differences_summary {


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25296

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
