### PR TITLE
RavenDB-25306 Fixed EmbeddingsGenerationConfiguration comparison

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.AI;
@@ -39,6 +37,19 @@ public class ChunkingOptions : IDynamicJson
         if (OverlapTokens > 0 &&
             MethodsSupportingOverlapTokens.Contains(ChunkingMethod) == false)
             errors.Add($"'{source}': {nameof(OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", MethodsSupportingOverlapTokens)}.");
+    }
+
+    internal static bool Compare(ChunkingOptions left, ChunkingOptions right)
+    {
+        if (left == null && right == null)
+            return true;
+        
+        if (left == null || right == null)
+            return false;
+        
+        return left.ChunkingMethod == right.ChunkingMethod &&
+               left.MaxTokensPerChunk == right.MaxTokensPerChunk &&
+               left.OverlapTokens == right.OverlapTokens;
     }
 }
 

--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -39,7 +39,7 @@ public class ChunkingOptions : IDynamicJson
             errors.Add($"'{source}': {nameof(OverlapTokens)} option is only supported for the following chunking methods: {string.Join(", ", MethodsSupportingOverlapTokens)}.");
     }
 
-    internal static bool Compare(ChunkingOptions left, ChunkingOptions right)
+    internal static bool AreEqual(ChunkingOptions left, ChunkingOptions right)
     {
         if (left == null && right == null)
             return true;

--- a/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
+++ b/src/Raven.Client/Documents/Operations/AI/ChunkingOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Sparrow.Json.Parsing;
 
@@ -47,9 +48,27 @@ public class ChunkingOptions : IDynamicJson
         if (left == null || right == null)
             return false;
         
-        return left.ChunkingMethod == right.ChunkingMethod &&
-               left.MaxTokensPerChunk == right.MaxTokensPerChunk &&
-               left.OverlapTokens == right.OverlapTokens;
+        return left.Equals(right);
+    }
+
+    private bool Equals(ChunkingOptions other)
+    {
+        return ChunkingMethod == other.ChunkingMethod && 
+               MaxTokensPerChunk == other.MaxTokensPerChunk && 
+               OverlapTokens == other.OverlapTokens;
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((ChunkingOptions)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine((int)ChunkingMethod, MaxTokensPerChunk, OverlapTokens);
     }
 }
 

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.AI;
@@ -26,5 +27,24 @@ public class EmbeddingPathConfiguration : IDynamicJson
         
         return left.Path == right.Path && 
                ChunkingOptions.AreEqual(left.ChunkingOptions, right.ChunkingOptions);
+    }
+
+    private bool Equals(EmbeddingPathConfiguration other)
+    {
+        return Path == other.Path && 
+               ChunkingOptions.AreEqual(ChunkingOptions, other.ChunkingOptions);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((EmbeddingPathConfiguration)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Path, ChunkingOptions);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
@@ -1,4 +1,3 @@
-using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.AI;
@@ -15,5 +14,17 @@ public class EmbeddingPathConfiguration : IDynamicJson
         jsv[nameof(Path)] = Path;
         jsv[nameof(ChunkingOptions)] = ChunkingOptions?.ToJson();
         return jsv;
+    }
+
+    internal static bool Compare(EmbeddingPathConfiguration left, EmbeddingPathConfiguration right)
+    {
+        if (left == null && right == null)
+            return true;
+        
+        if (left == null || right == null)
+            return false;
+        
+        return left.Path == right.Path && 
+               ChunkingOptions.Compare(left.ChunkingOptions, right.ChunkingOptions);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
@@ -16,7 +16,7 @@ public class EmbeddingPathConfiguration : IDynamicJson
         return jsv;
     }
 
-    internal static bool Compare(EmbeddingPathConfiguration left, EmbeddingPathConfiguration right)
+    internal static bool AreEqual(EmbeddingPathConfiguration left, EmbeddingPathConfiguration right)
     {
         if (left == null && right == null)
             return true;
@@ -25,6 +25,6 @@ public class EmbeddingPathConfiguration : IDynamicJson
             return false;
         
         return left.Path == right.Path && 
-               ChunkingOptions.Compare(left.ChunkingOptions, right.ChunkingOptions);
+               ChunkingOptions.AreEqual(left.ChunkingOptions, right.ChunkingOptions);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingPathConfiguration.cs
@@ -24,9 +24,8 @@ public class EmbeddingPathConfiguration : IDynamicJson
         
         if (left == null || right == null)
             return false;
-        
-        return left.Path == right.Path && 
-               ChunkingOptions.AreEqual(left.ChunkingOptions, right.ChunkingOptions);
+
+        return left.Equals(right);
     }
 
     private bool Equals(EmbeddingPathConfiguration other)

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -179,4 +179,48 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
     {
        return AiTaskIdentifierHelper.GenerateIdentifier(input);
     }
+    
+    internal override EtlConfigurationCompareDifferences Compare(EtlConfiguration<AiConnectionString> config, Dictionary<string, AiConnectionString> connectionStrings, List<(string TransformationName, EtlConfigurationCompareDifferences Difference)> transformationDiffs = null)
+    {
+        var differences = base.Compare(config, connectionStrings, transformationDiffs);
+        if (config is not EmbeddingsGenerationConfiguration other)
+            return differences;
+
+        if (Collection != other.Collection ||
+            Quantization != other.Quantization ||
+            EmbeddingsCacheExpiration != other.EmbeddingsCacheExpiration ||
+            EmbeddingsCacheForQueryingExpiration != other.EmbeddingsCacheForQueryingExpiration ||
+            EmbeddingsTransformation.Compare(EmbeddingsTransformation, other.EmbeddingsTransformation) == false ||
+            ChunkingOptions.Compare(ChunkingOptionsForQuerying,other.ChunkingOptionsForQuerying) == false)
+            differences |= EtlConfigurationCompareDifferences.Other;
+        
+        differences |= CompareEmbeddingsPathConfigurations(other.EmbeddingsPathConfigurations);
+
+        return differences;
+    }
+
+    private EtlConfigurationCompareDifferences CompareEmbeddingsPathConfigurations(List<EmbeddingPathConfiguration> other)
+    {
+        if (EmbeddingsPathConfigurations == null && 
+            other == null)
+            return EtlConfigurationCompareDifferences.None;
+        
+        if (EmbeddingsPathConfigurations == null ||
+            other == null)
+            return EtlConfigurationCompareDifferences.Other;
+        
+        if (EmbeddingsPathConfigurations.Count != other.Count)
+            return EtlConfigurationCompareDifferences.Other;
+        
+        foreach (var pathConfiguration in EmbeddingsPathConfigurations)
+        {
+            var otherPathConfiguration = other.SingleOrDefault(x => x.Path == pathConfiguration.Path);
+
+            if (otherPathConfiguration == null ||
+                EmbeddingPathConfiguration.Compare(pathConfiguration, otherPathConfiguration) == false)
+                return EtlConfigurationCompareDifferences.Other;
+        }
+
+        return EtlConfigurationCompareDifferences.None;
+    }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -33,6 +33,11 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
 
     public TimeSpan EmbeddingsCacheForQueryingExpiration { get; set; } = TimeSpan.FromDays(14);
 
+    private const string PathsTransformationName = "embeddings-from-paths";
+    private const string ScriptTransformationName = "embeddings-transform-script";
+
+    internal string TransformationName => EmbeddingsTransformation == null ? PathsTransformationName : ScriptTransformationName;
+
     private List<Transformation> _transforms;
 
     [JsonDeserializationIgnore]
@@ -49,7 +54,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
                 {
                     new Transformation
                     {
-                        Name = "embeddings-from-paths",
+                        Name = PathsTransformationName,
                         Collections = [Collection]
                     }
                 };
@@ -58,7 +63,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             [
                 new Transformation
                 {
-                    Name = "embeddings-transform-script",
+                    Name = ScriptTransformationName,
                     Collections = [Collection],
                     Script = EmbeddingsTransformation.Script
                 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsGenerationConfiguration.cs
@@ -190,8 +190,8 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             Quantization != other.Quantization ||
             EmbeddingsCacheExpiration != other.EmbeddingsCacheExpiration ||
             EmbeddingsCacheForQueryingExpiration != other.EmbeddingsCacheForQueryingExpiration ||
-            EmbeddingsTransformation.Compare(EmbeddingsTransformation, other.EmbeddingsTransformation) == false ||
-            ChunkingOptions.Compare(ChunkingOptionsForQuerying,other.ChunkingOptionsForQuerying) == false)
+            EmbeddingsTransformation.AreEqual(EmbeddingsTransformation, other.EmbeddingsTransformation) == false ||
+            ChunkingOptions.AreEqual(ChunkingOptionsForQuerying,other.ChunkingOptionsForQuerying) == false)
             differences |= EtlConfigurationCompareDifferences.Other;
         
         differences |= CompareEmbeddingsPathConfigurations(other.EmbeddingsPathConfigurations);
@@ -217,7 +217,7 @@ public sealed class EmbeddingsGenerationConfiguration : AbstractAiIntegrationCon
             var otherPathConfiguration = other.SingleOrDefault(x => x.Path == pathConfiguration.Path);
 
             if (otherPathConfiguration == null ||
-                EmbeddingPathConfiguration.Compare(pathConfiguration, otherPathConfiguration) == false)
+                EmbeddingPathConfiguration.AreEqual(pathConfiguration, otherPathConfiguration) == false)
                 return EtlConfigurationCompareDifferences.Other;
         }
 

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
@@ -28,7 +28,7 @@ public class EmbeddingsTransformation
             errors.Add($"Transformation script must use {GenerateEmbeddingsFunctionName} method.");
     }
 
-    internal static bool Compare(EmbeddingsTransformation left, EmbeddingsTransformation right)
+    internal static bool AreEqual(EmbeddingsTransformation left, EmbeddingsTransformation right)
     {
         if (left == null && right == null)
             return true;
@@ -37,6 +37,6 @@ public class EmbeddingsTransformation
             return false;
         
         return left.Script == right.Script &&
-               ChunkingOptions.Compare(left.ChunkingOptions, right.ChunkingOptions);
+               ChunkingOptions.AreEqual(left.ChunkingOptions, right.ChunkingOptions);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
@@ -27,4 +27,16 @@ public class EmbeddingsTransformation
         if (match.Length == 0)
             errors.Add($"Transformation script must use {GenerateEmbeddingsFunctionName} method.");
     }
+
+    internal static bool Compare(EmbeddingsTransformation left, EmbeddingsTransformation right)
+    {
+        if (left == null && right == null)
+            return true;
+        
+        if (left == null || right == null)
+            return false;
+        
+        return left.Script == right.Script &&
+               ChunkingOptions.Compare(left.ChunkingOptions, right.ChunkingOptions);
+    }
 }

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
@@ -36,9 +36,8 @@ public class EmbeddingsTransformation
         
         if (left == null || right == null)
             return false;
-        
-        return left.Script == right.Script &&
-               ChunkingOptions.AreEqual(left.ChunkingOptions, right.ChunkingOptions);
+
+        return left.Equals(right);
     }
 
     private bool Equals(EmbeddingsTransformation other)

--- a/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/EmbeddingsTransformation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Raven.Client.Documents.Operations.AI;
@@ -38,5 +39,24 @@ public class EmbeddingsTransformation
         
         return left.Script == right.Script &&
                ChunkingOptions.AreEqual(left.ChunkingOptions, right.ChunkingOptions);
+    }
+
+    private bool Equals(EmbeddingsTransformation other)
+    {
+        return Script == other.Script && 
+               ChunkingOptions.AreEqual(ChunkingOptions, other.ChunkingOptions);
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((EmbeddingsTransformation)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Script, ChunkingOptions);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -42,6 +42,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
     private const int DefaultMaxConcurrency = 4;
 
+    internal readonly string TransformationName = "GenAi-transform-script";
+
     [JsonDeserializationIgnore]
     [JsonIgnore]
     [Obsolete($"{nameof(GenAiConfiguration)} doesn't support multiple transformations. Please use {nameof(GenAiTransformation)} property instead.")]
@@ -55,7 +57,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             [
                 new Transformation
                 {
-                    Name = "GenAi-transform-script",
+                    Name = TransformationName,
                     Collections = [Collection],
                     Script = GenAiTransformation?.Script
                 }

--- a/src/Raven.Client/Documents/Operations/AI/UpdateEmbeddingsGenerationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/UpdateEmbeddingsGenerationOperation.cs
@@ -1,14 +1,15 @@
-﻿using Raven.Client.Documents.Conventions;
+﻿using System.Collections.Generic;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Http;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.AI;
 
-public class UpdateEmbeddingsGenerationOperation(long taskId, EmbeddingsGenerationConfiguration configuration) : IMaintenanceOperation<UpdateEtlOperationResult>
+public class UpdateEmbeddingsGenerationOperation(long taskId, EmbeddingsGenerationConfiguration configuration, List<string> transformationsToReset = null) : IMaintenanceOperation<UpdateEtlOperationResult>
 {
     public RavenCommand<UpdateEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new UpdateEtlOperation<AiConnectionString>.UpdateEtlCommand(conventions, taskId, configuration);
+        return new UpdateEtlOperation<AiConnectionString>.UpdateEtlCommand(conventions, taskId, configuration, transformationsToReset);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/UpdateEmbeddingsGenerationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/UpdateEmbeddingsGenerationOperation.cs
@@ -6,10 +6,15 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.AI;
 
-public class UpdateEmbeddingsGenerationOperation(long taskId, EmbeddingsGenerationConfiguration configuration, List<string> transformationsToReset = null) : IMaintenanceOperation<UpdateEtlOperationResult>
+public class UpdateEmbeddingsGenerationOperation(long taskId, EmbeddingsGenerationConfiguration configuration, bool reset = false) : IMaintenanceOperation<UpdateEtlOperationResult>
 {
     public RavenCommand<UpdateEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
+        List<string> transformationsToReset = null;
+
+        if (reset)
+            transformationsToReset = [configuration.TransformationName];
+        
         return new UpdateEtlOperation<AiConnectionString>.UpdateEtlCommand(conventions, taskId, configuration, transformationsToReset);
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/UpdateGenAiOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/UpdateGenAiOperation.cs
@@ -8,10 +8,15 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.AI;
 
-public class UpdateGenAiOperation(long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null, List<string> transformationsToReset = null) : IMaintenanceOperation<UpdateEtlOperationResult>
+public class UpdateGenAiOperation(long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null, bool reset = false) : IMaintenanceOperation<UpdateEtlOperationResult>
 {
     public RavenCommand<UpdateEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
+        List<string> transformationsToReset = null;
+
+        if (reset)
+            transformationsToReset = [configuration.TransformationName];
+        
         return new UpdateGenAiCommand(conventions, taskId, configuration, startingPoint, transformationsToReset);
     }
 
@@ -19,7 +24,7 @@ public class UpdateGenAiOperation(long taskId, GenAiConfiguration configuration,
     {
         private readonly StartingPointChangeVector _startingPoint;
 
-        public UpdateGenAiCommand(DocumentConventions conventions, long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint, List<string> transformationsToReset): base(conventions, taskId, configuration, transformationsToReset)
+        public UpdateGenAiCommand(DocumentConventions conventions, long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint, List<string> transformationsToReset) : base(conventions, taskId, configuration, transformationsToReset)
         {
             _startingPoint = startingPoint ?? StartingPointChangeVector.DoNotChange;
         }

--- a/src/Raven.Client/Documents/Operations/AI/UpdateGenAiOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/UpdateGenAiOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http;
 using System;
+using System.Collections.Generic;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Http;
@@ -7,18 +8,18 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.AI;
 
-public class UpdateGenAiOperation(long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null) : IMaintenanceOperation<UpdateEtlOperationResult>
+public class UpdateGenAiOperation(long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint = null, List<string> transformationsToReset = null) : IMaintenanceOperation<UpdateEtlOperationResult>
 {
     public RavenCommand<UpdateEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
-        return new UpdateGenAiCommand(conventions, taskId, configuration, startingPoint);
+        return new UpdateGenAiCommand(conventions, taskId, configuration, startingPoint, transformationsToReset);
     }
 
     internal sealed class UpdateGenAiCommand : UpdateEtlOperation<AiConnectionString>.UpdateEtlCommand
     {
         private readonly StartingPointChangeVector _startingPoint;
 
-        public UpdateGenAiCommand(DocumentConventions conventions, long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint): base(conventions, taskId, configuration)
+        public UpdateGenAiCommand(DocumentConventions conventions, long taskId, GenAiConfiguration configuration, StartingPointChangeVector startingPoint, List<string> transformationsToReset): base(conventions, taskId, configuration, transformationsToReset)
         {
             _startingPoint = startingPoint ?? StartingPointChangeVector.DoNotChange;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/UpdateEtlOperation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ConnectionStrings;
@@ -18,19 +19,22 @@ namespace Raven.Client.Documents.Operations.ETL
     {
         private readonly long _taskId;
         private readonly EtlConfiguration<T> _configuration;
+        private readonly List<string> _transformationsToReset;
 
         /// <inheritdoc cref="UpdateEtlOperation{T}"/>
         /// <param name="taskId">The identifier of the ETL task to update.</param>
         /// <param name="configuration">The new ETL configuration to apply.</param>
-        public UpdateEtlOperation(long taskId, EtlConfiguration<T> configuration)
+        /// <param name="transformationsToReset">Names of transformations to reset and reprocess all documents.</param>
+        public UpdateEtlOperation(long taskId, EtlConfiguration<T> configuration, List<string> transformationsToReset = null)
         {
             _taskId = taskId;
             _configuration = configuration;
+            _transformationsToReset = transformationsToReset;
         }
 
         public RavenCommand<UpdateEtlOperationResult> GetCommand(DocumentConventions conventions, JsonOperationContext ctx)
         {
-            return new UpdateEtlCommand(conventions, _taskId, _configuration);
+            return new UpdateEtlCommand(conventions, _taskId, _configuration, _transformationsToReset);
         }
 
         internal class UpdateEtlCommand : RavenCommand<UpdateEtlOperationResult>, IRaftCommand
@@ -38,12 +42,14 @@ namespace Raven.Client.Documents.Operations.ETL
             private readonly DocumentConventions _conventions;
             private readonly long _taskId;
             private readonly EtlConfiguration<T> _configuration;
+            private readonly List<string> _transformationsToReset;
 
-            public UpdateEtlCommand(DocumentConventions conventions, long taskId, EtlConfiguration<T> configuration)
+            public UpdateEtlCommand(DocumentConventions conventions, long taskId, EtlConfiguration<T> configuration, List<string> transformationsToReset)
             {
                 _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
                 _taskId = taskId;
                 _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+                _transformationsToReset = transformationsToReset;
             }
 
             public override bool IsReadRequest => false;
@@ -51,6 +57,9 @@ namespace Raven.Client.Documents.Operations.ETL
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/etl?id={_taskId}";
+                
+                if (_transformationsToReset != null)
+                    url += $"&reset={string.Join("&reset=", _transformationsToReset)}";
 
                 var request = new HttpRequestMessage
                 {

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
@@ -57,7 +57,6 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.RavenEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
             new AddRavenEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
-
         }
 
         public override bool Disabled => Configuration.Disabled;
@@ -79,7 +78,6 @@ namespace Raven.Server.ServerWide.Commands.ETL
         {
             new DeleteOngoingTaskCommand(TaskId, OngoingTaskType.SqlEtl, DatabaseName, null).UpdateDatabaseRecord(record, etag);
             new AddSqlEtlCommand(Configuration, DatabaseName, null).UpdateDatabaseRecord(record, etag);
-
         }
 
         public override bool Disabled => Configuration.Disabled;

--- a/test/SlowTests.Issues/Issues/RavenDB-25306.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25306.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25306 : EmbeddingsGenerationTestBase
+{
+    public RavenDB_25306(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task EmbeddingsGenerationTaskShouldHandleReset()
+    {
+        using (var store = GetDocumentStore())
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { Summary = "technical summary", Content = "technical content" };
+                
+                session.Store(dto);
+                session.SaveChanges();
+                
+                var aiTaskDone = Etl.WaitForEtlToComplete(store);
+                
+                var configuration = new EmbeddingsGenerationConfiguration
+                {
+                    Name = "ai-task-testing",
+                    Identifier = "ai-task-testing",
+                    ConnectionStringName = "ai-service-connection",
+                    EmbeddingsPathConfigurations = [
+                        new EmbeddingPathConfiguration() 
+                        { 
+                            Path = nameof(Dto.Content), 
+                            ChunkingOptions = new ChunkingOptions()
+                            {
+                                ChunkingMethod = ChunkingMethod.PlainTextSplitParagraphs
+                            }
+                        }
+                    ],
+                    Collection = "Dtos",
+                    ChunkingOptionsForQuerying = DefaultChunkingOptions
+                };
+
+                var connectionString = new AiConnectionString { Name = configuration.ConnectionStringName, EmbeddedSettings = new EmbeddedSettings() };
+                connectionString.Identifier = connectionString.GenerateIdentifier();
+
+                var putAiConnectionStringResult = store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+                Assert.NotNull(putAiConnectionStringResult.RaftCommandIndex);
+
+                var addAiIntegrationTaskResult = store.Maintenance.Send(new AddEmbeddingsGenerationOperation(configuration));
+                
+                Assert.NotNull(addAiIntegrationTaskResult.RaftCommandIndex);
+                Assert.NotNull(addAiIntegrationTaskResult.TaskId);
+                
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                
+                configuration.EmbeddingsPathConfigurations =
+                [
+                    new EmbeddingPathConfiguration()
+                    {
+                        Path = nameof(Dto.Summary), 
+                        ChunkingOptions = new ChunkingOptions()
+                        {
+                            ChunkingMethod = ChunkingMethod.PlainTextSplitParagraphs
+                        }
+                    }
+                ];
+                
+                aiTaskDone.Reset();
+                
+                store.Maintenance.Send(new UpdateEmbeddingsGenerationOperation(addAiIntegrationTaskResult.TaskId, configuration, transformationsToReset: ["embeddings-from-paths"]));
+                
+                Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
+                
+                AssertEmbeddingsForPath(store, configuration, connectionString, nameof(Dto.Summary), [dto.Summary], dto.Id);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Content { get; set; }
+        public string Summary { get; set; }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB-25306.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25306.cs
@@ -73,7 +73,7 @@ public class RavenDB_25306 : EmbeddingsGenerationTestBase
                 
                 aiTaskDone.Reset();
                 
-                store.Maintenance.Send(new UpdateEmbeddingsGenerationOperation(addAiIntegrationTaskResult.TaskId, configuration, transformationsToReset: ["embeddings-from-paths"]));
+                store.Maintenance.Send(new UpdateEmbeddingsGenerationOperation(addAiIntegrationTaskResult.TaskId, configuration, reset: true));
                 
                 Assert.True(await aiTaskDone.WaitAsync(DefaultEtlTimeout));
                 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25306/Modifying-the-Path-in-the-Embedding-Task-wasnt-picked-up

### Additional description

When comparing two embeddings generation task configurations, we want to compare properties that are specific for this type of task (e.g. `ChunkingOptionsForQuerying`). Previously we only compared generic ETL fields.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
