### PR TITLE
RavenDB-25301 : Fix enum overflow when migrating from 5.4 (release/v7.1)

### DIFF
--- a/src/Raven.Server/Smuggler/Migration/Importer.cs
+++ b/src/Raven.Server/Smuggler/Migration/Importer.cs
@@ -141,14 +141,14 @@ namespace Raven.Server.Smuggler.Migration
 
         private async Task MigrateDatabase(long operationId, ImportInfo importInfo)
         {
-
             var startDocumentEtag = importInfo?.LastEtag ?? 0;
             var startRaftIndex = importInfo?.LastRaftIndex ?? 0;
             var url = $"{Options.ServerUrl}/databases/{Options.DatabaseName}/smuggler/export?operationId={operationId}&startEtag={startDocumentEtag}&startRaftIndex={startRaftIndex}";
             var databaseSmugglerOptionsServerSide = new DatabaseSmugglerOptionsServerSide(AuthorizationStatus)
             {
                 OperateOnTypes = Options.OperateOnTypes,
-                RemoveAnalyzers = Options.RemoveAnalyzers
+                RemoveAnalyzers = Options.RemoveAnalyzers,
+                OperateOnDatabaseRecordTypes = Options.OperateOnDatabaseRecordTypes
             };
 
             if (importInfo != null)

--- a/test/InterversionTests/SmugglerTests.cs
+++ b/test/InterversionTests/SmugglerTests.cs
@@ -364,7 +364,7 @@ namespace InterversionTests
             using var store54 = await GetDocumentStoreAsync(Server54Version);
             using var storeCurrent = GetDocumentStore();
 
-            store54.Maintenance.Send(new CreateSampleDataOperation());
+            await store54.Maintenance.SendAsync(new CreateSampleDataOperation());
             using (var session = store54.OpenAsyncSession())
             {
                 for (var i = 0; i < 5; i++)
@@ -376,7 +376,7 @@ namespace InterversionTests
                 await session.SaveChangesAsync();
             }
 
-            var operation = await Migrate(store54, storeCurrent);
+            var operation = await Migrate(store54, storeCurrent, operateOnDatabaseRecordTypes: _operateOnRecordTypes54);
             await operation.WaitForCompletionAsync(_operationTimeout);
 
             var fromStat = await store54.Maintenance.SendAsync(new GetStatisticsOperation());
@@ -492,7 +492,7 @@ namespace InterversionTests
             Assert.Equal(fromMetadataCount, toMetadataCount);
         }
 
-        private static async Task<Operation> Migrate(DocumentStore @from, DocumentStore to, DatabaseItemType operateOnTypes = DatabaseItemType.None)
+        private static async Task<Operation> Migrate(DocumentStore @from, DocumentStore to, DatabaseItemType operateOnTypes = DatabaseItemType.None, DatabaseRecordItemType operateOnDatabaseRecordTypes = DatabaseRecordItemType.None)
         {
             using var client = new HttpClient();
             var url = new Uri($"{to.Urls.First()}/admin/remote-server/build/version?serverUrl={@from.Urls.First()}");
@@ -511,7 +511,8 @@ namespace InterversionTests
                 MigrationSettings = new DatabaseMigrationSettings
                 {
                     DatabaseName = @from.Database,
-                    OperateOnTypes = operateOnTypes
+                    OperateOnTypes = operateOnTypes,
+                    OperateOnDatabaseRecordTypes = operateOnDatabaseRecordTypes
                 }
             };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25301/InterversionTests.SmugglerTests.CanMigrateFrom54ToCurrent

see https://github.com/ravendb/ravendb/pull/21729

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
