### PR TITLE
RavenDB-25285 Failed to load notification after deleting documents

### DIFF
--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -326,7 +326,8 @@ export default class DatabasesService {
         return new deleteDocumentsCommand(...args).execute();
     }
 
-    async deleteCollection(...args: ConstructorParameters<typeof deleteCollectionCommand>) {
+    // Skip async to use JQueryPromise type
+    deleteCollection(...args: ConstructorParameters<typeof deleteCollectionCommand>) {
         return new deleteCollectionCommand(...args).execute();
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/DeleteDocumentsModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/DeleteDocumentsModal.tsx
@@ -3,7 +3,7 @@ import { Icon } from "components/common/Icon";
 import React, { useState } from "react";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
-import { useAsync, useAsyncCallback, UseAsyncReturn } from "react-async-hook";
+import { useAsync, UseAsyncReturn } from "react-async-hook";
 import { useServices } from "hooks/useServices";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
@@ -21,6 +21,8 @@ import pluralizeHelpers from "common/helpers/text/pluralizeHelpers";
 import genUtils from "common/generalUtils";
 import studioSettings from "common/settings/studioSettings";
 import { Switch } from "components/common/Checkbox";
+import useBoolean from "hooks/useBoolean";
+import { useIsMounted } from "components/hooks/useIsMounted";
 
 interface DeleteDocumentsModalProps {
     close: () => void;
@@ -59,11 +61,11 @@ export default function DeleteDocumentsModal({
         onDeleteCompleted
     );
 
-    const onConfirm = async () => {
+    const onConfirm = () => {
         if (!isConfirmed) {
             return;
         }
-        await deleteCollection.execute();
+        deleteCollection.execute();
     };
 
     const toggleIsRequireTypedConfirm = async () => {
@@ -144,58 +146,62 @@ function useDeleteCollection(
 ) {
     const { databasesService } = useServices();
     const dbName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const { value: isLoading, setValue: setIsLoading } = useBoolean(false);
+    const isMounted = useIsMounted();
 
-    const deleteCollectionAsync = useAsyncCallback(
-        async () => {
-            const collectionNameForApi = currentCollection().isAllDocuments ? "@all_docs" : currentCollection().name;
-            const result = await databasesService.deleteCollection(collectionNameForApi, dbName, excludedIds);
-            return result.OperationId;
-        },
-        {
-            onError: (error) => messagePublisher.reportError("Failed to delete collection", error.message),
-        }
-    );
+    const execute = () => {
+        setIsLoading(true);
+        const collectionNameForApi = currentCollection().isAllDocuments ? "@all_docs" : currentCollection().name;
 
-    const monitorOperationAsync = useAsyncCallback(
-        async (operationId: number) => {
-            notificationCenter.instance.openDetailsForOperationById(dbName, operationId);
-            close();
-            await notificationCenter.instance.databaseOperationsWatch
-                .monitorOperation(operationId)
-                .done(() => {
-                    if (excludedIds.length === 0) {
-                        messagePublisher.reportSuccess(`Deleted collection ${currentCollection().name}`);
-                    } else {
-                        messagePublisher.reportSuccess(
-                            `Deleted ${pluralizeHelpers.pluralize(documentCount, "document", "documents")} from ${currentCollection().name}`
-                        );
-                    }
+        // This is JQueryPromise. Use 'done' to prevent wrong order of execution in event loop
+        databasesService
+            .deleteCollection(collectionNameForApi, dbName, excludedIds)
+            .done((result) => {
+                const operationId = result.OperationId;
 
-                    if (excludedIds.length === 0) {
-                        // if entire collection was deleted then go to 'all documents'
-                        const allDocsCollection = collectionsTracker.default.getAllDocumentsCollection();
-                        if (currentCollection() !== allDocsCollection) {
-                            currentCollection(allDocsCollection);
+                // For slow connection, this operation may fail
+                try {
+                    notificationCenter.instance.openDetailsForOperationById(dbName, operationId);
+                } catch {
+                    onDeleteCompleted();
+                    close();
+                    return;
+                }
+
+                notificationCenter.instance.databaseOperationsWatch
+                    .monitorOperation(operationId)
+                    .done(() => {
+                        if (excludedIds.length === 0) {
+                            messagePublisher.reportSuccess(`Deleted collection ${currentCollection().name}`);
+                        } else {
+                            messagePublisher.reportSuccess(
+                                `Deleted ${pluralizeHelpers.pluralize(documentCount, "document", "documents")} from ${currentCollection().name}`
+                            );
                         }
-                    }
-                })
-                .always(() => onDeleteCompleted());
-        },
-        {
-            onError: (error) => messagePublisher.reportError("Failed to monitor delete operation", error.message),
-        }
-    );
 
-    const execute = async () => {
-        const operationId = await deleteCollectionAsync.execute();
-        if (operationId) {
-            await monitorOperationAsync.execute(operationId);
-        }
+                        if (excludedIds.length === 0) {
+                            // if entire collection was deleted then go to 'all documents'
+                            const allDocsCollection = collectionsTracker.default.getAllDocumentsCollection();
+                            if (currentCollection() !== allDocsCollection) {
+                                currentCollection(allDocsCollection);
+                            }
+                        }
+                    })
+                    .always(() => {
+                        onDeleteCompleted();
+                        close();
+                    });
+            })
+            .always(() => {
+                if (isMounted()) {
+                    setIsLoading(false);
+                }
+            });
     };
 
     return {
         execute,
-        loading: deleteCollectionAsync.loading || monitorOperationAsync.loading,
+        loading: isLoading,
     };
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/documents.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/documents.ts
@@ -363,7 +363,6 @@ class documents extends shardViewModelBase {
     private onDeleteCompleted() {
         this.spinners.delete(false);
         this.resetGrid(false);
-        this.refresh()
     }
 
     copySelectedDocs() {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25285/Failed-to-load-notification-after-deleting-documents

### Additional description

- use JQueryPromise 'done' to prevent wrong order of execution in event loop

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
