### PR TITLE
RavenDB-25325 - several improvements and refactorings to the remote attachments

### DIFF
--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsConfiguration.cs
@@ -9,10 +9,11 @@ namespace Raven.Client.Documents.Attachments
 {
     public sealed class RemoteAttachmentsConfiguration : IDynamicJson
     {
-        public Dictionary<string, RemoteAttachmentsDestinationConfiguration> Destinations { get; set; }
+        public Dictionary<string, RemoteAttachmentsDestinationConfiguration> Destinations { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public long? CheckFrequencyInSec { get; set; }
         public long? MaxItemsToProcess { get; set; }
         public int? ConcurrentUploads { get; set; }
+        public bool Disabled { get; set; }
 
         public override int GetHashCode()
         {
@@ -33,6 +34,7 @@ namespace Raven.Client.Documents.Attachments
             hashCode.Add(CheckFrequencyInSec);
             hashCode.Add(MaxItemsToProcess);
             hashCode.Add(ConcurrentUploads);
+            hashCode.Add(Disabled);
 
             return hashCode.ToHashCode();
         }
@@ -53,7 +55,9 @@ namespace Raven.Client.Documents.Attachments
                 return false;
             if (ConcurrentUploads != other.ConcurrentUploads)
                 return false;
-            
+            if (Disabled != other.Disabled)
+                return false;
+
             if (Destinations == null && other.Destinations == null)
                 return true;
 
@@ -73,8 +77,10 @@ namespace Raven.Client.Documents.Attachments
             return true;
         }
 
-        internal bool HasUploader()
+        internal bool HasDestination()
         {
+            if (Disabled)
+                return false;
             if (Destinations == null || Destinations.Count == 0)
                 return false;
 
@@ -90,6 +96,7 @@ namespace Raven.Client.Documents.Attachments
                 [nameof(CheckFrequencyInSec)] = CheckFrequencyInSec,
                 [nameof(MaxItemsToProcess)] = MaxItemsToProcess,
                 [nameof(ConcurrentUploads)] = ConcurrentUploads,
+                [nameof(Disabled)] = Disabled,
             };
         }
 
@@ -97,7 +104,22 @@ namespace Raven.Client.Documents.Attachments
         {
             var databaseNameStr = string.IsNullOrEmpty(databaseName) ? string.Empty : $" for database '{databaseName}'";
 
-            if (HasUploader() == false)
+            if (CheckFrequencyInSec <= 0)
+                throw new InvalidOperationException($"Remote attachments check frequency{databaseNameStr} must be greater than 0.");
+            if (MaxItemsToProcess <= 0)
+                throw new InvalidOperationException($"Max items to process{databaseNameStr} must be greater than 0.");
+            if (ConcurrentUploads <= 0)
+                throw new InvalidOperationException($"Concurrent attachments uploads{databaseNameStr} must be greater than 0.");
+
+            if (Destinations == null || Destinations.Count == 0)
+            {
+                // no destinations configured
+                return;
+            }
+
+            // assert the destinations
+            if (Destinations.Any(x => BackupConfiguration.CanBackupUsing(x.Value.S3Settings)
+                                      || BackupConfiguration.CanBackupUsing(x.Value.AzureSettings)) == false)
                 throw new InvalidOperationException($"Exactly one uploader for {nameof(RemoteAttachmentsConfiguration)}{databaseNameStr} must be configured.");
 
             foreach (var kvp in Destinations)
@@ -107,13 +129,6 @@ namespace Raven.Client.Documents.Attachments
 
                 kvp.Value.AssertConfiguration(kvp.Key, databaseName);
             }
-
-            if (CheckFrequencyInSec <= 0)
-                throw new InvalidOperationException($"Remote attachments check frequency{databaseNameStr} must be greater than 0.");
-            if (MaxItemsToProcess <= 0)
-                throw new InvalidOperationException($"Max items to process{databaseNameStr} must be greater than 0.");
-            if (ConcurrentUploads <= 0)
-                throw new InvalidOperationException($"Concurrent attachments uploads{databaseNameStr} must be greater than 0.");
 
             if (Destinations.Any(x => BackupConfiguration.CanBackupUsing(x.Value.S3Settings)
                                         && BackupConfiguration.CanBackupUsing(x.Value.AzureSettings)))

--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsConfiguration.cs
@@ -9,7 +9,8 @@ namespace Raven.Client.Documents.Attachments
 {
     public sealed class RemoteAttachmentsConfiguration : IDynamicJson
     {
-        public Dictionary<string, RemoteAttachmentsDestinationConfiguration> Destinations { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        internal static readonly StringComparer KeyComparer = StringComparer.OrdinalIgnoreCase;
+        public Dictionary<string, RemoteAttachmentsDestinationConfiguration> Destinations { get; set; } = new(KeyComparer);
         public long? CheckFrequencyInSec { get; set; }
         public long? MaxItemsToProcess { get; set; }
         public int? ConcurrentUploads { get; set; }
@@ -24,10 +25,14 @@ namespace Raven.Client.Documents.Attachments
             }
             else
             {
-                foreach (var kvp in Destinations)
+                hashCode.Add(Destinations.Count);
+
+                var orderedKeys = Destinations.Keys.OrderBy(k => k, KeyComparer);
+                foreach (var key in orderedKeys)
                 {
-                    hashCode.Add(kvp.Key.GetHashCode());
-                    hashCode.Add(kvp.Value.GetHashCode());
+                    // Use the KeyComparer to get the case-insensitive hash code for the key.
+                    hashCode.Add(KeyComparer.GetHashCode(key));
+                    hashCode.Add(Destinations[key] == null ? 0 : Destinations[key].GetHashCode());
                 }
             }
 
@@ -71,9 +76,11 @@ namespace Raven.Client.Documents.Attachments
             {
                 if (other.Destinations.TryGetValue(kvp.Key, out var otherConfig) == false)
                     return false;
-                if (kvp.Value.Equals(otherConfig) == false)
+
+                if (Equals(kvp.Value, otherConfig) == false)
                     return false;
             }
+
             return true;
         }
 
@@ -117,22 +124,18 @@ namespace Raven.Client.Documents.Attachments
                 return;
             }
 
-            // assert the destinations
-            if (Destinations.Any(x => BackupConfiguration.CanBackupUsing(x.Value.S3Settings)
-                                      || BackupConfiguration.CanBackupUsing(x.Value.AzureSettings)) == false)
-                throw new InvalidOperationException($"Exactly one uploader for {nameof(RemoteAttachmentsConfiguration)}{databaseNameStr} must be configured.");
-
             foreach (var kvp in Destinations)
             {
                 if (kvp.Value == null)
                     throw new InvalidOperationException($"Destination configuration for key {kvp.Key} is null{databaseNameStr}.");
 
                 kvp.Value.AssertConfiguration(kvp.Key, databaseName);
-            }
 
-            if (Destinations.Any(x => BackupConfiguration.CanBackupUsing(x.Value.S3Settings)
-                                        && BackupConfiguration.CanBackupUsing(x.Value.AzureSettings)))
-                throw new InvalidOperationException($"Only one uploader for {nameof(RemoteAttachmentsConfiguration)}{databaseNameStr} can be configured.");
+                if (BackupConfiguration.CanBackupUsing(kvp.Value.S3Settings) == false && BackupConfiguration.CanBackupUsing(kvp.Value.AzureSettings) == false)
+                    throw new InvalidOperationException($"Exactly one uploader for {nameof(RemoteAttachmentsConfiguration)}{databaseNameStr} must be configured.");
+                if (BackupConfiguration.CanBackupUsing(kvp.Value.S3Settings) && BackupConfiguration.CanBackupUsing(kvp.Value.AzureSettings))
+                    throw new InvalidOperationException($"Only one uploader for {nameof(RemoteAttachmentsConfiguration)}{databaseNameStr} can be configured.");
+            }
         }
     }
 }

--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsDestinationConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsDestinationConfiguration.cs
@@ -14,10 +14,32 @@ public sealed class RemoteAttachmentsDestinationConfiguration : IDynamicJson
     public override int GetHashCode()
     {
         var hashCode = new HashCode();
-        hashCode.Add(Identifier);
+        hashCode.Add(Identifier == null ? 0 : RemoteAttachmentsConfiguration.KeyComparer.GetHashCode(Identifier));
         hashCode.Add(Disabled);
-        hashCode.Add(S3Settings);
-        hashCode.Add(AzureSettings);
+        if (S3Settings != null)
+        {
+            // Do NOT include fields ignored by S3Settings.Equals().
+            hashCode.Add(S3Settings.Disabled);
+            hashCode.Add(S3Settings.AwsRegionName);
+            hashCode.Add(S3Settings.BucketName);
+            hashCode.Add(S3Settings.RemoteFolderName);
+            hashCode.Add(S3Settings.CustomServerUrl);
+            hashCode.Add(S3Settings.ForcePathStyle);
+            hashCode.Add(S3Settings.StorageClass);
+        }
+        else
+        {
+            hashCode.Add(0);
+        }
+        if (AzureSettings != null)
+        {
+            hashCode.Add(AzureSettings.Disabled);
+            hashCode.Add(AzureSettings.RemoteFolderName);
+        }
+        else
+        {
+            hashCode.Add(0);
+        }
 
         return hashCode.ToHashCode();
     }

--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsDestinationConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsDestinationConfiguration.cs
@@ -35,7 +35,7 @@ public sealed class RemoteAttachmentsDestinationConfiguration : IDynamicJson
 
     private bool Equals(RemoteAttachmentsDestinationConfiguration other)
     {
-        if (Identifier != other.Identifier)
+        if (string.Equals(Identifier, other.Identifier, StringComparison.OrdinalIgnoreCase) == false)
             return false;
         if (Disabled != other.Disabled)
             return false;
@@ -90,7 +90,7 @@ public sealed class RemoteAttachmentsDestinationConfiguration : IDynamicJson
         if (string.IsNullOrEmpty(Identifier))
             throw new InvalidOperationException($"Identifier{databaseNameStr} must have a value.");
 
-        if (key != Identifier)
+        if (string.Equals(key, Identifier, StringComparison.OrdinalIgnoreCase) == false)
             throw new InvalidOperationException($"Identifier '{Identifier}' does not match the key '{key}'{databaseNameStr}.");
     }
 }

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -97,25 +97,25 @@ public abstract unsafe class AbstractBackgroundWorkStorage<TWorkInfo> : Abstract
                             }
                             catch (DocumentConflictException)
                             {
-                                item = new TWorkInfo { Status = DocumentExpirationInfoStatus.Conflict };
+                                item = new TWorkInfo { Status = BackgroundWorkInfoStatus.Conflict };
                             }
 
                             switch (item.Status)
                             {
-                                case DocumentExpirationInfoStatus.Process when isFirstInTopology == false:
-                                case DocumentExpirationInfoStatus.Skip when isFirstInTopology == false:
-                                case DocumentExpirationInfoStatus.Conflict when isFirstInTopology == false:
+                                case BackgroundWorkInfoStatus.Process when isFirstInTopology == false:
+                                case BackgroundWorkInfoStatus.Skip when isFirstInTopology == false:
+                                case BackgroundWorkInfoStatus.Conflict when isFirstInTopology == false:
                                     break;
-                                case DocumentExpirationInfoStatus.Process:
-                                case DocumentExpirationInfoStatus.Delete:
+                                case BackgroundWorkInfoStatus.Process:
+                                case BackgroundWorkInfoStatus.Delete:
                                     toProcess.Enqueue(item);
                                     totalCount++;
                                     break;
-                                case DocumentExpirationInfoStatus.Skip:
+                                case BackgroundWorkInfoStatus.Skip:
                                     HandleSkippedItem(item);
                                     totalCount++;
                                     break;
-                                case DocumentExpirationInfoStatus.Conflict:
+                                case BackgroundWorkInfoStatus.Conflict:
                                     HandleDocumentConflict(options, ticksAsSlice, clonedId, toProcess, ref totalCount);
                                     break;
                                 default:

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -306,20 +306,9 @@ namespace Raven.Server.Documents
                         });
                     }
 
-                    var keyExists = false;
-                    RemoteAttachmentFlags? existingFlags = null;
-                    if (table.ReadByKey(keySlice, out TableValueReader oldValue))
+                    if (table.ReadByKey(keySlice, out TableValueReader oldValue) && TableValueToAttachmentFlags((int)AttachmentsTable.Flags, ref oldValue) == RemoteAttachmentFlags.None)
                     {
-                        existingFlags = TableValueToAttachmentFlags((int)AttachmentsTable.Flags, ref oldValue);
-                        if (existingFlags == RemoteAttachmentFlags.None)
-                        {
-                            keyExists = true;
-                        }
-                    }
-
-                    if (keyExists)
-                    {
-                        // This is an update to the attachment with the same stream and content type
+                        // This is an update to the local storage attachment with the same stream and content type
                         // Just updating the etag and casing of the name and the content type.
 
                         if (expectedChangeVector != null)
@@ -374,7 +363,7 @@ namespace Raven.Server.Documents
                                 // Delete the attachment stream only if we have a different hash
                                 using (TableValueToSlice(context, (int)AttachmentsTable.Hash, ref partialTvr, out Slice existingHash))
                                 {
-                                    putStream = (existingHash.Content.Match(base64Hash.Content) == false) || existingFlags is RemoteAttachmentFlags.Remote;
+                                    putStream = (existingHash.Content.Match(base64Hash.Content) == false) || TableValueToAttachmentFlags((int)AttachmentsTable.Flags, ref partialTvr) is RemoteAttachmentFlags.Remote;
                                     if (putStream)
                                     {
                                         using (TableValueToSlice(context, (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType,

--- a/src/Raven.Server/Documents/BackgroundWork/AttachmentRemoteInfo.cs
+++ b/src/Raven.Server/Documents/BackgroundWork/AttachmentRemoteInfo.cs
@@ -11,7 +11,7 @@ public class AttachmentRemoteInfo : BackgroundWorkInfo
     {
     }
 
-    public AttachmentRemoteInfo(Slice ticks, Slice attachmentKey, string destinationIdentifier, DocumentExpirationInfoStatus status)
+    public AttachmentRemoteInfo(Slice ticks, Slice attachmentKey, string destinationIdentifier, BackgroundWorkInfoStatus status)
         : base(ticks, attachmentKey, destinationIdentifier, status)
     {
     }

--- a/src/Raven.Server/Documents/BackgroundWork/BackgroundWorkInfo.cs
+++ b/src/Raven.Server/Documents/BackgroundWork/BackgroundWorkInfo.cs
@@ -7,7 +7,7 @@ public abstract class BackgroundWorkInfo
     public Slice Ticks { get; }
     protected Slice TreeKey { get; }
     protected string Identifier { get; }
-    public DocumentExpirationInfoStatus Status { get; set; }
+    public BackgroundWorkInfoStatus Status { get; set; }
 
     public abstract string GetIdentifier();
     public abstract Slice GetTreeKey();
@@ -16,7 +16,7 @@ public abstract class BackgroundWorkInfo
     {
     }
 
-    protected BackgroundWorkInfo(Slice ticks, Slice treeKey, string identifier, DocumentExpirationInfoStatus status)
+    protected BackgroundWorkInfo(Slice ticks, Slice treeKey, string identifier, BackgroundWorkInfoStatus status)
     {
         Status = status;
         Ticks = ticks;

--- a/src/Raven.Server/Documents/BackgroundWork/BackgroundWorkInfoStatus.cs
+++ b/src/Raven.Server/Documents/BackgroundWork/BackgroundWorkInfoStatus.cs
@@ -1,6 +1,6 @@
 ﻿namespace Raven.Server.Documents.BackgroundWork;
 
-public enum DocumentExpirationInfoStatus
+public enum BackgroundWorkInfoStatus
 {
     Process,
     Skip,

--- a/src/Raven.Server/Documents/BackgroundWork/DocumentBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/BackgroundWork/DocumentBackgroundWorkStorage.cs
@@ -19,10 +19,10 @@ public abstract class DocumentBackgroundWorkStorage : AbstractBackgroundWorkStor
             document.TryGetMetadata(out var metadata) == false ||
             HasPassed(metadata, options.CurrentTime, MetadataPropertyName) == false)
         {
-            return new DocumentExpirationInfo(ticksSlice, clonedId, null, DocumentExpirationInfoStatus.Delete);
+            return new DocumentExpirationInfo(ticksSlice, clonedId, null, BackgroundWorkInfoStatus.Delete);
         }
 
-        return new DocumentExpirationInfo(ticksSlice, clonedId, document.Id, DocumentExpirationInfoStatus.Process);
+        return new DocumentExpirationInfo(ticksSlice, clonedId, document.Id, BackgroundWorkInfoStatus.Process);
     }
 
     [DoesNotReturn]

--- a/src/Raven.Server/Documents/BackgroundWork/DocumentExpirationInfo.cs
+++ b/src/Raven.Server/Documents/BackgroundWork/DocumentExpirationInfo.cs
@@ -11,7 +11,7 @@ public class DocumentExpirationInfo : BackgroundWorkInfo
     {
     }
 
-    public DocumentExpirationInfo(Slice ticks, Slice documentLowerId, string documentId, DocumentExpirationInfoStatus status)
+    public DocumentExpirationInfo(Slice ticks, Slice documentLowerId, string documentId, BackgroundWorkInfoStatus status)
         : base(ticks, documentLowerId, documentId, status)
     {
     }

--- a/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
+++ b/src/Raven.Server/Documents/DataArchival/ArchiveDocumentsCommand.cs
@@ -54,7 +54,7 @@ internal class ArchiveDocumentsCommandDto: IReplayableCommandDto<DocumentsOperat
         return command;
     }
 
-    public (Slice Ticks, Slice LowerId, string Id, DocumentExpirationInfoStatus Status)[] ToArchive { get; set; }
+    public (Slice Ticks, Slice LowerId, string Id, BackgroundWorkInfoStatus Status)[] ToArchive { get; set; }
 
     public DateTime CurrentTime { get; set; }
 }

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -47,7 +47,7 @@ namespace Raven.Server.Documents.Expiration
 
             if (allExpired)
             {
-                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, DocumentExpirationInfoStatus.Process));
+                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, BackgroundWorkInfoStatus.Process));
                 totalCount++;
             }
         }

--- a/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpiredDocumentsCleaner.cs
@@ -248,7 +248,7 @@ namespace Raven.Server.Documents.Expiration
             return command;
         }
 
-        public (Slice, Slice, string, DocumentExpirationInfoStatus)[] Expired { get; set; }
+        public (Slice, Slice, string, BackgroundWorkInfoStatus)[] Expired { get; set; }
 
         public bool ForExpiration { get; set; }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/IGetAttachmentStrategy.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/IGetAttachmentStrategy.cs
@@ -27,8 +27,13 @@ public interface IGetAttachmentStrategy
                 $"Cannot perform '{operation}' for remote attachment '{name}' on document '{documentId}' because the database does not have a {nameof(RemoteAttachmentsConfiguration)} configured.");
         }
 
-        var destination = config.Destinations[attachment.RemoteParameters.Identifier];
-        if (destination == null)
+        if (config.Disabled)
+        {
+            throw new InvalidOperationException(
+                $"Cannot perform '{operation}' for remote attachment '{name}' on document '{documentId}' because the {nameof(RemoteAttachmentsConfiguration)} is disabled.");
+        }
+
+        if (config.Destinations == null || config.Destinations.TryGetValue(attachment.RemoteParameters.Identifier, out var destination) == false)
         {
             throw new InvalidOperationException(
                 $"Cannot perform '{operation}' for remote attachment '{name}' (identifier: '{attachment.RemoteParameters.Identifier}') on document '{documentId}' because the destination is not defined in {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)}.");

--- a/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
+++ b/src/Raven.Server/Documents/Refresh/RefreshStorage.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Refresh
 
             if (allExpired)
             {
-                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, DocumentExpirationInfoStatus.Process));
+                expiredDocs.Enqueue(new DocumentExpirationInfo(ticksAsSlice, clonedId, id, BackgroundWorkInfoStatus.Process));
                 totalCount++;
             }
         }

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -37,7 +37,7 @@ namespace Raven.Server.Documents
         private readonly List<Exception> _exceptions = new List<Exception>();
         private long _totalUploaded;
 
-        private bool _allHalted => Configuration == null || Configuration.Destinations.Count == 0 || Configuration.Destinations.All(x => x.Value.Disabled == true);
+        private bool _allHalted => Configuration == null || Configuration.Disabled || Configuration.Destinations == null || Configuration.Destinations.Count == 0 || Configuration.Destinations.All(x => x.Value.Disabled == true);
 
         public RemoteAttachmentsConfiguration Configuration { get; }
 
@@ -67,7 +67,7 @@ namespace Raven.Server.Documents
 
         internal async Task<int> ProcessRemoteAttachments(int batchSize, long maxItemsToProcess)
         {
-            if (Configuration.HasUploader() == false)
+            if (Configuration.HasDestination() == false)
             {
                 if (Logger.IsInfoEnabled)
                     Logger.Info($"Cannot process remote attachments on '{_database.Name}' because no destination is configured.");
@@ -128,17 +128,18 @@ namespace Raven.Server.Documents
 
                                 switch (attachment.Status)
                                 {
-                                    case DocumentExpirationInfoStatus.Delete:
+                                    case BackgroundWorkInfoStatus.Delete:
                                         if (Logger.IsDebugEnabled)
                                             Logger.Debug($"Skipping remote attachment with key: '{attachment.Key}' because it's identifier '{attachment.DestinationIdentifier}' IsNullOrEmpty.");
 
                                         // document or attachment was deleted, need to remove it from remote tree
                                         processed.Enqueue(attachment);
                                         continue;
-                                    case DocumentExpirationInfoStatus.Process:
+                                    case BackgroundWorkInfoStatus.Process:
+                                        // get the destination configuration for the identifier & create new uploader for the attachment
                                         if (directUploaders.TryGetValue(attachment.DestinationIdentifier, out var directUpload) == false)
                                         {
-                                            // get the destination configuration for the identifier & create new uploader for the attachment
+                                            // we are sure the destination exist because we got the item with "Process" status
                                             var destination = Configuration.Destinations[attachment.DestinationIdentifier];
                                             directUpload = new AttachmentUploader(UploaderSettings.GenerateDirectUploaderSettingsForAttachments(_database, attachment.DestinationIdentifier, destination.S3Settings, destination.AzureSettings), Logger, _token);
 
@@ -396,7 +397,7 @@ namespace Raven.Server.Documents
             return command;
         }
 
-        public (Slice, Slice, string, DocumentExpirationInfoStatus)[] Remote { get; set; }
+        public (Slice, Slice, string, BackgroundWorkInfoStatus)[] Remote { get; set; }
 
         public DateTime CurrentTime { get; set; }
     }

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Raven.Client;
@@ -195,15 +194,15 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
             if (Database.DocumentsStorage.GetTableValueReaderForDocument(options.Context, documentIdSlice, throwOnConflict: false, out _) == false)
             {
                 // doc was deleted
-                return new AttachmentRemoteInfo(ticksSlice, attachmentKey, null, DocumentExpirationInfoStatus.Delete);
+                return new AttachmentRemoteInfo(ticksSlice, attachmentKey, null, BackgroundWorkInfoStatus.Delete);
             }
 
             if (ShouldSkipItem(identifier))
             {
-                return new AttachmentRemoteInfo(ticksSlice, attachmentKey, identifier, DocumentExpirationInfoStatus.Skip);
+                return new AttachmentRemoteInfo(ticksSlice, attachmentKey, identifier, BackgroundWorkInfoStatus.Skip);
             }
 
-            return new AttachmentRemoteInfo(ticksSlice, attachmentKey, identifier, DocumentExpirationInfoStatus.Process);
+            return new AttachmentRemoteInfo(ticksSlice, attachmentKey, identifier, BackgroundWorkInfoStatus.Process);
         }
     }
 
@@ -274,7 +273,7 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
 
         if (allShouldRemote)
         {
-            expiredDocs.Enqueue(new AttachmentRemoteInfo(ticksAsSlice, clonedId, id, DocumentExpirationInfoStatus.Process));
+            expiredDocs.Enqueue(new AttachmentRemoteInfo(ticksAsSlice, clonedId, id, BackgroundWorkInfoStatus.Process));
             totalCount++;
         }
     }
@@ -365,7 +364,11 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
     {
         if (Configuration == null)
             throw new InvalidOperationException($"Cannot get remote attachment '{attachment.Key}' because {nameof(RemoteAttachmentsConfiguration)} is not configured on {Database.Name}.");
-        if (Configuration.Destinations.TryGetValue(attachment.RemoteParameters.Identifier, out var destination) == false)
+
+        if (Configuration.Disabled)
+            throw new InvalidOperationException($"Cannot get remote attachment '{attachment.Key}' because {nameof(RemoteAttachmentsConfiguration)} is disabled.");
+
+        if (Configuration.Destinations == null || Configuration.Destinations.TryGetValue(attachment.RemoteParameters.Identifier, out var destination) == false)
             throw new InvalidOperationException($"Cannot get remote attachment '{attachment.Key}' because destination for '{attachment.RemoteParameters.Identifier}' doesn't exist.");
         if (destination.Disabled)
             throw new InvalidOperationException($"Cannot get remote attachment '{attachment.Key}' because destination for '{attachment.RemoteParameters.Identifier}' is disabled.");
@@ -463,7 +466,7 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
             remoteAttachmentsSender?.Dispose();
             Configuration = dbRecord.RemoteAttachments;
 
-            if (dbRecord.RemoteAttachments.Destinations.All(x => x.Value.Disabled))
+            if (dbRecord.RemoteAttachments.HasDestination() == false)
                 return null;
 
             var cleaner = new RemoteAttachmentsSender(Database, dbRecord.RemoteAttachments);

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingReplicationHandler.cs
@@ -330,26 +330,20 @@ namespace Raven.Server.Documents.Replication.Incoming
                     {
                         case AttachmentReplicationItem attachmentReplicationItem:
 
-                            var gotStream = false;
                             if (_replicationInfo.ReplicatedAttachmentStreams != null && _replicationInfo.ReplicatedAttachmentStreams.TryGetValue(attachmentReplicationItem.Base64Hash, out var attachmentStream))
                             {
-                                // we populated the Stream Size to AttachmentSize when we received the attachment stream
+                                // when we created AttachmentReplicationItem with the attachment stream, we put the stream's size into AttachmentSize variable
                                 attachmentReplicationItem.AttachmentSize = attachmentStream.AttachmentSize;
-                                gotStream = true;
                             }
-
-                            if (gotStream == false)
+                            else
                             {
+                                // the attachment stream was not replicated, we check the local storage for the size of the attachment stream
                                 var attachmentSize = AttachmentsStorage.GetAttachmentStreamLength(context, attachmentReplicationItem.Base64Hash);
                                 if (attachmentSize != -1)
                                 {
                                     attachmentReplicationItem.AttachmentSize = attachmentSize;
-                                    gotStream = true;
                                 }
                             }
-
-                            // this is a serious issue, we have an attachment without a stream, the Replication Task will throw in such case, later
-                            Debug.Assert(gotStream == true, "gotStream == true");
 
                             break;
                     }

--- a/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
+++ b/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
@@ -435,6 +435,18 @@ namespace FastTests.Server.Documents.Attachments
                     CheckFrequencyInSec = 1
                 })));
                 Assert.Contains("Identifier 'conf-identifier' does not match the key 'test'", e.Message);
+
+                e = await Assert.ThrowsAsync<InvalidOperationException>(async () => await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(new RemoteAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            "S3-Users", null
+                        }
+                    },
+                    CheckFrequencyInSec = 1000,
+                })));
+                Assert.Contains("Destination configuration for key S3-Users is null", e.Message);
             }
         }
     }

--- a/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
+++ b/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
@@ -18,6 +18,42 @@ namespace FastTests.Server.Documents.Attachments
         }
 
         [RavenFact(RavenTestCategory.Attachments)]
+        public async Task CanPutAndGetRemoteAttachmentsConfigurationWithCaseInsensitiveIdentifier()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(new RemoteAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            "S3-uSeRs", new RemoteAttachmentsDestinationConfiguration()
+                            {
+                                S3Settings = new S3Settings()
+                                {
+                                    BucketName = "testS3Bucket-Users"
+                                },
+                                Disabled = false,
+                                Identifier = "s3-UsErS"
+                            }
+                        }
+                    },
+                    MaxItemsToProcess = 1,
+                }));
+
+                var config = await store.Maintenance.SendAsync(new GetRemoteAttachmentsConfigurationOperation());
+                var destination = config.Destinations.FirstOrDefault();
+                Assert.Equal(1, config.Destinations.Count);
+                Assert.NotNull(destination);
+                Assert.Equal("S3-uSeRs", destination.Key);
+                Assert.Equal("s3-UsErS", destination.Value.Identifier);
+                Assert.Equal("testS3Bucket-Users", destination.Value.S3Settings.BucketName);
+                Assert.Equal(false, destination.Value.Disabled);
+                Assert.Equal(null, config.CheckFrequencyInSec);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
         public async Task CanPutAndGetRemoteAttachmentsConfigurationWithDefaultRemoteFrequencyInSec()
         {
             using (var store = GetDocumentStore())
@@ -99,7 +135,8 @@ namespace FastTests.Server.Documents.Attachments
                                    }
                                }
                            },
-                    CheckFrequencyInSec = 10000
+                    CheckFrequencyInSec = 10000,
+                    Disabled = true,
                 };
 
                 await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(c2));
@@ -107,6 +144,7 @@ namespace FastTests.Server.Documents.Attachments
                 var config2 = await store.Maintenance.SendAsync(new GetRemoteAttachmentsConfigurationOperation());
                 var destination2 = config2.Destinations.FirstOrDefault();
                 Assert.Equal(1, config2.Destinations.Count);
+                Assert.Equal(true, config2.Disabled);
                 Assert.NotNull(destination2);
                 Assert.Equal("S3-Orders", destination2.Key);
                 Assert.Equal("S3-Orders", destination2.Value.Identifier);

--- a/test/InterversionTests/AttachmentsTests.cs
+++ b/test/InterversionTests/AttachmentsTests.cs
@@ -23,6 +23,7 @@ using Raven.Server.Documents.PeriodicBackup.Aws;
 using Raven.Server.Documents.PeriodicBackup.Restore;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Server.Documents.ETL.Olap;
 using Sparrow.Json;
 using Tests.Infrastructure;
@@ -335,6 +336,81 @@ namespace InterversionTests
                 {
                     if (File.Exists(file))
                         File.Delete(file);
+                }
+            }
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Interversion | RavenTestCategory.Attachments, RavenPlatform.Windows | RavenPlatform.Linux)]
+        [InlineData(Server62Version)]
+        public async Task ReplicationShouldSendMissingAttachments(string olderVersion)
+        {
+            using (var source = await GetDocumentStoreAsync(olderVersion))
+            using (var destination = GetDocumentStore())
+            {
+                await SetupReplicationAsync(source, destination);
+
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        fooStream.Position = 0;
+                        await session.StoreAsync(new User { Name = "Foo" }, $"FoObAr/{i}");
+                        session.Advanced.Attachments.Store($"FoObAr/{i}", "foo.png", fooStream, "image/png");
+                        await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentToReplicate<User>(destination, $"FoObAr/{i}", 15 * 1000));
+                    }
+                }
+
+                using (var session = destination.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        session.Delete($"FoObAr/{i}");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = source.OpenAsyncSession())
+                using (var fooStream2 = new MemoryStream(new byte[] { 4, 5, 6 }))
+                {
+                    for (int i = 0; i < 25; i++)
+                    {
+                        fooStream2.Position = 0;
+                        session.Advanced.Attachments.Store($"FoObAr/{i}", "foo2.png", fooStream2, "image/png");
+                        await session.SaveChangesAsync();
+
+                        Assert.NotNull(WaitForDocumentWithAttachmentToReplicate<User>(destination, $"FoObAr/{i}", "foo2.png", 30 * 1000));
+                    }
+                }
+
+                var buffer = new byte[3];
+                using (var session = destination.OpenAsyncSession())
+                {
+                    session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+                    for (int i = 0; i < 25; i++)
+                    {
+                        var user = await session.LoadAsync<User>($"FoObAr/{i}");
+                        var attachments = session.Advanced.Attachments.GetNames(user);
+                        Assert.Equal(2, attachments.Length);
+
+                        foreach (var name in attachments)
+                        {
+                            using (var attachment = await session.Advanced.Attachments.GetAsync(user, name.Name))
+                            {
+                                Assert.NotNull(attachment);
+                                Assert.Equal(3, await attachment.Stream.ReadAsync(buffer, 0, 3));
+                                if (attachment.Details.Name == "foo.png")
+                                {
+                                    Assert.Equal(1, buffer[0]);
+                                    Assert.Equal(2, buffer[1]);
+                                    Assert.Equal(3, buffer[2]);
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests.Client;
+using FastTests.Utils;
 using Orders;
 using Raven.Client;
 using Raven.Client.Documents;
@@ -19,10 +20,12 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.BackgroundWork;
 using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.Attachments;
 using Sparrow.Server;
 using Sparrow.Utils;
 using Tests.Infrastructure;
+using Voron;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -1609,6 +1612,167 @@ namespace SlowTests.Server.Documents.Attachments
 
                 // Verify source attachment no longer exists
                 Assert.Null(await store.Operations.SendAsync(new GetAttachmentOperation(sourceDocId, attachmentName, AttachmentType.Document, null))); 
+            }
+        }
+
+        [AmazonS3RetryFact]
+        public async Task CreateRemoteAttachmentThenMakeRevisionsEnabledThenAddAnotherAttachment()
+        {
+            await using (var holder = CreateCloudSettings())
+            using (var store = GetDocumentStore())
+            {
+                var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Fitzchak" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store.Operations.Send(new PutAttachmentOperation("users/1", new StoreAttachmentParameters("foo/bar", profileStream)
+                    {
+                        RemoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3)),
+                        ContentType = "image/png",
+                    }));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+                // Remote the attachment
+                var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                // Verify attachment is Remote
+                await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+                var remoteAttachment = await store.Operations.SendAsync(new GetAttachmentOperation("users/1", "foo/bar", AttachmentType.Document, null));
+                Assert.Equal(RemoteAttachmentFlags.Remote, remoteAttachment.Details.RemoteParameters.Flags);
+
+                await RevisionsHelper.SetupRevisionsAsync(store, modifyConfiguration: configuration =>
+                {
+                    configuration.Collections["Users"].PurgeOnDelete = true;
+                    configuration.Collections["Users"].MinimumRevisionsToKeep = 4;
+                });
+
+                using (var backgroundStream = new MemoryStream(new byte[] { 10, 20, 30, 40, 50 }))
+                {
+                    var result = store.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", backgroundStream, "ImGgE/jPeG"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("ImGgE/jPeG", result.ContentType);
+                    Assert.Equal("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U=", result.Hash);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var rev = await session.Advanced.Revisions.GetMetadataForAsync("users/1");
+                    Assert.Equal(2, rev.Count);
+
+                    var att1 = rev[0].GetObjects("@attachments");
+                    var att2 = rev[1].GetObjects("@attachments");
+                    Assert.Equal(1, att1.Length);
+                    Assert.Equal(1, att2.Length);
+
+                }
+
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                using (var hash1 = ctx.GetLazyString("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo="))
+                using (var hash2 = ctx.GetLazyString("igkD5aEdkdAsAB/VpYm1uFlfZIP9M2LSUsD6f6RVW9U="))
+                using (Slice.From(ctx.Allocator, hash1, out var hash1Slice))
+                using (Slice.From(ctx.Allocator, hash2, out var hash2Slice))
+                {
+                    Assert.False(database.DocumentsStorage.AttachmentsStorage.AttachmentExists(ctx, hash1));
+                    Assert.True(database.DocumentsStorage.AttachmentsStorage.AttachmentExists(ctx, hash2));
+                    Assert.Equal(0, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash1Slice).LocalAttachmentsCount);
+                    Assert.Equal(1, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash1Slice).RemoteAttachmentsCount);
+                    Assert.Equal(1, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash1Slice).Count);
+                    Assert.Equal(2, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash2Slice).LocalAttachmentsCount);
+                    Assert.Equal(0, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash2Slice).RemoteAttachmentsCount);
+                    Assert.Equal(2, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash2Slice).Count);
+                }
+            }
+        }
+
+
+        [AmazonS3RetryFact]
+        public async Task CreateRemoteAttachmentThenMakeRevisionsEnabledThenOverwriteTheAttachmentWithLocalStream()
+        {
+            await using (var holder = CreateCloudSettings())
+            using (var store = GetDocumentStore())
+            {
+                var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Fitzchak" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store.Operations.Send(new PutAttachmentOperation("users/1", new StoreAttachmentParameters("foo/bar", profileStream)
+                    {
+                        RemoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3)),
+                        ContentType = "image/png",
+                    }));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("image/png", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+                // Remote the attachment
+                var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                // Verify attachment is Remote
+                await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+                var remoteAttachment = await store.Operations.SendAsync(new GetAttachmentOperation("users/1", "foo/bar", AttachmentType.Document, null));
+                Assert.Equal(RemoteAttachmentFlags.Remote, remoteAttachment.Details.RemoteParameters.Flags);
+
+                await RevisionsHelper.SetupRevisionsAsync(store, modifyConfiguration: configuration =>
+                {
+                    configuration.Collections["Users"].PurgeOnDelete = true;
+                    configuration.Collections["Users"].MinimumRevisionsToKeep = 4;
+                });
+
+                using (var profileStream = new MemoryStream(new byte[] { 1, 2, 3 }))
+                {
+                    var result = store.Operations.Send(new PutAttachmentOperation("users/1", "foo/bar", profileStream, "ImGgE/jPeG"));
+                    Assert.Equal("foo/bar", result.Name);
+                    Assert.Equal("users/1", result.DocumentId);
+                    Assert.Equal("ImGgE/jPeG", result.ContentType);
+                    Assert.Equal("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo=", result.Hash);
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var rev = await session.Advanced.Revisions.GetMetadataForAsync("users/1");
+                    Assert.Equal(2, rev.Count);
+
+                    var att1 = rev[0].GetObjects("@attachments");
+                    var att2 = rev[1].GetObjects("@attachments");
+                    Assert.Equal(1, att1.Length);
+                    Assert.Equal(1, att2.Length);
+
+                }
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                using (var hash1 = ctx.GetLazyString("EcDnm3HDl2zNDALRMQ4lFsCO3J2Lb1fM1oDWOk2Octo="))
+                using (Slice.From(ctx.Allocator, hash1, out var hash1Slice))
+                {
+                    Assert.True(database.DocumentsStorage.AttachmentsStorage.AttachmentExists(ctx, hash1));
+                    // 1 doc + 1 rev
+                    Assert.Equal(2, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash1Slice).LocalAttachmentsCount);
+                    // 1 rev
+                    Assert.Equal(1, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash1Slice).RemoteAttachmentsCount);
+                    // overall
+                    Assert.Equal(3, database.DocumentsStorage.AttachmentsStorage.GetCountOfAttachmentsForHash(ctx, hash1Slice).Count);
+                }
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25325

### Additional description

This pull request introduces several improvements and refactorings to the remote attachments The key changes include adding a `Disabled` flag to the remote attachments configuration, and allow passing empty list of destinations

**Configuration and Validation Improvements:**

* Added a `Disabled` boolean property to `RemoteAttachmentsConfiguration`, allowing the entire remote attachments feature to be toggled on or off. All relevant logic and validation now respect this flag.
* Changed the `Destinations` dictionary in `RemoteAttachmentsConfiguration` to use case-insensitive keys for more robust identifier matching.
* Enforced case-insensitive comparison for destination identifiers in both equality checks and configuration assertions.

**Background Work Refactoring:**

* Renamed the `DocumentExpirationInfoStatus` enum and all related usages to the more general `BackgroundWorkInfoStatus`, reflecting its broader application beyond just document expiration. 


**Remote Attachments Logic:**

* Updated logic in `RemoteAttachmentsSender` and related classes to respect the new `Disabled` flag and improved destination checks.
* Improved error handling in attachment strategies to throw clear exceptions when the configuration is disabled or destinations are missing.

**Attachment Storage Improvements:**

* Fixed and clarified logic for updating and deleting attachments, particularly around checking existing flags and hashes. 

These changes collectively make the remote attachments feature more robust, configurable, and maintainable, while also improving the clarity and generality of background work processing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
