### PR TITLE
RavenDB-25330 Fix AVE on encrypted db query by clearing loaded documents cache during pulsed transactions

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3507,9 +3507,13 @@ namespace Raven.Server.Documents.Indexes
                                     {
                                         var originalEnumerator = enumerator;
 
-                                        enumerator = new PulsedTransactionEnumerator<IndexReadOperationBase.QueryResult, QueryResultsIterationState>(queryContext.Documents,
+                                        var pulsedEnumerator = new PulsedTransactionEnumerator<IndexReadOperationBase.QueryResult, QueryResultsIterationState>(queryContext.Documents,
                                             state => originalEnumerator,
                                             new QueryResultsIterationState(queryContext.Documents, DocumentDatabase.Configuration.Databases.PulseReadTransactionLimit));
+
+                                        pulsedEnumerator.OnPulse += retriever.ClearCache; // we have to clear cached blittables because they are no longer valid after cloning the transaction
+
+                                        enumerator = pulsedEnumerator;
                                     }
 
                                     using (enumerator)

--- a/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/IQueryResultRetriever.cs
@@ -21,6 +21,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         Document DirectGet(ref RetrieverInput retrieverInput, string id, DocumentFields fields);
 
+        void ClearCache();
     }
 
     public struct RetrieverInput

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -994,6 +994,13 @@ namespace Raven.Server.Documents.Queries.Results
             }
         }
 
+        public void ClearCache()
+        {
+            _loadedDocuments?.Clear();
+            _loadedDocumentsByAliasName?.Clear();
+            _timeSeriesRetriever?.ClearCache();
+        }
+        
         private sealed class QueryKey : ScriptRunnerCache.Key
         {
             private readonly Dictionary<string, DeclaredFunction> _functions;

--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -1283,5 +1283,10 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
             "yyyy-MM-ddTHH:mm:ss.fffZ",
             "yyyy-MM-ddTHH:mm:ss.fff"
         };
+        
+        public void ClearCache()
+        {
+            _loadedDocuments?.Clear();
+        }
     }
 }

--- a/src/Raven.Server/Utils/Enumerators/PulsedTransactionEnumerator.cs
+++ b/src/Raven.Server/Utils/Enumerators/PulsedTransactionEnumerator.cs
@@ -31,6 +31,8 @@ namespace Raven.Server.Utils.Enumerators
             _state = state;
             _innerEnumerator = _getEnumerator(state);
         }
+        
+        public Action OnPulse;
 
         public bool MoveNext()
         {
@@ -38,6 +40,7 @@ namespace Raven.Server.Utils.Enumerators
             {
                 Debug.Assert(_context.Transaction.InnerTransaction.IsWriteTransaction == false, $"{nameof(PulsedTransactionEnumerator<T, TState>)} is meant to be used with read transactions only");
 
+                OnPulse?.Invoke();
                 _context.CloneReadTransaction();
 
                 _innerEnumerator = _getEnumerator != null ? _getEnumerator(_state) : _getEnumerable(_state).GetEnumerator();

--- a/src/Raven.Server/Utils/LruDictionary.cs
+++ b/src/Raven.Server/Utils/LruDictionary.cs
@@ -61,4 +61,10 @@ public sealed class LruDictionary<TKey, TValue> where TKey : notnull
             }
         }
     }
+    
+    public void Clear()
+    {
+        _cache.Clear();
+        _list.Clear();
+    }
 }

--- a/test/SlowTests/Issues/RavenDB_25330.cs
+++ b/test/SlowTests/Issues/RavenDB_25330.cs
@@ -1,0 +1,139 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Config;
+using Raven.Server.Utils.Enumerators;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25330 : RavenTestBase
+    {
+        private const int NumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded = PulsedEnumerationState<object>.DefaultNumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded;
+
+        public RavenDB_25330(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Encryption)]
+        [InlineData(2 * NumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 50)]
+        [InlineData(4 * NumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded + 10)]
+        public async Task CanStreamQueryWithLoadAndPulsingReadTransaction(int numberOfTrainings)
+        {
+            string dbName = Encryption.SetupEncryptedDatabase(out var certificates, out var _);
+
+            using (var store = GetDocumentStore(new Options
+                   {
+                       AdminCertificate = certificates.ServerCertificateForCommunication.Value,
+                       ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                       ModifyDatabaseName = s => dbName,
+                       ModifyDatabaseRecord = record => {
+                           record.Settings[RavenConfiguration.GetKey(x => x.Databases.PulseReadTransactionLimit)] = "0";
+                           record.Encrypted = true;
+                       },
+                       Path = NewDataPath()
+                   }))
+            {
+                var customerId = "customers/1";
+                var packageId = "packages/1";
+
+                using (var bulk = store.BulkInsert())
+                {
+                    await bulk.StoreAsync(new Customer { Name = "Test Customer" }, customerId);
+                    await bulk.StoreAsync(new PurchasedPackage { Type = "Test Package" }, packageId);
+                }
+
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < numberOfTrainings; i++)
+                    {
+                        await bulk.StoreAsync(new Training
+                        {
+                            OrganizationId = "organizations/1",
+                            CustomerId = customerId,
+                            PurchasedPackageId = packageId
+                        });
+                    }
+                }
+
+                var index = new Trainings_Index();
+               
+                await index.ExecuteAsync(store);
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                var rql = $@"
+                    from index '{index.IndexName}' as t
+                    where t.OrganizationId == 'organizations/1'
+                    load t.CustomerId as c, t.PurchasedPackageId as p
+                    select {{
+                        TrainingId: id(t),
+                        CustomerName: c.Name,
+                        PackageType: p.Type
+                    }}";
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var query = session.Advanced
+                        .AsyncRawQuery<TrainingReport>(rql);
+
+                    var enumerator = await session.Advanced.StreamAsync(query);
+
+                    var count = 0;
+                    while (await enumerator.MoveNextAsync())
+                    {
+                        count++;
+                        var current = enumerator.Current.Document;
+
+                        Assert.NotNull(current);
+                        Assert.NotNull(current.CustomerName);
+                        Assert.NotNull(current.PackageType);
+                        Assert.Equal("Test Customer", current.CustomerName);
+                        Assert.Equal("Test Package", current.PackageType);
+                    }
+
+                    Assert.Equal(numberOfTrainings, count);
+                }
+            }
+        }
+
+        private class Customer
+        {
+            public string Name { get; set; }
+        }
+
+        private class PurchasedPackage
+        {
+            public string Type { get; set; }
+        }
+
+        private class Training
+        {
+            public string OrganizationId { get; set; }
+            public string CustomerId { get; set; }
+            public string PurchasedPackageId { get; set; }
+        }
+
+        private class TrainingReport
+        {
+            public string TrainingId { get; set; }
+            public string CustomerName { get; set; }
+            public string PackageType { get; set; }
+        }
+
+        private class Trainings_Index : AbstractIndexCreationTask<Training>
+        {
+            public Trainings_Index()
+            {
+                Map = trainings => from training in trainings
+                    select new
+                    {
+                        training.OrganizationId
+                    };
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25330

### Additional description

An AccessViolationException could occur when running a streaming query with `load` clauses on an encrypted database.

This was caused by the query result retriever's cache of loaded documents (blittables) becoming invalid after a read transaction was pulsed (cloned).

We now clear this cache when the transaction pulses, ensuring we won't try to access invalid references / pointers.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
