### PR TITLE
RavenDB-25398 IAttachmentsSessionOperations: Fix XML documentation

### DIFF
--- a/src/Raven.Client/Documents/Session/IAttachmentsSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAttachmentsSessionOperations.cs
@@ -4,42 +4,42 @@ using Raven.Client.Documents.Operations.Attachments;
 namespace Raven.Client.Documents.Session
 {
     /// <summary>
-    ///     Attachments advanced synchronous session operations
+    /// Advanced synchronous session operations for working with attachments.
     /// </summary>
     public interface IAttachmentsSessionOperations : IAttachmentsSessionOperationsBase
     {
         /// <summary>
-        /// Check if attachment exists
+        /// Checks whether an attachment exists for the specified document ID and attachment name.
         /// </summary>
         bool Exists(string documentId, string name);
 
         /// <summary>
-        /// Returns the attachment by the document id and attachment name.
+        /// Returns the attachment for the specified document ID and attachment name.
         /// </summary>
         AttachmentResult Get(string documentId, string name);
 
         /// <summary>
-        /// Returns the attachment by the document id and attachment name.
+        /// Returns the attachment for the specified entity instance and attachment name.
         /// </summary>
         AttachmentResult Get(object entity, string name);
 
         /// <summary>
-        /// Returns a range of the attachment by the document id and attachment name.
+        /// Returns a range of the attachment stream for the specified document ID and attachment name.
         /// </summary>
         AttachmentResult GetRange(string documentId, string name, long? from, long? to);
 
         /// <summary>
-        /// Returns a range of the attachment by the document id and attachment name.
+        /// Returns a range of the attachment stream for the specified entity instance and attachment name.
         /// </summary>
         AttachmentResult GetRange(object entity, string name, long? from, long? to);
 
         /// <summary>
-        /// Returns Enumerator of KeyValuePairs of attachment name and stream.
+        /// Returns an enumerator over multiple attachments. Each result includes the attachment stream and metadata.
         /// </summary>
         IEnumerator<AttachmentEnumeratorResult> Get(IEnumerable<AttachmentRequest> attachments);
 
         /// <summary>
-        /// Returns the revision attachment by the document id and attachment name.
+        /// Returns the attachment from a document revision for the specified document ID, attachment name, and change vector.
         /// </summary>
         AttachmentResult GetRevision(string documentId, string name, string changeVector);
     }

--- a/src/Raven.Client/Documents/Session/IAttachmentsSessionOperationsAsync.cs
+++ b/src/Raven.Client/Documents/Session/IAttachmentsSessionOperationsAsync.cs
@@ -6,42 +6,42 @@ using Raven.Client.Documents.Operations.Attachments;
 namespace Raven.Client.Documents.Session
 {
     /// <summary>
-    ///     Advanced async attachments session operations
+    /// Advanced asynchronous session operations for working with attachments.
     /// </summary>
     public interface IAttachmentsSessionOperationsAsync : IAttachmentsSessionOperationsBase
     {
         /// <summary>
-        /// Check if attachment exists
+        /// Checks whether an attachment exists for the specified document ID and attachment name.
         /// </summary>
         Task<bool> ExistsAsync(string documentId, string name, CancellationToken token = default);
 
         /// <summary>
-        /// Returns the attachment by the document id and attachment name.
+        /// Returns the attachment for the specified document ID and attachment name.
         /// </summary>
         Task<AttachmentResult> GetAsync(string documentId, string name, CancellationToken token = default);
 
         /// <summary>
-        /// Returns the attachment by the document id and attachment name.
+        /// Returns the attachment for the specified entity instance and attachment name.
         /// </summary>
         Task<AttachmentResult> GetAsync(object entity, string name, CancellationToken token = default);
 
         /// <summary>
-        /// Returns a range of the attachment by the document id and attachment name.
+        /// Returns a range of the attachment stream for the specified document ID and attachment name.
         /// </summary>
         Task<AttachmentResult> GetRangeAsync(string documentId, string name, long? from, long? to, CancellationToken token = default);
 
         /// <summary>
-        /// Returns a range of the attachment by the document id and attachment name.
+        /// Returns a range of the attachment stream for the specified entity instance and attachment name.
         /// </summary>
         Task<AttachmentResult> GetRangeAsync(object entity, string name, long? from, long? to, CancellationToken token = default);
 
         /// <summary>
-        /// Returns Enumerator of KeyValuePairs of attachment name and stream.
+        /// Returns an enumerator over multiple attachments. Each result includes the attachment stream and metadata.
         /// </summary>
         Task<IEnumerator<AttachmentEnumeratorResult>> GetAsync(IEnumerable<AttachmentRequest> attachments, CancellationToken token = default);
 
         /// <summary>
-        /// Returns the revision attachment by the document id and attachment name.
+        /// Returns the attachment from a document revision for the specified document ID, attachment name, and change vector.
         /// </summary>
         Task<AttachmentResult> GetRevisionAsync(string documentId, string name, string changeVector, CancellationToken token = default);
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25398/IAttachmentsSessionOperations-Fix-XML-documentation

### Additional description
Fix the XML documentation:
* Use `“entity instance”` instead of `“document id”` where relevant
* Improve text

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
