### PR TITLE
RavenDB-25317 - fix query string parameter in GetAiAgentsOperation

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/DeleteAiAgentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/DeleteAiAgentOperation.cs
@@ -35,7 +35,7 @@ public class DeleteAiAgentOperation : IMaintenanceOperation<AiAgentConfiguration
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            url = $"{node.Url}/databases/{node.Database}/admin/ai/agent?id={Uri.EscapeDataString(_identifier)}";
+            url = $"{node.Url}/databases/{node.Database}/admin/ai/agent?agentId={Uri.EscapeDataString(_identifier)}";
 
             var request = new HttpRequestMessage
             {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24458.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24458.cs
@@ -66,6 +66,12 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             agents[1].Name = agents[0].Name;
             await store.Maintenance.SendAsync(AddOrUpdateAiAgentOperation.Create(agents[1], AiAgentBasics.OutputSchema.Instance));
             await AssertAgentInRecordAsync(store, agents[1]);
+
+            var res = await store.Maintenance.SendAsync(new DeleteAiAgentOperation(agents[0].Identifier));
+            Assert.NotNull(res);
+
+            var e = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new GetAiAgentsOperation(agents[0].Identifier)));
+            Assert.Contains($"AI Agent 'shopping-assistant' doesn't exists", e.Message);
         }
 
         private static async Task AssertAgentInRecordAsync(DocumentStore store, AiAgentConfiguration agent)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25317

### Additional description

fix query string parameter in GetAiAgentsOperation according to what we expect in the handler

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
