### PR TITLE
RavenDB-22488: mask tail bytes for 32-bit compare

### DIFF
--- a/src/Sparrow/Memory.cs
+++ b/src/Sparrow/Memory.cs
@@ -296,9 +296,17 @@ namespace Sparrow
 
             if (size > 0)
             {
+                rbpx = Unsafe.ReadUnaligned<ulong>(ref Unsafe.SubtractByteOffset(ref bpx, sizeof(ulong)));
+                rbpy = Unsafe.ReadUnaligned<ulong>(ref Unsafe.SubtractByteOffset(ref bpy, sizeof(ulong)));
+
+                // RavenDB-22488: Mask away bytes beyond the caller slice; on 32-bit heaps the extra 8-byte load
+                // can span into neighboring objects whereas 64-bit stays within the padded header. For this
+                // reason the error can be seen on 32-bit processes but not on 64-bit processes and only on managed arrays.
+                ulong mask = ulong.MaxValue << (((sizeof(ulong) - size) & (sizeof(ulong) - 1)) << 3);
+                rbpx &= mask;
+                rbpy &= mask;
+
                 size = sizeof(ulong);
-                rbpx = Unsafe.ReadUnaligned<ulong>(ref Unsafe.SubtractByteOffset(ref bpx, size));
-                rbpy = Unsafe.ReadUnaligned<ulong>(ref Unsafe.SubtractByteOffset(ref bpy, size));
             }
 
             DONE:


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22488

### Additional description

32-bits processes align the heap arrays differently from 64-bits processes. Assumptions that are valid for 64-bits are not valid for 32-bits. While this has not been seen in production because we usually do not run this method on managed arrays, this PR solves the problem for good by ensuring that we cannot read garbage from the rest of the array object. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
