### PR TITLE
RavenDB-25233 : AiUsage token counts should use long instead of int  to prevent integer overflow

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
+++ b/src/Raven.Client/Documents/Operations/AI/AiUsage.cs
@@ -6,17 +6,17 @@ namespace Raven.Client.Documents.Operations.AI;
 
 public class AiUsage : IDynamicJsonValueConvertible
 {
-    public int PromptTokens { get; set; }
-    public int CompletionTokens { get; set; }
-    public int TotalTokens { get; set; }
-    public int CachedTokens { get; set; }
-    public int ReasoningTokens { get; set; }
+    public long PromptTokens { get; set; }
+    public long CompletionTokens { get; set; }
+    public long TotalTokens { get; set; }
+    public long CachedTokens { get; set; }
+    public long ReasoningTokens { get; set; }
 
     internal void UpdateFrom(BlittableJsonReaderObject json)
     {
-        json.TryGet("prompt_tokens", out int promptTokens);
-        json.TryGet("completion_tokens", out int completionTokens);
-        json.TryGet("total_tokens", out int totalTokens);
+        json.TryGet("prompt_tokens", out long promptTokens);
+        json.TryGet("completion_tokens", out long completionTokens);
+        json.TryGet("total_tokens", out long totalTokens);
 
         PromptTokens += promptTokens;
         CompletionTokens += completionTokens;
@@ -24,13 +24,13 @@ public class AiUsage : IDynamicJsonValueConvertible
 
         if (json.TryGet("prompt_tokens_details", out BlittableJsonReaderObject promptDetails) && promptDetails != null)
         {
-            if (promptDetails.TryGet("cached_tokens", out int cachedTokens))
+            if (promptDetails.TryGet("cached_tokens", out long cachedTokens))
                 CachedTokens += cachedTokens;
         }
 
         if (json.TryGet("completion_tokens_details", out BlittableJsonReaderObject completionTokensDetails) && completionTokensDetails != null)
         {
-            if (completionTokensDetails.TryGet("reasoning_tokens", out int reasoningTokens))
+            if (completionTokensDetails.TryGet("reasoning_tokens", out long reasoningTokens))
             {
                 ReasoningTokens += reasoningTokens;
             }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/ExceededTokenThresholdDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/ExceededTokenThresholdDetails.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
     {
         private ExceededTokenThresholdDetails() { }
 
-        private ExceededTokenThresholdDetails(string agentName, string conversationId, int tokenCount, int tokenLimit, List<ToolCallDetails> toolCalls, string recommendation)
+        private ExceededTokenThresholdDetails(string agentName, string conversationId, long tokenCount, long tokenLimit, List<ToolCallDetails> toolCalls, string recommendation)
         {
             AgentName = agentName;
             ConversationId = conversationId;
@@ -22,8 +22,8 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
 
         public string AgentName { get; set; }
         public string ConversationId { get; set; }
-        public int TokenCount { get; set; }
-        public int TokenThreshold { get; set; }
+        public long TokenCount { get; set; }
+        public long TokenThreshold { get; set; }
         public List<ToolCallDetails> ToolCalls { get; set; }
         public string Recommendation { get; set; }
 
@@ -40,7 +40,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             };
         }
 
-        public static ExceededTokenThresholdDetails Add(DatabaseNotificationCenter notificationCenter, string agentName, string conversationId, int tokenCount, int tokenThreshold, List<ToolCallDetails> toolCalls)
+        public static ExceededTokenThresholdDetails Add(DatabaseNotificationCenter notificationCenter, string agentName, string conversationId, long tokenCount, long tokenThreshold, List<ToolCallDetails> toolCalls)
         {
             var configurationKey = RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold);
             var message = $"In conversation '{conversationId}', the AI Agent '{agentName}' sent a request with {tokenCount} tokens to the LLM, exceeding the configured threshold of {tokenThreshold} tokens. " +


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25233/AiUsage-token-counts-should-use-long-instead-of-int-to-prevent-integer-overflow

### Additional description

changed all the token counters to long in order to prevent int overflow

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
