### PR TITLE
Ravendb-25316 : GenAiConfiguration doesn't validate mandatory fields

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -103,6 +103,12 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         else if (GenAiTransformation.ValidateScript(out var error) == false)
             errors.Add(error);
 
+        if (string.IsNullOrEmpty(Prompt))
+            errors.Add($"{nameof(Prompt)} must be provided");
+
+        if (string.IsNullOrEmpty(JsonSchema) && string.IsNullOrEmpty(SampleObject))
+            errors.Add("You must provide either a JSON schema or a sample object");
+
         if (TestMode == false && string.IsNullOrEmpty(UpdateScript))
             errors.Add("You must provide an update function");
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-25316.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-25316.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDB_25316_GenAiValidation(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        private static void SeedMinimalValidConfig(GenAiConfiguration cfg)
+        {
+            cfg.Name = "GenAi-Validation";
+            cfg.Identifier = "genai-validation";
+            cfg.Collection = "Docs";
+            cfg.Prompt = "You are a helpful assistant.";
+            cfg.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ text: this.Body });" };
+            cfg.UpdateScript = "this.Answer = $output.Answer;";
+
+            var sample = JsonConvert.SerializeObject(new { Answer = "text" });
+            cfg.SampleObject = sample;
+            cfg.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(sample);
+        }
+
+        private static long GetTaskId(IDocumentStore store, string name)
+        {
+            var info = store.Maintenance.Send(new GetOngoingTaskInfoOperation(name, OngoingTaskType.GenAi));
+            return info.TaskId;
+        }
+
+        private static void AssertWrappedInner(RavenException ex, params string[] substrings)
+        {
+            Assert.NotNull(ex);
+            Assert.NotNull(ex.InnerException);
+            var inner = Assert.IsType<InvalidOperationException>(ex.InnerException);
+            Assert.Contains("Invalid ETL configuration", inner.Message);
+            Assert.Contains("Prompt", inner.Message);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void AddGenAiShouldFailWhenPromptIsNullOrEmpty(Options options, GenAiConfiguration config, string promptValue)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+
+            config.Prompt = promptValue;
+
+            var ex = Assert.Throws<RavenException>(() =>
+                store.Maintenance.Send(new AddGenAiOperation(config)));
+
+            AssertWrappedInner(ex);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void UpdateGenAiShouldFailWhenPromptIsNullOrEmpty(Options options, GenAiConfiguration config, string promptValue)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+            store.Maintenance.Send(new AddGenAiOperation(config));
+            var taskId = GetTaskId(store, config.Name);
+
+            config.Prompt = promptValue;
+
+            var ex = Assert.Throws<RavenException>(() =>
+                store.Maintenance.Send(new UpdateGenAiOperation(taskId, config)));
+
+            AssertWrappedInner(ex);
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void AddGenAiShouldSucceedWhenOnlySampleObjectIsProvided(Options options, GenAiConfiguration config, string jsonSchema)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+            config.JsonSchema = jsonSchema;
+
+            store.Maintenance.Send(new AddGenAiOperation(config));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void AddGenAiShouldSucceedWhenOnlyJsonSchemaIsProvided(Options options, GenAiConfiguration config, string sampleObject)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+
+            config.SampleObject = sampleObject;
+            
+            store.Maintenance.Send(new AddGenAiOperation(config));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void UpdateGenAiShouldSucceedWhenOnlySampleObjectIsProvided(Options options, GenAiConfiguration config, string jsonSchema)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+            store.Maintenance.Send(new AddGenAiOperation(config));
+            var taskId = GetTaskId(store, config.Name);
+
+            config.JsonSchema = jsonSchema;
+
+            store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void UpdateGenAiShouldSucceedWhenOnlyJsonSchemaIsProvided(Options options, GenAiConfiguration config, string sampleObject)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+            store.Maintenance.Send(new AddGenAiOperation(config));
+            var taskId = GetTaskId(store, config.Name);
+
+            config.SampleObject = sampleObject;
+
+            store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null])]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [""])]
+        public void UpdateGenAiShouldFailWhenBothSampleObjectAndJsonSchemaAreNull(Options options, GenAiConfiguration config, string emptyOrNull)
+        {
+            using var store = GetDocumentStore();
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            SeedMinimalValidConfig(config);
+            config.ConnectionStringName = config.Connection.Name;
+            store.Maintenance.Send(new AddGenAiOperation(config));
+            var taskId = GetTaskId(store, config.Name);
+
+            config.JsonSchema = emptyOrNull;
+            config.SampleObject = emptyOrNull;
+
+            var ex = Assert.Throws<RavenException>(() =>
+                store.Maintenance.Send(new UpdateGenAiOperation(taskId, config)));
+
+            AssertWrappedInner(ex);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25316/GenAiConfiguration-doesnt-validate-mandatory-fields

### Additional description

Added guard that validates mandatory fields -> validates prompt is not null or empty and that we have `JsonSchema `or `SampleObject`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
