### PR TITLE
RavenDB-25299 : fixed the flaky test on RavenDB_24984

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
@@ -32,7 +32,8 @@ public class RavenDB_24984 : RavenTestBase
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-        var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, "your whole purpose is to run the tool called 'MyTool'")
+        var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName, "your whole purpose is to run the tool called 'MyTool'. When you finish," +
+                                                                                                " set Answer to exactly the last tool value as plain text, with no other text")
         {
             Identifier = "shopping-assistant",
             Actions =
@@ -44,10 +45,52 @@ public class RavenDB_24984 : RavenTestBase
                     ParametersSampleObject = "{}"
                 }
             ],
-            MaxModelIterationsPerCall = maxModelIterationsPerCall
+            MaxModelIterationsPerCall = maxModelIterationsPerCall,
         };
 
-        await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance);
+        var schemaJson = """
+                         {
+                           "name": "ZnYyQ3BUOGZYUXY3YXJqQm1uTGVOVytLeXdxQW82L0k5T0R4VGs3cFJzZz0",
+                           "strict": true,
+                           "schema": {
+                             "type": "object",
+                             "properties": {
+                               "Answer": {
+                                 "type": "string",
+                                 "description": "Answer to the user question"
+                               },
+                               "Relevant": {
+                                 "type": "boolean"
+                               },
+                               "RelevantOrdersId": {
+                                 "type": "array",
+                                 "items": {
+                                   "type": "string",
+                                   "description": "The order ids relevant to the query or response"
+                                 }
+                               },
+                               "MatchingProductsId": {
+                                 "type": "array",
+                                 "items": {
+                                   "type": "string",
+                                   "description": "All the product ids referenced either by the user or the system"
+                                 }
+                               }
+                             },
+                             "parallel_tool_calls" : false,
+                             "required": [
+                               "Answer",
+                               "Relevant",
+                               "RelevantOrdersId",
+                               "MatchingProductsId"
+                             ],
+                             "additionalProperties": false
+                           }
+                         }
+                         """;
+        agent.OutputSchema = schemaJson;
+        await store.AI.CreateAgentAsync(agent);
+
         var chat = store.AI.Conversation(
             agent.Identifier,
             "chats/",
@@ -56,7 +99,7 @@ public class RavenDB_24984 : RavenTestBase
         int lastNumber = 1;
         chat.Handle<object>("MyTool", _ => lastNumber++.ToString());
 
-        chat.SetUserPrompt("call the 'MyTool' tool until it returns the string '10' (or greater)");
+        chat.SetUserPrompt("call the 'MyTool' tool until it returns a value >= 10");
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
         var result = await chat.RunAsync<AiAgentBasics.OutputSchema>(cts.Token);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25299/SlowTests.Server.Documents.AI.AiAgent.RavenDB24984.ShouldStopUsingToolsWhenMaxModelIterationsPerCallIsReachedoptions

### Additional description

The issue was that the LLM called the tool call sometimes more than once at a time.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
