### PR TITLE
RavenDB-25400 handle AzureOpenAI refusal format

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -706,19 +706,30 @@ internal class ChatCompletionClient : IDisposable
                         };
                 }
             default:
-                UnsuccessfulRequestException.Throw(message, response.StatusCode, reqId);
+                if (errBjo.TryGet("code", out string errorCode) && errorCode == "content_filter")
+                {
+                    RefusedToAnswerException.Throw("content_filter", responseContent.ToString(), "content_filter", reqId);
+                }
+
+                UnsuccessfulRequestException.Throw(responseContent.ToString(), response.StatusCode, reqId);
                 break;
         }
     }
 
     internal static string GetRequestId(HttpResponseHeaders headers)
     {
-        if (headers.TryGetValues(Constants.Headers.RequestId, out var values) == false || values.IsNullOrEmpty())
+        if (headers.TryGetValues(Constants.Headers.RequestId, out IEnumerable<string> values))
         {
-            return string.Empty;
+            return values.FirstOrDefault() ?? string.Empty;
         }
 
-        return values.FirstOrDefault();
+        // Azure API Management uses a different header name
+        if (headers.TryGetValues("apim-request-id", out values))
+        {
+            return values.FirstOrDefault() ?? string.Empty;
+        }
+
+        return string.Empty;
     }
 
     private static readonly Regex GoDurationRegex = new(

--- a/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcessStatistics.cs
@@ -140,11 +140,16 @@ namespace Raven.Server.Documents.ETL
             
             LastLoadErrorTime = now;
 
-            LastLoadErrorsInCurrentBatch.Add(new EtlErrorInfo
+            if (LastLoadErrorsInCurrentBatch.Errors.Count == 0)
             {
-                Date = now,
-                Error = error
-            });
+                // this is a workaround for the case when we forget to register the real error
+                // so we want at least to show something
+                LastLoadErrorsInCurrentBatch.Add(new EtlErrorInfo
+                {
+                    Date = now,
+                    Error = error
+                });
+            }
 
             var message = $"Current ETL batch with '{count}' items was stopped. ";
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -318,6 +318,15 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             if (Configuration.TestMode)
                 throw new InvalidOperationException("Failed to run test", singleEx);
 
+            var msg =
+                $"Model call failed for context in document '{item.DocumentId}' ({singleEx.GetType().Name}). {Environment.NewLine}" +
+                $"Context was: {item.ContextOutput.Context}{Environment.NewLine}" +
+                $"{singleEx}";
+
+            Statistics.RecordPartialLoadError(msg, item.DocumentId);
+            if (Logger.IsWarnEnabled)
+                Logger.Warn(msg);
+
             switch (singleEx)
             {
                 // this item cannot be processed, because it has too many items, and retrying isn't going to change that
@@ -327,13 +336,6 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     // in this case, we _intentionally_ want to update the hash so we will _not_ try to update this known bad
                     // item again in the future.
                     item.UpdateHash = true;
-                    var msg =
-                        $"Model call failed for context in document '{item.DocumentId}' ({singleEx.GetType().Name}). {Environment.NewLine}" +
-                        $"Context was: {item.ContextOutput.Context}{Environment.NewLine}" +
-                        $"{singleEx}";
-
-                    Statistics.RecordPartialLoadError(msg, item.DocumentId);
-                    Logger.Warn(msg);
                     return null;
                 default:
                     // something bad happened, but this isn't the fault of this item (run out of rate limit, TCP error, etc.)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25400 

### Additional description

AzureOpenAI might have a different refusal format, which we need to take into account, because we have a special treatment for such error.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
