### PR TITLE
RavenDB-25366 use SetClrFunc whenever possible

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/Embeddings/EmbeddingsGenerationScriptTransformer.cs
@@ -57,22 +57,22 @@ internal sealed class EmbeddingsGenerationScriptTransformer : EtlTransformer<Emb
             DocumentScript.DebugMode = true;
 
         ObjectInstance embeddingsObject = new JsObject(DocumentScript.ScriptEngine);
-        embeddingsObject.FastSetProperty("generate", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "generate", EmbeddingsGenerate), false, false, false));
+        embeddingsObject.SetClfFunc("generate", EmbeddingsGenerate);
         DocumentScript.ScriptEngine.SetValue("embeddings", embeddingsObject);
 
         ObjectInstance textObject = new JsObject(DocumentScript.ScriptEngine);
-        textObject.FastSetProperty("split", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "split", SplitPlainText), false, false, false));
-        textObject.FastSetProperty("splitLines", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "splitLines", SplitPlainTextLines), false, false, false));
-        textObject.FastSetProperty("splitParagraphs", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "splitParagraphs", SplitPlainTextParagraphs), false, false, false));
+        textObject.SetClfFunc("split", SplitPlainText);
+        textObject.SetClfFunc("splitLines",  SplitPlainTextLines);
+        textObject.SetClfFunc("splitParagraphs", SplitPlainTextParagraphs);
         DocumentScript.ScriptEngine.SetValue("text", textObject);
 
         ObjectInstance markdownObject = new JsObject(DocumentScript.ScriptEngine);
-        markdownObject.FastSetProperty("splitLines", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "splitLines", SplitMarkDownLines), false, false, false));
-        markdownObject.FastSetProperty("splitParagraphs", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "splitParagraphs", SplitMarkDownParagraphs), false, false, false));
+        markdownObject.SetClfFunc("splitLines", SplitMarkDownLines);
+        markdownObject.SetClfFunc("splitParagraphs", SplitMarkDownParagraphs);
         DocumentScript.ScriptEngine.SetValue("markdown", markdownObject);
 
         ObjectInstance htmlObject = new JsObject(DocumentScript.ScriptEngine);
-        htmlObject.FastSetProperty("strip", new PropertyDescriptor(new ClrFunction(DocumentScript.ScriptEngine, "strip", StripHtml), false, false, false));
+        htmlObject.SetClfFunc("strip", StripHtml);
         DocumentScript.ScriptEngine.SetValue("html", htmlObject);
     }
 

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/AmazonSqs/AmazonSqsDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/AmazonSqs/AmazonSqsDocumentTransformer.cs
@@ -36,16 +36,13 @@ public sealed class AmazonSqsDocumentTransformer<T> : QueueDocumentTransformer<T
     {
         base.Initialize(debugMode);
 
-        DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo,
-            new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo,
-                LoadToFunctionTranslatorWithAttributes));
+        DocumentScript.ScriptEngine.SetClrFunc(Transformation.LoadTo, LoadToFunctionTranslatorWithAttributes);
 
         foreach (var queueName in LoadToDestinations)
         {
             var name = Transformation.LoadTo + queueName;
 
-            DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
-                (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args)));
+            DocumentScript.ScriptEngine.SetClrFunc(name, (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args));
         }
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/SQL/SqlDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/SQL/SqlDocumentTransformer.cs
@@ -28,11 +28,8 @@ internal sealed class
     {
         base.Initialize(debugMode);
         
-        DocumentScript.ScriptEngine.SetValue("varchar",
-            new ClrFunction(DocumentScript.ScriptEngine, "varchar", (value, values) => ToVarcharTranslator(VarcharFunctionCall.AnsiStringType, values)));
-
-        DocumentScript.ScriptEngine.SetValue("nvarchar",
-            new ClrFunction(DocumentScript.ScriptEngine, "nvarchar", (value, values) => ToVarcharTranslator(VarcharFunctionCall.StringType, values)));
+        DocumentScript.ScriptEngine.SetClrFunc("varchar", (_, values) => ToVarcharTranslator(VarcharFunctionCall.AnsiStringType, values));
+        DocumentScript.ScriptEngine.SetClrFunc("nvarchar", (_, values) => ToVarcharTranslator(VarcharFunctionCall.StringType, values));
     }
     
     private JsValue ToVarcharTranslator(JsValue type, JsValue[] args)

--- a/src/Raven.Server/Documents/Patch/EngineExtensions.cs
+++ b/src/Raven.Server/Documents/Patch/EngineExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Jint;
 using Jint.Native;
+using Jint.Native.Object;
+using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 
 namespace Raven.Server.Documents.Patch;
@@ -11,4 +13,12 @@ internal static class EngineExtensions
     /// Sets the <paramref name="func"/> under a specific <paramref name="name"/>.
     /// </summary>
     public static void SetClrFunc(this Engine engine, string name, Func<JsValue, JsValue[], JsValue> func) => engine.SetValue(name, new ClrFunction(engine, name, func));
+
+    /// <summary>
+    /// Sets the given <paramref name="func"/> as a readonly property of <paramref name="obj"/>.
+    /// </summary>
+    public static void SetClfFunc(this ObjectInstance obj, string name, Func<JsValue, JsValue[], JsValue> func)
+    {
+        obj.FastSetProperty(name, new PropertyDescriptor(new ClrFunction(obj.Engine, name, func), false, false, false));
+    }
 }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -400,7 +400,7 @@ namespace Raven.Server.Documents.Patch
 
                 foreach (var ts in runner._timeSeriesDeclaration)
                 {
-                    ScriptEngine.SetValue(ts.Key, NamedInvokeTimeSeriesFunction(ts.Key));
+                    ScriptEngine.SetClrFunc(ts.Key, (self, args) => InvokeTimeSeriesFunction(ts.Key, args));
                 }
             }
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -310,7 +310,7 @@ namespace Raven.Server.Documents.Patch
 
                 //console.log
                 ObjectInstance consoleObject = new JsObject(ScriptEngine);
-                consoleObject.FastSetProperty("log", new PropertyDescriptor(new ClrFunction(ScriptEngine, "log", OutputDebug), false, false, false));
+                consoleObject.SetClfFunc("log", OutputDebug);
                 ScriptEngine.SetValue("console", consoleObject);
 
                 //spatial.distance
@@ -324,16 +324,14 @@ namespace Raven.Server.Documents.Patch
                 var includeDocumentFunc = new ClrFunction(ScriptEngine, "include", IncludeDoc);
                 ObjectInstance includesObject = new JsObject(ScriptEngine);
                 includesObject.FastSetProperty("document", new PropertyDescriptor(includeDocumentFunc, false, false, false));
-                includesObject.FastSetProperty("cmpxchg", new PropertyDescriptor(new ClrFunction(ScriptEngine, "cmpxchg", IncludeCompareExchangeValue), false, false, false));
-                includesObject.FastSetProperty("revisions", new PropertyDescriptor(new ClrFunction(ScriptEngine, "revisions", IncludeRevisions), false, false, false));
+                includesObject.SetClfFunc("cmpxchg", IncludeCompareExchangeValue);
+                includesObject.SetClfFunc("revisions", IncludeRevisions);
                 ScriptEngine.SetValue("includes", includesObject);
 
                 // archived API
-                var unarchiveDocumentFunc = new ClrFunction(ScriptEngine, "unarchive", UnarchiveDoc);
-                var archiveAtDocumentFunc = new ClrFunction(ScriptEngine, "archiveAt", ArchiveAt);
                 ObjectInstance archivedObject = new JsObject(ScriptEngine);
-                archivedObject.FastSetProperty("archiveAt", new PropertyDescriptor(archiveAtDocumentFunc, false, false, false));
-                archivedObject.FastSetProperty("unarchive", new PropertyDescriptor(unarchiveDocumentFunc, false, false, false));
+                archivedObject.SetClfFunc("archiveAt", ArchiveAt);
+                archivedObject.SetClfFunc("unarchive", UnarchiveDoc);
                 ScriptEngine.SetValue("archived", archivedObject);
 
                 // includes - backward compatibility
@@ -462,29 +460,14 @@ namespace Raven.Server.Documents.Patch
                 if (args.Length != 2)
                     throw new ArgumentException($"{_timeSeriesSignature}: This method requires 2 arguments but was called with {args.Length}");
 
-                var append = new ClrFunction(ScriptEngine, "append", (thisObj, values) =>
-                    AppendTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
-
-                var increment = new ClrFunction(ScriptEngine, "increment", (thisObj, values) =>
-                    IncrementTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
-
-                var delete = new ClrFunction(ScriptEngine, "delete", (thisObj, values) =>
-                    DeleteRangeTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
-
-                var get = new ClrFunction(ScriptEngine, "get", (thisObj, values) =>
-                    GetRangeTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
-
-                var getStats = new ClrFunction(ScriptEngine, "getStats", (thisObj, values) =>
-                    GetStatsTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
-
                 var obj = new JsObject(ScriptEngine);
-                obj.FastSetDataProperty("append", append);
-                obj.FastSetDataProperty("increment", increment);
-                obj.FastSetDataProperty("delete", delete);
-                obj.FastSetDataProperty("get", get);
+                obj.SetClfFunc("append", (thisObj, values) => AppendTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
+                obj.SetClfFunc("increment", (thisObj, values) => IncrementTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
+                obj.SetClfFunc("delete", (thisObj, values) => DeleteRangeTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
+                obj.SetClfFunc("get", (thisObj, values) => GetRangeTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
                 obj.FastSetDataProperty("doc", args[0]);
                 obj.FastSetDataProperty("name", args[1]);
-                obj.FastSetDataProperty("getStats", getStats);
+                obj.SetClfFunc("getStats", (thisObj, values) => GetStatsTimeSeries(thisObj.Get("doc"), thisObj.Get("name"), values));
 
                 return obj;
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25366/CLR-Functions-setting-in-7.1

### Additional description

A follow up to #21650 . It visits the leftover callsites in 7.1 and uses the new function

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
