### PR TITLE
RavenDB-25301 : Fix enum overflow when migrating from 5.4

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -141,14 +141,14 @@ namespace Raven.Server.Smuggler.Migration
 
         private async Task MigrateDatabase(long operationId, ImportInfo importInfo)
         {
-
             var startDocumentEtag = importInfo?.LastEtag ?? 0;
             var startRaftIndex = importInfo?.LastRaftIndex ?? 0;
             var url = $"{Options.ServerUrl}/databases/{Options.DatabaseName}/smuggler/export?operationId={operationId}&startEtag={startDocumentEtag}&startRaftIndex={startRaftIndex}";
             var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus)
             {
                 OperateOnTypes = Options.OperateOnTypes,
-                RemoveAnalyzers = Options.RemoveAnalyzers
+                RemoveAnalyzers = Options.RemoveAnalyzers,
+                OperateOnDatabaseRecordTypes = Options.OperateOnDatabaseRecordTypes
             };
 
             if (importInfo != null)

--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -364,7 +364,7 @@ namespace InterversionTests
             using var store54 = await GetDocumentStoreAsync(Server54Version);
             using var storeCurrent = GetDocumentStore();
 
-            store54.Maintenance.Send(new CreateSampleDataOperation());
+            await store54.Maintenance.SendAsync(new CreateSampleDataOperation());
             using (var session = store54.OpenAsyncSession())
             {
                 for (var i = 0; i < 5; i++)
@@ -376,7 +376,7 @@ namespace InterversionTests
                 await session.SaveChangesAsync();
             }
 
-            var operation = await Migrate(store54, storeCurrent);
+            var operation = await Migrate(store54, storeCurrent, operateOnDatabaseRecordTypes: _operateOnRecordTypes54);
             await operation.WaitForCompletionAsync(_operationTimeout);
 
             var fromStat = await store54.Maintenance.SendAsync(new GetStatisticsOperation());
@@ -492,7 +492,7 @@ namespace InterversionTests
             Assert.Equal(fromMetadataCount, toMetadataCount);
         }
 
-        private static async Task<Operation> Migrate(DocumentStore @from, DocumentStore to, DatabaseItemType operateOnTypes = DatabaseItemType.None)
+        private static async Task<Operation> Migrate(DocumentStore @from, DocumentStore to, DatabaseItemType operateOnTypes = DatabaseItemType.None, DatabaseRecordItemType operateOnDatabaseRecordTypes = DatabaseRecordItemType.None)
         {
             using var client = new HttpClient();
             var url = new Uri($"{to.Urls.First()}/admin/remote-server/build/version?serverUrl={@from.Urls.First()}");
@@ -511,7 +511,8 @@ namespace InterversionTests
                 MigrationSettings = new DatabaseMigrationSettings
                 {
                     DatabaseName = @from.Database,
-                    OperateOnTypes = operateOnTypes
+                    OperateOnTypes = operateOnTypes,
+                    OperateOnDatabaseRecordTypes = operateOnDatabaseRecordTypes
                 }
             };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25301/InterversionTests.SmugglerTests.CanMigrateFrom54ToCurrent

### Additional description

- The recent fix [#21689](https://github.com/ravendb/ravendb/pull/21689) changed the definition of `SnowflakeEtls` in `DatabaseRecordItemType` from `1 << 31` to `1L << 31`.

- Before this change, the `OperateOnDatabaseRecordTypes` value that was sent by the importer was `-9`, and v5.4 was able to handle that (probably treated this as `None`)

- After this change, the default `OperateOnDatabaseRecordTypes` value became a large 64-bit number that v5.4 could not deserialize, since in 5.4 this enum is still defined as `int`, and it threw an exception: `Could not convert System.Int64 ('68719476727') to Raven.Client.Documents.Smuggler.DatabaseRecordItemType
---> System.OverflowException: Value was either too large or too small for an Int32` 

- To fix this, the importer now explicitly sets `Options.OperateOnDatabaseRecordTypes` rather than relying on `DefaultOperateOnDatabaseRecordTypes`.

- The interversion test (`CanMigrateFrom54ToCurrent`) was updated to pass `_operateOnRecordTypes54`, ensuring compatibility with v5.4.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
