### PR TITLE
RavenDB-25327 Add test and fix subject creation for certificates without common name - 6.2

### DIFF
--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -346,9 +346,15 @@ namespace Raven.Server.Utils
             log?.AppendLine("Subject key pair prepared.");
 
             // Prepare Distinguished Names
-            var subjectName = new X500DistinguishedName($"CN={commonNameValue}");
-            log?.AppendLine($"issuerDN = {issuerCN}");
+            var subjectName = new X500DistinguishedName(string.Empty);
+            if (string.IsNullOrEmpty(commonNameValue) == false)
+            {
+                var commonNameBuilder = new X500DistinguishedNameBuilder();
+                commonNameBuilder.AddCommonName(commonNameValue);
+                subjectName = commonNameBuilder.Build();
+            }
             log?.AppendLine($"subjectDN = {subjectName}");
+            log?.AppendLine($"issuerDN = {issuerCN}");
 
             // Create the Certificate Request
             var request = new CertificateRequest(subjectName, privateKey, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1);
@@ -495,17 +501,9 @@ namespace Raven.Server.Utils
             var issuerPrivateKey = serverCertificate.GetRSAPrivateKey();
             var issuerPublicKey = serverCertificate.GetRSAPublicKey();
 
-            // Extract the common name (CN) from the server certificate's subject.
-            string serverCommonName = serverCertificate.GetDisplayName();
-            if (serverCommonName == null)
-            {
-                throw new InvalidOperationException("Could not find Common Name (CN) in the server certificate's subject.");
-            }
-        
-
             // Call the native .NET method to create and sign the client certificate.
             CreateSelfSignedCertificateBasedOnPrivateKey(
-                commonNameValue: $"{serverCommonName.Replace("CN=", "")}-client-communication",
+                commonNameValue: "client-cert-for-cluster-communication",
                 issuerCN: serverCertificate.SubjectName,
                 issuerKeyPair: (issuerPrivateKey, issuerPublicKey),
                 isClientCertificate: true,

--- a/test/SlowTests/Issues/RavenDB-25327.cs
+++ b/test/SlowTests/Issues/RavenDB-25327.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Util;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25327 : RavenTestBase
+{
+    public RavenDB_25327(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Certificates)]
+    public void CanCreateCertificateForCommunication_UsingServerCertWith1EKU_AndMultipleSans_WithoutSubject()
+    {
+        const string firstDomain = "a.test-domain.com";
+        var suffix = Guid.NewGuid().ToString().Split('-')[0];
+        CertificateUtils.CreateCertificateAuthorityCertificate($"ca-{suffix}", out var kp, out var caSubjectName);
+        CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey(null,
+            caSubjectName,
+            kp,
+            false,
+            false,
+            DateTime.UtcNow.AddDays(7),
+            out var serverCertBytes,
+            sans: [firstDomain, "b.test-domain.com", "c.test-domain.com"],
+            with2Eku: false);
+
+        var serverCert = CertificateLoaderUtil.CreateCertificate(serverCertBytes, flags: CertificateLoaderUtil.FlagsForExport);
+        Assert.Contains(firstDomain, serverCert.GetDisplayName());
+        var clientCert = CertificateUtils.CreateClientCertificateFromServerCertificate(serverCert, out _);
+
+        Assert.NotNull(clientCert);
+        Assert.Equal("CN=client-cert-for-cluster-communication", clientCert.Subject);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25327 

### Additional description

Cherry-picked from v5.4.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
