### PR TITLE
RavenDB-25396 Handle ZipOnly value during secure setup package creation

### DIFF
--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -143,6 +143,7 @@ namespace Raven.Server.Commercial
             ServerStore serverStore,
             CancellationToken token)
         {
+            var zipOnly = setupInfo.ZipOnly;
             var progress = new SetupProgressAndResult(tuple =>
             {
                 if (Logger is { IsInfoEnabled: true })
@@ -182,6 +183,7 @@ namespace Raven.Server.Commercial
                     {
                         CompleteClusterConfigurationResult = completeClusterConfigurationResult,
                         Progress = progress,
+                        ZipOnly = zipOnly,
                         OnProgress = onProgress,
                         OnSettingsPath = () => serverStore.Configuration.ConfigPath,
                         SetupInfo = setupInfo,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25396/Secure-setup-package-doesnt-isnt-assigned-ZipOnly-mode

### Additional description

We want to properly handle the `ZipOnly` value during secure setup package creation. Currently it isn't taken into account, which results in an exception during such setup. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
