### PR TITLE
RavenDB-25372 - Take the database names from the cluster storage rather than from the online databases cache

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -182,6 +182,7 @@ public sealed partial class ClusterStateMachine
         var command = (PutLicenseCommand)CommandBase.CreateFrom(bjro);
         if (command.SkipLicenseAssertion)
             return;
+
         try
         {
             newLicenseLimits = LicenseManager.GetLicenseStatus(command.Value);
@@ -194,9 +195,10 @@ public sealed partial class ClusterStateMachine
         var items = context.Transaction.InnerTransaction.OpenTable(ItemsSchema, Items);
 
         AssertClusterSizeAndCores(serverStore, newLicenseLimits);
-        foreach (var database in serverStore.DatabasesLandlord.DatabasesCache.Values.GetEnumerator())
+
+        foreach (var databaseName in serverStore.Cluster.GetDatabaseNames(context))
         {
-            DatabaseRecord databaseRecord = serverStore.Cluster.ReadDatabase(context, ShardHelper.ToDatabaseName(database.Result.Name));
+            var databaseRecord = serverStore.Cluster.ReadDatabase(context, ShardHelper.ToDatabaseName(databaseName));
 
             AssertMultiNodeSharding(databaseRecord, newLicenseLimits, context);
             AssertStaticIndexesCount(databaseRecord, newLicenseLimits, context, items, type);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25372/Cluster-state-machine-is-stuck-due-to-a-failing-database-load-which-blocked-license-update

### Additional description

Retrieve database names from cluster storage instead of the online databases cache. This approach prevents instantiation errors when using cached `DocumentDatabase` instances and ensures we include all databases, regardless of their online status.

This is relevant only when changing the license manually.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
