### PR TITLE
RavenDB-24729 : fixed flaky test on GenAiBasics.CanGetGenAiOngoingTask

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -158,7 +158,7 @@ for(const comment of this.Comments)
         var secondBatchCompleted = await WaitForValueAsync(() =>
         {
             var stats = etlProcess.GetPerformanceStats()
-                .Where(x => x.NumberOfLoadedItems > 0 && x.LastLoadedEtag > 1)
+                .Where(x => x.NumberOfLoadedItems > 0 && x.LastLoadedEtag > 2)
                 .ToArray();
 
             return stats.Length > 0;
@@ -172,6 +172,14 @@ for(const comment of this.Comments)
             changeVector = session.Advanced.GetChangeVectorFor(doc);
         }
         Assert.NotNull(changeVector);
+
+        var stateUpdated = await WaitForValueAsync(() =>
+        {
+            var status = EtlProcess.GetProcessState(db, config.Name, config.Transforms[0].Name);
+        
+            return status.ChangeVector == changeVector;
+        }, expectedVal: true, timeout: 60_000);
+        Assert.True(stateUpdated);
 
         var op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi);
         var taskInfo = await store.Maintenance.SendAsync(op);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24729/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.CanGetGenAiOngoingTaskoptions-DatabaseMode-Single-config-OllamaAiIntegrationTask

### Additional description

The test failed because inside `EtlProcess.Run()` the ETL updates the statistics first, before updating the ETL process state. This creates a race: the document could already reach CV A:3 while the ETL checkpoint still reports A:2 or A:1.

If we remove the old wait on GetPerformanceStats and only relied on the later waits, we sometimes hit the opposite race: the document already reached CV A:3, but the ETL hadn’t yet completed the batch that processes it, so the ETL checkpoint still reported A:2 or A:1.

without waiting for LastLoadedEtag > 2, we could compare a “future” document CV against an “older” ETL state CV and fail in the reverse direction.

By waiting for both the stats and the ETL state to catch up, we eliminate this timing gap so both sides always compare the same final CV.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
