### PR TITLE
RavenDB-25298 Display Query in AiAgent_ExceededTokenThreshold alert

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/aiAgentExceededTokenThreshold.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/aiAgentExceededTokenThreshold.ts
@@ -14,6 +14,7 @@ interface ToolCallItem {
     name: string;
     type: string;
     arguments: string;
+    query: string;
 }
 
 class aiAgentExceededTokenThreshold extends abstractAlertDetails {
@@ -43,7 +44,8 @@ class aiAgentExceededTokenThreshold extends abstractAlertDetails {
             id: tc.Id,
             name: tc.Name,
             type: tc.Type,
-            arguments: tc.Arguments
+            arguments: tc.Arguments,
+            query: tc.Query
         }));
     }
     
@@ -54,16 +56,17 @@ class aiAgentExceededTokenThreshold extends abstractAlertDetails {
         grid.headerVisible(true);
 
         grid.init(() => this.fetcher(), () => {
-            const nameColumn = new textColumn<ToolCallItem>(grid, x => x.name, "Tool Name", "20%", {
-                sortable: x => x.name
-            });
-            const typeColumn = new textColumn<ToolCallItem>(grid, x => x.type, "Type", "15%", {
-                sortable: x => x.type
-            });
-            const argumentsColumn = new textColumn<ToolCallItem>(grid, x => x.arguments, "Arguments", "50%");
-            const idColumn = new textColumn<ToolCallItem>(grid, x => x.id, "ID", "15%");
-
-            return [nameColumn, typeColumn, argumentsColumn, idColumn];
+            return [
+                new textColumn<ToolCallItem>(grid, (x) => x.name, "Tool Name", "20%", {
+                    sortable: (x) => x.name,
+                }),
+                new textColumn<ToolCallItem>(grid, (x) => x.type, "Type", "15%", {
+                    sortable: (x) => x.type,
+                }),
+                new textColumn<ToolCallItem>(grid, (x) => x.arguments != null ? x.arguments : "N/A", "Arguments", "25%"),
+                new textColumn<ToolCallItem>(grid, (x) => x.query != null ? x.query : "N/A", "Query", "25%"),
+                new textColumn<ToolCallItem>(grid, (x) => x.id, "ID", "15%"),
+            ];
         });
 
         this.columnPreview.install(".aiAgentExceededTokenThresholdDetails", ".js-ai-agent-token-threshold-tooltip",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25298/Incomplete-Document-Id-in-the-alert

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
