### PR TITLE
RavenDB-25298 : fixed the bug of Incomplete Document Id in the alert

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -394,13 +394,23 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
                             ToolType toolType = GetToolType(configuration, name);
 
-                            toolCalls.Add(new ExceededTokenThresholdDetails.ToolCallDetails
+                            var tc = new ExceededTokenThresholdDetails.ToolCallDetails
                             {
                                 Id = id,
                                 Name = name,
                                 Type = toolType,
                                 Arguments = arguments
-                            });
+                            };
+
+                            if (toolType == ToolType.Query)
+                            {
+                                var q = configuration.FindQuery(name);
+                                if (q != null)
+                                {
+                                    tc.Query = q.Query;
+                                }
+                            }
+                            toolCalls.Add(tc);
                         }
                         return true;
                     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -374,7 +374,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             if (m.TryGet(ChatCompletionClient.Constants.RequestFields.Role, out string role) == false)
             {
                 continue;
-}
+            }
 
             switch (role)
             {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -163,6 +163,18 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         List<BlittableJsonReaderObject> historyDocs = default;
         bool shouldContinueConversation = true;
         var sw = Stopwatch.StartNew();
+
+        if (_conversationId[^1] == '|')
+        {
+            var res = await server.GenerateClusterIdentityAsync(_conversationId, database.IdentityPartsSeparator, database.Name, _raftId ?? Guid.NewGuid().ToString());
+            _conversationId = res.ClusterId;
+        }
+        else
+        {
+            _conversationId = database.DocumentsStorage.DocumentPut.BuildDocumentId(_conversationId, database.DocumentsStorage.GenerateNextEtag(), out _);
+        }
+        _document.Id = _conversationId;
+
         while (shouldContinueConversation)
         {
             using var request = talker.CreateCompletionRequest(_request.Attachments);
@@ -471,12 +483,6 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
-        if (_conversationId[^1] == '|')
-        {
-            var r = await server.GenerateClusterIdentityAsync(_conversationId, database.IdentityPartsSeparator, database.Name, _raftId ?? Guid.NewGuid().ToString());
-            _conversationId = r.ClusterId;
-        }
-
         var changeVectorLsv = context.GetLazyString(_document.ChangeVector);
         var cmd = new PutConversationCommand(_conversationId, _document, historyDocs, changeVectorLsv, _configuration, database);
         await database.TxMerger.Enqueue(cmd);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -164,17 +164,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         bool shouldContinueConversation = true;
         var sw = Stopwatch.StartNew();
 
-        if (_conversationId[^1] == '|')
-        {
-            var res = await server.GenerateClusterIdentityAsync(_conversationId, database.IdentityPartsSeparator, database.Name, _raftId ?? Guid.NewGuid().ToString());
-            _conversationId = res.ClusterId;
-        }
-        else
-        {
-            _conversationId = database.DocumentsStorage.DocumentPut.BuildDocumentId(_conversationId, database.DocumentsStorage.GenerateNextEtag(), out _);
-        }
-        _document.Id = _conversationId;
-
+        var pendingAlertsDetails = new List<ExceededTokenThresholdDetails>();
         while (shouldContinueConversation)
         {
             using var request = talker.CreateCompletionRequest(_request.Attachments);
@@ -190,13 +180,14 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             {
                 if (_document.TryGetDetailsOfRecentToolCall(_configuration, out var toolCalls))
                 {
-                    ExceededTokenThresholdDetails.Add(
-                        database.NotificationCenter,
-                        _configuration.Name,
-                        _conversationId,
-                        currentTurnUsage.PromptTokens,
-                        database.Configuration.Ai.ToolsTokenUsageThreshold,
-                        toolCalls
+                    pendingAlertsDetails.Add(ExceededTokenThresholdDetails.Add(
+                            database.NotificationCenter,
+                            _configuration.Name,
+                            _conversationId,
+                            currentTurnUsage.PromptTokens,
+                            database.Configuration.Ai.ToolsTokenUsageThreshold,
+                            toolCalls
+                        )
                     );
                 }
             }
@@ -229,6 +220,12 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         _elapsed = sw.Elapsed;
         _conversationId = await TryPersistAsync(context, historyDocs);
 
+        foreach (ExceededTokenThresholdDetails pendingAlertDetails in pendingAlertsDetails)
+        {
+            pendingAlertDetails.ConversationId = _conversationId;
+            database.NotificationCenter.Add(
+                ExceededTokenThresholdDetails.CreateAlert(pendingAlertDetails, database.Name));
+        }
         return (r.Result, talker.AiUsage);
     }
 
@@ -483,6 +480,12 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
+        if (_conversationId[^1] == '|')
+        {
+            var r = await server.GenerateClusterIdentityAsync(_conversationId, database.IdentityPartsSeparator, database.Name, _raftId ?? Guid.NewGuid().ToString());
+            _conversationId = r.ClusterId;
+        }
+
         var changeVectorLsv = context.GetLazyString(_document.ChangeVector);
         var cmd = new PutConversationCommand(_conversationId, _document, historyDocs, changeVectorLsv, _configuration, database);
         await database.TxMerger.Enqueue(cmd);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
@@ -33,6 +33,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
+            _id = _database.DocumentsStorage.DocumentPut.BuildDocumentId(_id, _database.DocumentsStorage.GenerateNextEtag(), out _);
+
             if (_historyDocs != null)
             {
                 foreach (var historyDoc in _historyDocs)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
@@ -33,8 +33,6 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
-            _id = _database.DocumentsStorage.DocumentPut.BuildDocumentId(_id, _database.DocumentsStorage.GenerateNextEtag(), out _);
-
             if (_historyDocs != null)
             {
                 foreach (var historyDoc in _historyDocs)

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/LargetToolResponseDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/LargetToolResponseDetails.cs
@@ -40,11 +40,11 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             };
         }
 
-        public static void Add(DatabaseNotificationCenter notificationCenter, string agentName, string conversationId, int tokenCount, int tokenThreshold, List<ToolCallDetails> toolCalls)
+        public static ExceededTokenThresholdDetails Add(DatabaseNotificationCenter notificationCenter, string agentName, string conversationId, int tokenCount, int tokenThreshold, List<ToolCallDetails> toolCalls)
         {
             var configurationKey = RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold);
             var message = $"In conversation '{conversationId}', the AI Agent '{agentName}' sent a request with {tokenCount} tokens to the LLM, exceeding the configured threshold of {tokenThreshold} tokens. " +
-                          $"You can adjust the limit by setting the '{configurationKey}' configuration value";
+            $"You can adjust the limit by setting the '{configurationKey}' configuration value";
 
             var hasActionTools = toolCalls.Any(tc => tc.Type == ToolType.Action);
             var hasQueryTools = toolCalls.Any(tc => tc.Type == ToolType.Query);
@@ -74,15 +74,16 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
                 recommendationBuilder.ToString()
                 );
 
-            var alert = AlertRaised.Create(
-                notificationCenter.Database,
-                $"AI Agent '{agentName}': Exceeded Token Threshold",
-                message,
-                AlertReason.AiAgent_ExceededTokenThreshold,
-                NotificationSeverity.Warning,
-                details: details);
+            return details;
+        }
 
-            notificationCenter.Add(alert);
+        public static AlertRaised CreateAlert(ExceededTokenThresholdDetails pendingAlertDetails, string databaseName)
+        {
+            var configurationKey = RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold);
+            var msg = $"In conversation '{pendingAlertDetails.ConversationId}', the AI Agent '{pendingAlertDetails.AgentName}' sent a request with {pendingAlertDetails.TokenCount} tokens to the LLM, exceeding the configured threshold of {pendingAlertDetails.TokenThreshold} tokens. " +
+                      $"You can adjust the limit by setting the '{configurationKey}' configuration value";
+            return AlertRaised.Create(databaseName, $"AI Agent '{pendingAlertDetails.AgentName}': Exceeded Token Threshold",
+                msg, AlertReason.AiAgent_ExceededTokenThreshold, NotificationSeverity.Warning, details: pendingAlertDetails);
         }
 
         public class ToolCallDetails : IDynamicJson
@@ -91,16 +92,23 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             public string Name { get; set; }
             public ToolType Type { get; set; }
             public string Arguments { get; set; }
+            public string Query { get; set; }
 
             public DynamicJsonValue ToJson()
             {
-                return new DynamicJsonValue
+                var djv = new DynamicJsonValue
                 {
                     [nameof(Id)] = Id,
                     [nameof(Name)] = Name,
                     [nameof(Type)] = Type.ToString(),
                     [nameof(Arguments)] = Arguments
                 };
+                if (Type == ToolType.Query)
+                {
+                    djv[nameof(Query)] = Query;
+                }
+
+                return djv;
             }
         }
     }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -208,8 +209,25 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 if (details.TryGet("TokenCount", out int tokenCount) == false || details.TryGet("TokenThreshold", out int tokenThreshold) == false || tokenCount <= tokenThreshold)
                     return false;
 
-                if (details.TryGet("ToolCalls", out BlittableJsonReaderArray toolCalls) == false || toolCalls.Length == 0)
+                if (details.TryGet("ConversationId", out string conversationId) == false ||
+                    string.IsNullOrWhiteSpace(conversationId))
                     return false;
+
+                char sep = db.IdentityPartsSeparator;
+
+                if (conversationId[^1] == sep || conversationId[^1] == '|')
+                    return false;
+
+                int lastSep = conversationId.LastIndexOf(sep);
+                if (lastSep >= 0)
+                {
+                    var suffix = conversationId.AsSpan(lastSep + 1);
+                    if (suffix.Length == 0 || !suffix.Contains('-'))
+                        return false;
+                }
+
+                if (details.TryGet("ToolCalls", out BlittableJsonReaderArray toolCalls) == false || toolCalls.Length == 0)
+                        return false;
 
                 var actualToolTypes = new HashSet<string>();
                 foreach (BlittableJsonReaderObject toolCall in toolCalls)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25298/Incomplete-Document-Id-in-the-alert

### Additional description

The problem originated because _conversationId was used for notifications and persistence before it was resolved into a concrete document ID. When the client passed a prefix (like chatbot/), the system stored and logged the incomplete ID, causing inconsistent alerts.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
