### PR TITLE
RavenDB-25368 - Fix "revert revision" after loading revisions and then 'SaveChanges'

### DIFF
--- a/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
@@ -79,7 +79,8 @@ namespace Raven.Client.Documents.Session.Operations
                 ChangeVector = metadata.GetChangeVector(),
                 Document = document,
                 Metadata = metadata,
-                Entity = entity
+                Entity = entity,
+                IgnoreChanges = true
             };
             _session.OnAfterConversionToEntityInvoke(id, document, entity);
 

--- a/test/SlowTests/Issues/RavenDB-25368.cs
+++ b/test/SlowTests/Issues/RavenDB-25368.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25368 : RavenTestBase
+    {
+        public RavenDB_25368(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Revisions | RavenTestCategory.ClientApi)]
+        public async Task LoadedRevisionsBecomingBatchCommandsAndChangesTheDoc()
+        {
+            const string id = "testObjs/1-A";
+
+            using var store = GetDocumentStore();
+
+            await RevisionsHelper.SetupRevisionsAsync(store, configuration: new RevisionsConfiguration
+            {
+                Default = new RevisionsCollectionConfiguration()
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var testObj = new TestObjV1 { Version = "v1" };
+                await session.StoreAsync(testObj, id);
+                await session.SaveChangesAsync();
+
+                testObj.Version = "v2";
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var obj = await session.LoadAsync<TestObjV2>(id);
+                await session.Advanced.Revisions.GetForAsync<TestObjV2>(obj.Id);
+
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var testObj = await session.LoadAsync<TestObjV1>(id);
+                var version = testObj.Version;
+                Assert.NotNull(version);
+                Assert.NotEmpty(version);
+                Assert.Equal("v2", version);
+            }
+        }
+
+        public class TestObjV1
+        {
+            public string Id { get; set; }
+            public string Version { get; set; }
+        }
+
+        public class TestObjV2
+        {
+            public string Id { get; set; }
+
+            public DateTime CreatedDate { get; set; }
+            public string CreatedByUserName { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25368/Unexpected-revert-revision

### Additional description

Fix "revert revision" after loading revisions and then 'SaveChanges'.
When user load revisions as different type (that looks different then the original doc form) and then 'SaveChanges',
the revisions 'entities' are treaten as a doc change => on creating the batch command, it looks like it's a document change (different properties) so it's being added as a change (command) to the batch command and changes the doc.
the solution:
On adding revisions entries, make `IgnoreChanges` as true => so it won't be treated as a doc change.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
