### PR TITLE
RavenDB-23491 Fixed index type assignment for test index definition

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Indexes/AdminIndexHandlerProcessorForTestIndex.cs
@@ -50,6 +50,8 @@ internal sealed class AdminIndexHandlerProcessorForTestIndex : AbstractAdminInde
             if (maxDocumentsPerIndex > documentsPerIndexUpperLimit || maxDocumentsPerIndex < documentsPerIndexLowerLimit)
                 throw new BadRequestException($"Number of documents to process cannot be bigger than {documentsPerIndexUpperLimit} or less than {documentsPerIndexLowerLimit}.");
 
+            testIndexDefinition.Type = testIndexDefinition.DetectStaticIndexType();
+            
             if (testIndexDefinition.Type.IsJavaScript() == false)
             {
                 // C# index without admin authorization


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23491/Bad-error-when-failing-to-run-index-test

### Additional description

We lacked server-side index type detection that we already had for normal indexes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
