### PR TITLE
RavenDB-25369 Client configuration view: Fix description for "Identity parts separator"

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/clientConfiguration/ClientDatabaseConfiguration.tsx
@@ -202,8 +202,9 @@ export default function ClientDatabaseConfiguration() {
                                                         placement="right"
                                                         message={
                                                             <>
-                                                                Set the default separator for automatically generated
-                                                                document identity IDs.
+                                                                Set the separator character for automatically generated{" "}
+                                                                <strong>Identity</strong> and <strong>HiLo</strong>{" "}
+                                                                document IDs.
                                                                 <br />
                                                                 Use any character except <code>&apos;|&apos;</code>{" "}
                                                                 (pipe).
@@ -261,8 +262,9 @@ export default function ClientDatabaseConfiguration() {
                                                     placement="right"
                                                     message={
                                                         <>
-                                                            Set the default separator for automatically generated
-                                                            document identity IDs.
+                                                            Set the separator character for automatically generated{" "}
+                                                            <strong>Identity</strong> and <strong>HiLo</strong> document
+                                                            IDs.
                                                             <br />
                                                             Use any character except <code>&apos;|&apos;</code> (pipe).
                                                         </>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/clientConfiguration/ClientGlobalConfiguration.tsx
@@ -123,8 +123,9 @@ export default function ClientGlobalConfiguration() {
                                             <PopoverWithHoverWrapper
                                                 message={
                                                     <>
-                                                        Set the default separator for automatically generated document
-                                                        identity IDs.
+                                                        Set the separator character for automatically generated{" "}
+                                                        <strong>Identity</strong> and <strong>HiLo</strong> document
+                                                        IDs.
                                                         <br />
                                                         Use any character except <code>&apos;|&apos;</code> (pipe).
                                                     </>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25369/Client-configuration-view-Fix-description-for-Identity-parts-separator

### Additional description
Fix tooltip text for "Identity parts separator".
This param applies to both:
* Identity IDs generated by the server
* HiLo IDs generated by the client

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
