### PR TITLE
RavenDB-25070 clarify revisions settings labels

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -116,6 +116,9 @@ export default function EditRevision(props: EditRevisionProps) {
     const { appUrl } = useAppUrls();
     const activeDatabaseName = useAppSelector(databaseSelectors.activeDatabaseName);
 
+    const isAgeRetentionActive =
+        formValues.isMinimumRevisionAgeToKeepEnabled && formValues.minimumRevisionAgeToKeep > 0;
+
     return (
         <Modal size="lg" show onHide={toggle} contentClassName="modal-border bulge-info">
             <Form onSubmit={handleSubmit(onSubmit)} autoComplete="off">
@@ -142,7 +145,17 @@ export default function EditRevision(props: EditRevisionProps) {
                         Purge revisions on document delete
                     </FormSwitch>
                     <FormSwitch control={control} name="isMinimumRevisionsToKeepEnabled">
-                        Limit # of revisions to keep
+                        <span>
+                            Set the number of revisions to keep
+                            <br />
+                            <span className="text-muted">
+                                (
+                                {isAgeRetentionActive
+                                    ? "When age-based retention is configured, this is the minimum number of revisions to keep"
+                                    : "The maximum number of revisions to keep"}
+                                )
+                            </span>
+                        </span>
                     </FormSwitch>
                     {formValues.isMinimumRevisionsToKeepEnabled && (
                         <div>
@@ -165,7 +178,7 @@ export default function EditRevision(props: EditRevisionProps) {
                         </div>
                     )}
                     <FormSwitch control={control} name="isMinimumRevisionAgeToKeepEnabled">
-                        Limit # of revisions to keep by age
+                        Set the number of revisions to keep by age
                     </FormSwitch>
                     {formValues.isMinimumRevisionAgeToKeepEnabled && (
                         <div className="mb-2">
@@ -192,7 +205,7 @@ export default function EditRevision(props: EditRevisionProps) {
                     {(formValues.isMinimumRevisionsToKeepEnabled || formValues.isMinimumRevisionAgeToKeepEnabled) && (
                         <>
                             <FormSwitch control={control} name="isMaximumRevisionsToDeleteUponDocumentUpdateEnabled">
-                                Set # of revisions to delete upon document update
+                                Set the number of revisions to delete upon document update
                             </FormSwitch>
                             {formValues.isMaximumRevisionsToDeleteUponDocumentUpdateEnabled && (
                                 <InputGroup className="mb-2">
@@ -228,7 +241,7 @@ export default function EditRevision(props: EditRevisionProps) {
                             {formValues.minimumRevisionsToKeep > 0 && (
                                 <>
                                     <li>
-                                        {formValues.minimumRevisionAgeToKeep > 0 ? (
+                                        {isAgeRetentionActive ? (
                                             <>
                                                 <span>At least</span>{" "}
                                                 <strong>{formValues.minimumRevisionsToKeep}</strong> of the latest
@@ -243,7 +256,7 @@ export default function EditRevision(props: EditRevisionProps) {
                                         </span>
                                         will be kept.
                                     </li>
-                                    {formValues.minimumRevisionAgeToKeep > 0 ? (
+                                    {isAgeRetentionActive ? (
                                         <li>
                                             Older revisions will be removed if they exceed{" "}
                                             <strong>{formattedMinimumRevisionAgeToKeep}</strong> on next revision

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EditRevision.tsx
@@ -151,7 +151,7 @@ export default function EditRevision(props: EditRevisionProps) {
                             <span className="text-muted">
                                 (
                                 {isAgeRetentionActive
-                                    ? "When age-based retention is configured, this is the minimum number of revisions to keep"
+                                    ? "The minimum number of revisions to keep (age-based retention enabled)"
                                     : "The maximum number of revisions to keep"}
                                 )
                             </span>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25070/Revision-settings-labels-are-confusing

### Additional description
Made the revision settings labels clearer.
Explicitly indicate when the number of revisions to keep acts as a maximum and when it acts as a minimum.

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
