### PR TITLE
RavenDB-25201 : added data for flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -150,10 +150,23 @@ public class RavenDB_24407 : RavenTestBase
         {
             Assert.True(chatDoc.LinkedConversations.Count > 0);
 
+            var prev = new System.Text.StringBuilder();
+            prev.AppendLine("=== Linked Conversations ===");
+            foreach (var conversationId in chatDoc.LinkedConversations)
+            {
+                var c = await GetChat(store, conversationId);
+                prev.AppendLine($"- {conversationId}");
+                prev.AppendLine(Dump(c));
+            }
+
+            prev.AppendLine("=== Current Conversation ===");
+            prev.Append(Dump(chatDoc));
+            
             // assert that the summarization happened during mid-chat (after a tool call)
             var historyChat = await GetChat(store, chatDoc.LinkedConversations.First());
             var lastMsg = historyChat.Messages.Last();
-            Assert.Equal("tool", lastMsg.Role);
+            Assert.True("tool" == lastMsg.Role, "Expected last history message role 'tool' but was '" + lastMsg.Role + "'.\n" +
+                                                prev);
         }
         else
         {
@@ -291,5 +304,21 @@ public class RavenDB_24407 : RavenTestBase
         {
             return await session.LoadAsync<Chat>(chatId);
         }
+    }
+
+    string Dump(Chat c)
+    {
+        var sb = new System.Text.StringBuilder();
+        if (c?.Messages == null)
+            return "(no messages)";
+        for (int i = 0; i < c.Messages.Count; i++)
+        {
+            var m = c.Messages[i];
+            var content = m.Content?.ToString(Formatting.None) ?? "";
+            if (content.Length > 300)
+                content = content.Substring(0, 300); //the start is usually the most relevant
+            sb.AppendLine($"[{i}] role={m.Role} content={content}");
+        }
+        return sb.ToString();
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -150,23 +151,10 @@ public class RavenDB_24407 : RavenTestBase
         {
             Assert.True(chatDoc.LinkedConversations.Count > 0);
 
-            var prev = new System.Text.StringBuilder();
-            prev.AppendLine("=== Linked Conversations ===");
-            foreach (var conversationId in chatDoc.LinkedConversations)
-            {
-                var c = await GetChat(store, conversationId);
-                prev.AppendLine($"- {conversationId}");
-                prev.AppendLine(Dump(c));
-            }
-
-            prev.AppendLine("=== Current Conversation ===");
-            prev.Append(Dump(chatDoc));
-            
-            // assert that the summarization happened during mid-chat (after a tool call)
             var historyChat = await GetChat(store, chatDoc.LinkedConversations.First());
             var lastMsg = historyChat.Messages.Last();
-            Assert.True("tool" == lastMsg.Role, "Expected last history message role 'tool' but was '" + lastMsg.Role + "'.\n" +
-                                                prev);
+
+            await AssertWithDumpAsync(lastMsg.Role, async () => await DumpAllAsync(store, chatDoc, chatDoc.LinkedConversations));
         }
         else
         {
@@ -306,11 +294,22 @@ public class RavenDB_24407 : RavenTestBase
         }
     }
 
-    string Dump(Chat c)
+    private static async Task AssertWithDumpAsync(
+        string lastMsgRole,
+        Func<Task<string>> dumpFactory)
     {
-        var sb = new System.Text.StringBuilder();
+        if (lastMsgRole != "tool")
+        {
+            var msg = await dumpFactory(); // build dump only on failure
+            Assert.Fail($"Expected last history message role 'tool' but was '{lastMsgRole}'.\n{msg}");
+        }
+    }
+
+    private static string Dump(Chat c)
+    {
         if (c?.Messages == null)
             return "(no messages)";
+        var sb = new System.Text.StringBuilder();
         for (int i = 0; i < c.Messages.Count; i++)
         {
             var m = c.Messages[i];
@@ -319,6 +318,23 @@ public class RavenDB_24407 : RavenTestBase
                 content = content.Substring(0, 300); //the start is usually the most relevant
             sb.AppendLine($"[{i}] role={m.Role} content={content}");
         }
+        return sb.ToString();
+    }
+
+    private static async Task<string> DumpAllAsync(DocumentStore store, Chat current, IEnumerable<string> links)
+     {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("=== Linked Conversations ===");
+        if (links != null)
+            foreach (var id in links)
+            {
+                var c = await store.OpenAsyncSession().LoadAsync<Chat>(id);
+                sb.AppendLine($"- {id}");
+                sb.AppendLine(Dump(c));
+            }
+
+        sb.AppendLine("=== Current Conversation ===");
+        sb.Append(Dump(current));
         return sb.ToString();
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25201/SlowTests.Server.Documents.AI.AiAgent.RavenDB24407.CanResumeConversationWithSummarizationoptions-DatabaseMode-Single-config

### Additional description

could not reprocude the test so added more data for the next time it will fail

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
