### PR TITLE
RavenDB-25331 Add User-Agent to HttpClient to prevent 403 Forbidden

### DIFF
--- a/test/SlowTests/Issues/RavenDB_3620.cs
+++ b/test/SlowTests/Issues/RavenDB_3620.cs
@@ -18,6 +18,7 @@ namespace SlowTests.Issues
 
         public RavenDB_3620(ITestOutputHelper output) : base(output)
         {
+            _client.DefaultRequestHeaders.UserAgent.ParseAdd("RavenDB_3620-test");
         }
 
         [Fact]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25331

### Additional description

Requests to ravendb.net were failing with a 403 Forbidden error. This is common bot protection behavior (WAF) when a User-Agent is missing.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
