### PR TITLE
RavenDB-25393 - Fix bigger revisions count after restore incremental backup

### DIFF
--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -243,14 +243,14 @@ namespace Raven.Server.Documents.Revisions
             if (docConfiguration.MinimumRevisionAgeToKeep.HasValue && lastModifiedTicks.HasValue)
                 return true;
 
+            if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.SkipRevisionCreationForSmuggler))
+            {
+                // Smuggler is configured to avoid creating new revisions during import
+                return false;
+            }
+
             if (existingDocument == null)
             {
-                if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.SkipRevisionCreationForSmuggler))
-                {
-                    // Smuggler is configured to avoid creating new revisions during import
-                    return false;
-                }
-
                 // we are not going to create a revision if it's an import from v3
                 // (since this import is going to import revisions as well)
                 if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.LegacyHasRevisions))

--- a/test/StressTests/Issues/RavenDB-25393.cs
+++ b/test/StressTests/Issues/RavenDB-25393.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues
+{
+    public class RavenDB_25393 : ReplicationTestBase
+    {
+        public RavenDB_25393(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [RavenTheory(RavenTestCategory.ClusterTransactions)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task RestoreIncrementalBackupCreatesExtraRevision(Options options)
+        {
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            using var store = GetDocumentStore(options);
+
+            using (var source = GetDocumentStore())
+            {
+                await RevisionsHelper.SetupRevisionsAsync(source, Server.ServerStore, configuration: new RevisionsConfiguration
+                {
+                    Default = new RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        MinimumRevisionsToKeep = 100
+                    }
+                });
+
+                var config = new PeriodicBackupConfiguration { LocalSettings = new LocalSettings { FolderPath = backupPath }, IncrementalBackupFrequency = "0 0 */12 * *" };
+                var backupTaskId = (await source.Maintenance.SendAsync(new UpdatePeriodicBackupOperation(config))).TaskId;
+                Backup.WaitForResponsibleNodeUpdate(Server.ServerStore, source.Database, backupTaskId);
+
+                using (var session = source.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User()
+                    {
+                        Name = "Shahar"
+                    }, "Users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var backupStatus = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+                await backupStatus.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                using (var session = source.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User()
+                    {
+                        Name = "Shahar Hikri"
+                    }, "Users/1");
+                    await session.SaveChangesAsync();
+
+                    await session.SaveChangesAsync();
+                }
+
+                var backupStatus2 = await source.Maintenance.SendAsync(new StartBackupOperation(false, backupTaskId));
+                await backupStatus2.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                await Backup.GetBackupFilesAndAssertCountAsync(backupPath, 2, backupStatus2.Id, source.Database);
+
+                Assert.Equal(2, (await source.Maintenance.ForDatabase(source.Database).SendAsync(new GetStatisticsOperation())).CountOfRevisionDocuments);
+            }
+
+            var restoredDatabaseName = GetDatabaseName() + "_Restore";
+            using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                   {
+                       BackupLocation = Directory.GetDirectories(backupPath).First(),
+                       DatabaseName = restoredDatabaseName
+            }))
+            {
+                var afterRestoreStats = await store.Maintenance.ForDatabase(restoredDatabaseName).SendAsync(new GetStatisticsOperation());
+                Assert.Equal(2, afterRestoreStats.CountOfRevisionDocuments);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25393/Restore-an-incremental-backup-has-an-extra-revision

### Additional description

Bigger revisions count after restoring incremental backup

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
