### PR TITLE
RavenDB-25420 Load & Lazy loads bugfixes

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
@@ -2342,6 +2343,60 @@ more responsive application.
             return true;
         }
 
+        public IEnumerable<(string Id, bool ExistsInSession)> GetDocumentsRequiredToLoad<TEnumerable>(string[] ids, TEnumerable includes)
+        where TEnumerable : IEnumerable<string>
+        {
+            foreach (var id in ids)
+            {
+                if (_knownMissingIds.Contains(id))
+                {
+                    yield return (id, true);
+                    continue;
+                }
+
+                // Check if a document was already loaded, the check if we've received it through include
+                if (DocumentsById.TryGetValue(id, out DocumentInfo documentInfo) == false &&
+                    IncludedDocumentsById.TryGetValue(id, out documentInfo) == false)
+                {
+                    yield return (id, false);
+                    continue;
+                }
+                
+                Debug.Assert(documentInfo is not null);
+                if ((documentInfo.Entity == null) && (documentInfo.Document == null))
+                {
+                    yield return (id, false);
+                    continue;
+                }
+                
+                if (includes == null)
+                {
+                    // Document exists in a session, there is no include, so we've the data we need
+                    yield return (id, true);
+                    continue;
+                }
+
+                var hasAll = true;
+                foreach (var include in includes)
+                {
+                    // We've to check if every include is present in the session
+                    IncludesUtil.Include(documentInfo.Document, include, s => { hasAll &= IsLoaded(s); });
+
+                    if (hasAll == false)
+                        break;
+                }
+
+                if (hasAll == false)
+                {
+                    // We missed at least one include, so we need to load the document
+                    yield return (id, false);
+                    continue;
+                }
+                
+                yield return (id, true);
+            }
+        }
+        
         protected void BuildEntityDocInfoByIdHolder<T>(
             IEnumerable<T> entities,
             out Dictionary<string, (object Entity, DocumentInfo Info)> idsEntitiesPairs

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2314,30 +2314,10 @@ more responsive application.
 
         public bool CheckIfIdAlreadyIncluded(string[] ids, IEnumerable<string> includes)
         {
-            foreach (var id in ids)
+            foreach (var (_, existsInSession) in GetDocumentsRequiredToLoad(ids, includes))
             {
-                if (_knownMissingIds.Contains(id))
-                    continue;
-
-                // Check if document was already loaded, the check if we've received it through include
-                if (DocumentsById.TryGetValue(id, out DocumentInfo documentInfo) == false &&
-                    IncludedDocumentsById.TryGetValue(id, out documentInfo) == false)
+                if (existsInSession == false)
                     return false;
-
-                if ((documentInfo.Entity == null) && (documentInfo.Document == null))
-                    return false;
-
-                if (includes == null)
-                    continue;
-
-                foreach (var include in includes)
-                {
-                    var hasAll = true;
-                    IncludesUtil.Include(documentInfo.Document, include, s => { hasAll &= IsLoaded(s); });
-
-                    if (hasAll == false)
-                        return false;
-                }
             }
 
             return true;
@@ -2348,6 +2328,7 @@ more responsive application.
         {
             foreach (var id in ids)
             {
+                
                 if (_knownMissingIds.Contains(id))
                 {
                     yield return (id, true);
@@ -2383,13 +2364,14 @@ more responsive application.
                     IncludesUtil.Include(documentInfo.Document, include, s => { hasAll &= IsLoaded(s); });
 
                     if (hasAll == false)
+                    {
+                        yield return (id, false);
                         break;
+                    }
                 }
 
                 if (hasAll == false)
                 {
-                    // We missed at least one include, so we need to load the document
-                    yield return (id, false);
                     continue;
                 }
                 

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1620,7 +1620,15 @@ more responsive application.
             }
             else
             {
-                RegisterCountersInternal(resultCounters, countersToInclude: null, fromQueryResult: false, gotAll: gotAll);
+                Dictionary<string, string[]> includeMap = null;
+                if (countersToInclude != null)
+                {
+                    includeMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var id in ids)
+                        includeMap[id] = countersToInclude;
+                }
+
+                RegisterCountersInternal(resultCounters, countersToInclude: includeMap, fromQueryResult: false, gotAll: gotAll);
             }
 
             RegisterMissingCounters(ids, countersToInclude);
@@ -1684,16 +1692,28 @@ more responsive application.
 
         private void RegisterCountersForDocument(string id, bool gotAll, BlittableJsonReaderArray counters, Dictionary<string, string[]> countersToInclude)
         {
-            if (CountersByDocId.TryGetValue(id, out var cache) == false)
+            if (CountersByDocId.TryGetValue(id, out var cache) == false || cache.Values == null)
             {
                 cache.Values = new Dictionary<string, long?>(StringComparer.OrdinalIgnoreCase);
             }
 
-            var deletedCounters = cache.Values.Count == 0
-                ? new HashSet<string>()
-                : countersToInclude[id].Length == 0 // IncludeAllCounters
-                    ? new HashSet<string>(cache.Values.Keys)
-                    : new HashSet<string>(countersToInclude[id]);
+            HashSet<string> deletedCounters;
+            if (cache.Values.Count == 0 || countersToInclude == null)
+            {
+                deletedCounters = new HashSet<string>();
+            }
+            else if (countersToInclude.TryGetValue(id, out var included) == false)
+            {
+                deletedCounters = new HashSet<string>();
+            }
+            else if (included.Length == 0) // IncludeAllCounters
+            {
+                deletedCounters = new HashSet<string>(cache.Values.Keys);
+            }
+            else
+            {
+                deletedCounters = new HashSet<string>(included);
+            }
 
             foreach (BlittableJsonReaderObject counterBlittable in counters)
             {
@@ -1702,7 +1722,20 @@ more responsive application.
                     counterBlittable.TryGet(nameof(CounterDetail.TotalValue), out long value) == false)
                     continue;
 
-                cache.Values[name] = value;
+                var merged = value;
+                if (TryGetDeferredCounterDelta(id, name, out var delta, out var deleted))
+                {
+                    if (deleted)
+                    {
+                        cache.Values.Remove(name);
+                        deletedCounters.Remove(name);
+                        continue;
+                    }
+
+                    merged += delta;
+                }
+
+                cache.Values[name] = merged;
                 deletedCounters.Remove(name);
             }
 
@@ -1710,12 +1743,43 @@ more responsive application.
             {
                 foreach (var name in deletedCounters)
                 {
+                    if (TryGetDeferredCounterDelta(id, name, out _, out var deleted) && deleted == false)
+                        continue; // there is a deferred operation for this counter, so we don't remove it
+
                     cache.Values.Remove(name);
                 }
             }
 
             cache.GotAll = gotAll;
             CountersByDocId[id] = cache;
+        }
+
+        private bool TryGetDeferredCounterDelta(string docId, string counter, out long delta, out bool deleted)
+        {
+            delta = 0;
+            deleted = false;
+
+            if (DeferredCommandsDictionary.TryGetValue((docId, CommandType.Counters, null), out var cmd) == false)
+                return false;
+
+            var batch = (CountersBatchCommandData)cmd;
+
+            foreach (var op in batch.Counters.Operations)
+            {
+                if (string.Equals(op.CounterName, counter, StringComparison.OrdinalIgnoreCase) == false)
+                    continue;
+
+                if (op.Type == CounterOperationType.Delete)
+                {
+                    deleted = true;
+                    return true;
+                }
+
+                if (op.Type == CounterOperationType.Increment)
+                    delta += op.Delta;
+            }
+
+            return delta != 0 || deleted;
         }
 
         private void SetGotAllInCacheIfNeeded(Dictionary<string, string[]> countersToInclude)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1700,11 +1700,11 @@ more responsive application.
             HashSet<string> deletedCounters;
             if (cache.Values.Count == 0 || countersToInclude == null)
             {
-                deletedCounters = new HashSet<string>();
+                deletedCounters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
             else if (countersToInclude.TryGetValue(id, out var included) == false)
             {
-                deletedCounters = new HashSet<string>();
+                deletedCounters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
             else if (included.Length == 0) // IncludeAllCounters
             {

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyLoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyLoadOperation.cs
@@ -33,20 +33,18 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
             _includes.ApplyIfNotNull(include => queryBuilder.AppendFormat("&include={0}", include));
 
             bool hasItems = false;
-            foreach (var id in _ids)
+            foreach (var (id, existsInSession) in _session.GetDocumentsRequiredToLoad(_ids, _includes))
             {
-                if (_session.IsLoadedOrDeleted(id))
+                if (existsInSession)
                 {
                     _alreadyInSession.Add(id);
+                    continue;
                 }
-                else
-                {
-                    hasItems = true;
-                    queryBuilder.AppendFormat("&id={0}", Uri.EscapeDataString(id));
-                }
+                
+                hasItems = true;
+                queryBuilder.AppendFormat("&id={0}", Uri.EscapeDataString(id));
             }
             
-
             if (hasItems == false)
             {
                 // no need to hit the server

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -24,6 +24,13 @@ namespace Raven.Client.Documents.Session.Operations
 
         private bool _resultsSet;
         private GetDocumentsResult _results;
+        
+        private bool SkipSessionCheck => _countersToInclude != null 
+                                              || _revisionsToIncludeByChangeVector != null
+                                              || _revisionsToIncludeByDateTimeBefore != null
+                                              || _compareExchangeValuesToInclude != null
+                                              || _includeAllCounters
+                                              || _timeSeriesToInclude != null;
 
         public LoadOperation(InMemoryDocumentSessionOperations session)
         {
@@ -32,8 +39,12 @@ namespace Raven.Client.Documents.Session.Operations
 
         public GetDocumentsCommand CreateRequest()
         {
-            if (_session.CheckIfIdAlreadyIncluded(_ids, _includes))
-                return null;
+            if (SkipSessionCheck == false)
+            {
+                var allDocumentsInSession = _session.CheckIfIdAlreadyIncluded(_ids, _includes);
+                if (allDocumentsInSession)
+                    return null;
+            }
 
             _session.IncrementRequestCount();
             if (Logger.IsInfoEnabled)

--- a/src/Raven.Client/Documents/Session/SessionCountersBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionCountersBase.cs
@@ -141,3 +141,4 @@ namespace Raven.Client.Documents.Session
 
     }
 }
+

--- a/src/Raven.Client/Documents/Session/SessionCountersBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionCountersBase.cs
@@ -64,6 +64,14 @@ namespace Raven.Client.Documents.Session
             {
                 Session.Defer(new CountersBatchCommandData(DocId, counterOp));
             }
+
+            if (Session.CountersByDocId.TryGetValue(DocId, out var cache) &&
+                cache.Values != null &&
+                cache.Values.TryGetValue(counter, out var val))
+            {
+                cache.Values[counter] = (val ?? 0) + delta;
+                Session.CountersByDocId[DocId] = cache;
+            }
         }
 
         /// <inheritdoc cref="ISessionDocumentCountersBase.Delete(string)"/> 
@@ -100,9 +108,10 @@ namespace Raven.Client.Documents.Session
                 Session.Defer(new CountersBatchCommandData(DocId, counterOp));
             }
 
-            if (Session.CountersByDocId.TryGetValue(DocId, out var cache))
+            if (Session.CountersByDocId.TryGetValue(DocId, out var cache) && cache.Values != null)
             {
-                cache.Values.Remove(counter);
+                cache.Values[counter] = null;
+                Session.CountersByDocId[DocId] = cache;
             }
 
         }

--- a/test/SlowTests/Client/Counters/QueryOnCounters.cs
+++ b/test/SlowTests/Client/Counters/QueryOnCounters.cs
@@ -3420,6 +3420,13 @@ from 'Users' as user select output(user)", query.ToString());
                         Company = "companies/1-A"
                     }, "orders/1-A");
                     session.CountersFor("orders/1-A").Increment("Downloads", 100);
+                    
+                    session.Store(new Order
+                    {
+                        Company = "companies/2-A"
+                    }, "orders/2-A");
+                    session.CountersFor("orders/2-A").Increment("Downloads", 50);
+                    
                     session.SaveChanges();
                 }
 
@@ -3456,6 +3463,13 @@ from 'Users' as user select output(user)", query.ToString());
                     session.Load<Order>("orders/1-A", i => i.IncludeCounter("Downloads"));
                     counterValue = session.CountersFor("orders/1-A").Get("Downloads");
                     Assert.Equal(700, counterValue);
+                    
+                    session.Load<Order>(["orders/1-A", "orders/2-A"], i => i.IncludeCounter("Downloads"));
+                    counterValue = session.CountersFor("orders/1-A").Get("Downloads");
+                    Assert.Equal(700, counterValue);
+                    
+                    var counterValue2 = session.CountersFor("orders/2-A").Get("Downloads");
+                    Assert.Equal(50, counterValue2);
                 }
             }
         }

--- a/test/SlowTests/Client/Counters/SessionCounters.cs
+++ b/test/SlowTests/Client/Counters/SessionCounters.cs
@@ -970,9 +970,9 @@ namespace SlowTests.Client.Counters
                     Assert.Equal(100, val);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
 
-                    session.CountersFor("users/1-A").Increment("likes", 50); // should not increment the counter value in cache
+                    session.CountersFor("users/1-A").Increment("likes", 50); // should increment the counter value in cache
                     val = session.CountersFor("users/1-A").Get("likes");
-                    Assert.Equal(100, val);
+                    Assert.Equal(150, val);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
 
                     session.CountersFor("users/1-A").Increment("dislikes", 200); // should not add the counter to cache
@@ -983,8 +983,6 @@ namespace SlowTests.Client.Counters
                     session.CountersFor("users/1-A").Increment("score", 1000); // should not add the counter to cache
                     Assert.Equal(2, session.Advanced.NumberOfRequests);
 
-                    // SaveChanges should updated counters values in cache
-                    // according to increment result
                     session.SaveChanges();
                     Assert.Equal(3, session.Advanced.NumberOfRequests);
 
@@ -1005,7 +1003,7 @@ namespace SlowTests.Client.Counters
         }
 
         [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Counters)]
-        public void SessionShouldRemoveCounterFromCacheAfterCounterDeletion()
+        public void SessionShouldSetCounterAsKnownMissingInCacheAfterCounterDeletion()
         {
             using (var store = GetDocumentStore())
             {
@@ -1027,9 +1025,10 @@ namespace SlowTests.Client.Counters
                     session.SaveChanges();
                     Assert.Equal(2, session.Advanced.NumberOfRequests);
 
+                    // should not go to server again
                     val = session.CountersFor("users/1-A").Get("likes");
                     Assert.Null(val);
-                    Assert.Equal(3, session.Advanced.NumberOfRequests);
+                    Assert.Equal(2, session.Advanced.NumberOfRequests);
 
                 }
             }

--- a/test/SlowTests/Client/Lazy/Async/RavenDB-25420.cs
+++ b/test/SlowTests/Client/Lazy/Async/RavenDB-25420.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Lazy.Async;
+
+public class RavenDB_25420(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private const string TimeSeriesName = "ts";
+    private readonly DateTime _baseLine = DateTime.UtcNow;
+
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [InlineData(20, 0, 1)] // no preload query, just the lazy load with includes
+    [InlineData(20, 1, 2)] // preload 1 book, lazy load other with includes
+    [InlineData(20, 2, 2)] // preload 2 books, lazy load other with includes
+    [InlineData(20, 5, 2)] // preload 2 books, lazy load other with includes
+    [InlineData(20, 18, 2)] // preload 18 books, lazy load other with includes
+    [InlineData(20, 20, 2)] // preload all books, what happens with the lazy includes in this scenario?
+    public async Task TestLazyLoadWhenSomeDocumentsMightBeAlreadyLoaded(int booksAndAuthorsCount, int preloadBooksCount, int maxExpectedRequests)
+    {
+        using var store = GetDocumentStore();
+
+        using (var session = store.OpenAsyncSession())
+        {
+            for (var i = 0; i < booksAndAuthorsCount; i++)
+            {
+                var author = new Author()
+                {
+                    Id = $"authors/{i}",
+                    Name = $"Author {i}"
+                };
+                var book = new Book()
+                {
+                    Id = $"books/{i}",
+                    Title = $"Book {i}",
+                    AuthorId = $"authors/{i}",
+                };
+                await session.StoreAsync(author);
+                await session.StoreAsync(book);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        // some books are preloaded
+        using (var session = store.OpenAsyncSession())
+        {
+            // preload N books
+            if (preloadBooksCount > 0)
+            {
+                await session.LoadAsync<Book>(Enumerable.Range(0, preloadBooksCount)
+                    .Select(i => $"books/{i}"));
+            }
+
+            var allBooksIds = new List<string>(Enumerable.Range(0, booksAndAuthorsCount).Select(i => $"books/{i}"));
+            var lazyBooks = session.Advanced.Lazily
+                .Include<Book>(doc => doc.AuthorId)
+                .LoadAsync<Book>(allBooksIds);
+
+            // execute pending lazy operations
+            await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
+
+            int requestCount = session.Advanced.NumberOfRequests;
+            Assert.True(requestCount <= 2); // preload + lazy load (if not already all in session)
+
+            var books = await lazyBooks.Value;
+            Assert.Equal(booksAndAuthorsCount, books.Count);
+            Assert.Equal(booksAndAuthorsCount, books.Select(item => item.Value.Id).Distinct().Count());
+
+            foreach (var pair in books)
+            {
+                var author = await session.LoadAsync<Author>(pair.Value.AuthorId);
+                Assert.NotNull(author);
+            }
+
+
+            Assert.True(
+                session.Advanced.NumberOfRequests <= maxExpectedRequests,
+                $"Expected no more than {maxExpectedRequests} requests, got {session.Advanced.NumberOfRequests}"
+            );
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadRevisionsInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out _, out _, out _, out var book1, out var book2, out var book3, out var updateTime);
+        using var session = store.OpenAsyncSession();
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+        Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id], builder => builder.IncludeRevisions(updateTime));
+
+        // Should not send any additional requests
+        var rv1 = await session.Advanced.Revisions.GetAsync<Book>(book1.Id, updateTime);
+        var rv2 = await session.Advanced.Revisions.GetAsync<Book>(book2.Id, updateTime);
+        var rv3 = await session.Advanced.Revisions.GetAsync<Book>(book3.Id, updateTime);
+        Assert.EndsWith("_O", rv1.Title);
+        Assert.EndsWith("_O", rv2.Title);
+        Assert.EndsWith("_O", rv3.Title);
+        Assert.Equal(2, session.Advanced.NumberOfRequests);
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadAllTimeSeriesInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out _, out _, out _, out var book1, out var book2, out var book3, out _);
+        using var session = store.OpenAsyncSession();
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+        Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+        // Should load the timeseries in bulk
+        var baseLineOffset = _baseLine.AddMinutes(5);
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id], builder => builder.IncludeAllTimeSeries(_baseLine, baseLineOffset));
+
+        var ts1 = await session.TimeSeriesFor<Book>(book1.Id, TimeSeriesName).GetAsync(_baseLine, baseLineOffset);
+        Assert.Equal(1, ts1.Length);
+        Assert.Equal(1, ts1[0].Values.Single());
+        
+        var ts2 = await session.TimeSeriesFor<Book>(book2.Id, TimeSeriesName).GetAsync(_baseLine, baseLineOffset);
+        Assert.Equal(1, ts2.Length);
+        Assert.Equal(2, ts2[0].Values.Single());
+
+        var ts3 = await session.TimeSeriesFor<Book>(book3.Id, TimeSeriesName).GetAsync(_baseLine, baseLineOffset);
+        Assert.Equal(1, ts3.Length);
+        Assert.Equal(3, ts3[0].Values.Single());
+
+        Assert.Equal(2, session.Advanced.NumberOfRequests);
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadTimeSeriesInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out _, out _, out _, out var book1, out var book2, out var book3, out _);
+        using var session = store.OpenAsyncSession();
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+        Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+        var baseLineOffset = _baseLine.AddMinutes(5);
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id], builder => builder.IncludeTimeSeries(TimeSeriesName, _baseLine, baseLineOffset));
+
+        var ts1 = await session.TimeSeriesFor<Book>(book1.Id, TimeSeriesName).GetAsync(_baseLine, baseLineOffset);
+        Assert.Equal(1, ts1.Length);
+        Assert.Equal(1, ts1[0].Values.Single());
+        
+        var ts2 = await session.TimeSeriesFor<Book>(book2.Id, TimeSeriesName).GetAsync(_baseLine, baseLineOffset);
+        Assert.Equal(1, ts2.Length);
+        Assert.Equal(2, ts2[0].Values.Single());
+
+        var ts3 = await session.TimeSeriesFor<Book>(book3.Id, TimeSeriesName).GetAsync(_baseLine, baseLineOffset);
+        Assert.Equal(1, ts3.Length);
+        Assert.Equal(3, ts3[0].Values.Single());
+
+        Assert.Equal(2, session.Advanced.NumberOfRequests);
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadCountersInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out _, out _, out _, out var book1, out var book2, out var book3, out _);
+        using var session = store.OpenAsyncSession();
+
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+        Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+        // Load counters in bulk
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id], b => b.IncludeCounter(nameof(Author)));
+
+        var c1 = await session.CountersFor(book1.Id).GetAsync(nameof(Author));
+        var c2 = await session.CountersFor(book2.Id).GetAsync(nameof(Author));
+        var c3 = await session.CountersFor(book3.Id).GetAsync(nameof(Author));
+        Assert.Equal(c1, 1);
+        Assert.Equal(c2, 2);
+        Assert.Equal(c3, 3);
+        Assert.Equal(2, session.Advanced.NumberOfRequests);
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadAllCountersInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out _, out _, out _, out var book1, out var book2, out var book3, out _);
+        using var session = store.OpenAsyncSession();
+
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+        Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+        // Load counters in bulk
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id], b => b.IncludeAllCounters());
+
+        var c1 = await session.CountersFor(book1.Id).GetAsync(nameof(Author));
+        var c2 = await session.CountersFor(book2.Id).GetAsync(nameof(Author));
+        var c3 = await session.CountersFor(book3.Id).GetAsync(nameof(Author));
+        Assert.Equal(c1, 1);
+        Assert.Equal(c2, 2);
+        Assert.Equal(c3, 3);
+        Assert.Equal(2, session.Advanced.NumberOfRequests);
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadCompareExchangeInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out _, out _, out _, out var book1, out var book2, out var book3, out _);
+        using var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide });
+
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+        Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+        // Load counters in bulk
+        await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id], b => b.IncludeCompareExchangeValue(p => p.CompareExchangeName));
+
+        var cmx1 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(book1.CompareExchangeName);
+        Assert.Equal("1", cmx1.Value);
+
+        var cmx2 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(book2.CompareExchangeName);
+        Assert.Equal("2", cmx2.Value);
+
+        var cmx3 = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(book3.CompareExchangeName);
+        Assert.Equal("3", cmx3.Value);
+        
+        Assert.Equal(2, session.Advanced.NumberOfRequests);
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task LoadIncludesInSingleCallEvenDocumentsAreAlreadyLoaded()
+    {
+        using var store = GetDocumentStoreWithDocuments(out var author1, out var author2, out var author3, out var book1, out var book2, out var book3, out _);
+        using (var session = store.OpenAsyncSession())
+        {
+            // preload all books
+            await session.LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // load with includes
+            await session.Include<Book>(x => x.AuthorId).LoadAsync<Book>([book1.Id, book2.Id, book3.Id]);
+            Assert.Equal(2, session.Advanced.NumberOfRequests);
+
+            var a1 = await session.LoadAsync<Author>(author1.Id);
+            Assert.NotNull(a1);
+            var a2 = await session.LoadAsync<Author>(author2.Id);
+            Assert.NotNull(a2);
+
+            var a3 = await session.LoadAsync<Author>(author3.Id);
+            Assert.NotNull(a3);
+
+            Assert.Equal(2, session.Advanced.NumberOfRequests);
+        }
+    }
+
+    private DocumentStore GetDocumentStoreWithDocuments(out Author author1, out Author author2, out Author author3, out Book book1, out Book book2, out Book book3, out DateTime updateTime)
+    {
+        var store = GetDocumentStore();
+        AsyncHelpers.RunSync(() => RevisionsHelper.SetupRevisionsAsync(store));
+
+        using (var session = store.OpenSession())
+        {
+            author1 = new Author() { Name = "Author1" };
+            author2 = new Author() { Name = "Author2" };
+            author3 = new Author() { Name = "Author3" };
+            session.Store(author1);
+            session.Store(author2);
+            session.Store(author3);
+            session.SaveChanges();
+
+            book1 = new Book() { AuthorId = author1.Id, Title = "Book1_O", CompareExchangeName = "Cmpx1" };
+            book2 = new Book() { AuthorId = author2.Id, Title = "Book2_O", CompareExchangeName = "Cmpx2" };
+            book3 = new Book() { AuthorId = author3.Id, Title = "Book3_O", CompareExchangeName = "Cmpx3" };
+            session.Store(book1);
+            session.Store(book2);
+            session.Store(book3);
+            session.SaveChanges();
+
+            var bts1 = session.TimeSeriesFor(book1.Id, TimeSeriesName);
+            bts1.Append(_baseLine.AddMinutes(1), 1D);
+
+            var bts2 = session.TimeSeriesFor(book2.Id, TimeSeriesName);
+            bts2.Append(_baseLine.AddMinutes(2), 2D);
+
+            var bts3 = session.TimeSeriesFor(book3.Id, TimeSeriesName);
+            bts3.Append(_baseLine.AddMinutes(3), 3D);
+
+            session.CountersFor(book1.Id).Increment(nameof(Author), 1);
+            session.CountersFor(book2.Id).Increment(nameof(Author), 2);
+            session.CountersFor(book3.Id).Increment(nameof(Author), 3);
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            updateTime = DateTime.UtcNow;
+            book1 = session.Load<Book>(book1.Id);
+            book2 = session.Load<Book>(book2.Id);
+            book3 = session.Load<Book>(book3.Id);
+            book1.Title = "Book1";
+            book2.Title = "Book2";
+            book3.Title = "Book3";
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+        {
+            CompareExchangeValue<string> item1 =
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(
+                    key: book1.CompareExchangeName,
+                    value: "1"
+                );
+            CompareExchangeValue<string> item2 =
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(
+                    key: book2.CompareExchangeName,
+                    value: "2"
+                );
+            CompareExchangeValue<string> item3 =
+                session.Advanced.ClusterTransaction.CreateCompareExchangeValue(
+                    key: book3.CompareExchangeName,
+                    value: "3"
+                );
+
+            session.SaveChanges();
+        }
+
+        return store;
+    }
+
+    private class Book
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+
+        public string AuthorId { get; set; }
+
+        public string CompareExchangeName { get; set; }
+    }
+
+    private class Author
+    {
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-15826.cs
+++ b/test/SlowTests/Issues/RavenDB-15826.cs
@@ -34,11 +34,36 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenAsyncSession())
             {
-                await session.Include<Item>(x => x.Refs).LoadAsync("items/d"); // include, some loaded
-                var a = await session.LoadAsync<Item>("items/c"); // include, some loaded
-                var items = session.Advanced.Lazily.LoadAsync<Item>(a.Refs);
+                await session.Include<Item>(x => x.Refs).LoadAsync("items/d"); // include, some loaded: Load DocIds [items/d], Includes[items/a]
+                var a = await session.LoadAsync<Item>("items/c"); // include, some loaded // DocsIds: [items/c, items/d], Includes[items/a]
+                var items = session.Advanced.Lazily.LoadAsync<Item>(a.Refs); // Load [items/a, items/b, items/c, items/d] Includes[items/a]
                 await session.Advanced.Eagerly.ExecuteAllPendingLazyOperationsAsync();
-                Dictionary<string, Item> itemsDic = await items.Value;
+                Dictionary<string, Item> itemsDic = await items.Value; //
+                Assert.Equal(a.Refs.Length, itemsDic.Count);
+                Assert.DoesNotContain(itemsDic, x => x.Value == null);
+            }
+        }
+        
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        public async Task CanIncludeLoadItemThatIsAlreadyOnSession()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Item(), "items/a");
+                await session.StoreAsync(new Item(), "items/b");
+                await session.StoreAsync(new Item { Refs = new[] { "items/a", "items/b" } }, "items/c");
+                await session.StoreAsync(new Item { Refs = new[] { "items/a", } }, "items/d");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.Include<Item>(x => x.Refs).LoadAsync("items/d"); // include, some loaded: Load DocIds [items/d], Includes[items/a]
+                var a = await session.LoadAsync<Item>("items/c"); // include, some loaded // DocsIds: [items/c, items/d], Includes[items/a]
+                var items = session.LoadAsync<Item>(a.Refs); // Load [items/a, items/b, items/c, items/d] Includes[items/a]
+                Dictionary<string, Item> itemsDic = await items;
                 Assert.Equal(a.Refs.Length, itemsDic.Count);
                 Assert.DoesNotContain(itemsDic, x => x.Value == null);
             }

--- a/test/SlowTests/Issues/RavenDB_14006.cs
+++ b/test/SlowTests/Issues/RavenDB_14006.cs
@@ -248,7 +248,8 @@ namespace SlowTests.Issues
                     Assert.Equal("Torun", value1.Value.City);
 
                     var company2 = session.Load<Company>("companies/1", includes => includes.IncludeCompareExchangeValue(x => x.ExternalId));
-
+                    numberOfRequests += 1; // RavenDB-25420
+                    
                     Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
 
                     Assert.Equal(company1, company2);
@@ -316,7 +317,8 @@ namespace SlowTests.Issues
                     Assert.Equal("Torun", value1.Value.City);
 
                     var company2 = await session.LoadAsync<Company>("companies/1", includes => includes.IncludeCompareExchangeValue(x => x.ExternalId));
-
+                    numberOfRequests += 1; // RavenDB-25420
+                    
                     Assert.Equal(numberOfRequests, session.Advanced.NumberOfRequests);
 
                     Assert.Equal(company1, company2);

--- a/test/SlowTests/Issues/RavenDB_25455.cs
+++ b/test/SlowTests/Issues/RavenDB_25455.cs
@@ -52,10 +52,8 @@ public class RavenDB_25455 : ReplicationTestBase
         var bookId1 = "books/1";
         var bookId2 = "books/2";
 
-
         const string counter1 = "Book1";
         const string counter2 = "Book2";
-
 
         using (var session = store.OpenAsyncSession())
         {
@@ -132,7 +130,6 @@ public class RavenDB_25455 : ReplicationTestBase
             Assert.Null(await session.CountersFor(bookId1).GetAsync(counter));
         }
     }
-
 
     private class Book
     {

--- a/test/SlowTests/Issues/RavenDB_25455.cs
+++ b/test/SlowTests/Issues/RavenDB_25455.cs
@@ -1,0 +1,142 @@
+﻿using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25455 : ReplicationTestBase
+{
+    public RavenDB_25455(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task CounterIsNotOverridenWhenLoadedOnceAgain()
+    {
+        using var store = GetDocumentStore();
+        var bookId1 = "books/1";
+        var bookId2 = "books/2";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Book { Id = bookId1, Title = "Book1" }, bookId1);
+            await session.StoreAsync(new Book { Id = bookId2, Title = "Book2" }, bookId2);
+            await session.SaveChangesAsync();
+
+            session.CountersFor(bookId1).Increment(nameof(Book), 1);
+            session.CountersFor(bookId2).Increment(nameof(Book), 2);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var loadDocs = await session.LoadAsync<Book>([bookId1], b => b.IncludeCounter(nameof(Book)));
+            loadDocs[bookId1].Title = "CurrentSessionObject";
+            session.CountersFor(bookId1).Increment(nameof(Book), 24);
+
+            Assert.Equal(25, await session.CountersFor(bookId1).GetAsync(nameof(Book)));
+            Assert.Equal("CurrentSessionObject", (await session.LoadAsync<Book>(bookId1)).Title);
+
+            var loadedMore = await session.LoadAsync<Book>([bookId1, bookId2], b => b.IncludeCounter(nameof(Book)));
+            Assert.Equal("CurrentSessionObject", loadedMore[bookId1].Title);
+            Assert.Equal(25, await session.CountersFor(bookId1).GetAsync(nameof(Book)));
+            Assert.Equal(2, await session.CountersFor(bookId2).GetAsync(nameof(Book)));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task CanIncludeCountersOfSameDocumentInSeparateLoads()
+    {
+        using var store = GetDocumentStore();
+        var bookId1 = "books/1";
+        var bookId2 = "books/2";
+
+
+        const string counter1 = "Book1";
+        const string counter2 = "Book2";
+
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Book(), bookId1);
+            await session.StoreAsync(new Book(), bookId2);
+
+            session.CountersFor(bookId1).Increment(counter1, 10);
+            session.CountersFor(bookId1).Increment(counter2, 20);
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<Book>(bookId1, b => b.IncludeCounter(counter1));
+            Assert.NotNull(doc);
+
+            var counter1Value = await session.CountersFor(bookId1).GetAsync(counter1);
+            Assert.Equal(10, counter1Value);
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // document books/1 already has counters tracked in the session
+            // including more counters of this document should not throw NRE
+
+            var moreDocs = await session.LoadAsync<Book>([bookId1, bookId2], b => b.IncludeCounter(counter2));
+            Assert.Equal(2, moreDocs.Count);
+
+            Assert.Equal(20, await session.CountersFor(bookId1).GetAsync(counter2));
+            Assert.Equal(null, await session.CountersFor(bookId2).GetAsync(counter2));
+
+            Assert.Equal(2, session.Advanced.NumberOfRequests);
+
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task DeletingTrackedCounterShouldReturnNullImmediately()
+    {
+        using var store = GetDocumentStore();
+        var bookId1 = "books/1";
+
+        const string counter = "Likes";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Book(), bookId1);
+            session.CountersFor(bookId1).Increment(counter, 10);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // track the counter in session (include -> no server request on Get)
+            var doc = await session.LoadAsync<Book>(bookId1, b => b.IncludeCounter(counter));
+            Assert.NotNull(doc);
+
+            Assert.Equal(10, await session.CountersFor(bookId1).GetAsync(counter));
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // delete should update in-session cache
+            session.CountersFor(bookId1).Delete(counter);
+
+            // should return null immediately, without going to server
+            Assert.Null(await session.CountersFor(bookId1).GetAsync(counter));
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // persist deletion
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // verify deletion persisted
+            Assert.Null(await session.CountersFor(bookId1).GetAsync(counter));
+        }
+    }
+
+
+    private class Book
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_25455.cs
+++ b/test/SlowTests/Issues/RavenDB_25455.cs
@@ -11,7 +11,7 @@ public class RavenDB_25455 : ReplicationTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.ClientApi)]
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Counters)]
     public async Task CounterIsNotOverridenWhenLoadedOnceAgain()
     {
         using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25420

### Additional description

Includes:
 - LazyLoad - Ensure all includes are loaded when loading "load" document from session.
 - Load - Consider parameters other than `Includes` when skipping a request to the server.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
