### PR TITLE
RavenDB-25352 RavenDB Docker container fails to start after LE setup + studio setup wizard -  server.pfx path incorrect in generated settings.json

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -143,7 +143,7 @@ public static class SettingsZipFileHelper
                     }
                 }
 
-                settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = Path.GetFileName(certPath) ?? certificateFileName;
+                settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certPath ?? certificateFileName;
                 if (string.IsNullOrEmpty(parameters.SetupInfo.Password) == false)
                     settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Security.CertificatePassword)] = parameters.SetupInfo.Password;
 

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -190,8 +190,7 @@ namespace Raven.Server.Commercial
                         OnWriteSettingsJsonLocally = indentedJson => SettingsZipFileHelper.WriteSettingsJsonLocally(serverStore.Configuration.ConfigPath, indentedJson),
                         OnGetCertificatePath = certificateFileName =>
                         {
-                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ??
-                                   Path.Combine(AppContext.BaseDirectory, certificateFileName);
+                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ?? certificateFileName;
                         },
                         OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
                         {
@@ -726,8 +725,7 @@ namespace Raven.Server.Commercial
                         OnWriteSettingsJsonLocally = indentedJson => SettingsZipFileHelper.WriteSettingsJsonLocally(serverStore.Configuration.ConfigPath, indentedJson),
                         OnGetCertificatePath = certificateFileName =>
                         {
-                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ??
-                                   Path.Combine(AppContext.BaseDirectory, certificateFileName);
+                            return serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ?? certificateFileName;
                         },
                         OnPutServerWideStudioConfigurationValues = async studioEnvironment =>
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25352/RavenDB-Docker-container-fails-to-start-after-LE-setup-studio-setup-wizard-server.pfx-path-incorrect-in-generated-settings.json

### Additional description

This bug was caused by this change: https://github.com/ravendb/ravendb/pull/21369
- Setup.Certificate.Path triggered to put the certificate in a different location
- OnGetCertificate path returned just the filename
- The rest of the path was lost

Added minimal fix - passed `isSetupPath` bool forward.
It handles `Setup.Certificate.Path` corner case, in which we're writing the full path to `settings.json`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
