### PR TITLE
RavenDB-23768 Incorrect CPU Usage Calculation on Machines with more t…

### DIFF
--- a/src/Raven.Server/Utils/Cpu/CpuHelper.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Raven.Client.Util;
 using Raven.Server.Config.Categories;
 using Raven.Server.Monitoring.Snmp.Objects.Server;
@@ -21,7 +22,10 @@ namespace Raven.Server.Utils.Cpu
             ICpuUsageCalculator calculator;
             if (PlatformDetails.RunningOnPosix == false)
             {
-                calculator = new WindowsCpuUsageCalculator();
+                if (GetActiveProcessorGroupCount() > 1)
+                    calculator = new WindowsCpuUsageCalculatorMultiGroup();
+                else
+                    calculator = new WindowsCpuUsageCalculatorOneGroup();
             }
             else if (PlatformDetails.RunningOnMacOsx)
             {
@@ -92,5 +96,8 @@ namespace Raven.Server.Utils.Cpu
                 return (0, 0);
             }
         }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern ushort GetActiveProcessorGroupCount();
     }
 }

--- a/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
+++ b/src/Raven.Server/Utils/Cpu/CpuUsageCalculator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -126,7 +126,7 @@ namespace Raven.Server.Utils.Cpu
         }
     }
 
-    internal sealed class WindowsCpuUsageCalculator : CpuUsageCalculator<WindowsInfo>
+    internal abstract class WindowsCpuUsageCalculator : CpuUsageCalculator<WindowsInfo>
     {
         protected override (double MachineCpuUsage, double? MachineIoWait) CalculateMachineCpuUsage(WindowsInfo windowsInfo)
         {
@@ -140,10 +140,148 @@ namespace Raven.Server.Utils.Cpu
             {
                 machineCpuUsage = (sysTotal - systemIdleDiff) * 100.00 / sysTotal;
             }
-
             return (machineCpuUsage, null);
         }
+    }
 
+    internal sealed class WindowsCpuUsageCalculatorMultiGroup : WindowsCpuUsageCalculator
+    {
+        private byte[] _multipleProcessorBuffer;
+        private const int MultipleProcessorStructSize = 48;
+        private readonly int _processorCount = Environment.ProcessorCount;
+        public WindowsCpuUsageCalculatorMultiGroup()
+        {
+            uint returnLength = 0;
+            _multipleProcessorBuffer = new byte[_processorCount * MultipleProcessorStructSize];
+            var status = NtQuerySystemInformation(SystemProcessorPerformanceInformation, _multipleProcessorBuffer, (uint)_multipleProcessorBuffer.Length, ref returnLength);
+            if (status == unchecked((int)0xC0000004)) // STATUS_INFO_LENGTH_MISMATCH
+            {
+                _multipleProcessorBuffer = new byte[returnLength];
+            }
+        }
+
+        protected override WindowsInfo GetProcessInfo()
+        {
+            try
+            {
+                ulong totalIdleTime = 0;
+                ulong totalKernelTime = 0;
+                ulong totalUserTime = 0;
+
+                ushort groupCount = GetActiveProcessorGroupCount();
+
+                var thread = GetCurrentThread();
+
+                for (ushort group = 0; group < groupCount; group++)
+                {
+                    uint processorsInGroup = GetActiveProcessorCount(group);
+                    if (processorsInGroup == 0)
+                        continue;
+
+                    // Build a mask with all CPUs in this group
+                    ulong maskValue = processorsInGroup >= 64
+                        ? ulong.MaxValue
+                        : ((1UL << (int)processorsInGroup) - 1UL);
+
+                    var newAffinity = new GroupAffinity
+                    {
+                        Group = group,
+                        Mask = (UIntPtr)maskValue,
+                        Reserved = new ushort[3]
+                    };
+
+                    if (SetThreadGroupAffinity(thread, ref newAffinity, out var previousAffinity) == false)
+                        continue;
+
+                    try
+                    {
+                        uint returnLength = (uint)(processorsInGroup * MultipleProcessorStructSize);
+                        if (_multipleProcessorBuffer == null || _multipleProcessorBuffer.Length < returnLength)
+                            _multipleProcessorBuffer = new byte[returnLength];
+
+                        var status = NtQuerySystemInformation(SystemProcessorPerformanceInformation, _multipleProcessorBuffer, returnLength, ref returnLength);
+                        if (status == unchecked((int)0xC0000004)) // STATUS_INFO_LENGTH_MISMATCH
+                        {
+                            _multipleProcessorBuffer = new byte[returnLength];
+                            status = NtQuerySystemInformation(SystemProcessorPerformanceInformation, _multipleProcessorBuffer, returnLength, ref returnLength);
+                        }
+
+                        if (status != 0)
+                        {
+                            // if this group fails, continue with others
+                            continue;
+                        }
+
+                        int structCount = (int)(returnLength / MultipleProcessorStructSize);
+                        for (int i = 0; i < structCount; i++)
+                        {
+                            int offset = i * MultipleProcessorStructSize;
+
+                            var idleTime = BitConverter.ToUInt64(_multipleProcessorBuffer, offset);
+                            var kernelTime = BitConverter.ToUInt64(_multipleProcessorBuffer, offset + 8);
+                            var userTime = BitConverter.ToUInt64(_multipleProcessorBuffer, offset + 16);
+
+                            totalIdleTime += idleTime;
+                            totalKernelTime += kernelTime;
+                            totalUserTime += userTime;
+                        }
+                    }
+                    finally
+                    {
+                        // restore original affinity
+                        SetThreadGroupAffinity(thread, ref previousAffinity, out _);
+                    }
+                }
+
+                if (totalIdleTime == 0 && totalKernelTime == 0 && totalUserTime == 0)
+                    return null;
+
+                return new WindowsInfo
+                {
+                    SystemIdleTime = totalIdleTime,
+                    SystemKernelTime = totalKernelTime,
+                    SystemUserTime = totalUserTime
+                };
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("Failure when trying to get CPU info for multiple processor groups", e);
+                return null;
+            }
+        }
+
+        [DllImport("ntdll.dll", SetLastError = true)]
+        internal static extern int NtQuerySystemInformation(int systemInformationClass, byte[] systemInformation, uint systemInformationLength, ref uint returnLength);
+
+        private const int SystemProcessorPerformanceInformation = 8;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern ushort GetActiveProcessorGroupCount();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern uint GetActiveProcessorCount(ushort groupNumber);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr GetCurrentThread();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetThreadGroupAffinity(
+            IntPtr hThread,
+            ref GroupAffinity groupAffinity,
+            out GroupAffinity previousGroupAffinity);
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct GroupAffinity
+        {
+            public UIntPtr Mask;
+            public ushort Group;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+            public ushort[] Reserved;
+        }
+    }
+    internal sealed class WindowsCpuUsageCalculatorOneGroup : WindowsCpuUsageCalculator
+    {
         protected override WindowsInfo GetProcessInfo()
         {
             var systemIdleTime = new FileTime();


### PR DESCRIPTION
…hen 64 cores

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23768

### Additional description
Windows splits CPUs into processor groups when a machine has more than 64 logical cores
GetSystemTimes() only reports CPU times for the current processor group, but the RavenDB server process can be scheduled on different groups over time.
As the process moves between groups, the returned kernel/user/idle values are taken from different group counters, which makes the deltas inconsistent.
This can produce incorrect CPU usage results such as negative values, values above 100%, or even integer overflow.
Switching to PerformanceCounter(... "_Total") avoids this by using a Windows-aggregated CPU value across all groups.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
