### PR TITLE
RavenDB-25128 Fixing a mutable builder (HandleReferencesBase.State.Owner) sharing issue.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStateRecord.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStateRecord.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using Corax;
 using Lucene.Net.Search;
-using Raven.Client.Documents.Linq;
 using Raven.Server.Documents.Indexes.Workers;
 using Raven.Server.Logging;
 using Sparrow.Logging;
@@ -23,7 +21,10 @@ public record IndexStateRecord(
     ImmutableDictionary<string, LuceneIndexState> LuceneSuggestionStates)
 {
 
-    public static IndexStateRecord Empty = new IndexStateRecord(
+    /// <summary>
+    /// Cannot use a shared instance here, since <see cref="HandleReferencesBase.State"/> have a mutable builder, we create a new value each time
+    /// </summary>
+    public static IndexStateRecord CreateEmpty() => new IndexStateRecord(
         ImmutableDictionary<string, string>.Empty,
         HandleReferencesBase.State.CreateEmpty(),
         HandleReferencesBase.State.CreateEmpty(),

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -280,7 +280,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
 
             if(tx.LowLevelTransaction.TryGetClientState(out IndexStateRecord rec) is false)
-                rec = IndexStateRecord.Empty;
+                rec = IndexStateRecord.CreateEmpty();
 
             return rec with { Collections = GetCollectionEtags(tx), DirectoriesByName = dirs.ToImmutable() };
         }
@@ -494,7 +494,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
         internal override void RecreateSearcher(Transaction asOfTx)
         {
             if (asOfTx.LowLevelTransaction.TryGetClientState(out IndexStateRecord stateRecord) is false)
-                stateRecord = IndexStateRecord.Empty;
+                stateRecord = IndexStateRecord.CreateEmpty();
             asOfTx.LowLevelTransaction.UpdateClientState(stateRecord with { LuceneIndexState = new LuceneIndexState(CreateIndexSearcher) });
         }
 

--- a/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/TransactionOperationContext.cs
@@ -51,7 +51,7 @@ namespace Raven.Server.ServerWide.Context
         private static IndexStateRecord GetIndexStateFrom(LowLevelTransaction llt)
         {
             if (llt.TryGetClientState(out IndexStateRecord r) is false)
-                r = IndexStateRecord.Empty;
+                r = IndexStateRecord.CreateEmpty();
             return r;
         }
 


### PR DESCRIPTION

The same instance of  `IndexStateRecords` was used by multiple indexes (hence also the same instance of `HandleReferencesBase.State.Owner` builder).


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25128

### Additional description


The `HandleReferencesBase.State` already had `CreateEmpty()`:

https://github.com/ravendb/ravendb/blob/dc496821e0f3b32f979f153ac89ef466b42b8163/src/Raven.Server/Documents/Indexes/Workers/HandleReferencesBase.ReferencesState.cs#L31-L34

but the issue was that it was assigned to a static `IndexStateRecord.Empty`:

https://github.com/ravendb/ravendb/blob/dc496821e0f3b32f979f153ac89ef466b42b8163/src/Raven.Server/Documents/Indexes/IndexStateRecord.cs#L26-L29

This resulted in sharing `HandleReferencesBase.State.Owner` between multiple indexing threads.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
