### PR TITLE
RavenDB-25325 - properly track the processed and processing documents in remote attachments

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -186,8 +186,36 @@ namespace Raven.Client
             /// </summary>
             public const string AttachmentSize = "Attachment-Size";
 
+            /// <summary>
+            /// HTTP header name for the scheduled remote attachment upload time.
+            /// </summary>
+            /// <remarks>
+            /// This header contains the timestamp (UTC) when an attachment should be uploaded to remote cloud storage.
+            /// Used in conjunction with <see cref="AttachmentRemoteParametersFlags"/> and <see cref="AttachmentRemoteParametersIdentifier"/>
+            /// to configure automatic offloading of attachments to cloud storage providers like Amazon S3 or Azure Blob Storage.
+            /// </remarks>
             public const string AttachmentRemoteParametersAt = "Attachment-RemoteParameters-At";
+
+            /// <summary>
+            /// HTTP header name for remote attachment configuration flags.
+            /// </summary>
+            /// <remarks>
+            /// This header contains flags that control remote attachment behavior, such as whether the attachment
+            /// should be uploaded immediately or at a scheduled time. Used with <see cref="AttachmentRemoteParametersAt"/>
+            /// and <see cref="AttachmentRemoteParametersIdentifier"/> to specify complete remote storage configuration.
+            /// The flags correspond to the <see cref="Client.Documents.Attachments.RemoteAttachmentFlags"/> enum values.
+            /// </remarks>
             public const string AttachmentRemoteParametersFlags = "Attachment-RemoteParameters-Flags";
+
+            /// <summary>
+            /// HTTP header name for remote attachment storage destination identifier.
+            /// </summary>
+            /// <remarks>
+            /// This header contains the unique identifier for the remote storage destination configuration where the attachment
+            /// should be uploaded. This identifier references a configured remote attachment destination (e.g., a specific S3 bucket
+            /// or Azure container) in the database's remote attachments configuration. Used with <see cref="AttachmentRemoteParametersAt"/>
+            /// and <see cref="AttachmentRemoteParametersFlags"/> to specify the complete remote storage parameters.
+            /// </remarks>
             public const string AttachmentRemoteParametersIdentifier = "Attachment-RemoteParameters-Identifier";
 
             internal const string DatabaseMissing = "Database-Missing";

--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsAzureSettings.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsAzureSettings.cs
@@ -4,12 +4,133 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Attachments;
 
+/// <summary>
+/// Configuration settings for storing attachments in Azure Blob Storage as part of the remote attachments feature.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class configures the remote storage destination for attachments using Microsoft Azure Blob Storage.
+/// Remote attachments allow offloading large attachment files from the local RavenDB database to cloud storage,
+/// helping to reduce database size and improve performance for scenarios with many or large attachments.
+/// </para>
+/// <para>
+/// Azure authentication can be configured using either:
+/// <list type="bullet">
+/// <item><description>Account Key: Using <see cref="AccountName"/> and <see cref="AccountKey"/></description></item>
+/// <item><description>Shared Access Signature (SAS): Using <see cref="AccountName"/> and <see cref="SasToken"/></description></item>
+/// </list>
+/// </para>
+/// <para>
+/// This class is typically used in conjunction with <see cref="RemoteAttachmentsDestinationConfiguration"/> to define
+/// where and how attachments should be uploaded to Azure Blob Storage.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var azureSettings = new RemoteAttachmentsAzureSettings
+/// {
+///     StorageContainer = "ravendb-attachments",
+///     RemoteFolderName = "production/attachments",
+///     AccountName = "mystorageaccount",
+///     AccountKey = "myaccountkey"
+/// };
+/// </code>
+/// </example>
 public sealed class RemoteAttachmentsAzureSettings : IRemoteAttachmentsSettings, IAzureSettings, IDynamicJson
 {
+    /// <summary>
+    /// Gets or sets the name of the Azure Blob Storage container where attachments will be stored.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The storage container name must follow Azure Blob Storage naming rules:
+    /// <list type="bullet">
+    /// <item><description>Must be between 3 and 63 characters long</description></item>
+    /// <item><description>Must contain only lowercase letters, numbers, and dashes</description></item>
+    /// <item><description>Must start and end with a letter or number</description></item>
+    /// <item><description>Cannot contain consecutive dashes</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// This property is required for the configuration to be valid and determines the primary location
+    /// where attachments will be stored within the Azure storage account.
+    /// </para>
+    /// </remarks>
+    /// <value>The name of the Azure storage container.</value>
     public string StorageContainer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional subfolder path within the storage container for organizing attachments.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property allows you to organize attachments into a specific folder structure within the Azure container.
+    /// For example, you might use different folder names for different databases, environments, or tenants.
+    /// </para>
+    /// <para>
+    /// The folder path can include forward slashes to create a multi-level directory structure.
+    /// If not specified, attachments will be stored in the root of the container.
+    /// </para>
+    /// </remarks>
+    /// <value>The remote folder name or <c>null</c> to use the container root.</value>
+    /// <example>"production/database1" or "attachments/2024"</example>
     public string RemoteFolderName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure storage account name.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the name of your Azure storage account and is required for authentication.
+    /// The account name is used in combination with either <see cref="AccountKey"/> or <see cref="SasToken"/>
+    /// to authenticate with Azure Blob Storage.
+    /// </para>
+    /// <para>
+    /// The storage account must have the appropriate permissions to create and write blobs to the specified container.
+    /// </para>
+    /// </remarks>
+    /// <value>The Azure storage account name.</value>
     public string AccountName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure storage account key for authentication.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The account key provides full access to the storage account. Use this property when authenticating
+    /// with the primary or secondary access key from your Azure storage account.
+    /// </para>
+    /// <para>
+    /// You should use either <see cref="AccountKey"/> or <see cref="SasToken"/> for authentication, but not both.
+    /// Account keys provide broader access than SAS tokens, so consider using a SAS token with limited permissions
+    /// if that better fits your security requirements.
+    /// </para>
+    /// </remarks>
+    /// <value>The Azure storage account key or <c>null</c> if using <see cref="SasToken"/>.</value>
     public string AccountKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Shared Access Signature (SAS) token for limited-scope authentication.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A SAS token provides delegated access to resources in your storage account with granular control
+    /// over permissions, expiration time, and allowed IP addresses. This is often preferred over using
+    /// an account key for security reasons.
+    /// </para>
+    /// <para>
+    /// The SAS token should have at minimum the following permissions for the specified container:
+    /// <list type="bullet">
+    /// <item><description>Write (w): To upload attachments</description></item>
+    /// <item><description>Read (r): To download attachments when needed</description></item>
+    /// <item><description>List (l): To enumerate attachments if required</description></item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// You should use either <see cref="SasToken"/> or <see cref="AccountKey"/> for authentication, but not both.
+    /// </para>
+    /// </remarks>
+    /// <value>The SAS token or <c>null</c> if using <see cref="AccountKey"/>.</value>
     public string SasToken { get; set; }
 
     internal bool HasSettings()

--- a/src/Raven.Client/Documents/Attachments/RemoteAttachmentsDestinationConfiguration.cs
+++ b/src/Raven.Client/Documents/Attachments/RemoteAttachmentsDestinationConfiguration.cs
@@ -76,6 +76,9 @@ public sealed class RemoteAttachmentsDestinationConfiguration : IDynamicJson
 
     internal bool HasUploader()
     {
+        if (Disabled)
+            return false;
+
         return S3Settings.IsConfigured() || AzureSettings.IsConfigured();
     }
 

--- a/src/Raven.Client/Documents/Operations/Attachments/AttachmentName.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/AttachmentName.cs
@@ -31,6 +31,14 @@ public class AttachmentName
     /// </summary>
     public long Size;
 
+    /// <summary>
+    /// Scheduling parameters for uploading the attachment to a remote (cloud) destination.
+    /// Optional; null if no remote upload has been requested.
+    /// </summary>
+    /// <remarks>
+    /// Set this to instruct RavenDB to perform a remote upload of the attachment at the specified time,
+    /// as defined by <see cref="RemoteAttachmentParameters.At"/> and identified by <see cref="RemoteAttachmentParameters.Identifier"/>.
+    /// </remarks>
     public RemoteAttachmentParameters RemoteParameters;
 
     internal virtual DynamicJsonValue ToJson()

--- a/src/Raven.Client/Documents/Operations/Attachments/DeleteAttachmentsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/DeleteAttachmentsOperation.cs
@@ -9,10 +9,25 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Attachments
 {
+    /// <summary>
+    /// Represents an operation to delete multiple attachments from the database in a single request.
+    /// </summary>
+    /// <remarks>
+    /// This operation can be used to efficiently remove multiple attachments associated with documents
+    /// by sending a bulk delete request to the server.
+    /// </remarks>
     public sealed class DeleteAttachmentsOperation : IOperation
     {
         private readonly IEnumerable<AttachmentRequest> _attachments;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteAttachmentsOperation"/> class.
+        /// </summary>
+        /// <param name="attachments">A collection of attachment requests specifying which attachments to delete.</param>
+        /// <remarks>
+        /// Use this constructor to create an operation that deletes multiple attachments in a single bulk request.
+        /// Each <see cref="AttachmentRequest"/> should specify the document ID and attachment name.
+        /// </remarks>
         public DeleteAttachmentsOperation(IEnumerable<AttachmentRequest> attachments)
         {
             _attachments = attachments;

--- a/src/Raven.Client/Documents/Operations/Attachments/IStoreAttachmentParameters.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/IStoreAttachmentParameters.cs
@@ -2,30 +2,59 @@
 
 namespace Raven.Client.Documents.Operations.Attachments;
 
+/// <summary>
+/// Defines the contract for parameters used when storing an attachment in the database.
+/// </summary>
+/// <remarks>
+/// This interface specifies the required and optional properties for attachment storage operations.
+/// Implementations can be used with various attachment storage methods including session operations,
+/// bulk insert operations, and direct store operations.
+/// </remarks>
 public interface IStoreAttachmentParameters
 {
     /// <summary>
-    /// The name of the attachment.
+    /// Gets the name of the attachment.
     /// </summary>
+    /// <remarks>
+    /// The attachment name is used to uniquely identify the attachment within the context of its parent document.
+    /// This property is required and cannot be null or whitespace.
+    /// </remarks>
     string Name { get; }
 
     /// <summary>
-    /// The stream of the attachment.
+    /// Gets the stream containing the attachment data.
     /// </summary>
+    /// <remarks>
+    /// The stream provides the binary content of the attachment to be stored in the database.
+    /// This property is required and cannot be null. The caller is responsible for managing the stream's lifetime.
+    /// </remarks>
     Stream Stream { get; }
 
     /// <summary>
-    /// The change vector of the attachment for concurrency control.
+    /// Gets or sets the change vector of the attachment for optimistic concurrency control.
     /// </summary>
+    /// <remarks>
+    /// The change vector can be used to ensure that the attachment is stored only if the current version matches the expected version.
+    /// This is useful for preventing concurrent modification conflicts. If null, no concurrency check is performed.
+    /// </remarks>
     string ChangeVector { get; set; }
 
     /// <summary>
-    /// The MIME type of the attachment.
+    /// Gets or sets the MIME type (Content-Type) of the attachment.
     /// </summary>
+    /// <remarks>
+    /// Specifies the media type of the attachment content (e.g., "image/png", "application/pdf", "text/plain").
+    /// If not specified, RavenDB may attempt to infer the content type from the attachment name or default to "application/octet-stream".
+    /// </remarks>
     string ContentType { get; set; }
 
     /// <summary>
-    /// The date to upload the attachment to cloud.
+    /// Gets or sets the parameters for scheduling the attachment upload to remote cloud storage.
     /// </summary>
+    /// <remarks>
+    /// When specified, this property instructs RavenDB to upload the attachment to a configured remote storage destination
+    /// at the scheduled time. This is useful for offloading large attachments to cloud storage providers like Amazon S3 or Azure Blob Storage.
+    /// If null, the attachment is stored only in the local RavenDB database. See <see cref="RemoteAttachmentParameters"/> for configuration details.
+    /// </remarks>
     RemoteAttachmentParameters RemoteParameters { get; set; }
 }

--- a/src/Raven.Client/Documents/Operations/Attachments/PutAttachmentOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/PutAttachmentOperation.cs
@@ -35,7 +35,7 @@ namespace Raven.Client.Documents.Operations.Attachments
         /// <param name="name">The name of the attachment.</param>
         /// <param name="stream">The stream containing the binary content of the attachment.</param>
         /// <param name="contentType">The MIME type of the attachment (optional).</param>
-        /// <param name="remoteParameters">The parameters for retiring the attachment.</param>
+        /// <param name="remoteParameters">The parameters for uploading the attachment to remote storage.</param>
         /// <param name="changeVector">An optional change vector for concurrency control.</param>
         public PutAttachmentOperation(string documentId, string name, Stream stream, string contentType = null, RemoteAttachmentParameters remoteParameters = null, string changeVector = null)
         {

--- a/src/Raven.Client/Documents/Operations/Attachments/StoreAttachmentParameters.cs
+++ b/src/Raven.Client/Documents/Operations/Attachments/StoreAttachmentParameters.cs
@@ -23,6 +23,19 @@ public class StoreAttachmentParameters : IStoreAttachmentParameters
     /// <inheritdoc />
     public RemoteAttachmentParameters RemoteParameters { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StoreAttachmentParameters"/> class.
+    /// </summary>
+    /// <param name="name">The name of the attachment to store. Cannot be null or whitespace.</param>
+    /// <param name="stream">The stream containing the attachment data. Cannot be null.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="name"/> is null or whitespace, or when <paramref name="stream"/> is null.
+    /// </exception>
+    /// <remarks>
+    /// Use this constructor to create parameters for storing an attachment with the specified name and stream.
+    /// Optional properties such as <see cref="ChangeVector"/>, <see cref="ContentType"/>, and <see cref="RemoteParameters"/>
+    /// can be set after construction to provide additional control over the attachment storage behavior.
+    /// </remarks>
     public StoreAttachmentParameters(string name, Stream stream)
     {
         if (string.IsNullOrWhiteSpace(name))

--- a/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsBase.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSessionAttachmentsBase.cs
@@ -97,6 +97,17 @@ namespace Raven.Client.Documents.Session
             Store(document.Id, name, stream, contentType);
         }
 
+        /// <summary>
+        /// Stores attachment to be sent in the session using the provided parameters
+        /// </summary>
+        /// <param name="documentId">The document identifier</param>
+        /// <param name="parameters">The attachment storage parameters containing name, stream, content type, change vector, and remote upload settings</param>
+        /// <remarks>
+        /// This overload provides a convenient way to store an attachment using a <see cref="StoreAttachmentParameters"/> object,
+        /// which encapsulates all attachment properties including optional settings like <see cref="StoreAttachmentParameters.ContentType"/>,
+        /// <see cref="StoreAttachmentParameters.ChangeVector"/> for concurrency control, and <see cref="StoreAttachmentParameters.RemoteParameters"/>
+        /// for scheduling remote cloud storage uploads. The attachment will be sent to the server when <see cref="IDocumentSession.SaveChanges"/> is called.
+        /// </remarks>
         public void Store(string documentId, StoreAttachmentParameters parameters)
         {
             Store(documentId, parameters.Name, parameters.Stream, parameters.ContentType, parameters.RemoteParameters);

--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -30,7 +30,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage<TWorkInfo> : Abstract
         MetadataPropertyName = metadataPropertyName;
     }
 
-    protected abstract void ProcessDocument(DocumentsOperationContext context, Slice treeKey, string identifier, DateTime currentTime);
+    protected abstract void ProcessDocument(DocumentsOperationContext context, Slice lowerId, string identifier, DateTime currentTime);
     protected abstract void HandleDocumentConflict(BackgroundWorkParameters options, Slice ticksAsSlice, Slice clonedId, Queue<TWorkInfo> expiredDocs, ref int totalCount);
     protected abstract TWorkInfo GetBackgroundWorkInfo(BackgroundWorkParameters options, Slice clonedId, Slice ticksSlice);
 
@@ -41,11 +41,11 @@ public abstract unsafe class AbstractBackgroundWorkStorage<TWorkInfo> : Abstract
             $"The due date format for document '{treeKey}' is not valid: '{expirationDate}'. Use the following format: {Database.Time.GetUtcNow():O}");
     }
 
-    public void Put(DocumentsOperationContext context, Slice treeKey, string processDateString)
+    public void Put(DocumentsOperationContext context, Slice lowerId, string processDateString)
     {
         if (DateTime.TryParseExact(processDateString, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
                 out DateTime processDate) == false)
-            ThrowWrongDateFormat(treeKey, processDateString);
+            ThrowWrongDateFormat(lowerId, processDateString);
 
         // We explicitly enable adding items that have already been expired, we have to, because if the time lag is short, it is possible
         // that we add an item that expire in 1 second, but by the time we process it, it already expired. The user did nothing wrong here
@@ -56,7 +56,7 @@ public abstract unsafe class AbstractBackgroundWorkStorage<TWorkInfo> : Abstract
 
         var tree = context.Transaction.InnerTransaction.ReadTree(_treeName);
         using (Slice.External(context.Allocator, (byte*)&ticksBigEndian, sizeof(long), out Slice ticksSlice))
-            tree.MultiAdd(ticksSlice, treeKey);
+            tree.MultiAdd(ticksSlice, lowerId);
     }
 
     public Queue<TWorkInfo> GetDocuments(BackgroundWorkParameters options, ref int totalCount, out Stopwatch duration, CancellationToken cancellationToken)

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -449,7 +449,8 @@ namespace Raven.Server.Documents
                         DocumentId = documentId,
                         Hash = hash,
                         Size = stream?.Length ?? -1,
-                        CollectionName = collectionName
+                        CollectionName = collectionName,
+                        RemoteParameters = remoteParams
                     };
                 }
             }
@@ -1528,41 +1529,6 @@ namespace Raven.Server.Documents
             return table?.NumberOfEntries ?? 0;
         }
 
-        public static (string DocId, string AttachmentName) ExtractDocIdAndAttachmentNameFromTombstone(Slice attachmentTombstoneId)
-        {
-            var p = attachmentTombstoneId.Content.Ptr;
-            var size = attachmentTombstoneId.Size;
-
-            ExtractDocIdAndAttachmentNameFromTombstone(p, size, out int sizeOfDocId, out int attachmentNameIndex, out int sizeOfAttachmentName, out _);
-
-            var doc = Encodings.Utf8.GetString(p, sizeOfDocId);
-            var name = Encodings.Utf8.GetString(p + attachmentNameIndex, sizeOfAttachmentName);
-
-            return (doc, name);
-        }
-
-        internal static void ExtractDocIdAndAttachmentNameFromTombstone(byte* p, int size, out int sizeOfDocId, out int attachmentNameIndex, out int sizeOfAttachmentName, out int attachmentHashIndex)
-        {
-            sizeOfDocId = AttachmentKey.GetSizeOfDocId(new ReadOnlySpan<byte>(p, size));
-
-            attachmentNameIndex = sizeOfDocId +
-                                  1 + // separator
-                                  1 + // type: d
-                                  1;
-
-            sizeOfAttachmentName = 0;
-
-            for (; sizeOfAttachmentName < size - (sizeOfDocId + 3); sizeOfAttachmentName++)
-            {
-                if (p[attachmentNameIndex + sizeOfAttachmentName] == SpecialChars.RecordSeparator)
-                    break;
-            }
-
-            attachmentHashIndex = attachmentNameIndex
-                                  + sizeOfAttachmentName
-                                  + 1; // sep
-        }
-
         public long GetNumberOfAttachmentsForFlag(DocumentsOperationContext context, RemoteAttachmentFlags flag)
         {
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
@@ -1805,7 +1771,7 @@ namespace Raven.Server.Documents
                 return AttachmentType.Document;
             }
 
-            internal static int FindNextSeparator(ReadOnlySpan<byte> key, int start)
+            private static int FindNextSeparator(ReadOnlySpan<byte> key, int start)
             {
                 for (var i = start; i < key.Length; i++)
                 {

--- a/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
+++ b/src/Raven.Server/Documents/Expiration/ExpirationStorage.cs
@@ -19,11 +19,11 @@ namespace Raven.Server.Documents.Expiration
         {
         }
 
-        protected override void ProcessDocument(DocumentsOperationContext context, Slice documentLowerId, string id, DateTime currentTime)
+        protected override void ProcessDocument(DocumentsOperationContext context, Slice lowerId, string id, DateTime currentTime)
         {
             try
             {
-                using (var doc = Database.DocumentsStorage.Get(context, documentLowerId, DocumentFields.Data, throwOnConflict: true))
+                using (var doc = Database.DocumentsStorage.Get(context, lowerId, DocumentFields.Data, throwOnConflict: true))
                 {
                     if (doc == null || doc.TryGetMetadata(out var metadata) == false)
                         return;
@@ -31,13 +31,13 @@ namespace Raven.Server.Documents.Expiration
                     if (HasPassed(metadata, currentTime, MetadataPropertyName) == false)
                         return;
 
-                    Database.DocumentsStorage.Delete(context, documentLowerId, id, expectedChangeVector: null);
+                    Database.DocumentsStorage.Delete(context, lowerId, id, expectedChangeVector: null);
                 }
             }
             catch (DocumentConflictException)
             {
-                if (GetConflictedExpiration(context, currentTime, documentLowerId).AllExpired)
-                    Database.DocumentsStorage.Delete(context, documentLowerId, id, expectedChangeVector: null);
+                if (GetConflictedExpiration(context, currentTime, lowerId).AllExpired)
+                    Database.DocumentsStorage.Delete(context, lowerId, id, expectedChangeVector: null);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForPutAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForPutAttachment.cs
@@ -102,6 +102,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
                 else
                 {
                     writer.WriteComma();
+                    writer.WritePropertyName(nameof(AttachmentDetails.RemoteParameters));
                     writer.WriteStartObject();
                     writer.WritePropertyName(nameof(RemoteAttachmentParameters.Identifier));
                     writer.WriteString(result.RemoteParameters.Identifier);

--- a/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Aws/RavenAwsS3Client.cs
@@ -255,11 +255,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Aws
             return AsyncHelpers.RunSync(() => ListObjectsAsync(prefix, delimiter, listFolders, includeFolders, take, continuationToken, startAfter));
         }
 
-        public IDictionary<string, string> GetObjectMetadata(string key)
-        {
-            return AsyncHelpers.RunSync(() => GetObjectMetadataAsync(key));
-        }
-
         public async Task<IDictionary<string, string>> GetObjectMetadataAsync(string key)
         {
             try

--- a/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Azure/RavenAzureClient.cs
@@ -267,11 +267,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Azure
             return new AzureMultiPartUploader(_client, key, metadata, _progress, _cancellationToken);
         }
 
-        public IDictionary<string, string> GetObjectMetadata(string key)
-        {
-            return AsyncHelpers.RunSync(() => GetObjectMetadataAsync(key));
-        }
-
         public async Task<IDictionary<string, string>> GetObjectMetadataAsync(string key)
         {
             try

--- a/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/GoogleCloud/RavenGoogleCloudClient.cs
@@ -10,7 +10,6 @@ using Google.Apis.Upload;
 using Google.Cloud.Storage.V1;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.Operations.Backups;
-using Raven.Client.Util;
 using Sparrow;
 using Sparrow.Server.Utils;
 using Object = Google.Apis.Storage.v1.Data.Object;
@@ -224,11 +223,6 @@ namespace Raven.Server.Documents.PeriodicBackup.GoogleCloud
             {
                 throw new InvalidOperationException($"Bucket {_bucketName} not found", e);
             }
-        }
-
-        public IDictionary<string, string> GetObjectMetadata(string key)
-        {
-            return AsyncHelpers.RunSync(() => GetObjectMetadataAsync(key));
         }
 
         public async Task<IDictionary<string, string>> GetObjectMetadataAsync(string key)

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/DownloadFromAzure.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/DownloadFromAzure.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations.Backups;

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -80,6 +80,7 @@ namespace Raven.Server.Documents
             var currentTime = _database.Time.GetUtcNow();
             var directUploaders = new ConcurrentDictionary<string, Lazy<AttachmentUploader>>();
             var uploadTasks = new Task<AttachmentRemoteInfo>[Configuration.ConcurrentUploads ?? DefaultConcurrentThreadsNumber];
+            var docsStates = new Dictionary<string, Queue<AttachmentRemoteInfo>>(StringComparer.OrdinalIgnoreCase);
 
             try
             {
@@ -92,6 +93,7 @@ namespace Raven.Server.Documents
                     Stopwatch duration;
                     _totalUploaded = 0L;
                     _exceptions.Clear();
+                    docsStates.Clear();
                     var processed = new Queue<AttachmentRemoteInfo>();
 
                     using (var tx = context.OpenReadTransaction())
@@ -114,7 +116,6 @@ namespace Raven.Server.Documents
                             return totalCount;
                         }
 
-                        var processing = new HashSet<string>();
                         Array.Fill(uploadTasks, Task.FromResult<AttachmentRemoteInfo>(null));
 
                         try
@@ -129,13 +130,6 @@ namespace Raven.Server.Documents
                                     break;
                                 }
 
-                                if (processing.Add(document.Id) == false)
-                                {
-                                    // this document was processed or is currently being processed in this batch, we can skip the upload for it
-                                    processed.Enqueue(document);
-                                    continue;
-                                }
-
                                 switch (document.Status)
                                 {
                                     case BackgroundWorkInfoStatus.Delete:
@@ -146,11 +140,36 @@ namespace Raven.Server.Documents
                                         processed.Enqueue(document);
                                         continue;
                                     case BackgroundWorkInfoStatus.Process:
+                                        if (docsStates.TryGetValue(document.Id, out var states))
+                                        {
+                                            if (states == null)
+                                            {
+                                                if (Logger.IsDebugEnabled)
+                                                    Logger.Debug($"Processing document with id: '{document.LowerId}' without uploading to remote destination, because it is already was processed in this batch.");
+
+                                                // this document was already processed, we add the duplicate to processed queue
+                                                processed.Enqueue(document);
+                                                continue;
+                                            }
+
+                                            // this document is currently being processed, we add it to the duplicates queue
+                                            // we will handle its result in HandleUploadTaskResult when the current processing task finish
+                                            if (Logger.IsDebugEnabled)
+                                                Logger.Debug($"Marking document with id: '{document.LowerId}' as being processed in current batch.");
+
+                                            states.Enqueue(document);
+
+                                            continue;
+                                        }
+
+                                        // add duplicates queue for this document which is being processed now
+                                        docsStates.Add(document.Id, new Queue<AttachmentRemoteInfo>());
+
                                         var index = Task.WaitAny(uploadTasks);
                                         try
                                         {
                                             var res = await uploadTasks[index];
-                                            HandleUploadTaskResult(res, processed);
+                                            HandleUploadTaskResult(res, processed, docsStates);
                                         }
                                         catch (Exception e)
                                         {
@@ -186,7 +205,7 @@ namespace Raven.Server.Documents
                                 try
                                 {
                                     var res = await t;
-                                    HandleUploadTaskResult(res, processed);
+                                    HandleUploadTaskResult(res, processed, docsStates);
                                 }
                                 catch (Exception e)
                                 {
@@ -195,44 +214,46 @@ namespace Raven.Server.Documents
                             }
                         }
 
-                        if (toRemote.Count != processed.Count)
-                        {
-                            // we had skipped items
-                            if (Logger.IsDebugEnabled)
-                                Logger.Debug($"Skipping upload attachments of '{toRemote.Count - processed.Count:#,#;;0}' documents, Uploaded: {new Size(_totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRemote.Select(x => processed.Contains(x) == false))}");
-                        }
-
                         if (processed.Count == 0)
                         {
-                            if (Logger.IsDebugEnabled)
-                                Logger.Debug($"Skipping upload attachments of whole batch of '{toRemote.Count:#,#;;0}' documents, Uploaded: {new Size(_totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRemote.Select(x => processed.Contains(x) == false))}");
+                            if (Logger.IsTraceEnabled)
+                                Logger.Debug($"Skipping upload attachments of whole batch of '{toRemote.Count:#,#;;0}' documents, Uploaded: {new Size(_totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'. Skipped keys: {string.Join(", ", toRemote.Select(x => $"{x.Id}"))}");
+                            else if (Logger.IsDebugEnabled)
+                                Logger.Debug($"Skipping upload attachments of whole batch of '{toRemote.Count:#,#;;0}' documents, Uploaded: {new Size(_totalUploaded, SizeUnit.Bytes)}, read tx open time: '{duration.ElapsedMilliseconds}'.");
 
                             if (_exceptions.Count == 0)
                             {
                                 continue;
                             }
 
+                            var e = new AggregateException($"Failed to upload all attachments. Failed keys: {string.Join(", ", toRemote.Select(x => x.Id).Distinct(StringComparer.OrdinalIgnoreCase).Select(x => $"{x}"))}", _exceptions);
+                            ForTestingPurposes?.BeforeAllBatchFailure?.Invoke(e);
+
                             // we have exceptions and nothing was uploaded to remote storage, we need to throw
-                            throw new AggregateException("Failed to upload all attachments.", _exceptions);
+                            throw e;
                         }
                     }
 
                     var command = new UpdateRemoteAttachmentsCommand(processed, _database, currentTime);
                     await _database.TxMerger.Enqueue(command);
 
+                    ForTestingPurposes?.BeforeEndOfTheBatch?.Invoke(_exceptions);
+
                     if (Logger.IsInfoEnabled)
                     {
                         var uploadedSizeText = Client.Util.Size.Humane(_totalUploaded);
-                        var remoteCount = command.RemoteCount;
+                        var docsCount = processed.Select(x => x.Id)
+                            .Distinct(StringComparer.OrdinalIgnoreCase).Count();
+                        var attachmentsCount = command.RemoteCount;
                         var elapsedMs = duration.ElapsedMilliseconds;
 
                         if (_exceptions.Count == 0)
                         {
-                            Logger.Info($"Successfully uploaded attachments of {remoteCount:#,#;;0} documents to remote cloud storage in {elapsedMs:#,#;;0} ms. Total uploaded: {uploadedSizeText}");
+                            Logger.Info($"Successfully uploaded {attachmentsCount:#,#;;0} attachments of {docsCount:#,#;;0} documents to remote cloud storage in {elapsedMs:#,#;;0} ms. Total uploaded: {uploadedSizeText}");
                         }
                         else
                         {
-                            Logger.Info($"Partially uploaded attachments of {remoteCount:#,#;;0} documents to remote cloud storage in {elapsedMs:#,#;;0} ms. Total uploaded: {uploadedSizeText}. Failed to upload {_exceptions.Count:#,#;;0} attachments:{Environment.NewLine}{new AggregateException(_exceptions)}");
+                            Logger.Info($"Partially uploaded {attachmentsCount:#,#;;0} attachments of {docsCount:#,#;;0} documents to remote cloud storage in {elapsedMs:#,#;;0} ms. Total uploaded: {uploadedSizeText}. Failed to upload {_exceptions.Count:#,#;;0} attachments:{Environment.NewLine}{new AggregateException(_exceptions)}");
                         }
                     }
                 }
@@ -250,11 +271,23 @@ namespace Raven.Server.Documents
             return totalCount;
         }
 
-        private void HandleUploadTaskResult(AttachmentRemoteInfo res, Queue<AttachmentRemoteInfo> processed)
+        private void HandleUploadTaskResult(AttachmentRemoteInfo res, Queue<AttachmentRemoteInfo> processed, Dictionary<string, Queue<AttachmentRemoteInfo>> docStates)
         {
             if (res != null)
             {
                 processed.Enqueue(res);
+
+                if (docStates.TryGetValue(res.Id, out var queue))
+                {
+                    while (queue.TryDequeue(out var item))
+                    {
+                        // process the items that were waiting for this document to be processed
+                        processed.Enqueue(item);
+                    }
+                }
+
+                docStates[res.Id] = null; // mark as processed
+
                 _totalUploaded += res.AttachmentsSize;
             }
         }
@@ -280,12 +313,15 @@ namespace Raven.Server.Documents
                             continue;
 
                         var identifier = attachment.RemoteParameters.Identifier;
-                        var lazyUploader = uploaders.GetOrAdd(identifier, new Lazy<AttachmentUploader>(() =>
+
+                        if (Configuration.Destinations.TryGetValue(identifier, out var destination) == false || destination.HasUploader() == false)
                         {
-                            // we are sure the destination exist because we got the item with "Process" status
-                            var destination = Configuration.Destinations[identifier];
-                            return new AttachmentUploader(UploaderSettings.GenerateDirectUploaderSettingsForAttachments(_database, identifier, destination.S3Settings, destination.AzureSettings), Logger, _token);
-                        }));
+                            // destination no longer exist or is disabled, skip uploading this attachment
+                            continue;
+                        }
+
+                        var lazyUploader = uploaders.GetOrAdd(identifier, new Lazy<AttachmentUploader>(() => 
+                            new AttachmentUploader(UploaderSettings.GenerateDirectUploaderSettingsForAttachments(_database, identifier, destination.S3Settings, destination.AzureSettings), Logger, _token)));
                         var uploader = lazyUploader.Value;
                         var hash = attachment.Base64Hash.ToString();
                         var objectSizeFromMetadata = await uploader.GetObjectSizeAsync(string.Empty, attachment.Base64Hash.ToString());
@@ -385,6 +421,24 @@ namespace Raven.Server.Documents
                     CurrentTime = _currentTime
                 };
             }
+        }
+
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal sealed class TestingStuff
+        {
+            internal Action<List<Exception>> BeforeEndOfTheBatch;
+
+            internal Action<AggregateException> BeforeAllBatchFailure;
         }
     }
 

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -324,7 +324,7 @@ namespace Raven.Server.Documents
                             new AttachmentUploader(UploaderSettings.GenerateDirectUploaderSettingsForAttachments(_database, identifier, destination.S3Settings, destination.AzureSettings), Logger, _token)));
                         var uploader = lazyUploader.Value;
                         var hash = attachment.Base64Hash.ToString();
-                        var objectSizeFromMetadata = await uploader.GetObjectSizeAsync(string.Empty, attachment.Base64Hash.ToString());
+                        var objectSizeFromMetadata = await uploader.GetObjectSizeAsync(string.Empty, hash);
                         Stream attachmentStream;
                         if (objectSizeFromMetadata.HasValue)
                         {
@@ -440,23 +440,6 @@ namespace Raven.Server.Documents
 
             internal Action<AggregateException> BeforeAllBatchFailure;
         }
-    }
-
-    internal class RemoteAttachmentsStatsScope
-    {
-        public UploadProgress AzureUpload { get; set; }
-
-        public UploadProgress FtpUpload { get; set; }
-
-        public UploadProgress GlacierUpload { get; set; }
-
-        public UploadProgress GoogleCloudUpload { get; set; }
-
-        public UploadProgress S3Upload { get; set; }
-
-        public int NumberOfAttachments { get; set; }
-
-        public string AttachmentName { get; set; }
     }
 
     internal sealed class UpdateRemoteAttachmentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, RemoteAttachmentsSender.UpdateRemoteAttachmentsCommand>

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -76,9 +76,9 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
         }
     }
 
-    protected override void ProcessDocument(DocumentsOperationContext context, Slice treeKey, string docId, DateTime currentTime)
+    protected override void ProcessDocument(DocumentsOperationContext context, Slice lowerId, string docId, DateTime currentTime)
     {
-        using (var doc = Database.DocumentsStorage.Get(context, treeKey, DocumentFields.Data | DocumentFields.Id, throwOnConflict: true))
+        using (var doc = Database.DocumentsStorage.Get(context, lowerId, DocumentFields.Data | DocumentFields.Id, throwOnConflict: true))
         {
             if (doc == null || doc.TryGetMetadata(out var metadata) == false)
                 return;
@@ -88,7 +88,7 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
 
             foreach (var attachmentInMetadata in EnumerateAttachmentsFromMetadataAndCheckIfShouldSkip(attachments, currentTime, ShouldSkipItem))
             {
-                Database.DocumentsStorage.AttachmentsStorage.MarkAsRemoteAttachment(context, attachmentInMetadata, treeKey, docId);
+                Database.DocumentsStorage.AttachmentsStorage.MarkAsRemoteAttachment(context, attachmentInMetadata, lowerId, docId);
             }
 
             Database.DocumentsStorage.AttachmentsStorage.UpdateDocumentAfterAttachmentChange(context, docId);

--- a/src/Raven.Server/Documents/Replication/DocumentInfoHelper.cs
+++ b/src/Raven.Server/Documents/Replication/DocumentInfoHelper.cs
@@ -17,18 +17,12 @@ namespace Raven.Server.Documents.Replication
         private LazyStringValue _tmpLazyStringInstance;
         private readonly JsonOperationContext _context;
         private readonly bool _contextOwner;
-        public LazyStringValue GetDocumentId(Slice key)
+        public unsafe LazyStringValue GetDocumentId(Slice key)
         {
-            return GetDocumentId(key, start: 0);
-        }
-
-        public unsafe LazyStringValue GetDocumentId(Slice key, int start)
-        {
-            var sepIdx = key.Content.IndexOf(SpecialChars.RecordSeparator, start);
-            var idSize = sepIdx - start;
+            var sepIdx = key.Content.IndexOf(SpecialChars.RecordSeparator);
             if (_tmpLazyStringInstance == null)
                 _tmpLazyStringInstance = new LazyStringValue(null, null, 0, _context);
-            _tmpLazyStringInstance.Renew(null, key.Content.Ptr + start, idSize, _context);
+            _tmpLazyStringInstance.Renew(null, key.Content.Ptr, sepIdx, _context);
             return _tmpLazyStringInstance;
         }
 

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
@@ -100,7 +100,5 @@ namespace Raven.Server.NotificationCenter.Notifications
         ConflictRevisionsExceeded,
         
         SqlConnectionString_DeprecatedFactoryReplaced,
-
-        Attachments_RemoteAttachmentWithoutIdentifier
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/Processors/BuildVersion.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/BuildVersion.cs
@@ -12,7 +12,8 @@ namespace Raven.Server.Smuggler.Documents.Processors
                 >= 50 and < 60 => BuildVersionType.V5,
                 >= 40 and < 50 => BuildVersionType.V4,
                 >= 80000 => BuildVersionType.GreaterThanCurrent,
-                >= 70000 and <= 79999 => BuildVersionType.V7,
+                >= 70000 and <= 71999 => BuildVersionType.V7,
+                >= 72000 and <= 79999 => BuildVersionType.V72,
                 >= 60000 and <= 69999 => BuildVersionType.V6,
                 >= 50000 and <= 59999 => BuildVersionType.V5,
                 >= 40000 and <= 49999 => BuildVersionType.V4,
@@ -29,6 +30,7 @@ namespace Raven.Server.Smuggler.Documents.Processors
         V5,
         V6,
         V7,
+        V72,
         GreaterThanCurrent
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -1762,10 +1762,9 @@ namespace Raven.Server.Smuggler.Documents
 
                     var data = builder.CreateReader();
                     builder.Reset();
-                    string collectionName = null;
                     if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata))
                     {
-                        if (metadata.TryGet(Constants.Documents.Metadata.Collection, out  collectionName))
+                        if (metadata.TryGet(Constants.Documents.Metadata.Collection, out string collectionName))
                         {
                             if (collectionsHashSet.Count > 0 && collectionsHashSet.Contains(collectionName) == false)
                             {
@@ -1814,7 +1813,7 @@ namespace Raven.Server.Smuggler.Documents
                         }
                     }
 
-                    data = GetAttachmentMetadata(metadata, hashBySize, modifier, collectionName, data, context);
+                    data = GetAttachmentMetadata(metadata, hashBySize, modifier, data, context);
 
                     _result.LegacyLastDocumentEtag = modifier.LegacyEtag;
 
@@ -1844,13 +1843,11 @@ namespace Raven.Server.Smuggler.Documents
             }
         }
 
-        private BlittableJsonReaderObject GetAttachmentMetadata(BlittableJsonReaderObject metadata, Dictionary<string, long> hashBySize, BlittableMetadataModifier modifier,
-            string collectionName, BlittableJsonReaderObject data, JsonOperationContext context)
+        private BlittableJsonReaderObject GetAttachmentMetadata(BlittableJsonReaderObject metadata, Dictionary<string, long> hashBySize, BlittableMetadataModifier modifier, BlittableJsonReaderObject data, JsonOperationContext context)
         {
             // hashBySize == null means there were no attachment streams in the dump
 
-            //TODO: egor change that according to feature version
-            if (_buildVersionType < BuildVersionType.V7)
+            if (_buildVersionType < BuildVersionType.V72)
             {
                 if (metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray att) && att.Length > 0)
                 {

--- a/src/Sparrow.Server/ByteString.cs
+++ b/src/Sparrow.Server/ByteString.cs
@@ -352,12 +352,7 @@ namespace Sparrow.Server
 
         public int IndexOf(byte c)
         {
-            return IndexOf(c, start: 0);
-        }
-
-        public int IndexOf(byte c, int start)
-        {
-            for (int i = start; i < Length; i++)
+            for (int i = 0; i < Length; i++)
             {
                 if (this[i] == c)
                     return i;

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -40,6 +40,380 @@ namespace SlowTests.Server.Documents.Attachments
         }
 
         [AmazonS3RetryFact]
+        public async Task RemoteAttachmentWithDisabledIdentifierShouldBeSkipped()
+        {
+            int attachmentsCount = 1;
+            int size = 3;
+            await using (var holder = CreateCloudSettings())
+            {
+                using (var store = GetDocumentStore())
+                {
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+
+                    var badIdentifierDisabled = "new-identifier"; // should be skipped
+
+                    ModifyRemoteAttachmentsConfig = config =>
+                    {
+                        config.Destinations.Add(badIdentifierDisabled, new RemoteAttachmentsDestinationConfiguration
+                        {
+                            S3Settings = new RemoteAttachmentsS3Settings()
+                            {
+                                BucketName = "TEST"
+                            },
+                            Disabled = true,
+                        });
+
+                    };
+
+                    var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+
+                    await CreateDocs(store, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(store, identifier, size, ids, attachmentsPerDoc);
+
+                    var id = ids.First().Id;
+                    using (var session = store.OpenSession())
+                    {
+                        var profileStream = new MemoryStream([1, 2, 3]);
+                        var remoteParams = new RemoteAttachmentParameters(badIdentifierDisabled, DateTime.UtcNow.AddMinutes(3));
+                        session.Advanced.Attachments.Store(id, new StoreAttachmentParameters("att-bad-identifier.png", profileStream)
+                        {
+                            RemoteParameters = remoteParams,
+                            ContentType = "image/png"
+                        });
+
+                        session.SaveChanges();
+                        using AttachmentResult a = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
+
+                        Attachments.Add(new RemoteAttachment()
+                        {
+                            Name = a.Details.Name,
+                            DocumentId = id,
+                            Stream = profileStream,
+                            ContentType = a.Details.ContentType,
+                            Hash = a.Details.Hash,
+                            RemoteParameters = remoteParams
+                        });
+                    }
+
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                    GetStorageAttachmentsMetadataFromAllAttachments(database);
+                    Assert.Equal(attachmentsCount + 1, Attachments.Count);
+
+                    List<Exception> myExceptions = null;
+                    database.RemoteAttachmentsSender.ForTestingPurposesOnly().BeforeEndOfTheBatch = exceptions =>
+                    {
+                        myExceptions = exceptions;
+                    };
+
+                    // move in time & start remote
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                    var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+                    Assert.Equal(1, cloudObjects.Count);
+
+                    var stats = store.Maintenance.Send(new GetDetailedStatisticsOperation());
+                    Assert.Equal(1, stats.CountOfRemoteAttachments);
+                    Assert.Equal(2, stats.CountOfAttachments);
+
+                    Assert.NotNull(myExceptions);
+                    Assert.Equal(0, myExceptions.Count);
+                    using AttachmentResult bad = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
+
+                    Assert.Equal("att-bad-identifier.png", bad.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.None, bad.Details.RemoteParameters.Flags);
+                    Assert.NotNull(bad.Details.RemoteParameters.At);
+
+                    var goodName = Attachments.First(x => x.Name != "att-bad-identifier.png").Name;
+                    using AttachmentResult good = await store.Operations.SendAsync(new GetAttachmentOperation(id, goodName, AttachmentType.Document, null));
+
+                    Assert.Equal(goodName, good.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.Remote, good.Details.RemoteParameters.Flags);
+                    Assert.NotNull(good.Details.RemoteParameters.At);
+
+                }
+            }
+        }
+
+        [AmazonS3RetryTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RemoteAttachmentWithBadIdentifierShouldBeSkippedWithError(bool uploadAdditional)
+        {
+            int attachmentsCount = 1;
+            int size = 3;
+            await using (var holder = CreateCloudSettings())
+            {
+                using (var store = GetDocumentStore())
+                {
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+
+                    var badIdentifierEnabled = "test-identifier"; // should be skipped
+
+                    ModifyRemoteAttachmentsConfig = config =>
+                    {
+                        config.Destinations.Add(badIdentifierEnabled, new RemoteAttachmentsDestinationConfiguration
+                        {
+                            S3Settings = new RemoteAttachmentsS3Settings()
+                            {
+                                BucketName = "TEST2"
+                            },
+                            Disabled = false,
+                        });
+                    };
+
+                    var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+
+                    await CreateDocs(store, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(store, identifier, size, ids, attachmentsPerDoc);
+
+                    var id = ids.First().Id;
+                    using (var session = store.OpenSession())
+                    {
+                        var profileStream = new MemoryStream([1, 2, 3]);
+                        var remoteParams = new RemoteAttachmentParameters(badIdentifierEnabled, DateTime.UtcNow.AddMinutes(3));
+                        session.Advanced.Attachments.Store(id, new StoreAttachmentParameters("att-bad-identifier.png", profileStream)
+                        {
+                            RemoteParameters = remoteParams,
+                            ContentType = "image/png"
+                        });
+
+                        session.SaveChanges();
+                        using AttachmentResult a = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
+
+                        Attachments.Add(new RemoteAttachment()
+                        {
+                            Name = a.Details.Name,
+                            DocumentId = id,
+                            Stream = profileStream,
+                            ContentType = a.Details.ContentType,
+                            Hash = a.Details.Hash,
+                            RemoteParameters = remoteParams
+                        });
+                    }
+
+                        var id2 = "Orders/322";
+                    if (uploadAdditional)
+                    {
+                        using (var session = store.OpenAsyncSession())
+                        {
+                            await session.StoreAsync(new Query.Order { Id = id2, OrderedAt = new DateTime(2024, 1, 1), ShipVia = $"Shippers/2", Company = $"Companies/2" });
+
+                            await session.SaveChangesAsync();
+
+                            var profileStream = new MemoryStream([3, 2, 2]);
+                            var remoteParams = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3));
+                            session.Advanced.Attachments.Store(id2, new StoreAttachmentParameters("egor.png", profileStream)
+                            {
+                                RemoteParameters = remoteParams,
+                                ContentType = "image/png"
+                            });
+
+                            await session.SaveChangesAsync();
+                            using AttachmentResult a = await store.Operations.SendAsync(new GetAttachmentOperation(id2, "egor.png", AttachmentType.Document, null));
+
+                            Attachments.Add(new RemoteAttachment()
+                            {
+                                Name = a.Details.Name,
+                                DocumentId = id2,
+                                Stream = profileStream,
+                                ContentType = a.Details.ContentType,
+                                Hash = a.Details.Hash,
+                                RemoteParameters = remoteParams
+                            });
+                        }
+                    }
+
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                    GetStorageAttachmentsMetadataFromAllAttachments(database);
+                    if (uploadAdditional)
+                    {
+                        Assert.Equal(attachmentsCount + 2, Attachments.Count);
+                    }
+                    else
+                    {
+                        Assert.Equal(attachmentsCount + 1, Attachments.Count);
+                    }
+
+                    AggregateException myException = null;
+                    database.RemoteAttachmentsSender.ForTestingPurposesOnly().BeforeAllBatchFailure = exceptions =>
+                    {
+                        myException = exceptions;
+                    };
+
+                    // move in time & start remote
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                    // nothing was uploaded because we had a faulty identifier
+                    if (uploadAdditional)
+                    {
+                        var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+
+                        Assert.Equal(1, cloudObjects.Count);
+
+                    }
+                    else
+                    {
+                        var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, 0, 15_000);
+
+                        Assert.Equal(0, cloudObjects.Count);
+
+                    }
+
+                    var stats = store.Maintenance.Send(new GetDetailedStatisticsOperation());
+                    if (uploadAdditional)
+                    {
+
+                        Assert.Equal(1, stats.CountOfRemoteAttachments);
+                        Assert.Equal(3, stats.CountOfAttachments);
+
+
+                    }
+                    else
+                    {
+                        Assert.Equal(0, stats.CountOfRemoteAttachments);
+                        Assert.Equal(2, stats.CountOfAttachments);
+
+                    }
+
+
+                    Assert.NotNull(myException);
+                    Assert.Equal(1, myException.InnerExceptions.Count);
+                    Assert.Contains("Failed to upload all attachments. Failed keys: Orders/0", myException.Message);
+
+                    using AttachmentResult bad = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
+
+                    Assert.Equal("att-bad-identifier.png", bad.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.None, bad.Details.RemoteParameters.Flags);
+                    Assert.NotNull(bad.Details.RemoteParameters.At);
+
+                    var goodName = Attachments.First(x => x.Name != "att-bad-identifier.png" && x.DocumentId == id).Name;
+                    using AttachmentResult good = await store.Operations.SendAsync(new GetAttachmentOperation(id, goodName, AttachmentType.Document, null));
+
+                    Assert.Equal(goodName, good.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.None, good.Details.RemoteParameters.Flags);
+                    Assert.NotNull(good.Details.RemoteParameters.At);
+
+
+                    if (uploadAdditional)
+                    {
+                        var goodName2 = Attachments.First(x => x.DocumentId == id2).Name;
+                        using AttachmentResult good2 = await store.Operations.SendAsync(new GetAttachmentOperation(id2, goodName2, AttachmentType.Document, null));
+
+                        Assert.Equal(goodName2, good2.Details.Name);
+                        Assert.Equal(RemoteAttachmentFlags.Remote, good2.Details.RemoteParameters.Flags);
+                        Assert.NotNull(good2.Details.RemoteParameters.At);
+                    }
+
+                }
+            }
+        }
+
+        [AmazonS3RetryFact]
+        public async Task RemoteAttachmentWithoutDestinationOnDocumentWithRemoteAttachmentWithDestinationShouldBeSkipped()
+        {
+            int attachmentsCount = 1;
+            int size = 3;
+            await using (var holder = CreateCloudSettings())
+            {
+                using (var store = GetDocumentStore())
+                {
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+
+                    var removedIdentifier = "test-identifier"; // should be skipped
+
+                    ModifyRemoteAttachmentsConfig = config =>
+                    {
+
+                        config.Destinations.Add(removedIdentifier, new RemoteAttachmentsDestinationConfiguration
+                        {
+                            S3Settings = new RemoteAttachmentsS3Settings()
+                            {
+                                BucketName = "TEST2"
+                            },
+                            Disabled = false,
+                        });
+                    };
+
+                    var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+
+                    await CreateDocs(store, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(store, identifier, size, ids, attachmentsPerDoc);
+
+                    var id = ids.First().Id;
+                    using (var session = store.OpenSession())
+                    {
+                        var profileStream = new MemoryStream([1, 2, 3]);
+                        var remoteParams = new RemoteAttachmentParameters(removedIdentifier, DateTime.UtcNow.AddMinutes(3));
+                        session.Advanced.Attachments.Store(id, new StoreAttachmentParameters("att-bad-identifier.png", profileStream)
+                        {
+                            RemoteParameters = remoteParams,
+                            ContentType = "image/png"
+                        });
+
+                        session.SaveChanges();
+                        using AttachmentResult a = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
+
+                        Attachments.Add(new RemoteAttachment()
+                        {
+                            Name = a.Details.Name,
+                            DocumentId = id,
+                            Stream = profileStream,
+                            ContentType = a.Details.ContentType,
+                            Hash = a.Details.Hash,
+                            RemoteParameters = remoteParams
+                        });
+                    }
+
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                    GetStorageAttachmentsMetadataFromAllAttachments(database);
+                    Assert.Equal(attachmentsCount + 1, Attachments.Count);
+
+                    ModifyRemoteAttachmentsConfig = null;
+                    identifier = await PutRemoteAttachmentsConfiguration(store, Settings); // rewrite the config without 2nd identifier
+
+                    List<Exception> myExceptions = null;
+                    database.RemoteAttachmentsSender.ForTestingPurposesOnly().BeforeEndOfTheBatch = exceptions =>
+                    {
+                        myExceptions = exceptions;
+                    };
+
+                    // move in time & start remote
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                    var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+                    Assert.Equal(1, cloudObjects.Count);
+
+                    var stats = store.Maintenance.Send(new GetDetailedStatisticsOperation());
+                    Assert.Equal(1, stats.CountOfRemoteAttachments);
+                    Assert.Equal(2, stats.CountOfAttachments);
+
+                    Assert.NotNull(myExceptions);
+                    Assert.Equal(0, myExceptions.Count);
+
+                    using AttachmentResult bad = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
+
+                    Assert.Equal("att-bad-identifier.png", bad.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.None, bad.Details.RemoteParameters.Flags);
+                    Assert.NotNull(bad.Details.RemoteParameters.At);
+
+                    var goodName = Attachments.First(x => x.Name != "att-bad-identifier.png").Name;
+                    using AttachmentResult good = await store.Operations.SendAsync(new GetAttachmentOperation(id, goodName, AttachmentType.Document, null));
+
+                    Assert.Equal(goodName, good.Details.Name);
+                    Assert.Equal(RemoteAttachmentFlags.Remote, good.Details.RemoteParameters.Flags);
+                    Assert.NotNull(good.Details.RemoteParameters.At);
+
+                }
+            }
+        }
+
+        [AmazonS3RetryFact]
         public async Task RemoteAttachmentWithoutDestinationShouldBeSkipped()
         {
             int attachmentsCount=1;

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -537,12 +537,17 @@ namespace SlowTests.Server.Documents.Attachments
                     using (var profileStream = new MemoryStream(new byte[] { 3, 2, 2 }))
                     {
                         // remote of this attachment should happen in baseline + 40 mins
-                        var result = store.Operations.Send(new PutAttachmentOperation(data.DocumentId, new StoreAttachmentParameters("profile.png", profileStream) { RemoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3)), ContentType = "image/png" }));
+                        var remoteParams = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3));
+                        var result = store.Operations.Send(new PutAttachmentOperation(data.DocumentId, new StoreAttachmentParameters("profile.png", profileStream) { RemoteParameters = remoteParams, ContentType = "image/png" }));
                         Assert.Equal("profile.png", result.Name);
                         Assert.Equal(data.DocumentId, result.DocumentId);
                         Assert.Equal("image/png", result.ContentType);
                         Assert.Equal("bucfDXJ3eWRJYpgggJrnskJtMuMyFohjO2GHATxTmUs=", result.Hash);
                         Assert.Equal(3, result.Size);
+                        Assert.NotNull(result.RemoteParameters);
+                        Assert.Equal(remoteParams.Identifier, result.RemoteParameters.Identifier);
+                        Assert.Equal(remoteParams.At, result.RemoteParameters.At);
+                        Assert.Equal(RemoteAttachmentFlags.None, result.RemoteParameters.Flags);
                     }
 
                     var names = new List<string>() { data.Name, "profile.png" }.OrderBy(x => x).ToList();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25325

### Additional description

This pull request refactors and improves the remote attachments upload logic in RavenDB, focusing on more robust handling of duplicate/parallel uploads, improved error reporting, and better configurability for testing. The changes address edge cases when documents are processed multiple times in a batch, enhance logging and diagnostics, and add mechanisms for easier testing.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
