### PR TITLE
RavenDB-25227 : GenAiBasics.ShouldResendContextWhenUpdateScriptChanges NRE fix

### DIFF
--- a/src/Raven.Server/Documents/ETL/Stats/EtlStatsAggregator.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlStatsAggregator.cs
@@ -54,6 +54,9 @@ namespace Raven.Server.Documents.ETL.Stats
 
         private EtlPerformanceStats CreatePerformanceStats(bool completed)
         {
+            if (Scope == null || Stats == null)
+                return null;
+
             return new EtlPerformanceStats(Scope.Duration)
             {
                 Id = Id,
@@ -81,9 +84,6 @@ namespace Raven.Server.Documents.ETL.Stats
         {
             if (_performanceStats != null)
                 return _performanceStats;
-
-            if (Scope == null || Stats == null)
-                return null;
 
             if (Completed)
                 return ToPerformanceStats();

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -498,6 +498,60 @@ if($output.Blocked)
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task CanReproduceNullScopeNreInEtlStats(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Prompt = "Check if the following blog post comment is spam or not";
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(new
+        {
+            Blocked = true,
+            Reason = "Concise reason for why this comment was marked as spam or ham"
+        });
+        config.UpdateScript = @"    
+const idx = this.Comments.findIndex(c => c.Id == $input.Id);  
+if($output.Blocked)
+{
+    this.Comments.splice(idx, 1);
+}";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+        };
+
+        await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+
+        var db = await GetDatabase(store.Database);
+
+        var hit = await WaitForValueAsync(() =>
+        {
+            var process = db.EtlLoader.Processes.FirstOrDefault();
+            if (process == null)
+                return false;
+
+            var latest = process.GetLatestPerformanceStats();
+            if (latest == null)
+                return false;
+
+
+            latest.ToPerformanceStats(); // if NRE happens, the test fails immediately
+
+            return true;
+
+        }, expectedVal: true, timeout: 5000);
+
+        Assert.True(hit, "ToPerformanceStats() should not throw NullReferenceException anymore.");
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task ShouldUseTaskIdentifierInMetadataHashes(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
@@ -659,7 +713,7 @@ for(const comment of this.Comments)
         var value = await WaitForValueAsync(() =>
         {
             stats = etlProcess.GetPerformanceStats()
-                .Where(x => x.NumberOfLoadedItems > 0)
+                .Where(x => x != null && x.NumberOfLoadedItems > 0)
                 .ToArray();
             return stats.Length > 0;
         }, expectedVal: true, timeout: 60_000);
@@ -725,7 +779,7 @@ for(const comment of this.Comments)
         value = await WaitForValueAsync(() =>
         {
             stats2 = etlProcess.GetPerformanceStats()
-                .Where(x => x.NumberOfLoadedItems > 0 && x.LastLoadedEtag == etag + 1 && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
+                .Where(x => x != null && x.NumberOfLoadedItems > 0 && x.LastLoadedEtag == etag + 1 && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
                 .ToArray();
             return stats2.Length > 0;
         }, expectedVal: true, timeout: 60_000);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25227/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenUpdateScriptChangesoptions-DatabaseMode-Single

### Additional description

according to issue 25227 we can get NRE on that test, I have added a test that has more chance to trigger that NRE without the scope == null guard.
after the fix I did, it should return null in case the scope is null, so no NRE should happen.
if we want to reproduce the case, we can add a sleep for about half a second between the creation of the `AddPerformanceStats(statsAggregator)` and the `statsAggregator.CreateScope()` on `EtlProcess.cs`.
Additionally, made the existing test more robust so it will handle null as a return value.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
