### PR TITLE
RavenDB-25213 Testfix: without an ORDER BY clause, the order of documents is not guaranteed in a sharding mode.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-20248.cs
+++ b/test/SlowTests/Issues/RavenDB-20248.cs
@@ -71,8 +71,8 @@ public class RavenDB_20248 : RavenTestBase
             var queryResult = query.ToList();
             
             Assert.Equal(2, queryResult.Count);
-            Assert.Equal(queryResult[0].Name, "Name1" + "Test");
-            Assert.Equal(queryResult[1].Name, "Name3" + "Test");
+            Assert.Contains(queryResult, p => p.Name == "Name1" + "Test");
+            Assert.Contains(queryResult, p => p.Name == "Name3" + "Test");
         }
     }
     


### PR DESCRIPTION
…

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25213
https://issues.hibernatingrhinos.com/issue/RavenDB-23537

### Additional description
 Testfix: without an ORDER BY clause, the order of documents is not guaranteed in a sharding mode.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
