### PR TITLE
RavenDB-25429 if we delete the entire database skip checking for rehabs

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -398,10 +398,13 @@ namespace Raven.Server.Documents
             if (directDelete == false)
                 return false;
 
-            if (rawRecord.Topology.Rehabs.Contains(_serverStore.NodeTag) && fromReplication == false)
-                // If the deletion was issued from the cluster observer to maintain the replication factor we need to make sure
-                // that all the documents were replicated from this node, therefore the deletion will be called from the replication code.
-                return false;
+            if (rawRecord.EntireDatabasePendingDeletion() == false)
+            {
+                if (rawRecord.Topology.Rehabs.Contains(_serverStore.NodeTag) && fromReplication == false)
+                    // If the deletion was issued from the cluster observer to maintain the replication factor we need to make sure
+                    // that all the documents were replicated from this node, therefore the deletion will be called from the replication code.
+                    return false;
+            }
 
             // We materialize the values here because we close the read transaction
             var record = rawRecord.MaterializedRecord;

--- a/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
+++ b/test/RachisTests/DatabaseCluster/RemoveNodeFromCluster.cs
@@ -10,6 +10,8 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Rachis;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -517,6 +519,193 @@ namespace RachisTests.DatabaseCluster
                     return record.Topology.PriorityOrder.Contains(removed.NodeTag);
                 }, false);
             }
+        }
+
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task CanDeleteRehabRestoreInProgress()
+        {
+            var db = GetDatabaseName();
+            var (_, leader) = await CreateRaftCluster(1, watcherCluster: true);
+            var topology = new DatabaseTopology
+            {
+                Rehabs = new List<string> { "A" },
+                DemotionReasons = new Dictionary<string, string>
+                {
+                    { "A", "Manually In Rehab" }
+                },
+                PromotablesStatus = new Dictionary<string, DatabasePromotionStatus>
+                {
+                    { "A", DatabasePromotionStatus.NotResponding }
+                },
+                Stamp = new LeaderStamp
+                {
+                    Index = 1,
+                    Term = 1,
+                    LeadersTicks = -2
+                },
+                PriorityOrder = [],
+                NodesModifiedAt = DateTime.UtcNow,
+                DatabaseTopologyIdBase64 = "nRZdLNYhrk2izN75386Z6c",
+                ClusterTransactionIdBase64 = "TG/MuQS8UkeY/xznGEcqCa"
+            };
+            var record = new DatabaseRecord(db)
+            {
+                Topology = topology,
+                DeletionInProgress = new Dictionary<string, DeletionInProgressStatus>()
+                {
+                    { "A", DeletionInProgressStatus.HardDelete }
+                },
+                DatabaseState = DatabaseStateStatus.RestoreInProgress
+            };
+            var r = await leader.ServerStore.Engine.PutToLeaderAsync(new AddDatabaseCommand(Guid.NewGuid().ToString())
+            {
+                Name = db,
+                Record = record
+            });
+
+            await leader.ServerStore.Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, r.Index);
+            
+            await AssertWaitForTrueAsync(() =>
+            {
+                using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var names = leader.ServerStore.Cluster.GetDatabaseNames(context);
+                    return Task.FromResult(names.Contains(db) == false);
+                }
+            });
+        }
+
+        [RavenFact(RavenTestCategory.Cluster, Skip = "very rare case, need to figure out a workaround")]
+        public async Task CanDeleteFromNonExistingNode()
+        {
+            var db = GetDatabaseName();
+            var (_, leader) = await CreateRaftCluster(1, watcherCluster: true);
+            var topology = new DatabaseTopology
+            {
+                Rehabs = new List<string> { "A", "B" },
+                DemotionReasons = new Dictionary<string, string>
+                {
+                    { "A", "Manually In Rehab" },
+                    { "B", "Manually In Rehab" }
+                },
+                PromotablesStatus = new Dictionary<string, DatabasePromotionStatus>
+                {
+                    { "A", DatabasePromotionStatus.NotResponding },
+                    { "B", DatabasePromotionStatus.NotResponding }
+                },
+                Stamp = new LeaderStamp
+                {
+                    Index = 1,
+                    Term = 1,
+                    LeadersTicks = -2
+                },
+                PriorityOrder = [],
+                NodesModifiedAt = DateTime.UtcNow,
+                DatabaseTopologyIdBase64 = "nRZdLNYhrk2izN75386Z6c",
+                ClusterTransactionIdBase64 = "TG/MuQS8UkeY/xznGEcqCa"
+            };
+            var record = new DatabaseRecord(db)
+            {
+                Topology = topology,
+                DeletionInProgress = new Dictionary<string, DeletionInProgressStatus>()
+                {
+                    { "A", DeletionInProgressStatus.HardDelete },
+                    { "B", DeletionInProgressStatus.HardDelete }
+                }
+            };
+            var r = await leader.ServerStore.Engine.PutToLeaderAsync(new AddDatabaseCommand(Guid.NewGuid().ToString())
+            {
+                Name = db,
+                Record = record
+            });
+
+            await leader.ServerStore.Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, r.Index);
+
+            using (var store = new DocumentStore
+                   {
+                       Database = db,
+                       Urls = [leader.WebUrl]
+                   }.Initialize())
+            {
+                var getDatabaseRecordOp = new GetDatabaseRecordOperation(db);
+                var currentRecord = await store.Maintenance.Server.SendAsync(getDatabaseRecordOp);
+
+                currentRecord.Topology.RemoveFromTopology("B");
+
+                var op = new ModifyDatabaseTopologyOperation(db, currentRecord.Topology);
+                await store.Maintenance.Server.SendAsync(op);
+            }
+
+            WaitForUserToContinueTheTest(leader.WebUrl, debug: false);
+
+            await AssertWaitForTrueAsync(() =>
+            {
+                using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var names = leader.ServerStore.Cluster.GetDatabaseNames(context);
+                    return Task.FromResult(names.Contains(db) == false);
+                }
+            });
+        }
+
+        [RavenFact(RavenTestCategory.Cluster)]
+        public async Task CanDeleteRehabWithoutObserver()
+        {
+            var db = GetDatabaseName();
+            var (_, leader) = await CreateRaftCluster(3, watcherCluster: true);
+            leader.ServerStore.Observer.Suspended = true;
+            var topology = new DatabaseTopology
+            {
+                Rehabs = new List<string> { "A", "B" },
+                DemotionReasons = new Dictionary<string, string>
+                {
+                    { "A", "Manually In Rehab" },
+                    { "B", "Manually In Rehab" }
+                },
+                PromotablesStatus = new Dictionary<string, DatabasePromotionStatus>
+                {
+                    { "A", DatabasePromotionStatus.NotResponding },
+                    { "B", DatabasePromotionStatus.NotResponding }
+                },
+                Stamp = new LeaderStamp
+                {
+                    Index = 1,
+                    Term = 1,
+                    LeadersTicks = -2
+                },
+                PriorityOrder = [],
+                NodesModifiedAt = DateTime.UtcNow,
+                DatabaseTopologyIdBase64 = "nRZdLNYhrk2izN75386Z6c",
+                ClusterTransactionIdBase64 = "TG/MuQS8UkeY/xznGEcqCa"
+            };
+            var record = new DatabaseRecord(db)
+            {
+                Topology = topology,
+                DeletionInProgress = new Dictionary<string, DeletionInProgressStatus>()
+                {
+                    { "A", DeletionInProgressStatus.HardDelete },
+                    { "B", DeletionInProgressStatus.HardDelete }
+                }
+            };
+            var r = await leader.ServerStore.Engine.PutToLeaderAsync(new AddDatabaseCommand(Guid.NewGuid().ToString())
+            {
+                Name = db,
+                Record = record
+            });
+
+            await leader.ServerStore.Engine.WaitForCommitIndexChange(RachisConsensus.CommitIndexModification.GreaterOrEqual, r.Index);
+
+            await AssertWaitForTrueAsync(() =>
+            {
+                using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var names = leader.ServerStore.Cluster.GetDatabaseNames(context);
+                    return Task.FromResult(names.Contains(db) == false);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25429

### Additional description

The issue was that we prevented deletion of an entire database if any nodes were in "rehab" state, and the fix allows full deletion without checking for rehab nodes in such cases.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
