### PR TITLE
RavenDB-25426 - add patch for remote attachment

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/PutAttachmentCommandData.cs
@@ -49,7 +49,7 @@ namespace Raven.Client.Documents.Commands.Batches
         public string ContentType { get; }
         public CommandType Type { get; } = CommandType.AttachmentPUT;
         public RemoteAttachmentParameters RemoteParameters { get; }
-        public string Hash { get; }
+        internal string Hash { get; }
         internal bool FromEtl { get; }
         internal long? SizeInBytes { get; }
 

--- a/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
@@ -16,7 +16,8 @@ namespace Raven.Server.Documents.Patch
         public readonly DynamicJsonArray AppendTimeSeries = new DynamicJsonArray();
         public readonly DynamicJsonArray IncrementTimeSeries = new DynamicJsonArray();
         public readonly DynamicJsonArray DeleteTimeSeries = new DynamicJsonArray();
-     
+        public readonly DynamicJsonArray RemoteAttachments = new DynamicJsonArray();
+
         public DynamicJsonValue GetDebugActions()
         {
             return new DynamicJsonValue
@@ -32,7 +33,8 @@ namespace Raven.Server.Documents.Patch
                 [nameof(GetTimeSeries)] = new DynamicJsonArray(GetTimeSeries.Items),
                 [nameof(AppendTimeSeries)] = new DynamicJsonArray(AppendTimeSeries.Items),
                 [nameof(IncrementTimeSeries)] = new DynamicJsonArray(IncrementTimeSeries.Items),
-                [nameof(DeleteTimeSeries)] = new DynamicJsonArray(DeleteTimeSeries.Items)
+                [nameof(DeleteTimeSeries)] = new DynamicJsonArray(DeleteTimeSeries.Items),
+                [nameof(RemoteAttachments)] = new DynamicJsonArray(RemoteAttachments.Items)
             };
         }
 
@@ -50,6 +52,7 @@ namespace Raven.Server.Documents.Patch
             AppendTimeSeries.Clear();
             IncrementTimeSeries.Clear();
             DeleteTimeSeries.Clear();
+            RemoteAttachments.Clear();
         }
     }
 }

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -191,7 +191,8 @@ namespace Raven.Server.Documents.Patch
                 {
                     DocumentCompareResult compareResult = default;
                     bool shouldUpdateMetadata = nonPersistentFlags.HasFlag(NonPersistentDocumentFlags.ResolveCountersConflict) ||
-                                                nonPersistentFlags.HasFlag(NonPersistentDocumentFlags.ResolveTimeSeriesConflict);
+                                                nonPersistentFlags.HasFlag(NonPersistentDocumentFlags.ResolveTimeSeriesConflict) ||
+                                                nonPersistentFlags.HasFlag(NonPersistentDocumentFlags.ResolveAttachmentsConflict);
 
                     if (shouldUpdateMetadata == false)
                     {
@@ -298,6 +299,7 @@ namespace Raven.Server.Documents.Patch
         {
             var nonPersistentFlags = AddResolveFlagOrUpdateRelatedDocuments(context, id, run.DocumentCountersToUpdate, resolveFlag: NonPersistentDocumentFlags.ResolveCountersConflict);
             nonPersistentFlags |= AddResolveFlagOrUpdateRelatedDocuments(context, id, run.DocumentTimeSeriesToUpdate, resolveFlag: NonPersistentDocumentFlags.ResolveTimeSeriesConflict);
+            nonPersistentFlags |= AddResolveFlagOrUpdateRelatedDocuments(context, id, run.DocumentAttachmentsToUpdate, resolveFlag: NonPersistentDocumentFlags.ResolveAttachmentsConflict);
 
             return nonPersistentFlags;
         }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -235,6 +235,24 @@ namespace Raven.Server.Documents.Patch
             return TimeSeriesRetriever.ParseDateTime(arg.AsString());
         }
 
+        private static DateTime GetRemoteAttachmentAtArg(JsValue arg, string signature, string argName)
+        {
+            if (arg.IsDate())
+                return arg.AsDate().ToDateTime().EnsureUtc();
+
+            if (arg.IsString() == false)
+                throw new ArgumentException($"{signature} : {argName} must be of type 'DateInstance' or a DateTime string. {GetTypes(arg)}");
+
+            var valueAsStr = arg.AsString();
+
+            if (DateTime.TryParseExact(valueAsStr, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var attachmentRemoteAt) == false)
+                throw new ArgumentException($"Unable to parse the value of remote attachment 'At' parameter . Got: {valueAsStr}{Environment.NewLine}" +
+                                            $"The supported time formats are:{Environment.NewLine}" +
+                                            $"{string.Join(Environment.NewLine, DefaultFormat.DateTimeFormatsToRead.OrderBy(f => f.Length))}");
+
+            return attachmentRemoteAt.EnsureUtc();
+        }
+
         private static string GetTypes(JsValue value) => $"JintType({value.Type}) .NETType({value.GetType().Name})";
 
         public sealed class SingleRun
@@ -271,10 +289,12 @@ namespace Raven.Server.Documents.Patch
             private readonly ConcurrentLruRegexCache _regexCache;
             public HashSet<string> DocumentCountersToUpdate;
             public HashSet<string> DocumentTimeSeriesToUpdate;
+            public HashSet<string> DocumentAttachmentsToUpdate;
             public JavaScriptUtils JavaScriptUtils;
 
             private const string _timeSeriesSignature = "timeseries(doc, name)";
             private const string _unarchiveSignature = "unarchive(doc)";
+            private const string _attachmentsSignature = "attachments(doc, name)";
             public const string GetMetadataMethod = "getMetadata";
 
             public SingleRun(DocumentDatabase database, RavenConfiguration configuration, ScriptRunner runner, List<Prepared<Script>> scriptsSource, bool ignoreValidationErrors)
@@ -373,7 +393,8 @@ namespace Raven.Server.Documents.Patch
                 //TimeSeries
                 ScriptEngine.SetClrFunc("timeseries", TimeSeries);
                 ScriptEngine.Execute(ScriptRunnerCache.PolyfillJs);
-
+                //Attachments
+                ScriptEngine.SetClrFunc("attachments", Attachments);
                 // Clr Functions, apply if any
                 if (runner._clrFunctions != null)
                 {
@@ -808,6 +829,55 @@ namespace Raven.Server.Documents.Patch
                 }
 
                 return new JsArray(ScriptEngine, entries.ToArray());
+            }
+
+            private JsValue Attachments(JsValue self, JsValue[] args)
+            {
+                AssertValidDatabaseContext(_attachmentsSignature);
+
+                if (args.Length != 2)
+                    throw new ArgumentException($"{_attachmentsSignature}: This method requires 2 arguments but was called with {args.Length}");
+
+                var obj = new JsObject(ScriptEngine);
+                obj.SetClfFunc("remote", (thisObj, values) => RemoteAttachments(thisObj.Get("doc"), thisObj.Get("name"), values));
+                obj.FastSetDataProperty("doc", args[0]);
+                obj.FastSetDataProperty("name", args[1]);
+
+                return obj;
+            }
+
+            private JsValue RemoteAttachments(JsValue document, JsValue name, JsValue[] args)
+            {
+                AssertValidDatabaseContext("attachments(doc, name).remote");
+                const string signature2Args = "attachments(doc, name).remote(identifier, at)";
+
+                if (args.Length != 2)
+                    throw new ArgumentException($"There is no overload with {args.Length} arguments for this method should be {signature2Args} ");
+
+                var (id, doc) = GetIdAndDocFromArg(document, _attachmentsSignature);
+
+                string attachmentName = GetStringArg(name, _attachmentsSignature, "name");
+                string identifier = GetStringArg(args[0], signature2Args, "identifier");
+                var at = GetRemoteAttachmentAtArg(args[1], signature2Args, "at");
+
+                _database.DocumentsStorage.AttachmentsStorage.RemoteAttachmentsStorage.PutRemoteAttachmentFromPatch(_docsCtx, doc, id, attachmentName, identifier, at);
+
+                DocumentAttachmentsToUpdate ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                DocumentAttachmentsToUpdate.Add(id);
+
+                if (DebugMode)
+                {
+                    DebugActions.RemoteAttachments.Add(new DynamicJsonValue
+                    {
+                        ["DocId"] = id,
+                        ["DocData"] = doc.ToString(),
+                        ["Name"] = attachmentName,
+                        ["Identifier"] = identifier,
+                        ["At"] = at,
+                    });
+                }
+
+                return JsValue.Undefined;
             }
 
             private void GenericSortTwoElementArray(JsValue[] args, [CallerMemberName] string caller = null)
@@ -2222,6 +2292,7 @@ namespace Raven.Server.Documents.Patch
                 CompareExchangeValueIncludes?.Clear();
                 DocumentCountersToUpdate?.Clear();
                 DocumentTimeSeriesToUpdate?.Clear();
+                DocumentAttachmentsToUpdate?.Clear();
                 PutOrDeleteCalled = false;
                 UnarchiveCalled = false;
                 OriginalDocumentId = null;
@@ -2312,6 +2383,7 @@ namespace Raven.Server.Documents.Patch
 
                 _run.DocumentCountersToUpdate?.Clear();
                 _run.DocumentTimeSeriesToUpdate?.Clear();
+                _run.DocumentAttachmentsToUpdate?.Clear();
 
                 _holder.Parent.ReturnRunner(_holder);
                 _run = null;

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -2,12 +2,14 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Extensions;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Documents.BackgroundWork;
@@ -248,17 +250,6 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
         return downloader.StreamForDownloadDestination(Database, folderName, objKeyName);
     }
 
-    private static unsafe LazyStringValue GetStringFromIdSlice(DocumentsOperationContext context, Slice identifierSlice)
-    {
-        var lzs = context.GetLazyStringValue(identifierSlice.Content.Ptr, out bool success);
-        if (success == false)
-        {
-            throw new InvalidOperationException($"Failed to get string from id: {identifierSlice}");
-        }
-
-        return lzs;
-    }
-
     public long TryUpdateRemoteAttachment(DocumentsOperationContext context, DateTime? newRemoteAtDt, long currentDt, string newIdentifier, string currentIdentifier, Slice keySlice)
     {
         // Handle case where there's no current upload date
@@ -307,6 +298,38 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<Attachment
 
         remoteAt = remoteAtDt.Value.Ticks;
         Put(context, keySlice, remoteAtDt.Value.GetDefaultRavenFormat(), identifier);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PutRemoteAttachmentFromPatch(DocumentsOperationContext context, BlittableJsonReaderObject document, string docId, string attachmentName, string identifier, DateTime at)
+    {
+        if (document.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
+            metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
+            return;
+
+        var attachmentsStorage = Database.DocumentsStorage.AttachmentsStorage;
+        foreach (BlittableJsonReaderObject attachment in attachments)
+        {
+            if (attachment.TryGet(nameof(AttachmentName.Name), out LazyStringValue name) == false ||
+                attachment.TryGet(nameof(AttachmentName.ContentType), out LazyStringValue contentType) == false ||
+                attachment.TryGet(nameof(AttachmentName.Hash), out LazyStringValue hash) == false ||
+                attachment.TryGet(nameof(AttachmentName.Size), out long size) == false)
+                throw new ArgumentException($"The attachment info is missing a mandatory value: {attachment}");
+
+            if (name == attachmentName)
+            {
+                if (attachment.TryGet(nameof(AttachmentName.RemoteParameters), out BlittableJsonReaderObject readerObject) && readerObject != null)
+                {
+                    RemoteAttachmentParameters current = JsonDeserializationClient.RemoteAttachmentParameters(readerObject);
+                    if (current.IsRemoteStorageAttachment())
+                        throw new InvalidOperationException($"Cannot update remote attachment '{name}' in document '{docId}' because it is already marked as remote.");
+                }
+
+                attachmentsStorage.PutAttachment(context, docId, name, contentType, hash, size, new RemoteAttachmentParameters(identifier, at), stream: null,
+                    updateDocument: false); // we will update the document in PatchDocumentCommand
+                break;
+            }
+        }
     }
 
     public RemoteAttachmentsSender UpdateRemoteAttachmentsFromDatabaseRecord(DatabaseRecord dbRecord, RemoteAttachmentsSender remoteAttachmentsSender)

--- a/test/SlowTests/Server/Documents/Attachments/RemoteAttachmentsHolder.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RemoteAttachmentsHolder.cs
@@ -88,7 +88,7 @@ public abstract class RemoteAttachmentsHolder<TSettings> : RemoteAttachmentsHold
         await DeleteObjects(Settings);
     }
 
-    public async Task PopulateDocsWithRandomAttachments(DocumentStore store, string identifier, int size, List<(string Id, string Collection)> ids, int attachmentsPerDoc, int start = 0)
+    public async Task PopulateDocsWithRandomAttachments(DocumentStore store, string identifier, int size, List<(string Id, string Collection)> ids, int attachmentsPerDoc, int start = 0, bool remote = true)
     {
         // put attachments
         foreach (var (id, collection) in ids)
@@ -109,7 +109,12 @@ public abstract class RemoteAttachmentsHolder<TSettings> : RemoteAttachmentsHold
                 var profileStream = new MemoryStream(b);
                 var name = $"test_{i + start}.png";
 
-                var remoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3));
+                RemoteAttachmentParameters remoteParameters = null;
+                if (remote)
+                {
+                    remoteParameters = new RemoteAttachmentParameters(identifier, DateTime.UtcNow.AddMinutes(3));
+                }
+
                 await store.Operations.SendAsync(new PutAttachmentOperation(id, new StoreAttachmentParameters(name, profileStream)
                 {
                     RemoteParameters = remoteParameters,

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -39,6 +39,103 @@ namespace SlowTests.Server.Documents.Attachments
         {
         }
 
+        [AmazonS3RetryTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanPatchRemoteAttachments(bool patchMultiple)
+        {
+            int attachmentsCount = 2;
+            int size = 3;
+            await using (var holder = CreateCloudSettings())
+            {
+                using (var store = GetDocumentStore())
+                {
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+
+                    var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+                    await CreateDocs(store, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(store, identifier, size, ids, attachmentsPerDoc, remote: false);
+
+                    var id = ids.First().Id;
+
+                    var database = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
+                    GetStorageAttachmentsMetadataFromAllAttachments(database);
+                    Assert.Equal(attachmentsCount, Attachments.Count);
+                    var att1 = Attachments.First().Name;
+                    var att2 = Attachments.Last().Name;
+                    using (AttachmentResult att = await store.Operations.SendAsync(new GetAttachmentOperation(id, att1, AttachmentType.Document, null)))
+                    {
+                        Assert.Equal(att.Details.Name, att1);
+                        Assert.Null(att.Details.RemoteParameters);
+                    }
+
+                    if (patchMultiple)
+                    {
+                        using (AttachmentResult att = await store.Operations.SendAsync(new GetAttachmentOperation(id, att2, AttachmentType.Document, null)))
+                        {
+                            Assert.Equal(att.Details.Name, att2);
+                            Assert.Null(att.Details.RemoteParameters);
+                        }
+                    }
+
+                    var dt = DateTime.UtcNow.AddMinutes(3);
+
+                    var patch = new PatchRequest
+                    {
+                        Script = "attachments(this, args.name).remote(args.identifier, args.at);",
+                        Values =
+                        {
+                            { "name", att1 },
+                            { "identifier", identifier },
+                            { "at", dt },
+                        }
+                    };
+
+                    var result = await store.Operations.SendAsync(new PatchOperation(id, null, patch));
+                    Assert.Equal(result, PatchStatus.Patched);
+                    if (patchMultiple)
+                    {
+                        patch.Values["name"] = att2;
+                        var result2 = await store.Operations.SendAsync(new PatchOperation(id, null, patch));
+                        Assert.Equal(result2, PatchStatus.Patched);
+                    }
+
+                    using (AttachmentResult att = await store.Operations.SendAsync(new GetAttachmentOperation(id, att1, AttachmentType.Document, null)))
+                    {
+                        Assert.Equal(att.Details.Name, att1);
+                        Assert.NotNull(att.Details.RemoteParameters);
+
+                        Assert.Equal(identifier, att.Details.RemoteParameters.Identifier);
+                        Assert.Equal(dt, att.Details.RemoteParameters.At);
+                    }
+
+                    if (patchMultiple)
+                    {
+                        using (AttachmentResult att = await store.Operations.SendAsync(new GetAttachmentOperation(id, att2, AttachmentType.Document, null)))
+                        {
+                            Assert.Equal(att.Details.Name, att2);
+                            Assert.NotNull(att.Details.RemoteParameters);
+
+                            Assert.Equal(identifier, att.Details.RemoteParameters.Identifier);
+                            Assert.Equal(dt, att.Details.RemoteParameters.At);
+                        }
+                    }
+
+                    // move in time & start remote
+                        database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                    var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, patchMultiple ? 2 : 1, 15_000);
+                    Assert.Equal(patchMultiple ? 2 : 1, cloudObjects.Count);
+
+                    var stats = store.Maintenance.Send(new GetDetailedStatisticsOperation());
+                    Assert.Equal(patchMultiple ? 2 : 1, stats.CountOfRemoteAttachments);
+                    Assert.Equal(2, stats.CountOfAttachments);
+                }
+            }
+        }
+
         [AmazonS3RetryFact]
         public async Task RemoteAttachmentWithDisabledIdentifierShouldBeSkipped()
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25426/Remote-attachments-Server-Side-Patch-Phase-1

### Additional description

This pull request introduces support for patching remote attachments via JavaScript patch scripts in RavenDB. It adds a new `attachments(doc, name).remote(identifier, at)` function to the patch scripting engine, updates the server-side logic to handle remote attachment patching, and includes comprehensive tests to verify the new functionality. The changes are grouped below by theme.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
