### PR TITLE
RavenDB-25197 Add suffix to cert common name in tests

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19148.cs
+++ b/test/SlowTests/Issues/RavenDB-19148.cs
@@ -23,8 +23,9 @@ public class RavenDB_19148 : ClusterTestBase
     [Fact]
     public async Task CanAuthUsingWellKnownIssuer()
     {
-        var ca = CertificateUtils.CreateCertificateAuthorityCertificate("auth", out var caKey, out var caName);
-        CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey("admin", caName, caKey, true, false,
+        var suffix = Guid.NewGuid().ToString().Split('-')[0];
+        var ca = CertificateUtils.CreateCertificateAuthorityCertificate($"auth-{suffix}", out var caKey, out var caName);
+        CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey($"admin-{suffix}", caName, caKey, true, false,
             DateTime.UtcNow.Date.AddMonths(3), out var certBytes);
 
         byte[] caBytes = ca.Export(X509ContentType.Cert);

--- a/test/SlowTests/Issues/RavenDB-21535.cs
+++ b/test/SlowTests/Issues/RavenDB-21535.cs
@@ -19,17 +19,7 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Certificates)]
         public void KnownIssuerCert_CanNotAccess_WithoutSAN()
         {
-            var ca = CertificateUtils.CreateCertificateAuthorityCertificate("ca", out var caKeyPair, out _);
-            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
-
-            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
-                commonNameValue: "admin",
-                issuerCN: ca.SubjectName,
-                issuerKeyPair: caKeyPair,
-                isClientCertificate: true,
-                isCaCertificate: false,
-                notAfter: DateTime.UtcNow.Date.AddMonths(1),
-                certBytes: out var clientCertBytes);
+            string caBase64 = GenerateCaAndServerCert(out byte[] clientCertBytes);
 
             var client = new X509Certificate2(clientCertBytes);
 
@@ -55,18 +45,7 @@ namespace SlowTests.Issues
         [InlineData("localhost", "localhost")]
         public void KnownIssuerCert_CanAccess_WithValidSAN(string publicDomain, string san)
         {
-            var ca = CertificateUtils.CreateCertificateAuthorityCertificate("ca", out var caKeyPair, out _);
-            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
-
-            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
-                commonNameValue: "admin",
-                issuerCN: ca.SubjectName,
-                issuerKeyPair: caKeyPair,
-                isClientCertificate: true,
-                isCaCertificate: false,
-                notAfter: DateTime.UtcNow.Date.AddMonths(1),
-                certBytes: out var clientCertBytes,
-                sans: new[] { san });
+            string caBase64 = GenerateCaAndServerCert(out byte[] clientCertBytes, san);
 
             var client = new X509Certificate2(clientCertBytes);
 
@@ -92,18 +71,7 @@ namespace SlowTests.Issues
         [InlineData("aaa.localhost", "aaa.localhost.bbb")]
         public void KnownIssuerCert_CanNotAccess_WithInvalidSAN(string publicDomain, string san)
         {
-            var ca = CertificateUtils.CreateCertificateAuthorityCertificate("ca", out var caKeyPair, out _);
-            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
-
-            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
-                commonNameValue: "admin",
-                issuerCN: ca.SubjectName,
-                issuerKeyPair: caKeyPair,
-                isClientCertificate: true,
-                isCaCertificate: false,
-                notAfter: DateTime.UtcNow.Date.AddMonths(1),
-                certBytes: out var clientCertBytes,
-                sans: new[] { san });
+            string caBase64 = GenerateCaAndServerCert(out byte[] clientCertBytes, san);
 
             var client = new X509Certificate2(clientCertBytes);
 
@@ -124,18 +92,7 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Certificates)]
         public void KnownIssuerCert_CanAccess_WhenSANValidation_IsDisabled_AndNotMatchingServerDomainName()
         {
-            var ca = CertificateUtils.CreateCertificateAuthorityCertificate("ca", out var caKeyPair, out _);
-            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
-
-            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
-                commonNameValue: "admin",
-                issuerCN: ca.SubjectName,
-                issuerKeyPair: caKeyPair,
-                isClientCertificate: true,
-                isCaCertificate: false,
-                notAfter: DateTime.UtcNow.Date.AddMonths(1),
-                certBytes: out var clientCertBytes,
-                sans: new[] { LocalDomainName });
+            string caBase64 = GenerateCaAndServerCert(out byte[] clientCertBytes, LocalDomainName);
 
             var client = new X509Certificate2(clientCertBytes);
 
@@ -150,6 +107,25 @@ namespace SlowTests.Issues
 
             var result = server.AuthenticateConnectionCertificate(client, null);
             Assert.Equal(RavenServer.AuthenticationStatus.ClusterAdmin, result.Status);
+        }
+
+        private static string GenerateCaAndServerCert(out byte[] clientCertBytes, params string[] sans)
+        {
+            var suffix = Guid.NewGuid().ToString().Split('-')[0];
+            
+            var ca = CertificateUtils.CreateCertificateAuthorityCertificate($"ca-{suffix}", out var caKeyPair, out _);
+            var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
+
+            CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(
+                commonNameValue: $"admin-{suffix}",
+                issuerCN: ca.SubjectName,
+                issuerKeyPair: caKeyPair,
+                isClientCertificate: true,
+                isCaCertificate: false,
+                notAfter: DateTime.UtcNow.Date.AddMonths(1),
+                out clientCertBytes,
+                sans: sans);
+            return caBase64;
         }
 
         private const string LocalDomainName = "localhost";

--- a/test/SlowTests/Issues/RavenDB-24495.cs
+++ b/test/SlowTests/Issues/RavenDB-24495.cs
@@ -32,8 +32,8 @@ public class RavenDB_24495 : ClusterTestBase
     public async Task CanReplaceServerCertificate_WithBouncyCastleGeneratedCertificate(bool with2Eku)
     {
         var result = await CreateRaftClusterWithSsl(3, with2Eku: with2Eku);
-        
-        var newCertBytes = CertificateUtils.CreateSelfSignedTestCertificate("server-bc", "replace-server-cert-test", with2Eku: with2Eku);
+        var suffix = Guid.NewGuid().ToString().Split('-')[0];
+        var newCertBytes = CertificateUtils.CreateSelfSignedTestCertificate($"server-bc-{suffix}", $"replace-server-cert-test-{suffix}", with2Eku: with2Eku);
         
         var first = result.Certificates.ServerCertificate.Value.Thumbprint;
         var certForCommunication = result.Certificates.ServerCertificateForCommunication.Value;
@@ -54,8 +54,9 @@ public class RavenDB_24495 : ClusterTestBase
     [RavenFact(RavenTestCategory.Certificates)]
     public async Task CreateZipArchive_ShouldHaveTheSameContent()
     {
-        const string certName = "test";
-        var clientCertBytes = CertificateUtils.CreateSelfSignedTestCertificate(certName, "zip-archive-test", with2Eku: true);
+        var suffix = Guid.NewGuid().ToString().Split('-')[0];
+        var certName = $"test-{suffix}";
+        var clientCertBytes = CertificateUtils.CreateSelfSignedTestCertificate(certName, $"zip-archive-test-{suffix}", with2Eku: true);
 
         using var ms = new MemoryStream();
         using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25197 

### Additional description

Some tests generate certificate with the same common name. This maybe the cause of issues when running tests in parallel.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
