### PR TITLE
RavenDB-25411 Perform `Min` method instead `Sum` in case of duplicates in MultiVectorSearch query (applied on distance value).

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/SortAndRemoveDuplicates.cs
+++ b/bench/Micro.Benchmark/Benchmarks/SortAndRemoveDuplicates.cs
@@ -30,22 +30,6 @@ public class SortAndRemoveDuplicates
         _workingScoreArray = new float[totalElementsNumber];
         _workingArray = new long[totalElementsNumber];
     }
-
-    [Benchmark(Baseline = true)]
-    public int SortAndMergeDuplicatesWithBranch()
-    {
-        _sourceArray.AsSpan().CopyTo(_workingArray);
-        _sourceScoreArray.AsSpan().CopyTo(_workingScoreArray);
-        return Sparrow.Server.Utils.Sorting.SortAndMergeDuplicates(_workingArray.AsSpan(), _workingScoreArray.AsSpan());
-    }
-    
-    [Benchmark]
-    public int SortAndMergeDuplicatesBranchless()
-    {
-        _sourceArray.AsSpan().CopyTo(_workingArray);
-        _sourceScoreArray.AsSpan().CopyTo(_workingScoreArray);
-        return SortAndMergeDuplicatesBranchless(_workingArray.AsSpan(), _workingScoreArray.AsSpan());
-    }
     
     [Benchmark]
     public int SortAndRemoveDuplicatesWithBranch()
@@ -87,43 +71,5 @@ public class SortAndRemoveDuplicates
         }
 
         return outputIdx + 1;
-    }
-    
-    private static int SortAndMergeDuplicatesBranchless(Span<long> valuesToDeduplicate, Span<float> itemsAssociated)
-    {
-        if (valuesToDeduplicate.Length <= 1)
-            return valuesToDeduplicate.Length;
-            
-        valuesToDeduplicate.Sort(itemsAssociated);
-
-        // We need to fill in the gaps left by removing deduplication process.
-        // If there are no duplicated the writes at the architecture level will execute
-        // way faster than if there are.
-
-        int nextI = 0;
-        int outputIdx = 0;
-        while (nextI < valuesToDeduplicate.Length - 1)
-        {
-            int i = nextI;
-            nextI++;
-            var nextItemHasSameId = (valuesToDeduplicate[nextI] == valuesToDeduplicate[i]).ToInt32();
-            var nextItemHasDifferentId = nextItemHasSameId ^ 1;
-                
-            // When elements are equal, add previous element to next
-            itemsAssociated[nextI] += nextItemHasSameId * itemsAssociated[outputIdx];
-            outputIdx += nextItemHasDifferentId;
-                
-            valuesToDeduplicate[outputIdx] = valuesToDeduplicate[nextI];
-            itemsAssociated[outputIdx] = itemsAssociated[nextI];
-        }
-
-        outputIdx++;
-        if (outputIdx != valuesToDeduplicate.Length)
-        {
-            valuesToDeduplicate[outputIdx] = valuesToDeduplicate[^1];
-            itemsAssociated[outputIdx] = itemsAssociated[^1];
-        }
-
-        return outputIdx;
     }
 }

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -100,7 +100,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             nearestSearch.Dispose();
         }
 
-        var uniqueCount = Sorting.SortAndMergeDuplicates(_matches.Results, _distances.Results);
+        var uniqueCount = Sorting.SortAndMinOnDuplicates(_matches.Results, _distances.Results);
         _matches.Truncate(uniqueCount);
         _distances.Truncate(uniqueCount);
 

--- a/src/Sparrow.Server/Utils/Sorting.cs
+++ b/src/Sparrow.Server/Utils/Sorting.cs
@@ -7,9 +7,7 @@ namespace Sparrow.Server.Utils
 {
     internal static class Sorting
     {
-        public static int SortAndMergeDuplicates<T, W>(Span<T> values, Span<W> itemsAssociated)
-            where T : unmanaged, IBinaryNumber<T>
-            where W : unmanaged, IAdditionOperators<W, W, W>
+        public static int SortAndMinOnDuplicates(Span<long> values, Span<float> itemsAssociated)
         {
             if (values.Length <= 1)
                 return values.Length;
@@ -21,7 +19,7 @@ namespace Sparrow.Server.Utils
             {
                 if (values[i] == values[outputIdx])
                 {
-                    itemsAssociated[outputIdx] += itemsAssociated[i];
+                    itemsAssociated[outputIdx] = Math.Min(itemsAssociated[outputIdx], itemsAssociated[i]);
                 }
                 else
                 {

--- a/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
+++ b/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
@@ -202,12 +202,12 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
     }
 
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
-    public void SortAndMergeDuplicatesShouldWork()
+    public void SortAndMinOnDuplicatesShouldWork()
     {
         Span<long> values = [2, 1, 2, 3];
         Span<float> itemsAssociated = [0.5f, 0.4f, 0.5f, 0.7f];
 
-        var length = Sorting.SortAndMergeDuplicates(values, itemsAssociated);
+        var length = Sorting.SortAndMinOnDuplicates(values, itemsAssociated);
 
         Assert.Equal(3, length);
     
@@ -216,7 +216,7 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
         Assert.Equal(3, values[2]);
 
         Assert.Equal(0.4f, itemsAssociated[0]);
-        Assert.Equal(1.0f, itemsAssociated[1]);
+        Assert.Equal(0.5f, itemsAssociated[1]);
         Assert.Equal(0.7f, itemsAssociated[2]);
     }
     

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -441,7 +441,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public async Task MultiVectorSearchSumsDuplicates(Options options)
+    public async Task MultiVectorSearchMinOnDuplicates(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -469,7 +469,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
                     .ToList();
                 
                 Assert.Equal(2, multiVectorTextualQueryResult.Count);
-                Assert.Equal("fruit", multiVectorTextualQueryResult.First().TextualValue);
+                Assert.Equal("pizza", multiVectorTextualQueryResult.First().TextualValue);
             }
         }
     }

--- a/test/SlowTests/SparrowTests/SortAndMergeDuplicatesTests.cs
+++ b/test/SlowTests/SparrowTests/SortAndMergeDuplicatesTests.cs
@@ -15,7 +15,7 @@ public class SortAndMergeDuplicatesTests(ITestOutputHelper output) : NoDisposalN
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
-    public void MergeDuplicatesAndSortShouldWork(int seed)
+    public void MinOnDuplicatesAndSortShouldWork(int seed)
     {
         var random = new Random(seed);
         var totalElementsNumber = random.Next(1, 1024);
@@ -35,14 +35,14 @@ public class SortAndMergeDuplicatesTests(ITestOutputHelper output) : NoDisposalN
         var valuesCopy = (float[])values.Clone();
         
         // This works in place
-        var uniqueCount = Sorting.SortAndMergeDuplicates(arrayWithRepetitions.AsSpan(), values.AsSpan());
+        var uniqueCount = Sorting.SortAndMinOnDuplicates(arrayWithRepetitions.AsSpan(), values.AsSpan());
         
         // Do the same work using LINQ
         var result = arrayWithRepetitionsCopy.Zip(valuesCopy)
             .GroupBy(x => x.First)
             .Select(group => (
                     Id: group.Key,
-                    Value: group.Sum(x => x.Second)
+                    Value: group.Min(x => x.Second)
                 )
             )
             .ToArray();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25411

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation:
- MultiVectorSearch order
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
