### PR TITLE
RavenDB-25308 - Enrich `HttpOperationException` with response content for Embedding Generations

### DIFF
--- a/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
+++ b/src/Raven.Server/Documents/AI/Embeddings/EmbeddingsGenerator.cs
@@ -387,11 +387,22 @@ public class EmbeddingsGenerator(DocumentDatabase database, RavenLogger logger, 
                 }
                 _parent.ProcessInBackground(new StoreEmbeddings(works, Configuration.Quantization));
             }
+            catch (HttpOperationException httpEx)
+            {
+                var enrichedException = new HttpOperationException($"{httpEx.Message}{Environment.NewLine}ResponseContent:{Environment.NewLine}{httpEx.ResponseContent}", httpEx);
+                PropagateExceptionToWorks(enrichedException);
+            }
             catch (Exception e)
+            {
+                PropagateExceptionToWorks(e);
+            }
+
+            return;
+            void PropagateExceptionToWorks(Exception exToPropagate)
             {
                 foreach (var work in works)
                 {
-                    work.TaskCompletionSource.TrySetException(e);
+                    work.TaskCompletionSource.TrySetException(exToPropagate);
                     work.Owner.RemoveFromCache(work.CacheKey);
                 }
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25308

### Additional description

The extraction of the exact reason why the AI provider determined that the request was invalid, based on the underlying response content for embedding generation.

How it was:
```
Microsoft.SemanticKernel.HttpOperationException: Response status code does not indicate success: 400 (Bad Request).
 ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 400 (Bad Request).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at Microsoft.SemanticKernel.Http.HttpClientExtensions.SendWithSuccessCheckAsync(HttpClient client, HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\InternalUtilities\src\Http\HttpClientExtensions.cs:line 49
   --- End of inner exception stack trace ---
   at Microsoft.SemanticKernel.Http.HttpClientExtensions.SendWithSuccessCheckAsync(HttpClient client, HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\InternalUtilities\src\Http\HttpClientExtensions.cs:line 53
   at Microsoft.SemanticKernel.Http.HttpClientExtensions.SendWithSuccessCheckAsync(HttpClient client, HttpRequestMessage request, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\InternalUtilities\src\Http\HttpClientExtensions.cs:line 70
   at Microsoft.SemanticKernel.Connectors.Google.Core.ClientBase.SendRequestAndGetStringBodyAsync(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\Connectors\Connectors.Google\Core\ClientBase.cs:line 59
   at Microsoft.SemanticKernel.Connectors.Google.Core.GoogleAIEmbeddingClient.GenerateEmbeddingsAsync(IList`1 data, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\Connectors\Connectors.Google\Core\GoogleAI\GoogleAIEmbeddingClient.cs:line 68
   at Microsoft.SemanticKernel.Embeddings.EmbeddingGenerationExtensions.EmbeddingGenerationServiceEmbeddingGenerator`2.GenerateAsync(IEnumerable`1 values, EmbeddingGenerationOptions options, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\SemanticKernel.Abstractions\AI\Embeddings\EmbeddingGenerationServiceExtensions.cs:line 140
   at Raven.Server.Documents.AI.Embeddings.EmbeddingsGenerator.AiWorker.FlushBatchAsync(List`1 batch, List`1 embeddings, List`1 works) in D:\Work\ravendb-7.1\src\Raven.Server\Documents\AI\Embeddings\EmbeddingsGenerator.cs:line 360
   --- End of inner exception stack trace ---
   at Raven.Server.Documents.AI.Embeddings.EmbeddingsGenerator.BatchGenerator.WaitForGenerationAsync() in D:\Work\ravendb-7.1\src\Raven.Server\Documents\AI\Embeddings\EmbeddingsGenerator.cs:line 825
   at Raven.Server.Documents.ETL.Providers.AI.Embeddings.EmbeddingsGenerationTask.LoadInternal(IEnumerable`1 items, DocumentsOperationContext context, EmbeddingsGenerationStatsScope scope) in D:\Work\ravendb-7.1\src\Raven.Server\Documents\ETL\Providers\AI\Embeddings\EmbeddingsGenerationTask.cs:line 153
   at Raven.Server.Documents.ETL.EtlProcess`6.Load(IEnumerable`1 items, DocumentsOperationContext context, TStatsScope stats) in D:\Work\ravendb-7.1\src\Raven.Server\Documents\ETL\EtlProcess.cs:line 486
 ```
 
 Now:
 ```
 Microsoft.SemanticKernel.HttpOperationException: Response status code does not indicate success: 400 (Bad Request).
ResponseContent:
{
  "error": {
    "code": 400,
    "message": "* BatchEmbedContentsRequest.requests: at most 100 requests can be in one batch\n",
    "status": "INVALID_ARGUMENT"
  }
}

 ---> Microsoft.SemanticKernel.HttpOperationException: Response status code does not indicate success: 400 (Bad Request).
 ---> System.Net.Http.HttpRequestException: Response status code does not indicate success: 400 (Bad Request).
   at System.Net.Http.HttpResponseMessage.EnsureSuccessStatusCode()
   at Microsoft.SemanticKernel.Http.HttpClientExtensions.SendWithSuccessCheckAsync(HttpClient client, HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\InternalUtilities\src\Http\HttpClientExtensions.cs:line 49
   --- End of inner exception stack trace ---
   at Microsoft.SemanticKernel.Http.HttpClientExtensions.SendWithSuccessCheckAsync(HttpClient client, HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\InternalUtilities\src\Http\HttpClientExtensions.cs:line 53
   at Microsoft.SemanticKernel.Http.HttpClientExtensions.SendWithSuccessCheckAsync(HttpClient client, HttpRequestMessage request, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\InternalUtilities\src\Http\HttpClientExtensions.cs:line 70
   at Microsoft.SemanticKernel.Connectors.Google.Core.ClientBase.SendRequestAndGetStringBodyAsync(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\Connectors\Connectors.Google\Core\ClientBase.cs:line 59
   at Microsoft.SemanticKernel.Connectors.Google.Core.GoogleAIEmbeddingClient.GenerateEmbeddingsAsync(IList`1 data, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\Connectors\Connectors.Google\Core\GoogleAI\GoogleAIEmbeddingClient.cs:line 68
   at Microsoft.SemanticKernel.Embeddings.EmbeddingGenerationExtensions.EmbeddingGenerationServiceEmbeddingGenerator`2.GenerateAsync(IEnumerable`1 values, EmbeddingGenerationOptions options, CancellationToken cancellationToken) in D:\Work\semantic-kernel\dotnet\src\SemanticKernel.Abstractions\AI\Embeddings\EmbeddingGenerationServiceExtensions.cs:line 140
   at Raven.Server.Documents.AI.Embeddings.EmbeddingsGenerator.AiWorker.FlushBatchAsync(List`1 batch, List`1 embeddings, List`1 works) in D:\Work\ravendb-7.1\src\Raven.Server\Documents\AI\Embeddings\EmbeddingsGenerator.cs:line 360
   --- End of inner exception stack trace ---
   at Raven.Server.Documents.AI.Embeddings.EmbeddingsGenerator.BatchGenerator.WaitForGenerationAsync() in D:\Work\ravendb-7.1\src\Raven.Server\Documents\AI\Embeddings\EmbeddingsGenerator.cs:line 825
   at Raven.Server.Documents.ETL.Providers.AI.Embeddings.EmbeddingsGenerationTask.LoadInternal(IEnumerable`1 items, DocumentsOperationContext context, EmbeddingsGenerationStatsScope scope) in D:\Work\ravendb-7.1\src\Raven.Server\Documents\ETL\Providers\AI\Embeddings\EmbeddingsGenerationTask.cs:line 153
   at Raven.Server.Documents.ETL.EtlProcess`6.Load(IEnumerable`1 items, DocumentsOperationContext context, TStatsScope stats) in D:\Work\ravendb-7.1\src\Raven.Server\Documents\ETL\EtlProcess.cs:line 486
```
### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed