### PR TITLE
RavenDB-25356 Add support for optional chaining and template literals…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/AcornimaVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/AcornimaVisitor.cs
@@ -85,6 +85,30 @@ namespace Raven.Server.Documents.Indexes.Static
                 case NodeType.CatchClause:
                     VisitCatchClause(statement.As<CatchClause>());
                     break;
+                case NodeType.ChainExpression:
+                    VisitChainExpression(statement.As<ChainExpression>());
+                    break;
+                case NodeType.TemplateLiteral:
+                    VisitTemplateLiteral(statement.As<TemplateLiteral>());
+                    break;
+                case NodeType.ForOfStatement:
+                    VisitForOfStatement(statement.As<ForOfStatement>());
+                    break;
+                case NodeType.ClassDeclaration:
+                    VisitClassDeclaration(statement.As<ClassDeclaration>());
+                    break;
+                case NodeType.ImportDeclaration:
+                    VisitImportDeclaration(statement.As<ImportDeclaration>());
+                    break;
+                case NodeType.ExportNamedDeclaration:
+                    VisitExportNamedDeclaration(statement.As<ExportNamedDeclaration>());
+                    break;
+                case NodeType.ExportAllDeclaration:
+                    VisitExportAllDeclaration(statement.As<ExportAllDeclaration>());
+                    break;
+                case NodeType.ExportDefaultDeclaration:
+                    VisitExportDefaultDeclaration(statement.As<ExportDefaultDeclaration>());
+                    break;
                 default:
                     VisitUnknownNode(statement);
                     break;
@@ -323,6 +347,12 @@ namespace Raven.Server.Documents.Indexes.Static
                 case NodeType.SpreadElement:
                     VisitSpreadElement(expression.As<SpreadElement>());
                     break;
+                case NodeType.ChainExpression:
+                    VisitChainExpression(expression.As<ChainExpression>());
+                    break;
+                case NodeType.TemplateLiteral:
+                    VisitTemplateLiteral(expression.As<TemplateLiteral>());
+                    break;
                 default:
                     VisitUnknownNode(expression);
                     break;
@@ -357,6 +387,11 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public virtual void VisitThisExpression(ThisExpression thisExpression)
         {
+        }
+
+        public virtual void VisitChainExpression(ChainExpression chainExpression)
+        {
+            VisitExpression(chainExpression.Expression);
         }
 
         public virtual void VisitSequenceExpression(SequenceExpression sequenceExpression)
@@ -684,6 +719,9 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public virtual void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
         {
+            // Visit the tag (callee) and the template literal (quasi)
+            VisitExpression(taggedTemplateExpression.Tag);
+            VisitTemplateLiteral(taggedTemplateExpression.Quasi);
         }
 
         public virtual void VisitSuper(Super super)
@@ -717,6 +755,14 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public virtual void VisitTemplateLiteral(TemplateLiteral templateLiteral)
         {
+            foreach (var q in templateLiteral.Quasis)
+            {
+                VisitTemplateElement(q);
+            }
+            foreach (var expr in templateLiteral.Expressions)
+            {
+                VisitExpression(expr);
+            }
         }
 
         public virtual void VisitTemplateElement(TemplateElement templateElement)

--- a/test/SlowTests.Issues/Issues/RavenDB_25356.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25356.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25356 : RavenTestBase
+    {
+        public RavenDB_25356(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_Run_RawQuery_With_OptionalChaining_And_TemplateLiteral(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var rql = @"from ""Employees""  as e
+select {
+    F: e?.FirstName,
+    Name: `${e.FirstName} ${e.LastName}`,
+}";
+
+                    // The goal of the test is just to ensure this runs without any errors
+                    // Materialize the results to force server-side execution
+                    var results = session.Advanced.RawQuery<object>(rql)
+                        .WaitForNonStaleResults()
+                        .ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        private class Companies_ByNamePhoneCity_JS : AbstractJavaScriptIndexCreationTask
+        {
+            public Companies_ByNamePhoneCity_JS()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map(""Companies"", (company) => {
+    if (company.Address.Country === ""USA"") {
+        return {
+            Name: company?.Name,
+            Phone: `{company.Extension}-{company.Phone}`,
+            City: company.Address.City
+        };
+    }
+})"
+                };
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Indexes)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_Create_JavaScript_Index_With_OptionalChaining_And_TemplateLiteral(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                new Companies_ByNamePhoneCity_JS().Execute(store);
+            }
+        }
+    }
+}


### PR DESCRIPTION
… in queries and JavaScript indexes

That was limited by the expression visitor alone, so we unblocked that by adding the visitor methods to handle that.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25356 

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Low 

### Backward compatibility

- [x] Non breaking change

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works

