### PR TITLE
RavenDB-25367 SessionInfo now provides the database name as its property

### DIFF
--- a/src/Raven.Client/Documents/Session/SessionInfo.cs
+++ b/src/Raven.Client/Documents/Session/SessionInfo.cs
@@ -68,6 +68,8 @@ namespace Raven.Client.Documents.Session
             _canUseLoadBalanceBehavior = _canUseLoadBalanceBehavior || _session.Conventions.LoadBalanceBehavior == LoadBalanceBehavior.UseSessionContext;
         }
 
+        public string DatabaseName => _session.DatabaseName;
+
         private void SetContextInternal(string sessionKey)
         {
             if (_sessionIdUsed)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25367/Extend-SessionInfo-with-DatabaseName

### Additional description

This PR externalizes `DatabaseName` as a property of `SessionInfo` accessible via `.Advanced` property.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
