### PR TITLE
RavenDB-25326 - Handling the `RemoteAttachments` license attribute

### DIFF
--- a/src/Raven.Client/Exceptions/Commercial/LimitType.cs
+++ b/src/Raven.Client/Exceptions/Commercial/LimitType.cs
@@ -161,6 +161,9 @@ namespace Raven.Client.Exceptions.Commercial
         CustomSorters,
 
         [Description("Custom Analyzers")]
-        CustomAnalyzers
+        CustomAnalyzers,
+
+        [Description("Remote Attachments")]
+        RemoteAttachments,
     }
 }

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1152,6 +1152,7 @@ namespace Raven.Server.Commercial
             var dynamicNodesDistributionCount = 0;
             var additionalAssembliesFromNuGetCount = 0;
             var revisionCompressionCount = 0;
+            var remoteAttachmentsCount = 0;
 
             using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
             using (context.OpenReadTransaction())
@@ -1230,6 +1231,10 @@ namespace Raven.Server.Commercial
                     if (databaseRecord.AiAgents != null &&
                         databaseRecord.AiAgents.Count > 0)
                         aiAgentCount++;
+
+                    if (databaseRecord.RemoteAttachments != null &&
+                        databaseRecord.RemoteAttachments.HasDestination())
+                        remoteAttachmentsCount++;
 
                     var backupTypes = GetBackupTypes(databaseRecord.PeriodicBackups);
                     if (backupTypes.HasSnapshotBackup)
@@ -1373,6 +1378,12 @@ namespace Raven.Server.Commercial
             {
                 var message = GenerateDetails(revisionCompressionCount, "Revision compression");
                 throw GenerateLicenseLimit(LimitType.DocumentsCompression, message);
+            }
+
+            if (remoteAttachmentsCount > 0 && newLicenseStatus.HasRemoteAttachments == false)
+            {
+                var  message = GenerateDetails(remoteAttachmentsCount, "Remote attachments");
+                throw GenerateLicenseLimit(LimitType.RemoteAttachments, message);
             }
         }
 
@@ -1814,6 +1825,18 @@ namespace Raven.Server.Commercial
 
             const string details = "Your current license doesn't include the read-only certificates feature";
             throw GenerateLicenseLimit(LimitType.ReadOnlyCertificates, details);
+        }
+
+        public void AssertCanAddRemoteAttachments()
+        {
+            if (IsValid(out var licenseLimit) == false)
+                throw licenseLimit;
+
+            if (LicenseStatus.HasRemoteAttachments)
+                return;
+
+            const string details = "Your current license doesn't include the remote attachments feature";
+            throw GenerateLicenseLimit(LimitType.RemoteAttachments, details);
         }
 
         public bool CanUseOpenTelemetryMonitoring(bool withNotification, bool metersRegistered)

--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -274,6 +274,8 @@ namespace Raven.Server.Commercial
 
         public bool CanSetupDefaultRevisionsConfiguration => Enabled(LicenseAttribute.SetupDefaultRevisionsConfiguration);
 
+        public bool HasRemoteAttachments => Enabled(LicenseAttribute.RemoteAttachments);
+
         public int? MaxNumberOfRevisionsToKeep => GetValue<int?>(LicenseAttribute.MaxNumberOfRevisionsToKeep, agplValue: 2);
 
         public int? MaxNumberOfRevisionAgeToKeepInDays => GetValue<int?>(LicenseAttribute.MaxNumberOfRevisionAgeToKeepInDays, agplValue: 45);
@@ -387,6 +389,7 @@ namespace Raven.Server.Commercial
                 [nameof(MaxNumberOfCustomAnalyzersPerDatabase)] = MaxNumberOfCustomAnalyzersPerDatabase,
                 [nameof(MaxNumberOfCustomAnalyzersPerCluster)] = MaxNumberOfCustomAnalyzersPerCluster,
                 [nameof(CanSetupDefaultRevisionsConfiguration)] = CanSetupDefaultRevisionsConfiguration,
+                [nameof(HasRemoteAttachments)] = HasRemoteAttachments,
             };
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Remote/AbstractRemoteAttachmentHandlerProcessorForAddRemoteConfig.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Remote/AbstractRemoteAttachmentHandlerProcessorForAddRemoteConfig.cs
@@ -26,6 +26,7 @@ internal abstract class AbstractRemoteAttachmentHandlerProcessorForAddRemoteConf
 
     protected override void OnBeforeUpdateConfiguration(ref RemoteAttachmentsConfiguration configuration, JsonOperationContext context)
     {
+        RequestHandler.ServerStore.LicenseManager.AssertCanAddRemoteAttachments();
         configuration.AssertConfiguration(RequestHandler.DatabaseName);
     }
 

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -35,7 +35,6 @@ public sealed partial class ClusterStateMachine
     private const int MinBuildVersion60000 = 60_000;
     private const int MinBuildVersion60102 = 60_026;
     private const int MinBuildVersion60105 = 60_039;
-    private const int MinBuildVersion72000 = 72_000;
 
     private static readonly List<string> _licenseLimitsCommandsForCreateDatabase = new()
     {
@@ -1235,9 +1234,6 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (databaseRecord.RemoteAttachments == null || databaseRecord.RemoteAttachments.HasDestination())
-            return;
-
-        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion72000) == false)
             return;
 
         throw new LicenseLimitException(LimitType.RemoteAttachments, "Your license doesn't support adding the remote attachments configuration.");

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -35,6 +35,7 @@ public sealed partial class ClusterStateMachine
     private const int MinBuildVersion60000 = 60_000;
     private const int MinBuildVersion60102 = 60_026;
     private const int MinBuildVersion60105 = 60_039;
+    private const int MinBuildVersion72000 = 72_000;
 
     private static readonly List<string> _licenseLimitsCommandsForCreateDatabase = new()
     {
@@ -69,6 +70,9 @@ public sealed partial class ClusterStateMachine
         nameof(AddGenAiCommand),
         nameof(AddOrUpdateAiAgentCommand),
         nameof(AddSnowflakeEtlCommand)
+        nameof(AddEmbeddingsGenerationCommand),
+        nameof(UpdateEmbeddingsGenerationCommand),
+        nameof(EditRemoteAttachmentsCommand),
     };
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
@@ -193,6 +197,9 @@ public sealed partial class ClusterStateMachine
                 if (AssertClientConfiguration(serverStore.LicenseManager.LicenseStatus, context) == false)
                     throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding the client configuration.");
                 break;
+            case nameof(EditRemoteAttachmentsCommand):
+                AssertRemoteAttachmentsConfiguration(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
+                break;
         }
     }
 
@@ -259,6 +266,7 @@ public sealed partial class ClusterStateMachine
             AssertGenAi(databaseRecord, newLicenseLimits, context);
             AssertAiAgent(databaseRecord, newLicenseLimits, context);
             AssertDocumentsCompressionLicenseLimits(databaseRecord, newLicenseLimits, context);
+            AssertRemoteAttachmentsConfiguration(databaseRecord, newLicenseLimits, context);
         }
     }
 
@@ -1219,6 +1227,20 @@ public sealed partial class ClusterStateMachine
 
         if (licenseStatus.HasSnmpMonitoring == false)
             throw new LicenseLimitException(LimitType.Snmp, message);
+    }
+
+    private void AssertRemoteAttachmentsConfiguration(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context)
+    {
+        if (licenseStatus.HasRemoteAttachments)
+            return;
+
+        if (databaseRecord.RemoteAttachments == null || databaseRecord.RemoteAttachments.HasDestination())
+            return;
+
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion72000) == false)
+            return;
+
+        throw new LicenseLimitException(LimitType.RemoteAttachments, "Your license doesn't support adding the remote attachments configuration.");
     }
 
     private enum DatabaseRecordElementType

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -68,9 +68,7 @@ public sealed partial class ClusterStateMachine
         nameof(UpdateGenAiCommand),
         nameof(AddGenAiCommand),
         nameof(AddOrUpdateAiAgentCommand),
-        nameof(AddSnowflakeEtlCommand)
-        nameof(AddEmbeddingsGenerationCommand),
-        nameof(UpdateEmbeddingsGenerationCommand),
+        nameof(AddSnowflakeEtlCommand),
         nameof(EditRemoteAttachmentsCommand),
     };
 

--- a/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
@@ -130,6 +130,7 @@ export class LicenseStubs {
             HasDataArchival: true,
             HasRevisionsInSubscriptions: true,
             HasMultiNodeSharding: true,
+            HasRemoteAttachments: true,
             MaxNumberOfRevisionsToKeep: null,
             MaxNumberOfRevisionAgeToKeepInDays: null,
             MinPeriodForExpirationInHours: null,

--- a/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
+++ b/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
@@ -16,7 +16,7 @@ namespace FastTests.Server.Documents.Attachments
         {
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments, LicenseRequired = true)]
         public async Task CanPutAndGetRemoteAttachmentsConfigurationWithCaseInsensitiveIdentifier()
         {
             using (var store = GetDocumentStore())
@@ -50,7 +50,7 @@ namespace FastTests.Server.Documents.Attachments
             }
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments, LicenseRequired = true)]
         public async Task CanPutAndGetRemoteAttachmentsConfigurationWithDefaultRemoteFrequencyInSec()
         {
             using (var store = GetDocumentStore())
@@ -84,7 +84,7 @@ namespace FastTests.Server.Documents.Attachments
             }
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments, LicenseRequired = true)]
         public async Task CanPutAndGetRemoteAttachmentsConfiguration()
         {
             using (var store = GetDocumentStore())
@@ -145,7 +145,7 @@ namespace FastTests.Server.Documents.Attachments
             }
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Attachments, LicenseRequired = true)]
         public async Task CanPutAndUpdateRemoteAttachmentsConfiguration()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25326/Remote-attachments-Server-Side-Licensing-Phase-1

### Additional description

Handling the `RemoteAttachments` license attribute

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed