### PR TITLE
RavenDB-25324: Introduce dedicated DocumentEntryId

### DIFF
--- a/src/Corax/Indexing/DocumentEntryId.cs
+++ b/src/Corax/Indexing/DocumentEntryId.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace Corax.Indexing
+{
+    /// <summary>
+    /// Strongly-typed document entry identifier. Prevents confusion with ContainerEntryId (storage layer)
+    /// since both were represented as raw longs. The type system now catches ID misuse at compile time,
+    /// eliminating bugs like deduplication failures, duplicate processing, corruption, and wrong query results.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = sizeof(long))]
+    public readonly struct DocumentEntryId : IEquatable<DocumentEntryId>, IComparable<DocumentEntryId>
+    {
+        [FieldOffset(0)]
+        private readonly long _id;
+
+        public DocumentEntryId(long id)
+        {
+            _id = id;
+        }
+
+        public static readonly DocumentEntryId Invalid = new(-1);
+
+        public bool IsValid => _id > 0;
+        public bool IsEmpty => _id == 0;
+
+        public static explicit operator long(DocumentEntryId entryId) => entryId._id;
+        public static explicit operator DocumentEntryId(long id) => new(id);
+
+        public bool Equals(DocumentEntryId other) => _id == other._id;
+        public override bool Equals(object obj) => obj is DocumentEntryId other && Equals(other);
+        public override int GetHashCode() => _id.GetHashCode();
+        public override string ToString() => $"{nameof(DocumentEntryId)}({_id})";
+
+        public int CompareTo(DocumentEntryId other) => _id.CompareTo(other._id);
+
+        public static bool operator ==(DocumentEntryId left, DocumentEntryId right) => left._id == right._id;
+        public static bool operator !=(DocumentEntryId left, DocumentEntryId right) => left._id != right._id;
+        public static bool operator <(DocumentEntryId left, DocumentEntryId right) => left._id < right._id;
+        public static bool operator >(DocumentEntryId left, DocumentEntryId right) => left._id > right._id;
+        public static bool operator <=(DocumentEntryId left, DocumentEntryId right) => left._id <= right._id;
+        public static bool operator >=(DocumentEntryId left, DocumentEntryId right) => left._id >= right._id;
+
+        /// <summary>
+        /// Reinterprets a Span of DocumentEntryId as a Span of long for performance-critical operations like sorting.
+        /// Safe because DocumentEntryId is explicitly laid out with Size = sizeof(long) and a single long field at offset 0.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<long> AsLongSpan(Span<DocumentEntryId> span)
+        {
+            return MemoryMarshal.Cast<DocumentEntryId, long>(span);
+        }
+
+        /// <summary>
+        /// Reinterprets a ReadOnlySpan of DocumentEntryId as a ReadOnlySpan of long.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ReadOnlySpan<long> AsLongSpan(ReadOnlySpan<DocumentEntryId> span)
+        {
+            return MemoryMarshal.Cast<DocumentEntryId, long>(span);
+        }
+    }
+}

--- a/src/Corax/Indexing/EntriesModifications.cs
+++ b/src/Corax/Indexing/EntriesModifications.cs
@@ -135,21 +135,27 @@ internal unsafe struct EntriesModifications
         Updates = new();
     }
 
-    public void Addition([NotNull] ByteStringContext context, long entryId, int termsPerEntryIndex, short freq, InserterMode termType)
+    /// <summary>
+    /// Records document entry addition. Document-layer API.
+    /// </summary>
+    public void Addition([NotNull] ByteStringContext context, DocumentEntryId entryId, int termsPerEntryIndex, short freq, InserterMode termType)
     {
         if (Additions.HasCapacityFor(1) == false)
             Additions.Grow(context, 1);
         AddToList(ref Additions, entryId, termsPerEntryIndex, freq, termType);
     }
 
-    public void Removal([NotNull] ByteStringContext context, long entryId, int termsPerEntryIndex, short freq, InserterMode termType)
+    /// <summary>
+    /// Records document entry removal. Document-layer API.
+    /// </summary>
+    public void Removal([NotNull] ByteStringContext context, DocumentEntryId entryId, int termsPerEntryIndex, short freq, InserterMode termType)
     {
         if (Removals.HasCapacityFor(1) == false)
             Removals.Grow(context, 1);
         AddToList(ref Removals, entryId, termsPerEntryIndex, freq, termType);
     }
 
-    private void AddToList(ref NativeList<TermInEntryModification> list, long entryId, int termsPerEntryIndex, short freq, InserterMode inserterMode)
+    private void AddToList(ref NativeList<TermInEntryModification> list, DocumentEntryId entryId, int termsPerEntryIndex, short freq, InserterMode inserterMode)
     {
         AssertPreparationIsNotFinished();
         NeedToUpdate = true;
@@ -268,6 +274,7 @@ internal unsafe struct EntriesModifications
         for (int i = 0; i < Additions.Count; i++)
         {
             ref var cur = ref Additions[i];
+            // Encoding boundary: document-layer ID -> storage-layer long
             additions[i] = EntryIdEncodings.Encode(cur.EntryId, cur.Frequency, TermIdMask.Single);
         }
 

--- a/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
+++ b/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
@@ -22,7 +22,7 @@ public partial class IndexWriter
         private NativeList<DocumentEntryId> _entriesForTermsAdditionsBufferEntryId;
         private NativeList<ContainerEntryId> _entriesForTermsAdditionsBufferTermId;
         private readonly List<DocumentEntryId> _additionsForTerm, _removalsForTerm;
-        private readonly HashSet<long> _entriesAlreadyAdded;
+        private readonly HashSet<DocumentEntryId> _entriesAlreadyAdded;
         private ContainerEntryId _termContainerId;
         
         public EntriesToTermsTracker(IndexWriter writer)
@@ -80,7 +80,7 @@ public partial class IndexWriter
             foreach (DocumentEntryId removal in CollectionsMarshal.AsSpan(_removalsForTerm))
             {
                 // if already added, we don't need to remove it in this batch
-                if (_entriesAlreadyAdded.Contains((long)removal))
+                if (_entriesAlreadyAdded.Contains(removal))
                     continue;
                 _entriesForTermsRemovalsBuffer.AddUnsafe(removal);
             }
@@ -93,7 +93,7 @@ public partial class IndexWriter
             
             foreach (DocumentEntryId addition in CollectionsMarshal.AsSpan(_additionsForTerm))
             {
-                if (_entriesAlreadyAdded.Add((long)addition) == false)
+                if (_entriesAlreadyAdded.Add(addition) == false)
                     continue;
                 
                 _entriesForTermsAdditionsBufferEntryId.AddUnsafe(addition);

--- a/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
+++ b/src/Corax/Indexing/IndexWriter.EntriesToTermsTracker.cs
@@ -18,10 +18,10 @@ public partial class IndexWriter
     private class EntriesToTermsTracker : IDisposable
     {
         private readonly IndexWriter _writer;
-        private ContextBoundNativeList<long> _entriesForTermsRemovalsBuffer;
-        private NativeList<long> _entriesForTermsAdditionsBufferEntryId;
+        private ContextBoundNativeList<DocumentEntryId> _entriesForTermsRemovalsBuffer;
+        private NativeList<DocumentEntryId> _entriesForTermsAdditionsBufferEntryId;
         private NativeList<ContainerEntryId> _entriesForTermsAdditionsBufferTermId;
-        private readonly List<long> _additionsForTerm, _removalsForTerm;
+        private readonly List<DocumentEntryId> _additionsForTerm, _removalsForTerm;
         private readonly HashSet<long> _entriesAlreadyAdded;
         private ContainerEntryId _termContainerId;
         
@@ -49,7 +49,7 @@ public partial class IndexWriter
             SetRange(_removalsForTerm, entries.Removals);
             ProcessCurrentEntries();
             
-            void SetRange(List<long> list, in NativeList<TermInEntryModification> span)
+            void SetRange(List<DocumentEntryId> list, in NativeList<TermInEntryModification> span)
             {
                 list.Clear();
                 list.EnsureCapacity(span.Count);
@@ -77,10 +77,10 @@ public partial class IndexWriter
         private void ProcessCurrentEntries()
         {
             _entriesForTermsRemovalsBuffer.EnsureCapacityFor(_removalsForTerm.Count + _entriesForTermsRemovalsBuffer.Count);
-            foreach (long removal in CollectionsMarshal.AsSpan(_removalsForTerm))
+            foreach (DocumentEntryId removal in CollectionsMarshal.AsSpan(_removalsForTerm))
             {
                 // if already added, we don't need to remove it in this batch
-                if (_entriesAlreadyAdded.Contains(removal))
+                if (_entriesAlreadyAdded.Contains((long)removal))
                     continue;
                 _entriesForTermsRemovalsBuffer.AddUnsafe(removal);
             }
@@ -91,9 +91,9 @@ public partial class IndexWriter
             if (_entriesForTermsAdditionsBufferEntryId.HasCapacityFor(_additionsForTerm.Count) == false)
                 _entriesForTermsAdditionsBufferEntryId.Grow(_writer._entriesAllocator, _additionsForTerm.Count);
             
-            foreach (long addition in CollectionsMarshal.AsSpan(_additionsForTerm))
+            foreach (DocumentEntryId addition in CollectionsMarshal.AsSpan(_additionsForTerm))
             {
-                if (_entriesAlreadyAdded.Add(addition) == false)
+                if (_entriesAlreadyAdded.Add((long)addition) == false)
                     continue;
                 
                 _entriesForTermsAdditionsBufferEntryId.AddUnsafe(addition);
@@ -112,13 +112,15 @@ public partial class IndexWriter
             var entriesToTermsTree = _writer._entriesToTermsTree.LookupFor<Int64LookupKey>(fieldName);
             if (_entriesForTermsRemovalsBuffer.Count > 0)
             {
-                Sort.Run(_entriesForTermsRemovalsBuffer.ToSpan());
+                // Sort using long representation since VxSort only supports primitive types
+                var longSpan = DocumentEntryId.AsLongSpan(_entriesForTermsRemovalsBuffer.ToSpan());
+                Sort.Run(longSpan);
 
                 entriesToTermsTree.InitializeCursorState();
 
                 foreach (var entryId in _entriesForTermsRemovalsBuffer)
                 {
-                    Int64LookupKey key = entryId;
+                    Int64LookupKey key = (long)entryId;
                     if (entriesToTermsTree.TryGetNextValue(ref key, out _))
                         entriesToTermsTree.TryRemoveExistingValue(ref key, out _);
                 }
@@ -132,7 +134,7 @@ public partial class IndexWriter
                 entriesToTermsTree.InitializeCursorState();
                 for (int idX = 0; idX < _entriesForTermsAdditionsBufferEntryId.Count; ++idX)
                 {
-                    Int64LookupKey key = entriesIds[idX];
+                    Int64LookupKey key = (long)entriesIds[idX];
                     entriesToTermsTree.TryGetNextValue(ref key, out _);
                     entriesToTermsTree.AddOrSetAfterGetNext(ref key, (long)entriesTerms[idX]);
                 }

--- a/src/Corax/Indexing/IndexWriter.Exceptions.cs
+++ b/src/Corax/Indexing/IndexWriter.Exceptions.cs
@@ -19,7 +19,7 @@ public partial class IndexWriter
             $"Attempt to remove term: '{term}' for field {indexedFieldName}, but it does not exists! This is a bug.");
     }
     
-    private static void ThrowMoreThanOneRemovalFoundForSingleItem(long idInTree, in EntriesModifications entries, long existingEntryId, short existingFrequency)
+    private static void ThrowMoreThanOneRemovalFoundForSingleItem(long idInTree, in EntriesModifications entries, DocumentEntryId existingEntryId, short existingFrequency)
     {
         throw new InvalidOperationException($"More than one removal found for a single item, which is impossible. " +
                                             $"{Environment.NewLine}Current tree id: {idInTree}" +

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -19,14 +19,14 @@ public partial class IndexWriter
     public sealed class IndexEntryBuilder :  IIndexEntryBuilder, IDisposable
     {
         private readonly IndexWriter _parent;
-        private long _entryId;
+        private DocumentEntryId _entryId;
         private int _termPerEntryIndex;
         public bool Active;
         private int _buildingList;
         private Slice _documentId;
         private bool _mapFinishedSuccessfully = false;
 
-        public long EntryId => _entryId;
+        public DocumentEntryId EntryId => _entryId;
 
         public IndexEntryBuilder(IndexWriter parent)
         {
@@ -38,7 +38,7 @@ public partial class IndexWriter
             _parent.BoostEntry(_entryId, boost);
         }
 
-        public void Init(long entryId, int termsPerEntryIndex, Slice documentId)
+        public void Init(DocumentEntryId entryId, int termsPerEntryIndex, Slice documentId)
         {
             Active = true;
             _mapFinishedSuccessfully = false;
@@ -263,7 +263,7 @@ public partial class IndexWriter
         private void RecordSpatialPointForEntry(IndexedField field, (double Lat, double Lng) coords)
         {
             field.Spatial ??= new();
-            ref var terms = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Spatial, _entryId, out var exists);
+            ref var terms = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Spatial, (long)_entryId, out var exists);
             if (exists == false)
             {
                 terms = new IndexedField.SpatialEntry {Locations = new List<(double, double)>(), TermsPerEntryIndex = _termPerEntryIndex};

--- a/src/Corax/Indexing/IndexWriter.Testing.cs
+++ b/src/Corax/Indexing/IndexWriter.Testing.cs
@@ -37,7 +37,7 @@ public partial class IndexWriter
                     keysPtr[i] = keys[i];
                     if ((keys[i] & (long)TermIdMask.EnsureIsSingleMask) != 0)
                     {
-                        keysPtr[i] = EntryIdEncodings.GetContainerId(keys[i]);
+                        keysPtr[i] = (long)EntryIdEncodings.GetContainerId(keys[i]);
                         continue;
                     }
 

--- a/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
+++ b/src/Corax/Indexing/IndexWriter.TextualFieldInserter.cs
@@ -551,7 +551,7 @@ public unsafe partial class IndexWriter
 
                 // Decoding the posting list id yields the container root that stores the posting list. We keep it as
                 // ContainerId so later steps talk to the correct root instead of a payload slot.
-                long containerId = EntryIdEncodings.GetContainerId(cur);
+                long containerId = (long)EntryIdEncodings.GetContainerId(cur);
                 postingListPagesProcessingBuffer.Add(containerId / Voron.Global.Constants.Storage.PageSize);
             }
 

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -46,7 +46,7 @@ namespace Corax.Indexing
         // Structures used for document boosting. BoostedDocs is an in-memory cache for all documents that have been boosted during indexing.
         // DocumentBoost is a fixed tree that contains persisted boost values.
         private FixedSizeTree _documentBoost;
-        private List<(long EntryId, float Boost)> _boostedDocs;
+        private List<(DocumentEntryId EntryId, float Boost)> _boostedDocs;
         
         private Tree _indexMetadata;
         private long _numberOfTermModifications;
@@ -310,7 +310,7 @@ namespace Corax.Indexing
 
             _indexedEntries.Add(keySlice); // Register entry by key.
             int index = InsertTermsPerEntry(entryId);
-            _entryBuilder.Init(entryId, index, keySlice);
+            _entryBuilder.Init(new DocumentEntryId(entryId), index, keySlice);
             return _entryBuilder;
         }
 
@@ -337,7 +337,7 @@ namespace Corax.Indexing
                 DisablePaginationBasedOnEntryIdSupport();
 
             int index = InsertTermsPerEntry(entryId);
-            _entryBuilder.Init(entryId, index, keySlice);
+            _entryBuilder.Init(new DocumentEntryId(entryId), index, keySlice);
             return _entryBuilder;
         }
 
@@ -365,7 +365,7 @@ namespace Corax.Indexing
         /// </summary>
         /// <param name="entryId">Document id</param>
         /// <param name="documentBoost">Document boost value</param>
-        private void BoostEntry(long entryId, float documentBoost)
+        private void BoostEntry(DocumentEntryId entryId, float documentBoost)
         {
             if (documentBoost.AlmostEquals(1f))
             {
@@ -386,10 +386,10 @@ namespace Corax.Indexing
 
 
         /// <summary>Remove a document boosting from the tree.</summary>
-        /// <param name="entryId">Container id of entry (without encodings)</param>
-        private void RemoveDocumentBoost(long entryId)
+        /// <param name="entryId">Document entry id</param>
+        private void RemoveDocumentBoost(DocumentEntryId entryId)
         {
-            _documentBoost.Delete(entryId);
+            _documentBoost.Delete((long)entryId);
         }
 
         private IndexedField GetDynamicIndexedField(ByteStringContext context, string currentFieldName)
@@ -561,7 +561,7 @@ namespace Corax.Indexing
                     ThrowUnableToLocateEntry(entryToDelete);
 
                 ContainerEntryId entryTermsId = (ContainerEntryId)entryTermsIdLong;
-                RemoveDocumentBoost(entryToDelete);
+                RemoveDocumentBoost(new DocumentEntryId(entryToDelete));
                 Container.Get(_transaction.LowLevelTransaction, entryTermsId, out var entryTerms);
                 var termsPerEntryIndex = InsertTermsPerEntry(entryToDelete);
                 RecordTermDeletionsForEntry(entryTerms, _transaction.LowLevelTransaction, _fieldsByRootPage, _nullTermsMarkers, _nonExistingTermsMarkers,
@@ -622,7 +622,7 @@ namespace Corax.Indexing
                 }
 
                 ref var term = ref field.Storage.GetAsRef(termLocation);
-                term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
+                term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
                 scope.Dispose();
 
                 if (reader.HasNumeric == false)
@@ -636,7 +636,7 @@ namespace Corax.Indexing
                 }
 
                 term = ref field.Storage.GetAsRef(termLocation);
-                term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
+                term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, freq: 1, InserterMode.Numerical);
 
                 termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Doubles, reader.CurrentDouble, out exists);
                 if (exists == false)
@@ -646,7 +646,7 @@ namespace Corax.Indexing
                 }
 
                 term = ref field.Storage.GetAsRef(termLocation);
-                term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
+                term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, freq: 1, InserterMode.Numerical);
             }
         }
 
@@ -661,7 +661,7 @@ namespace Corax.Indexing
             }
 
             ref var term = ref field.Storage.GetAsRef(termLocation);
-            term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
+            term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
         }
 
         public Dictionary<long, string> GetIndexedFieldNamesByRootPage()
@@ -740,7 +740,7 @@ namespace Corax.Indexing
                     // we'll delete them, but treat this as a _new_ entry, not an update to an existing
                     // one
                     RecordAndPrepareDocumentsIdsForDeletion(containerId, out var setsAreDisjoint, out var isSingleDocument, out var singleDocumentEntryId);
-                    entryId = isSingleDocument ? singleDocumentEntryId : Constants.IndexSearcher.InvalidId;
+                    entryId = isSingleDocument ? (long)singleDocumentEntryId : Constants.IndexSearcher.InvalidId;
 
                     Debug.Assert(isSingleDocument || setsAreDisjoint,
                         $"A single document can be deleted twice (delete + update), however if it's not a single document, the sets are supposed to be disjoint.");
@@ -877,33 +877,36 @@ namespace Corax.Indexing
         /// <param name="idInTree">With frequencies and container type.</param>
         /// <param name="setsAreDisjoint">Intersection between PostingList and _deletedEntries. We may use it as indicator for flushing batch.</param>
         [SkipLocalsInit]
-        private void RecordAndPrepareDocumentsIdsForDeletion(long postingListId, out bool setsAreDisjoint, out bool isSingleDocument, out long singleDocumentEntryId)
+        private void RecordAndPrepareDocumentsIdsForDeletion(long postingListId, out bool setsAreDisjoint, out bool isSingleDocument, out DocumentEntryId singleDocumentEntryId)
         {
             Debug.Assert(_entriesToDelete.Count == 0);
 
             var countOfAlreadyDeletedEntries = _deletedEntries.Count;
             setsAreDisjoint = true;
-            var containerEntryId = (ContainerEntryId)EntryIdEncodings.GetContainerId(postingListId);
 
             if ((postingListId & (long)TermIdMask.EnsureIsSingleMask) == (long)TermIdMask.Single)
             {
-                singleDocumentEntryId = (long)containerEntryId;
-                Debug.Assert(singleDocumentEntryId > 0);
-                var isNewDocument = _deletedEntries.Add((long)containerEntryId);
+                // Encoding duality: TermIdMask.Single stores DocumentEntryId in bits, posting lists store ContainerEntryId.
+                // Use DecodeAndDiscardFrequency for Single, GetContainerId for posting-lists.
+                singleDocumentEntryId = EntryIdEncodings.DecodeAndDiscardFrequency(postingListId);
+                Debug.Assert(singleDocumentEntryId.IsValid);
+                var isNewDocument = _deletedEntries.Add((long)singleDocumentEntryId);
                 if (isNewDocument)
-                    _entriesToDelete.Add(singleDocumentEntryId);
+                    _entriesToDelete.Add((long)singleDocumentEntryId);
                 setsAreDisjoint &= isNewDocument;
                 _numberOfModifications -= _deletedEntries.Count - countOfAlreadyDeletedEntries;
                 isSingleDocument = true;
                 return;
             }
 
+            // For posting lists, extract the container ID
+            var containerEntryId = EntryIdEncodings.GetContainerId(postingListId);
 
             const int bufferSize = 1024;
             var bufferPtr = stackalloc long[bufferSize];
             var buffer = new Span<long>(bufferPtr, bufferSize);
             isSingleDocument = false;
-            singleDocumentEntryId = Constants.IndexSearcher.InvalidId;
+            singleDocumentEntryId = DocumentEntryId.Invalid;
             if ((postingListId & (long)TermIdMask.PostingList) != 0)
             {
                 var setSpace = Container.GetMutable(_transaction.LowLevelTransaction, containerEntryId);
@@ -1093,7 +1096,7 @@ namespace Corax.Indexing
             _boostedDocs.Sort();
             foreach (var (entryId, documentBoost) in _boostedDocs)
             {
-                using var __ = _documentBoost.DirectAdd(entryId, out _, out byte* boostPtr);
+                using var __ = _documentBoost.DirectAdd((long)entryId, out _, out byte* boostPtr);
                 float* floatBoostPtr = (float*)boostPtr;
                 *floatBoostPtr = documentBoost;
             }
@@ -1204,7 +1207,7 @@ namespace Corax.Indexing
             var containerId = EntryIdEncodings.GetContainerId(idInTree);
 
             var llt = _transaction.LowLevelTransaction;
-            Container.GetMutable(llt, new ContainerEntryId(containerId), out var item);
+            Container.GetMutable(llt, containerId, out var item);
 
             Debug.Assert(entries.Removals.ToSpan().ToArray().Distinct().Count() == entries.Removals.Count, $"Removals list is not distinct.");
 
@@ -1241,7 +1244,7 @@ namespace Corax.Indexing
 
             if (_smallPostingListWorkingBuffer.Count == 0)
             {
-                Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
+                Container.Delete(llt, _postingListContainerId, containerId);
                 termIdInTree = Constants.IndexSearcher.InvalidId;
                 return AddEntriesToTermResult.RemoveTermId;
             }
@@ -1257,13 +1260,13 @@ namespace Corax.Indexing
             {
                 var mutableSpace = item.ToSpan();
                 encoded.CopyTo(mutableSpace);
-
+                
                 // can update in place
                 termIdInTree = Constants.IndexSearcher.InvalidId;
                 return AddEntriesToTermResult.NothingToDo;
             }
 
-            Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
+            Container.Delete(llt, _postingListContainerId, containerId);
 
             termIdInTree = AllocatedSpaceForSmallSet(encoded, llt, out Span<byte> space);
 
@@ -1274,15 +1277,18 @@ namespace Corax.Indexing
 
         private long AllocatedSpaceForSmallSet(Span<byte> encoded, LowLevelTransaction llt, out Span<byte> space)
         {
-            long termIdInTree = (long)Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
+            // Allocate returns storage-level ContainerEntryId
+            ContainerEntryId termIdInTree = Container.Allocate(llt, _postingListContainerId, encoded.Length, out space);
 
-            return EntryIdEncodings.Encode(termIdInTree, 0, TermIdMask.SmallPostingList);
+            // Encode for storage: cast ContainerEntryId to long
+            return EntryIdEncodings.Encode((long)termIdInTree, 0, TermIdMask.SmallPostingList);
         }
 
         private AddEntriesToTermResult AddEntriesToTermResultSingleValue(Span<byte> tmpBuf, long idInTree, ref EntriesModifications entries, out long termId)
         {
             entries.AssertPreparationIsNotFinished();
 
+            // Decode returns document-layer ID and frequency from encoded storage value
             var (existingEntryId, existingFrequency) = EntryIdEncodings.Decode(idInTree);
 
             // In case when existingEntryId and only addition is the same:
@@ -1297,7 +1303,7 @@ namespace Corax.Indexing
                 {
                     Debug.Assert(entries.Removals.Count == 0 || entries.Removals.ToSpan()[0].EntryId == existingEntryId);
 
-                    var newId = EntryIdEncodings.Encode(single.EntryId, single.Frequency, (long)TermIdMask.Single);
+                    var newId = EntryIdEncodings.Encode(single.EntryId, single.Frequency, TermIdMask.Single);
                     if (newId == idInTree)
                     {
                         termId = Constants.IndexSearcher.InvalidId;
@@ -1341,7 +1347,7 @@ namespace Corax.Indexing
                 if (isIncluded == false)
                 {
                     // We are not processing recorded terms for this document because it already exists on the disk. We do not have to know the actual term type.
-                    entries.Addition(_entriesAllocator, existingEntryId, -1, existingFrequency, InserterMode.Ignore); 
+                    entries.Addition(_entriesAllocator, existingEntryId, -1, existingFrequency, InserterMode.Ignore);
                 }
             }
 
@@ -1361,7 +1367,7 @@ namespace Corax.Indexing
         {
             var containerId = EntryIdEncodings.GetContainerId(id);
             var llt = _transaction.LowLevelTransaction;
-            var setSpace = Container.GetMutable(llt, new ContainerEntryId(containerId));
+            var setSpace = Container.GetMutable(llt, containerId);
             ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
 
             entries.GetEncodedAdditionsAndRemovals(_entriesAllocator, out var additions, out var removals);
@@ -1378,8 +1384,8 @@ namespace Corax.Indexing
 
                 llt.FreePage(postingListState.RootPage);
 
-                Container.Delete(llt, _postingListContainerId, new ContainerEntryId(containerId));
-                RemovePostingListFromLargePostingListsSet(containerId);
+                Container.Delete(llt, _postingListContainerId, containerId);
+                RemovePostingListFromLargePostingListsSet((long)containerId);
 
                 return AddEntriesToTermResult.RemoveTermId;
             }
@@ -1431,7 +1437,7 @@ namespace Corax.Indexing
             {
                 entries.AssertPreparationIsNotFinished();
                 ref var single = ref entries.Additions.ToSpan()[0];
-                termId = EntryIdEncodings.Encode(single.EntryId, single.Frequency, (long)TermIdMask.Single);
+                termId = EntryIdEncodings.Encode(single.EntryId, single.Frequency, TermIdMask.Single);
                 return;
             }
 

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -99,7 +99,7 @@ namespace Corax.Indexing
         // Example:
         // _termsPerEntryIds: [(Index: 0, Value: 1 (docId))]
         // _termsPerEntryId: [0: [(id(): "Doc1"), (Field1: "Term1")], ...]
-        private NativeList<long> _termsPerEntryIds;
+        private NativeList<DocumentEntryId> _termsPerEntryIds;
         private NativeList<NativeList<RecordedTerm>> _termsPerEntryId;
         
         // Private context used by the index writer to store temporary data during an indexing process. We do not want to grow transaction's allocator too much for temporary data.
@@ -310,11 +310,11 @@ namespace Corax.Indexing
 
             _indexedEntries.Add(keySlice); // Register entry by key.
             int index = InsertTermsPerEntry(entryId);
-            _entryBuilder.Init(new DocumentEntryId(entryId), index, keySlice);
+            _entryBuilder.Init(entryId, index, keySlice);
             return _entryBuilder;
         }
 
-        private int InsertTermsPerEntry(long entryId)
+        private int InsertTermsPerEntry(DocumentEntryId entryId)
         {
             int index = _termsPerEntryId.Count;
             _termsPerEntryId.EnsureCapacityFor(_entriesAllocator, 1);
@@ -328,7 +328,7 @@ namespace Corax.Indexing
 
         public IndexEntryBuilder Index(ReadOnlySpan<byte> key)
         {
-            long entryId = InitBuilder();
+            DocumentEntryId entryId = InitBuilder();
 
             // We do not dispose because we will be storing the slice in the hash set.
             Slice.From(_transaction.Allocator, key, ByteStringType.Immutable, out var keySlice);
@@ -337,7 +337,7 @@ namespace Corax.Indexing
                 DisablePaginationBasedOnEntryIdSupport();
 
             int index = InsertTermsPerEntry(entryId);
-            _entryBuilder.Init(new DocumentEntryId(entryId), index, keySlice);
+            _entryBuilder.Init(entryId, index, keySlice);
             return _entryBuilder;
         }
 
@@ -347,7 +347,7 @@ namespace Corax.Indexing
             _indexMetadata.Add(Constants.IndexWriter.PaginationBasedOnEntryIdSupportStatus, (long)EntryIdPaginationSupportStatus.Disabled);
         }
 
-        private long InitBuilder()
+        private DocumentEntryId InitBuilder()
         {
             if (_entryBuilder.Active)
                 ThrowPreviousBuilderIsNotDisposed();
@@ -355,7 +355,7 @@ namespace Corax.Indexing
             _numberOfModifications++;
             var entryId = ++_lastEntryId;
 
-            return entryId;
+            return new DocumentEntryId(entryId);
         }
 
         /// <summary>
@@ -560,12 +560,13 @@ namespace Corax.Indexing
                 if (_entryIdToLocation.TryRemove(entryToDelete, out var entryTermsIdLong) == false)
                     ThrowUnableToLocateEntry(entryToDelete);
 
+                var documentToDelete = new DocumentEntryId(entryToDelete);
                 ContainerEntryId entryTermsId = (ContainerEntryId)entryTermsIdLong;
-                RemoveDocumentBoost(new DocumentEntryId(entryToDelete));
+                RemoveDocumentBoost(documentToDelete);
                 Container.Get(_transaction.LowLevelTransaction, entryTermsId, out var entryTerms);
-                var termsPerEntryIndex = InsertTermsPerEntry(entryToDelete);
+                var termsPerEntryIndex = InsertTermsPerEntry(documentToDelete);
                 RecordTermDeletionsForEntry(entryTerms, _transaction.LowLevelTransaction, _fieldsByRootPage, _nullTermsMarkers, _nonExistingTermsMarkers,
-                    _compactTreeDictionaryId, entryToDelete, termsPerEntryIndex);
+                    _compactTreeDictionaryId, documentToDelete, termsPerEntryIndex);
 
 
                 Container.Delete(_transaction.LowLevelTransaction, _entriesTermsContainerId, (ContainerEntryId)entryTermsId);
@@ -575,7 +576,7 @@ namespace Corax.Indexing
         }
 
         private void RecordTermDeletionsForEntry(Container.Item entryTerms, LowLevelTransaction llt, Dictionary<long, IndexedField> fieldsByRootPage,
-            HashSet<long> nullTermMarkers, HashSet<long> nonExistingTermMarkers, long dicId, long entryToDelete, int termsPerEntryIndex)
+            HashSet<long> nullTermMarkers, HashSet<long> nonExistingTermMarkers, long dicId, DocumentEntryId entryToDelete, int termsPerEntryIndex)
         {
             var reader = new EntryTermsReader(llt, nullTermMarkers, nonExistingTermMarkers, entryTerms.Address, entryTerms.Length, dicId);
             reader.Reset();
@@ -622,7 +623,7 @@ namespace Corax.Indexing
                 }
 
                 ref var term = ref field.Storage.GetAsRef(termLocation);
-                term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
+                term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
                 scope.Dispose();
 
                 if (reader.HasNumeric == false)
@@ -636,7 +637,7 @@ namespace Corax.Indexing
                 }
 
                 term = ref field.Storage.GetAsRef(termLocation);
-                term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, freq: 1, InserterMode.Numerical);
+                term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
 
                 termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Doubles, reader.CurrentDouble, out exists);
                 if (exists == false)
@@ -646,11 +647,11 @@ namespace Corax.Indexing
                 }
 
                 term = ref field.Storage.GetAsRef(termLocation);
-                term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, freq: 1, InserterMode.Numerical);
+                term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
             }
         }
 
-        private void RemoveMarkerTerm(IndexedField field, EntryTermsReader reader, Slice termSlice, long entryToDelete, int termsPerEntryIndex)
+        private void RemoveMarkerTerm(IndexedField field, EntryTermsReader reader, Slice termSlice, DocumentEntryId entryToDelete, int termsPerEntryIndex)
         {
             ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, termSlice, out var exists);
             if (exists == false)
@@ -661,7 +662,7 @@ namespace Corax.Indexing
             }
 
             ref var term = ref field.Storage.GetAsRef(termLocation);
-            term.Removal(_entriesAllocator, new DocumentEntryId(entryToDelete), termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
+            term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, reader.Frequency, InserterMode.ExactInsert);
         }
 
         public Dictionary<long, string> GetIndexedFieldNamesByRootPage()
@@ -727,7 +728,7 @@ namespace Corax.Indexing
             return TryDeleteEntry(termSlice, out _);
         }
 
-        private bool TryDeleteEntry(Slice termSlice, out long entryId)
+        private bool TryDeleteEntry(Slice termSlice, out DocumentEntryId entryId)
         {
             if (_indexedEntries.Contains(termSlice) == false)
             {
@@ -740,7 +741,7 @@ namespace Corax.Indexing
                     // we'll delete them, but treat this as a _new_ entry, not an update to an existing
                     // one
                     RecordAndPrepareDocumentsIdsForDeletion(containerId, out var setsAreDisjoint, out var isSingleDocument, out var singleDocumentEntryId);
-                    entryId = isSingleDocument ? (long)singleDocumentEntryId : Constants.IndexSearcher.InvalidId;
+                    entryId = isSingleDocument ? singleDocumentEntryId : DocumentEntryId.Invalid;
 
                     Debug.Assert(isSingleDocument || setsAreDisjoint,
                         $"A single document can be deleted twice (delete + update), however if it's not a single document, the sets are supposed to be disjoint.");
@@ -750,7 +751,7 @@ namespace Corax.Indexing
                     return isSingleDocument;
                 }
 
-                entryId = Constants.IndexSearcher.InvalidId;
+                entryId = DocumentEntryId.Invalid;
                 return false;
             }
 
@@ -837,7 +838,7 @@ namespace Corax.Indexing
 
             _tempListBuffer = new(_entriesAllocator);
             _termsPerEntryId = new NativeList<NativeList<RecordedTerm>>();
-            _termsPerEntryIds = new NativeList<long>();
+            _termsPerEntryIds = new NativeList<DocumentEntryId>();
             _numberOfModifications = 0;
             _numberOfTermModifications = 0;
             _initialNumberOfEntries = _indexMetadata?.ReadInt64(Constants.IndexWriter.NumberOfEntriesSlice) ?? 0;
@@ -1120,7 +1121,7 @@ namespace Corax.Indexing
                 ContainerEntryId entryTermsId = Container.Allocate(_transaction.LowLevelTransaction, _entriesTermsContainerId, size, out var space);
                 writer.Write(space);
 
-                _entryIdToLocation.Add(termsPerEntryIds[i], (long)entryTermsId);
+                _entryIdToLocation.Add((long)termsPerEntryIds[i], (long)entryTermsId);
             }
         }
 

--- a/src/Corax/Indexing/TermInEntryModification.cs
+++ b/src/Corax/Indexing/TermInEntryModification.cs
@@ -5,7 +5,8 @@ namespace Corax.Indexing;
 
 internal struct TermInEntryModification : IEquatable<TermInEntryModification>, IComparable<TermInEntryModification>
 {
-    public long EntryId;
+    // Document entry ID (index-layer identifier, not storage-layer ContainerEntryId)
+    public DocumentEntryId EntryId;
     public int TermsPerEntryIndex; 
     public short Frequency;
     
@@ -17,7 +18,7 @@ internal struct TermInEntryModification : IEquatable<TermInEntryModification>, I
 
     public override string ToString() => EntryId + ", " + Frequency;
 
-    public TermInEntryModification(long entryId, int termPerEntryIndex, short frequency, InserterMode inserterMode)
+    public TermInEntryModification(DocumentEntryId entryId, int termPerEntryIndex, short frequency, InserterMode inserterMode)
     {
         EntryId = entryId;
         TermsPerEntryIndex = termPerEntryIndex;

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -171,7 +171,7 @@ public partial class IndexSearcher
         else if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
         {
             var smallSetId = EntryIdEncodings.GetContainerId(containerId);
-            Container.Get(_transaction.LowLevelTransaction, new ContainerEntryId(smallSetId), out var small);
+            Container.Get(_transaction.LowLevelTransaction, smallSetId, out var small);
             matches = TermMatch.YieldSmall(this, Allocator, small, termRatioToWholeCollection, field.HasBoost);
         }
         else
@@ -185,7 +185,7 @@ public partial class IndexSearcher
     public PostingList GetPostingList(long containerId)
     {
         var setId = EntryIdEncodings.GetContainerId(containerId);
-        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(setId));
+        var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, setId);
 
         ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
         var set = new PostingList(_transaction.LowLevelTransaction, Slices.Empty, setState);
@@ -257,7 +257,7 @@ public partial class IndexSearcher
         if ((containerId & (long)TermIdMask.PostingList) != 0)
         {
             var setId = EntryIdEncodings.GetContainerId(containerId);
-            var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(setId));
+            var setStateSpan = Container.GetReadOnly(_transaction.LowLevelTransaction, setId);
             ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             return setState.NumberOfEntries;
         }
@@ -265,7 +265,7 @@ public partial class IndexSearcher
         if ((containerId & (long)TermIdMask.SmallPostingList) != 0)
         {
             var smallSetId = EntryIdEncodings.GetContainerId(containerId);
-            var small = Container.GetReadOnly(_transaction.LowLevelTransaction, new ContainerEntryId(smallSetId));
+            var small = Container.GetReadOnly(_transaction.LowLevelTransaction, smallSetId);
             var itemsCount = VariableSizeEncoding.Read<int>(small, out _);
 
             return itemsCount;

--- a/src/Corax/Querying/Matches/MultiTermMatch.cs
+++ b/src/Corax/Querying/Matches/MultiTermMatch.cs
@@ -198,7 +198,7 @@ namespace Corax.Querying.Matches
                         switch (termType)
                         {
                             case TermIdMask.Single:
-                                long entryId = EntryIdEncodings.GetContainerId(postingListId);
+                                long entryId = (long)EntryIdEncodings.GetContainerId(postingListId);
                                 if (entryId <= _max)
                                     sortedIds[currentIdx++] = entryId;
                                 postingListCalls++;
@@ -253,7 +253,7 @@ namespace Corax.Querying.Matches
                     if (termType == TermIdMask.SmallPostingList)
                     {
                         // Always has sufficient capacity due to the BufferSize constraint
-                        _smallPostListIds.AddByRefUnsafe() = EntryIdEncodings.GetContainerId(_itBuffer[i]);
+                        _smallPostListIds.AddByRefUnsafe() = (long)EntryIdEncodings.GetContainerId(_itBuffer[i]);
                     }
                 }
                 
@@ -266,7 +266,7 @@ namespace Corax.Querying.Matches
 
             private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)
             {
-                if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx + read - 1]) > _max)
+                if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || (long)EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx + read - 1]) > _max)
                     _postListIt = default;
                 
                 EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx..], read);

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -324,7 +324,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                     switch (termType)
                     {
                         case TermIdMask.Single:
-                            long entryId = EntryIdEncodings.GetContainerId(postingListId);
+                            long entryId = (long)EntryIdEncodings.GetContainerId(postingListId);
                             if(entryId >= _min && entryId <= _max)
                                 sortedIds[currentIdx++] = entryId;
                             break;
@@ -373,7 +373,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                 if (termType == TermIdMask.SmallPostingList)
                 {
                     var smallSetId = EntryIdEncodings.GetContainerId(_itBuffer[i]);
-                    _smallPostListIds.Add(smallSetId);
+                    _smallPostListIds.Add((long)smallSetId);
                 }
             }
 
@@ -386,7 +386,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
 
         private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)
         {
-            if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx + read - 1]) > _max)
+            if (_postListIt.Fill(sortedIds[currentIdx..], out var read) == false || (long)EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds[currentIdx + read - 1]) > _max)
                 _postListIt = default;
 
             EntryIdEncodings.DecodeAndDiscardFrequency(sortedIds.Slice(currentIdx), read);

--- a/src/Corax/Querying/Matches/TermMatch.cs
+++ b/src/Corax/Querying/Matches/TermMatch.cs
@@ -173,7 +173,7 @@ namespace Corax.Querying.Matches
             {
                 _current = bm25Relevance is not null
                     ? current
-                    : EntryIdEncodings.DecodeAndDiscardFrequency(value),
+                    : (long)EntryIdEncodings.DecodeAndDiscardFrequency(value),
                 _bm25Relevance = bm25Relevance,
                 _returnedValue = false
             };
@@ -237,7 +237,7 @@ namespace Corax.Querying.Matches
                         long current = decodedMatches[decodedIndex];
                         long decodedEntryId = typeof(TBoostingMode) == typeof(HasBoosting)
                             ? term._bm25Relevance.Add(current)
-                            : EntryIdEncodings.DecodeAndDiscardFrequency(current);
+                            : (long)EntryIdEncodings.DecodeAndDiscardFrequency(current);
 
                         while (buffer[bufferIndex] < decodedEntryId)
                         {
@@ -332,11 +332,11 @@ namespace Corax.Querying.Matches
                     if (it.Fill(postingListBuffer, out var postingListCount, maxValidValue) == false || postingListCount == 0)
                         break;
                     
-                    var postingListMinValue = EntryIdEncodings.DecodeAndDiscardFrequency(Unsafe.Add(ref postingListStartPtr, 0));
+                    var postingListMinValue = (long)EntryIdEncodings.DecodeAndDiscardFrequency(Unsafe.Add(ref postingListStartPtr, 0));
                     if (matchesMax < postingListMinValue)
                         continue;
                     
-                    var postingListMaxValue = EntryIdEncodings.DecodeAndDiscardFrequency(Unsafe.Add(ref postingListStartPtr, postingListCount - 1));
+                    var postingListMaxValue = (long)EntryIdEncodings.DecodeAndDiscardFrequency(Unsafe.Add(ref postingListStartPtr, postingListCount - 1));
                     var matchesMinValue = Unsafe.Add(ref matchesStartPtr, matchesIdx);
                     if (postingListMaxValue < matchesMinValue)
                         continue;
@@ -345,7 +345,7 @@ namespace Corax.Querying.Matches
                     while (postingListIdx < postingListCount && matchesIdx < matchesCount)
                     {
                         var currentMatchesMin = Unsafe.Add(ref matchesStartPtr, matchesIdx);
-                        var currentPostingListMin = EntryIdEncodings.DecodeAndDiscardFrequency(Unsafe.Add(ref postingListStartPtr, postingListIdx));
+                        var currentPostingListMin = (long)EntryIdEncodings.DecodeAndDiscardFrequency(Unsafe.Add(ref postingListStartPtr, postingListIdx));
                         
                         if (typeof(TBoostingMode) == typeof(HasBoosting) && currentMatchesMin == currentPostingListMin)
                             term._bm25Relevance.Add(Unsafe.Add(ref postingListStartPtr, postingListIdx));

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.Exists.cs
@@ -195,7 +195,7 @@ namespace Corax.Querying.Matches.TermProviders
                 if ((termCount[i] & (long)TermIdMask.EnsureIsSingleMask) != 0)
                 {
                     Debug.Assert((termCount[i] & (long)TermIdMask.PostingList) != 0 || (termCount[i] & (long)TermIdMask.SmallPostingList) != 0);
-                    containersIds[i] = EntryIdEncodings.GetContainerId(termCount[i]);
+                    containersIds[i] = (long)EntryIdEncodings.GetContainerId(termCount[i]);
                     continue;
                 }
                 

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.NumericRange.cs
@@ -250,12 +250,12 @@ namespace Corax.Querying.Matches.TermProviders
                 
                 if ((termId & (long)TermIdMask.PostingList) != 0)
                 {
-                    postingLists.Add(allocator, EntryIdEncodings.GetContainerId(termId));
+                    postingLists.Add(allocator, (long)EntryIdEncodings.GetContainerId(termId));
                     postingListsType.Add(allocator, TermIdMask.PostingList);
                 }
                 else if ((termId & (long)TermIdMask.SmallPostingList) != 0)
                 {
-                    postingLists.Add(allocator, EntryIdEncodings.GetContainerId(termId));
+                    postingLists.Add(allocator, (long)EntryIdEncodings.GetContainerId(termId));
                     postingListsType.Add(allocator, TermIdMask.SmallPostingList);
                 }
                 else

--- a/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
+++ b/src/Corax/Querying/Matches/TermProviders/TermProvider.TermRange.cs
@@ -251,12 +251,12 @@ public struct TermRangeProvider<TLookupIterator, TLow, THigh> : ITermProvider, I
             
             if ((termId & (long)TermIdMask.PostingList) != 0)
             {
-                postingLists.Add(allocator, EntryIdEncodings.GetContainerId(termId));
+                postingLists.Add(allocator, (long)EntryIdEncodings.GetContainerId(termId));
                 postingListsType.Add(allocator, TermIdMask.PostingList);
             }
             else if ((termId & (long)TermIdMask.SmallPostingList) != 0)
             {
-                postingLists.Add(allocator, EntryIdEncodings.GetContainerId(termId));
+                postingLists.Add(allocator, (long)EntryIdEncodings.GetContainerId(termId));
                 postingListsType.Add(allocator, TermIdMask.SmallPostingList);
             }
             else

--- a/src/Corax/Utils/Bm25Relevance.cs
+++ b/src/Corax/Utils/Bm25Relevance.cs
@@ -159,12 +159,14 @@ public sealed unsafe class Bm25Relevance : IDisposable
     public long Add(long entry)
     {
         if (IsStored == false)
-            return EntryIdEncodings.Decode(entry).EntryId;
+            return (long)EntryIdEncodings.Decode(entry).EntryId;
 
-        (*(_matchBuffer + _currentId), *(_scoreBuffer + _currentId)) = EntryIdEncodings.Decode(entry);
+        var decoded = EntryIdEncodings.Decode(entry);
+        *(_matchBuffer + _currentId) = (long)decoded.EntryId;
+        *(_scoreBuffer + _currentId) = decoded.Frequency;
         _currentId += 1;
 
-        return *(_matchBuffer + _currentId - 1);
+        return (long)*(_matchBuffer + _currentId - 1);
     }
 
     [DoesNotReturn]

--- a/src/Corax/Utils/EntryIdEncodings.cs
+++ b/src/Corax/Utils/EntryIdEncodings.cs
@@ -9,6 +9,7 @@ using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
 using Corax.Indexing;
 using Sparrow;
+using Voron.Data.Containers;
 
 namespace Corax.Utils;
 
@@ -28,6 +29,9 @@ public static class EntryIdEncodings
     private const byte ContainerTypeOffset = 2;
     private const long MaxEntryId = 1L << 54;
 
+    /// <summary>
+    /// Encodes storage-layer container IDs. Used when encoding ContainerEntryId (cast to long).
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static long Encode(long entryId, short count, TermIdMask containerType)
     {
@@ -37,21 +41,32 @@ public static class EntryIdEncodings
     }
 
     /// <summary>
-    /// Returns id of entry without offset and frequency
+    /// Type-safe overload for document entry IDs. Prefer this to avoid accidentally passing
+    /// a container ID where a document ID is expected.
     /// </summary>
-    /// <param name="entryId"></param>
-    /// <returns></returns>
-    public static (long EntryId, short Frequency) Decode(long entryId)
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static long Encode(DocumentEntryId entryId, short count, TermIdMask containerType)
     {
-        return (entryId >> EntryIdOffset, FrequencyReconstructionFromQuantization(((entryId >> ContainerTypeOffset) & Mask)));
+        return Encode((long)entryId, count, containerType);
     }
 
     /// <summary>
-    /// Container id (page) without encodings.
+    /// Returns both the document entry ID and frequency from an encoded value.
     /// </summary>
-    public static long GetContainerId(long entryId)
+    public static (DocumentEntryId EntryId, short Frequency) Decode(long entryId)
     {
-        return (entryId >> EntryIdOffset);
+        var rawId = entryId >> EntryIdOffset;
+        var freq = FrequencyReconstructionFromQuantization(((entryId >> ContainerTypeOffset) & Mask));
+        return (new DocumentEntryId(rawId), freq);
+    }
+
+    /// <summary>
+    /// Extracts the storage container ID from a posting list encoding.
+    /// For single-document entries (TermIdMask.Single), use DecodeAndDiscardFrequency instead.
+    /// </summary>
+    public static ContainerEntryId GetContainerId(long entryId)
+    {
+        return new ContainerEntryId(entryId >> EntryIdOffset);
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
@@ -64,9 +79,10 @@ public static class EntryIdEncodings
             entryId = (entryId << EntryIdOffset) | (FrequencyQuantization(frequency) << ContainerTypeOffset);
         }
     }
-
+    
+    // Decodes single-document entries (TermIdMask.Single) to DocumentEntryId, discarding frequency.
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-    public static long DecodeAndDiscardFrequency(long entryId) => entryId >> EntryIdOffset;
+    public static DocumentEntryId DecodeAndDiscardFrequency(long entryId) => new DocumentEntryId(entryId >> EntryIdOffset);
 
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static void DecodeAndDiscardFrequencyVector256(Span<long> entries, int read)

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -43,7 +43,7 @@ public class FacetIndexingRepro : StorageTest
         using (var builder = iw.Index("entryKey"))
         {
             builder.Write(0, Encoding.UTF8.GetBytes(entryKey));
-            entryId = builder.EntryId;
+            entryId = (long)builder.EntryId;
             builder.EndWriting();
         }
         iw.Commit();

--- a/test/FastTests/Corax/Bugs/IndexEntryReaderBigDoc.cs
+++ b/test/FastTests/Corax/Bugs/IndexEntryReaderBigDoc.cs
@@ -36,7 +36,7 @@ public class IndexEntryReaderBigDoc : StorageTest
             {
                 writer.Write(0, "users/1"u8);
 
-                entryId = writer.EntryId;
+                entryId = (long)writer.EntryId;
                 
                 writer.IncrementList();
                 {

--- a/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
+++ b/test/FastTests/Corax/Bugs/OptimizedUpdatesOnIndexes.cs
@@ -29,7 +29,7 @@ public class OptimizedUpdatesOnIndexes : StorageTest
                 entry.Write(0, "cars/1"u8);
                 entry.Write(1, "Lightning"u8);
                 entry.Write(2, "12"u8);
-                oldId = entry.EntryId;
+                oldId = (long)entry.EntryId;
                 entry.EndWriting();
             }
             
@@ -53,7 +53,7 @@ public class OptimizedUpdatesOnIndexes : StorageTest
                 entry.Write(0, "cars/1"u8);
                 entry.Write(1, "Lightning"u8);
                 entry.Write(2, "13"u8);
-                newId = entry.EntryId;
+                newId = (long)entry.EntryId;
                 entry.EndWriting();
             }
             

--- a/test/FastTests/Corax/Bugs/RavenDB-19283.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-19283.cs
@@ -45,7 +45,7 @@ public class RavenDB_19283 : StorageTest
                 writer.Write(0, Encoding.UTF8.GetBytes("users/1"));
                 var tags = Enumerable.Range(0, 10000).Select(x => options[x % options.Length]);
 
-                entryId = writer.EntryId;
+                entryId = (long)writer.EntryId;
                 
                 writer.IncrementList();
                 {

--- a/test/FastTests/Corax/Bugs/RavenDB_24217.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB_24217.cs
@@ -33,7 +33,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
                     builder.Write(PrimaryKey, entry.PrimaryKeyBytes);
                     builder.Write(SecondaryKey, entry.SecondaryKeyBytes);
                     builder.EndWriting();
-                    entriesIds[i] = builder.EntryId;
+                    entriesIds[i] = (long)builder.EntryId;
                 }
             }
 
@@ -53,7 +53,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
                     builder.Write(PrimaryKey, entry.PrimaryKeyBytes);
                     builder.Write(SecondaryKey, entry.SecondaryKeyBytes);
                     builder.EndWriting();
-                    entry.EntryId = builder.EntryId;
+                    entry.EntryId = (long)builder.EntryId;
                 }
             }
 
@@ -136,7 +136,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
                 builder.Write(SecondaryKey, "1"u8);
                 builder.EndWriting();
 
-                doc1Id = builder.EntryId;
+                doc1Id = (long)builder.EntryId;
             }
 
             using (var builder = writer.Update("doc/0"u8))
@@ -145,7 +145,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
                 builder.Write(SecondaryKey, "0"u8);
                 builder.EndWriting();
 
-                doc0Id = builder.EntryId;
+                doc0Id = (long)builder.EntryId;
             }
 
             writer.Commit();
@@ -230,7 +230,7 @@ public class RavenDB_24217(ITestOutputHelper output) : StorageTest(output)
                     builder.Write(PrimaryKey, newEntry.PrimaryKeyBytes);
                     builder.Write(SecondaryKey, Encodings.Utf8.GetBytes(docId.ToString()));
                     builder.EndWriting();
-                    newEntry.EntryId = builder.EntryId;
+                    newEntry.EntryId = (long)builder.EntryId;
                 }
             }
 

--- a/test/FastTests/Corax/DynamicFieldsTests.cs
+++ b/test/FastTests/Corax/DynamicFieldsTests.cs
@@ -47,7 +47,7 @@ public unsafe class DynamicFieldsTests : StorageTest
             {
                 writer.Write(Constants.IndexWriter.DynamicField, fieldName, Encoding.UTF8.GetBytes(""));
                 writer.Write(0, "users/1"u8);
-                entryId = writer.EntryId;
+                entryId = (long)writer.EntryId;
                 writer.EndWriting();
             }
             indexWriter.Commit();
@@ -250,7 +250,7 @@ public unsafe class DynamicFieldsTests : StorageTest
                 entry.Write(1, "Oren"u8);
                 entry.Write(Constants.IndexWriter.DynamicField,"Name", "Oren"u8);
                 entry.EndWriting();
-                documentId = entry.EntryId;
+                documentId = (long)entry.EntryId;
             }
             writer.Commit();
         }
@@ -451,7 +451,7 @@ public unsafe class DynamicFieldsTests : StorageTest
                     }
                 }
                 writer.DecrementList();
-                entryId = writer.EntryId;
+                entryId = (long)writer.EntryId;
                 writer.EndWriting();
             }
             indexWriter.Commit();

--- a/test/FastTests/Corax/EntriesModificationsTests.cs
+++ b/test/FastTests/Corax/EntriesModificationsTests.cs
@@ -19,15 +19,15 @@ public class EntriesModificationsTests : NoDisposalNeeded
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
         var entries = new EntriesModifications(0);
         
-        entries.Addition(bsc, 2, -1, 1, InserterMode.ExactInsert);
-        entries.Removal(bsc, 1, -1,1, InserterMode.ExactInsert);
-        entries.Addition(bsc, 3, -1,1, InserterMode.ExactInsert);
-        entries.Removal(bsc, 2, -1,1, InserterMode.ExactInsert);
+        entries.Addition(bsc, new DocumentEntryId(2), -1, 1, InserterMode.ExactInsert);
+        entries.Removal(bsc, new DocumentEntryId(1), -1,1, InserterMode.ExactInsert);
+        entries.Addition(bsc, new DocumentEntryId(3), -1,1, InserterMode.ExactInsert);
+        entries.Removal(bsc, new DocumentEntryId(2), -1,1, InserterMode.ExactInsert);
         entries.Prepare(bsc);
 
         AssertEntriesCase(ref entries);
         Assert.Equal(1, entries.Updates.Count);
-        Assert.Equal(2, entries.Updates.ToSpan()[0].EntryId);
+        Assert.Equal(new DocumentEntryId(2), entries.Updates.ToSpan()[0].EntryId);
     }
     private static void AssertEntriesCase(ref EntriesModifications entries)
     {

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -1995,7 +1995,7 @@ namespace FastTests.Corax
                     }
                 }
 
-                entry.IndexEntryId = builder.EntryId;
+                entry.IndexEntryId = (long)builder.EntryId;
                 builder.EndWriting();
             }
             indexWriter.Commit();

--- a/test/SlowTests/Corax/DeleteTest.cs
+++ b/test/SlowTests/Corax/DeleteTest.cs
@@ -92,8 +92,8 @@ public class DeleteTest : StorageTest
             var terms = fields?.CompactTreeFor("Content");
             Assert.True(terms!.TryGetValue("9", out var containerId));
             Assert.NotEqual(0, containerId & (long)TermIdMask.PostingList);
-            var setId = EntryIdEncodings.DecodeAndDiscardFrequency(containerId);
-            var setStateSpan = Container.GetMutable(llt, (ContainerEntryId)setId);
+            var setId = EntryIdEncodings.GetContainerId(containerId);
+            var setStateSpan = Container.GetMutable(llt, setId);
             ref var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
             using var _ = Slice.From(llt.Allocator, "Content", ByteStringType.Immutable, out var fieldName);
             var set = new PostingList(llt, fieldName, in setState);
@@ -111,7 +111,7 @@ public class DeleteTest : StorageTest
                     for (int i = 0; i < total; i++)
                     {
                         var current = buffer[i];
-                        Assert.False(previousIds.BinarySearch(EntryIdEncodings.DecodeAndDiscardFrequency(current)) >= 0);
+                        Assert.False(previousIds.BinarySearch((long)EntryIdEncodings.DecodeAndDiscardFrequency(current)) >= 0);
                     }
                 }
             }

--- a/test/SlowTests/Corax/RavenDB-22469.cs
+++ b/test/SlowTests/Corax/RavenDB-22469.cs
@@ -37,7 +37,7 @@ public class RavenDB_22469(ITestOutputHelper output) : StorageTest(output)
                 builder.Write(1, Encodings.Utf8.GetBytes($"_{e - i}"));
                 builder.DecrementList();
                 builder.EndWriting();
-                entriesIds.Add(builder.EntryId);
+                entriesIds.Add((long)builder.EntryId);
             }
             indexWriter.Commit();
         }

--- a/test/SlowTests/Issues/RavenDB-24529.cs
+++ b/test/SlowTests/Issues/RavenDB-24529.cs
@@ -36,7 +36,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
         {
             using (var builder = writer.Index("doc1"))
             {
-                doc1Id = builder.EntryId;
+                doc1Id = (long)builder.EntryId;
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc1"));
                 builder.IncrementList();
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"));
@@ -47,7 +47,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
 
             using (var builder = writer.Index("doc2"))
             {
-                doc2Id = builder.EntryId;
+                doc2Id = (long)builder.EntryId;
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc2"));
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"), 1, 1.0);
                 builder.EndWriting();
@@ -55,7 +55,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
 
             using (var builder = writer.Index("doc3"))
             {
-                doc3Id = builder.EntryId;
+                doc3Id = (long)builder.EntryId;
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc3"));
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"), 1, 1.0);
                 builder.EndWriting();
@@ -134,7 +134,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
         {
             using (var builder = writer.Index("doc1"))
             {
-                doc1Id = builder.EntryId;
+                doc1Id = (long)builder.EntryId;
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc1"));
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"));
                 builder.EndWriting();
@@ -142,7 +142,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
 
             using (var builder = writer.Index("doc2"))
             {
-                doc2Id = builder.EntryId;
+                doc2Id = (long)builder.EntryId;
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc2"));
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"), 1, 1.0);
                 builder.EndWriting();
@@ -150,7 +150,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
 
             using (var builder = writer.Index("doc3"))
             {
-                doc3Id = builder.EntryId;
+                doc3Id = (long)builder.EntryId;
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc3"));
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"), 1, 1.0);
                 builder.EndWriting();
@@ -298,21 +298,21 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
         {
             if (fieldPath != "Int" || fieldId != 1)
                 return;
-            intTextualField.Add(builder.EntryId);
+            intTextualField.Add((long)builder.EntryId);
         }
 
         void InsertNumericalValue(string fieldPath, int fieldId)
         {
             if (fieldPath != "Int" || fieldId != 1)
                 return;
-            intNumericalField.Add(builder.EntryId);
-            intTextualField.Add(builder.EntryId);
+            intNumericalField.Add((long)builder.EntryId);
+            intTextualField.Add((long)builder.EntryId);
         }
 
         void UpdateDocument()
         {
-            intTextualField.Remove(builder.EntryId);
-            intNumericalField.Remove(builder.EntryId);
+            intTextualField.Remove((long)builder.EntryId);
+            intNumericalField.Remove((long)builder.EntryId);
         }
 
         void EndWritingPreviousEntry()
@@ -411,7 +411,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
                 {
                     builder.Write(0, "id()", Encodings.Utf8.GetBytes($"doc{i}"));
                     builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"), 1L, 1D);
-                    allNumerical.Add(builder.EntryId);
+                    allNumerical.Add((long)builder.EntryId);
                     builder.EndWriting();
                 }
             }
@@ -438,7 +438,7 @@ public class RavenDB_24529(ITestOutputHelper output) : StorageTest(output)
             {
                 builder.Write(0, "id()", Encodings.Utf8.GetBytes("doc1"));
                 builder.Write(1, "Int", Encodings.Utf8.GetBytes("1"), 1L, 1D);
-                allNumerical.Add(builder.EntryId);
+                allNumerical.Add((long)builder.EntryId);
                 builder.EndWriting();
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25324

### Additional description

Following the work in RavenDB-25323, we're introducing DocumentEntryId to prevent confusion between document entry IDs (index layer) and container entry IDs (storage layer). Both were just longs before, which meant the compiler couldn't catch us if we accidentally mixed them up. To make matters worse, frequency is also encoded into the posting list longs making the errors even more subtle.

This matters because mixing these IDs causes nasty bugs that only show up later: deduplication breaks, documents get indexed twice, the index gets corrupted, or queries return wrong results. The kind of bugs that surface weeks or months after they're introduced.

Now the type system catches these mistakes at compile time. You have to explicitly cast at layer boundaries, which makes it obvious in code review when we're crossing from one layer to another.

Key changes:
- Added DocumentEntryId struct (zero-cost wrapper around long)
- Updated collections to use DocumentEntryId instead of raw longs
- Added typed Encode() overload for document layer operations
- Added comments explaining the encoding duality at critical points

The remaining casts are intentional, mostly at storage boundaries when calling Voron APIs that expect longs.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed 