### PR TITLE
RavenDB-25182 Testfix : wait for the first iteration in a indexing process.

### DIFF
--- a/test/SlowTests/Issues/RavenDB-24649.cs
+++ b/test/SlowTests/Issues/RavenDB-24649.cs
@@ -120,7 +120,7 @@ public class RavenDB_24649(ITestOutputHelper output) : RavenTestBase(output)
                 
                 var elapsed = index.GetElapsedTimeFromLastQuery();
                 var lastQueriedTime = index.GetLastQueryingTime();
-                var lastIndexingTime = index.LastIndexingTime;
+                var lastIndexingTime = await WaitAndAssertForGreaterThanAsync(() => Task.FromResult(index.LastIndexingTime!.Value), lastQueriedTime!.Value, timeout: Timeout, interval: Interval);
                 
                 Assert.True(lastQueriedTime < lastIndexingTime, $"{lastQueriedTime} < {lastIndexingTime}");
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25182
### Additional description

```
10/14/2025 11:05:29 PM < 8/22/2025 1:56:52 PM
```
The last indexing time is read from disk, but it will be updated during the first iteration of the indexing loop. This indicates a potential race condition between the assertion and the start of the indexing thread.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
