### PR TITLE
RavenDB-7070 Disposes the `ByteStringContext` allocator in `StorageTest` base.

### DIFF
--- a/test/FastTests/Voron/StorageTest.cs
+++ b/test/FastTests/Voron/StorageTest.cs
@@ -23,7 +23,7 @@ namespace FastTests.Voron
         protected StorageEnvironmentOptions Options;
         protected readonly string DataDir = RavenTestHelper.NewDataPath(nameof(StorageTest), 0);
 
-        protected ByteStringContext Allocator { get; } = new ByteStringContext(SharedMultipleUseFlag.None);
+        protected ByteStringContext Allocator { get; private set; } = new ByteStringContext(SharedMultipleUseFlag.None);
 
         protected StorageTest(StorageEnvironmentOptions options, ITestOutputHelper output) : base(output)
         {
@@ -120,6 +120,12 @@ namespace FastTests.Voron
             aggregator.Execute(() =>
             {
                 IOExtensions.DeleteDirectory(DataDir);
+            });
+            
+            aggregator.Execute(() =>
+            {
+                Allocator?.Dispose();
+                Allocator = null;
             });
 
             aggregator.ThrowIfNeeded();


### PR DESCRIPTION
### Additional description
Disposes the `ByteStringContext` allocator in `StorageTest` base.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
