### PR TITLE
RavenDB-25272 use local stream for remote attachment if possible

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForBulkPostAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForBulkPostAttachment.cs
@@ -58,7 +58,6 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
                         else
                         {
                             strategy = new RegularBulkPostAttachmentStrategyProcessor(RequestHandler);
-                            canDisposeReadTransaction = false;
                         }
 
                         strategy.CheckAttachmentFlagAndThrowIfNeeded(context, attachment, id, name);
@@ -67,8 +66,12 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
                             writer.WriteComma();
                         first = false;
 
-                        var attachmentStream = strategy.GetAttachmentStream(downloader, attachment);
+                        (var attachmentStream, var isLocal) = strategy.GetAttachmentStream(context, downloader, attachment);
                         tasks.Add(attachmentStream);
+                        if (isLocal)
+                        {
+                            canDisposeReadTransaction = false;
+                        }
 
                         strategy.WriteAttachmentDetails(writer, attachment, id);
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForGetAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForGetAttachment.cs
@@ -78,9 +78,7 @@ internal sealed class AttachmentHandlerProcessorForGetAttachment : AbstractAttac
                 HttpContext.Response.Headers[Constants.Headers.AttachmentRemoteParametersFlags] = attachment.RemoteParameters.Flags.ToString();
             }
 
-            strategy.DisposeReadTransactionIfNeeded(tx);
-
-            await strategy.WriteResponseStream(context, attachment, tcs);
+            await strategy.WriteResponseStream(context, tx, attachment, tcs);
         }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/AbstractBulkPostAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/AbstractBulkPostAttachmentStrategyProcessor.cs
@@ -18,7 +18,7 @@ internal abstract class AbstractBulkPostAttachmentStrategyProcessor<TRequestHand
     }
 
     public abstract void CheckAttachmentFlagAndThrowIfNeeded(DocumentsOperationContext context, Attachment attachment, string documentId, string name);
-    public abstract Task<Stream> GetAttachmentStream(DirectFileDownloader downloader, Attachment attachment);
+    public abstract (Task<Stream> Stream, bool IsLocal) GetAttachmentStream(DocumentsOperationContext context, DirectFileDownloader downloader, Attachment attachment);
     public abstract DirectFileDownloader GetAttachmentsDownloader(Attachment attachment, OperationCancelToken tcs);
 
     public void WriteAttachmentDetails(AsyncBlittableJsonTextWriter writer, Attachment attachment, string documentId)

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/AbstractGetAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/AbstractGetAttachmentStrategyProcessor.cs
@@ -14,7 +14,6 @@ internal abstract class AbstractGetAttachmentStrategyProcessor<TRequestHandler, 
     {
     }
 
-    public abstract void DisposeReadTransactionIfNeeded(DocumentsTransaction tx);
     public abstract void CheckAttachmentFlagAndConfigurationAndThrowIfNeeded(DocumentsOperationContext context, Attachment attachment, string documentId, string name);
-    public abstract Task WriteResponseStream(DocumentsOperationContext context, Attachment attachment, OperationCancelToken token);
+    public abstract Task WriteResponseStream(DocumentsOperationContext context, DocumentsTransaction tx, Attachment attachment, OperationCancelToken token);
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/IBulkPostAttachmentStrategy.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/IBulkPostAttachmentStrategy.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies;
 public interface IBulkPostAttachmentStrategy
 {
     public void CheckAttachmentFlagAndThrowIfNeeded(DocumentsOperationContext context, Attachment attachment, string documentId, string name);
-    public Task<Stream> GetAttachmentStream(DirectFileDownloader downloader, Attachment attachment);
+    public (Task<Stream> Stream, bool IsLocal) GetAttachmentStream(DocumentsOperationContext context, DirectFileDownloader downloader, Attachment attachment);
     public DirectFileDownloader GetAttachmentsDownloader(Attachment attachment, OperationCancelToken tcs);
     public void WriteAttachmentDetails(AsyncBlittableJsonTextWriter writer, Attachment attachment, string documentId);
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/IGetAttachmentStrategy.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/IGetAttachmentStrategy.cs
@@ -8,9 +8,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies;
 
 public interface IGetAttachmentStrategy
 {
-    public void DisposeReadTransactionIfNeeded(DocumentsTransaction tx);
     public void CheckAttachmentFlagAndConfigurationAndThrowIfNeeded(DocumentsOperationContext context, Attachment attachment, string documentId, string name);
-    public Task WriteResponseStream(DocumentsOperationContext context, Attachment attachment, OperationCancelToken tcs);
+    public Task WriteResponseStream(DocumentsOperationContext context, DocumentsTransaction tx, Attachment attachment, OperationCancelToken tcs);
 
     public static void CheckAttachmentFlagAndConfigurationAndThrowIfNeededInternal(DocumentsOperationContext context, DocumentDatabase database, Attachment attachment, string documentId, string name, string operation)
     {

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RegularBulkPostAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RegularBulkPostAttachmentStrategyProcessor.cs
@@ -23,9 +23,9 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies
             }
         }
 
-        public override Task<Stream> GetAttachmentStream(DirectFileDownloader downloader, Attachment attachment)
+        public override (Task<Stream> Stream, bool IsLocal) GetAttachmentStream(DocumentsOperationContext context, DirectFileDownloader downloader, Attachment attachment)
         {
-            return Task.FromResult(attachment.Stream);
+            return (Task.FromResult(attachment.Stream), true);
         }
 
         public override DirectFileDownloader GetAttachmentsDownloader(Attachment attachment, OperationCancelToken tcs)

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RegularGetAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RegularGetAttachmentStrategyProcessor.cs
@@ -13,17 +13,12 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies
         {
         }
 
-        public override void DisposeReadTransactionIfNeeded(DocumentsTransaction tx)
-        {
-            // noop
-        }
-
         public override void CheckAttachmentFlagAndConfigurationAndThrowIfNeeded(DocumentsOperationContext context, Attachment attachment, string documentId, string name)
         {
             // noop
         }
 
-        public override async Task WriteResponseStream(DocumentsOperationContext context, Attachment attachment, OperationCancelToken tcs)
+        public override async Task WriteResponseStream(DocumentsOperationContext context, DocumentsTransaction tx, Attachment attachment, OperationCancelToken tcs)
         {
             var (sendBody, start, bytesRemaining) = RangeHelper.SetRangeHeaders(HttpContext, attachment.Size);
             if (!sendBody)

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RemoteBulkPostAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RemoteBulkPostAttachmentStrategyProcessor.cs
@@ -19,10 +19,16 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies
             IGetAttachmentStrategy.CheckAttachmentFlagAndConfigurationAndThrowIfNeededInternal(context, RequestHandler.Database, attachment, documentId, name, nameof(GetAttachmentsOperation));
         }
 
-        public override Task<Stream> GetAttachmentStream(DirectFileDownloader downloader, Attachment attachment)
+        public override (Task<Stream> Stream, bool IsLocal) GetAttachmentStream(DocumentsOperationContext context, DirectFileDownloader downloader, Attachment attachment)
         {
-            return RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.StreamForDownloadDestinationInternal(downloader,
-                attachment.Base64Hash.ToString());
+            var stream = RequestHandler.Database.DocumentsStorage.AttachmentsStorage.GetAttachmentStream(context, attachment.Base64Hash);
+            if (stream != null)
+            {
+                return (Task.FromResult(stream), true);
+            }
+
+            return (RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.StreamForDownloadDestinationInternal(downloader,
+                attachment.Base64Hash.ToString()), false);
         }
 
         public override DirectFileDownloader GetAttachmentsDownloader(Attachment attachment, OperationCancelToken tcs)

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RemoteGetAttachmentStrategyProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Strategies/RemoteGetAttachmentStrategyProcessor.cs
@@ -17,16 +17,20 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments.Strategies
             IGetAttachmentStrategy.CheckAttachmentFlagAndConfigurationAndThrowIfNeededInternal(context, RequestHandler.Database, attachment, documentId, name, nameof(GetAttachmentOperation));
         }
 
-        public override void DisposeReadTransactionIfNeeded(DocumentsTransaction tx)
+        public override async Task WriteResponseStream(DocumentsOperationContext context, DocumentsTransaction tx, Attachment attachment, OperationCancelToken tcs)
         {
-            tx.Dispose();
-        }
+            var stream = RequestHandler.Database.DocumentsStorage.AttachmentsStorage.GetAttachmentStream(context, attachment.Base64Hash);
+            if (stream == null)
+            {
+                tx.Dispose(); // we are reading from remote, we can dispose the transaction
+                using var downloader = RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.GetDownloader(attachment, tcs);
+                stream = await RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.StreamForDownloadDestinationInternal(downloader, attachment.Base64Hash.ToString());
+            }
 
-        public override async Task WriteResponseStream(DocumentsOperationContext context, Attachment attachment, OperationCancelToken tcs)
-        {
-            using var downloader = RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.GetDownloader(attachment, tcs);
-            await using var stream = await RequestHandler.Database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.StreamForDownloadDestinationInternal(downloader, attachment.Base64Hash.ToString());
-            await stream.CopyToAsync(RequestHandler.ResponseBodyStream(), tcs.Token);
+            await using (stream)
+            {
+                await stream.CopyToAsync(RequestHandler.ResponseBodyStream(), tcs.Token);
+            }
         }
     }
 }

--- a/test/SlowTests/Server/Documents/Attachments/DocumentSessionRemoteAttachmentsAsyncTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/DocumentSessionRemoteAttachmentsAsyncTests.cs
@@ -7,7 +7,7 @@ using Orders;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
-using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Attachments.Remote;
 using Raven.Client.Extensions;
 using Tests.Infrastructure;
 using Xunit;
@@ -903,6 +903,151 @@ namespace SlowTests.Server.Documents.Attachments
                 var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
                 database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                 await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var attachments = await session.Advanced.Attachments.GetAsync(new List<AttachmentRequest> { new AttachmentRequest(id, "test.png") });
+                    Assert.NotNull(attachments);
+                    Assert.True(attachments.MoveNext());
+                    var attachment = attachments.Current;
+                    Assert.NotNull(attachment);
+                    Assert.Equal("test.png", attachment.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.Remote, attachment.Details.RemoteParameters.Flags);
+                }
+            }
+        }
+
+        [AmazonS3RetryFact]
+        public async Task CanGetRemoteAttachmentByEntityAndNameFromLocalAsync()
+        {
+            await using (var holder = CreateCloudSettings())
+            using (var store = GetDocumentStore())
+            {
+                var identifier = await PutRemoteAttachmentsConfiguration(store, Settings, collections: null);
+                var id = "Orders/4";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order { Id = id, OrderedAt = new DateTime(2024, 1, 1), ShipVia = $"Shippers/4", Company = $"Companies/4" });
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    using var profileStream = new MemoryStream(new byte[] { 1, 2, 3 });
+                    session.Advanced.Attachments.Store(id, new StoreAttachmentParameters("test.png", profileStream) { RemoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3)), ContentType = "image/png" });
+                    await session.SaveChangesAsync();
+                }
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                var id2 = "Order/44";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order { Id = id2, OrderedAt = new DateTime(2024, 1, 1), ShipVia = $"Shippers/4", Company = $"Companies/4" });
+                    await session.SaveChangesAsync();
+                }
+                using (var session = store.OpenAsyncSession())
+                {
+                    using var profileStream = new MemoryStream(new byte[] { 1, 2, 3 });
+                    session.Advanced.Attachments.Store(id2, new StoreAttachmentParameters("testtesttest.png", profileStream));
+                    await session.SaveChangesAsync();
+                }
+
+                // I put dummy config for the old identifier so the attachment will be read from local storage
+                var config = new RemoteAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            identifier, new RemoteAttachmentsDestinationConfiguration()
+                            {
+                                S3Settings = new RemoteAttachmentsS3Settings()
+                                {
+                                    BucketName = "EGOR"
+                                },
+                                Disabled = false,
+                            }
+                        }
+                    },
+                    CheckFrequencyInSec = 1000
+                };
+
+                ModifyRemoteAttachmentsConfig?.Invoke(config);
+                await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(config));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var order = await session.LoadAsync<Order>(id);
+                    var attachment = await session.Advanced.Attachments.GetAsync(order, "test.png");
+                    Assert.NotNull(attachment);
+                    Assert.Equal("test.png", attachment.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.Remote, attachment.Details.RemoteParameters.Flags);
+                }
+            }
+        }
+
+        [AmazonS3RetryFact]
+        public async Task CanGetEnumeratorOfRemoteAttachmentsFromLocalAsync()
+        {
+            await using (var holder = CreateCloudSettings())
+            using (var store = GetDocumentStore())
+            {
+                var identifier = await PutRemoteAttachmentsConfiguration(store, Settings, collections: null);
+                var id = "Orders/4";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order { Id = id, OrderedAt = new DateTime(2024, 1, 1), ShipVia = $"Shippers/4", Company = $"Companies/4" });
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    using var profileStream = new MemoryStream(new byte[] { 1, 2, 3 });
+                    session.Advanced.Attachments.Store(id, new StoreAttachmentParameters("test.png", profileStream) { RemoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3)), ContentType = "image/png" });
+                    await session.SaveChangesAsync();
+                }
+
+                var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                var id2 = "Order/44";
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order { Id = id2, OrderedAt = new DateTime(2024, 1, 1), ShipVia = $"Shippers/4", Company = $"Companies/4" });
+                    await session.SaveChangesAsync();
+                }
+                using (var session = store.OpenAsyncSession())
+                {
+                    using var profileStream = new MemoryStream(new byte[] { 1, 2, 3 });
+                    session.Advanced.Attachments.Store(id2, new StoreAttachmentParameters("testtesttest.png", profileStream));
+                    await session.SaveChangesAsync();
+                }
+
+                // I put dummy config for the old identifier so the attachment will be read from local storage
+                var config = new RemoteAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            identifier, new RemoteAttachmentsDestinationConfiguration()
+                            {
+                                S3Settings = new RemoteAttachmentsS3Settings()
+                                {
+                                    BucketName = "EGOR"
+                                },
+                                Disabled = false,
+                            }
+                        }
+                    },
+                    CheckFrequencyInSec = 1000
+                };
+
+                ModifyRemoteAttachmentsConfig?.Invoke(config);
+                await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(config));
+
 
                 using (var session = store.OpenAsyncSession())
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25272

### Additional description

This pull request refactors the attachment streaming logic in RavenDB to better handle local and remote attachments, and take the local stream if it exists, in case of remote attachment

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
