### PR TITLE
RavenDB-25355: Reimplementation of the requests per second meter.

### DIFF
--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -103,7 +103,7 @@ namespace Raven.Server.Dashboard
 
             var rate = (int)RefreshRate.TotalSeconds;
             trafficWatchInfo.TrafficWatch.RequestsPerSecond = (int)Math.Ceiling(serverStore.Server.Metrics.Requests.RequestsPerSec.GetRate(rate));
-            trafficWatchInfo.TrafficWatch.AverageRequestDuration = serverStore.Server.Metrics.Requests.AverageDuration.GetRate();
+            trafficWatchInfo.TrafficWatch.AverageRequestDuration = serverStore.Server.Metrics.Requests.AverageDuration;
 
             using (serverStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
@@ -125,7 +125,7 @@ namespace Raven.Server.Dashboard
                             {
                                 Database = databaseName,
                                 RequestsPerSecond = database.Metrics.Requests.RequestsPerSec.GetIntRate(rate),
-                                AverageRequestDuration = database.Metrics.Requests.AverageDuration.GetRate(),
+                                AverageRequestDuration = database.Metrics.Requests.AverageDuration,
                                 DocumentWritesPerSecond = database.Metrics.Docs.PutsPerSec.GetIntRate(rate),
                                 AttachmentWritesPerSecond = database.Metrics.Attachments.PutsPerSec.GetIntRate(rate),
                                 CounterWritesPerSecond = database.Metrics.Counters.PutsPerSec.GetIntRate(rate),
@@ -236,7 +236,7 @@ namespace Raven.Server.Dashboard
                 {
                     Database = database.Name,
                     RequestsPerSecond = database.Metrics.Requests.RequestsPerSec.GetIntRate(rate),
-                    AverageRequestDuration = database.Metrics.Requests.AverageDuration.GetRate(),
+                    AverageRequestDuration = database.Metrics.Requests.AverageDuration,
                     DocumentWritesPerSecond = database.Metrics.Docs.PutsPerSec.GetIntRate(rate),
                     AttachmentWritesPerSecond = database.Metrics.Attachments.PutsPerSec.GetIntRate(rate),
                     CounterWritesPerSecond = database.Metrics.Counters.PutsPerSec.GetIntRate(rate),

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -414,7 +414,7 @@ public sealed class MetricsProvider
         result.MapReduceIndexReducedPerSec = database.Metrics.MapReduceIndexes.ReducedPerSec.OneMinuteRate;
         result.RequestsPerSec = database.Metrics.Requests.RequestsPerSec.OneMinuteRate;
         result.RequestsCount = (int)database.Metrics.Requests.RequestsPerSec.Count;
-        result.RequestAverageDurationInMs = database.Metrics.Requests.AverageDuration.GetRate();
+        result.RequestAverageDurationInMs = database.Metrics.Requests.AverageDuration;
         return result;
     }
 

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/3/DatabaseAverageRequestTime.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Database/5.2.X/3/DatabaseAverageRequestTime.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Database
 
         private static int GetCount(DocumentDatabase database)
         {
-            return (int)database.Metrics.Requests.AverageDuration.GetRate();
+            return (int)database.Metrics.Requests.AverageDuration;
         }
     }
 }

--- a/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.7/ServerRequestAverageDuration.cs
+++ b/src/Raven.Server/Monitoring/Snmp/Objects/Server/1.7/ServerRequestAverageDuration.cs
@@ -14,7 +14,7 @@ namespace Raven.Server.Monitoring.Snmp.Objects.Server
             _metrics = metrics;
         }
 
-        private int Value => (int)_metrics.Requests.AverageDuration.GetRate();
+        private int Value => (int)_metrics.Requests.AverageDuration;
         
         protected override Gauge32 GetData()
         {

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -250,8 +250,8 @@ namespace Raven.Server
                 if (sp != null && requestHandlerContext.HttpContext.WebSockets.IsWebSocketRequest == false) // exclude web sockets
                 {
                     var requestDuration = sp.ElapsedMilliseconds;
-                    requestHandlerContext.RavenServer?.Metrics.Requests.UpdateDuration(requestDuration);
-                    requestHandlerContext.DatabaseMetrics?.Requests.UpdateDuration(requestDuration);
+                    requestHandlerContext.RavenServer?.Metrics.Requests.RecordRequest(requestDuration);
+                    requestHandlerContext.DatabaseMetrics?.Requests.RecordRequest(requestDuration);
                 }
 
                 if (_logger.IsInfoEnabled && SkipHttpLogging == false)

--- a/src/Raven.Server/Routing/RequestRouter.cs
+++ b/src/Raven.Server/Routing/RequestRouter.cs
@@ -19,6 +19,7 @@ using Raven.Server.Extensions;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 using Raven.Server.Web;
+using Raven.Server.Utils.Metrics;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
@@ -273,8 +274,9 @@ namespace Raven.Server.Routing
             var tuple = tryMatch.Value.TryGetHandler(reqCtx);
             var handler = tuple.Item1 ?? await tuple.Item2;
 
-            reqCtx.DatabaseMetrics?.Requests.RequestsPerSec.Mark();
-            _serverMetrics.Requests.RequestsPerSec.Mark();
+            // We defer all throughput accounting until the request actually completes so the
+            // reported rates track true throughput rather than arrival pressure.
+            var requestStartNs = Clock.Nanoseconds;
 
             Interlocked.Increment(ref _serverMetrics.Requests.ConcurrentRequestsCount);
 
@@ -424,6 +426,16 @@ namespace Raven.Server.Routing
             finally
             {
                 Interlocked.Decrement(ref _serverMetrics.Requests.ConcurrentRequestsCount);
+
+                var elapsedNs = Clock.Nanoseconds - requestStartNs;
+                if (elapsedNs < 0)
+                    elapsedNs = 0;
+
+                var elapsedMilliseconds = elapsedNs / (double)Clock.NanosecondsInMillisecond;
+
+                var duration = reqCtx.HttpContext.WebSockets.IsWebSocketRequest ? 0L : (long)elapsedMilliseconds;
+                _serverMetrics.Requests.RecordRequest(duration);
+                reqCtx.DatabaseMetrics?.Requests.RecordRequest(duration);
             }
         }
 

--- a/src/Raven.Server/Utils/MetricCounters.cs
+++ b/src/Raven.Server/Utils/MetricCounters.cs
@@ -36,7 +36,6 @@ namespace Raven.Server.Utils
         private void CreateNew()
         {
             Requests.RequestsPerSec = new MeterMetric();
-            Requests.AverageDuration = new Ewma(1 - Math.Exp(-1.0 / 60 / 5), 1);
 
             MapIndexes.IndexedPerSec = new MeterMetric();
             MapReduceIndexes.MappedPerSec = new MeterMetric();
@@ -52,16 +51,17 @@ namespace Raven.Server.Utils
         public sealed class RequestCounters
         {
             public MeterMetric RequestsPerSec { get; internal set; }
-            
-            public Ewma AverageDuration { get; internal set; }
 
             public long ConcurrentRequestsCount;
 
-            public void UpdateDuration(long value)
+            public void RecordRequest(long durationMilliseconds)
             {
-                AverageDuration.Update(value);
-                AverageDuration.Tick();
+                RequestsPerSec.Mark(1, durationMilliseconds);
             }
+
+            public double AverageDuration => RequestsPerSec.GetAverageDuration();
+
+            public double GetAverageDuration(TimeSpan window) => RequestsPerSec.GetAverageDuration(window);
         }
 
         public abstract class MetricsWritesBase : IDynamicJson
@@ -126,7 +126,7 @@ namespace Raven.Server.Utils
                 {
                     [nameof(Requests.RequestsPerSec)] = Requests.RequestsPerSec.CreateMeterData(),
                     [nameof(Requests.ConcurrentRequestsCount)] = Requests.ConcurrentRequestsCount,
-                    [nameof(Requests.AverageDuration)] = Requests.AverageDuration.GetRate()
+                    [nameof(Requests.AverageDuration)] = Math.Round(Requests.AverageDuration, 2)
                 },
                 [nameof(Docs)] = Docs,
                 [nameof(Attachments)] = Attachments,

--- a/src/Raven.Server/Utils/Metrics/MeterMetric.cs
+++ b/src/Raven.Server/Utils/Metrics/MeterMetric.cs
@@ -1,127 +1,100 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Utils.Metrics
 {
+    // Sliding-window histogram over a fixed quantum (100ms).
+    // - O(1) write path with minimal contention (single atomic per field)
+    // - Time-bounded reads that ignore stale buckets strictly outside the requested window
+    // - Stable moving-average semantics (boxcar) with bounded boundary bias (<= one quantum)
     public sealed class MeterMetric
     {
+        private const double BucketDurationSeconds = 0.1;
+
+        private static readonly long BucketDurationNanoseconds = (long)(BucketDurationSeconds * Clock.NanosecondsInSecond);
+        private static readonly TimeSpan MaxWindow = TimeSpan.FromMinutes(15);
+        private static readonly long MaxWindowNanoseconds = (long)(MaxWindow.TotalSeconds * Clock.NanosecondsInSecond);
+        private static readonly int BucketCount = (int)(MaxWindowNanoseconds / BucketDurationNanoseconds) + 2;
+
+        private struct Bucket
+        {
+            public long Count;
+            public long DurationSum;
+            public long Start;
+        }
+
+        // Ring-buffer of aggregated quanta. Each bucket carries its quantum start timestamp so readers can
+        // distinguish fresh from wrapped/stale data without scanning or zeroing the whole array.
+        private readonly Bucket[] _buckets = new Bucket[BucketCount];
+
         private long _count;
-        private long _lastCount;
-
-        private readonly double[] _m15Rate = new double[60 * 15];
-        private int _index;
-
         private readonly long _startTime;
-        private long _lastTick;
+        private readonly Func<long> _now;
 
+        private static long DefaultNow() => Clock.Nanoseconds;
 
-        public MeterMetric()
+        public MeterMetric(Func<long> nowProvider = null)
         {
-            MetricsScheduler.Instance.StartTickingMetric(this);
-            _startTime = Clock.Nanoseconds;
+            _now = nowProvider ?? DefaultNow;
+            _startTime = _now();
         }
 
-        public double OneSecondRate;
-        public double FifteenMinuteRate => GetRate(60 * 15);
-        public double FiveMinuteRate => GetRate(60 * 5);
-        public double OneMinuteRate => GetRate(60);
-        public double FiveSecondRate => GetRate(5);
+        public double OneSecondRate => GetRate(TimeSpan.FromSeconds(1));
+        public double FiveSecondRate => GetRate(TimeSpan.FromSeconds(5));
+        public double OneMinuteRate => GetRate(TimeSpan.FromMinutes(1));
+        public double FiveMinuteRate => GetRate(TimeSpan.FromMinutes(5));
+        public double FifteenMinuteRate => GetRate(TimeSpan.FromMinutes(15));
 
-        internal double GetRate(int count)
+        internal double GetRate(int seconds)
         {
-            if (count == 0)
-                return 0.0;
-
-            var oldCount = count;
-            double sum = 0;
-            var index = Volatile.Read(ref _index) % _m15Rate.Length;
-            for (int i = index; i >= 0 && count >= 0; i--, count--)
-            {
-                sum += _m15Rate[i];
-            }
-            for (int i = _m15Rate.Length - 1; i >= 0 && count >= 0; i--, count--)
-            {
-                sum += _m15Rate[i];
-            }
-            return sum / oldCount;
+            return seconds <= 0 ? 0d : GetRate(TimeSpan.FromSeconds(seconds));
         }
 
-        internal int GetIntRate(int count)
+        internal int GetIntRate(int seconds)
         {
-            if (count == 0)
-                return 0;
-
-            var oldCount = count;
-            double sum = 0;
-            var index = Volatile.Read(ref _index) % _m15Rate.Length;
-            for (int i = index; i >= 0 && count >= 0; i--, count--)
-            {
-                sum += _m15Rate[i];
-            }
-            for (int i = _m15Rate.Length - 1; i >= 0 && count >= 0; i--, count--)
-            {
-                sum += _m15Rate[i];
-            }
-            return (int)Math.Ceiling(sum / oldCount);
+            return (int)Math.Ceiling(GetRate(seconds));
         }
 
-        public double MeanRate => GetMeanRate(Clock.Nanoseconds - _startTime);
+        public double MeanRate => GetMeanRate(_now() - _startTime);
 
-        public long Count => _count;
-
+        public long Count => Volatile.Read(ref _count);
 
         public void Tick()
         {
-            var current = Volatile.Read(ref _count);
-            var last = _lastCount;
-            _lastCount = current;
-            var lastTime = _lastTick;
-            _lastTick = Clock.Nanoseconds;
-            var timeDiff = ((double)(_lastTick - lastTime) / Clock.NanosecondsInSecond);
-            if (timeDiff <= 0)
-            {
-                OneSecondRate = 0;
-            }
-            else
-            {
-                OneSecondRate = (current - last) / timeDiff;
-            }
-
-            var index = Interlocked.Increment(ref _index);
-            _m15Rate[index % (60 * 15)] = OneSecondRate;
+            // Kept for compatibility with existing schedulers; all updates happen in Mark().
         }
 
-        public void Mark(long val)
+        public void Mark(long value, long duration = 0)
         {
-            if (val == 0)
+            if (value == 0 && duration == 0)
                 return;
 
-            Interlocked.Add(ref _count, val);
+            var now = _now();
+
+            // Record completions into the current quantum and keep a monotonic total (for MeanRate/diagnostics).
+            AddToBucket(now, value, duration);
+
+            if (value != 0)
+                Interlocked.Add(ref _count, value);
         }
 
-        /// <summary>
-        /// This can be called if we _know_ that there can only be one thread calling
-        /// this, so we don't need to expensive interlocked calls
-        /// </summary>
-        public void MarkSingleThreaded(long val)
+        public void MarkSingleThreaded(long value, long duration = 0)
         {
-            if (val == 0)
-                return;
-
-            _count += val;
+            // Callers with single-threaded guarantees take this path today; forward to the main implementation
+            // to avoid diverging semantics and keep JIT optimisations focused in one place.
+            Mark(value, duration);
         }
 
         public double GetMeanRate(double elapsed)
         {
-            var count = Volatile.Read(ref _count);
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (elapsed == 0)
-            {
+            var total = Volatile.Read(ref _count);
+            if (elapsed <= 0)
                 return 0.0;
-            }
 
-            return count / elapsed * Clock.NanosecondsInSecond;
+            return total / elapsed * Clock.NanosecondsInSecond;
         }
 
         public void Mark()
@@ -131,42 +104,167 @@ namespace Raven.Server.Utils.Metrics
 
         public DynamicJsonValue CreateMeterData(bool allResults = false, bool filterEmpty = true)
         {
-            var meterValue = this;
-
-            var r = new DynamicJsonValue
+            var result = new DynamicJsonValue
             {
-                ["Current"] = Math.Round(meterValue.OneSecondRate, 1),
-                ["Count"] = meterValue.Count,
-                ["MeanRate"] = Math.Round(meterValue.MeanRate, 1),
-                ["OneMinuteRate"] = Math.Round(meterValue.OneMinuteRate, 1),
-                ["FiveMinuteRate"] = Math.Round(meterValue.FiveMinuteRate, 1),
-                ["FifteenMinuteRate"] = Math.Round(meterValue.FifteenMinuteRate, 1)
+                ["Current"] = Math.Round(OneSecondRate, 1),
+                ["Count"] = Count,
+                ["MeanRate"] = Math.Round(MeanRate, 1),
+                ["OneMinuteRate"] = Math.Round(OneMinuteRate, 1),
+                ["FiveMinuteRate"] = Math.Round(FiveMinuteRate, 1),
+                ["FifteenMinuteRate"] = Math.Round(FifteenMinuteRate, 1)
             };
 
             if (allResults == false)
-                return r;
+                return result;
 
-            var results = new DynamicJsonValue();
-            r["Raw"] = results;
-            var index = Volatile.Read(ref _index) % _m15Rate.Length;
-            var current = DateTime.UtcNow;
-            var now = new TimeSpan(current.Hour, current.Minute, current.Second);
-            var oneSec = TimeSpan.FromSeconds(1);
-            for (int i = index; i >= 0; i--)
+            var nowNs = _now();
+            var nowUtc = DateTime.UtcNow;
+            var bucketSeconds = BucketDurationNanoseconds / (double)Clock.NanosecondsInSecond;
+
+            var buckets = new List<(long Start, double Rate)>();
+            for (int i = 0; i < BucketCount; i++)
             {
-                var d = _m15Rate[i];
-                if (filterEmpty == false || Math.Abs(d) > double.Epsilon)
-                    results[now.ToString()] = Math.Round(d, 1);
-                now = now - oneSec;
+                ref var bucket = ref _buckets[i];
+                var start = Volatile.Read(ref bucket.Start);
+                if (start == 0)
+                    continue;
+
+                if (nowNs - start > MaxWindowNanoseconds)
+                    continue;
+
+                var count = Volatile.Read(ref bucket.Count);
+                if (filterEmpty && count == 0)
+                    continue;
+
+                buckets.Add((start, count / bucketSeconds));
             }
-            for (int i = _m15Rate.Length - 1; i >= 0; i--)
+
+            buckets.Sort((a, b) => a.Start.CompareTo(b.Start));
+
+            // Emit raw 100ms samples so diagnostics can plot the exact workload shape (no smoothing).
+            var raw = new DynamicJsonValue();
+            foreach (var (start, rate) in buckets)
             {
-                var d = _m15Rate[i];
-                if (Math.Abs(d) > double.Epsilon)
-                    results[now.Add(TimeSpan.FromSeconds(-i)).ToString()] = Math.Round(d, 1);
-                now = now - oneSec;
+                var ageSeconds = (nowNs - start) / (double)Clock.NanosecondsInSecond;
+                var timestamp = nowUtc - TimeSpan.FromSeconds(ageSeconds);
+                raw[timestamp.ToString("O", CultureInfo.InvariantCulture)] = Math.Round(rate, 1);
             }
-            return r;
+
+            result["Raw"] = raw;
+            return result;
+        }
+
+        // A small CAS loop guards bucket advancement to avoid the "clear-after-publish" race.
+        // Protocol:
+        // - Writers claim a bucket by CAS-ing Start to a sentinel value (ClaimedStart).
+        // - Under the claim, we zero Count/DurationSum, then publish the real Start via a release write.
+        // - Readers acquire Start and skip buckets with Start <= 0 (never used or claimed/in-progress).
+        // This ensures no thread observes half-initialized state. The loop runs only at quantum boundaries.
+        private void AddToBucket(long timestamp, long value, long duration)
+        {
+            var quantum = timestamp / BucketDurationNanoseconds;
+            var bucketStart = quantum * BucketDurationNanoseconds;
+            var index = (int)(quantum % BucketCount);
+
+            ref var bucket = ref _buckets[index];
+
+            const long ClaimedStart = -1; // sentinel: bucket claimed for reinitialization
+
+            while (true)
+            {
+                var start = Volatile.Read(ref bucket.Start);
+                if (start == bucketStart)
+                    break; // already advanced for this quantum
+
+                if (start > 0 && bucketStart < start)
+                {
+                    // Another thread advanced further; follow it to avoid going backward.
+                    bucketStart = start;
+                    break;
+                }
+
+                if (start == ClaimedStart)
+                    continue; // someone else is initializing; wait until they publish
+
+                // Try to claim for reinitialization
+                if (Interlocked.CompareExchange(ref bucket.Start, ClaimedStart, start) != start)
+                    continue; // Lost the race; retry
+
+                // Own the bucket under the claim: zero fields, then publish with release semantics
+                Volatile.Write(ref bucket.Count, 0);
+                Volatile.Write(ref bucket.DurationSum, 0);
+                Volatile.Write(ref bucket.Start, bucketStart);
+                break;
+            }
+
+            if (value != 0)
+                Interlocked.Add(ref bucket.Count, value);
+            if (duration != 0)
+                Interlocked.Add(ref bucket.DurationSum, duration);
+        }
+
+        private double GetRate(TimeSpan window)
+        {
+            if (window <= TimeSpan.Zero)
+                return 0.0;
+
+            var windowNs = (long)(window.TotalSeconds * Clock.NanosecondsInSecond);
+            if (windowNs <= 0)
+                return 0.0;
+
+            var total = Accumulate(windowNs, out _, out _);
+
+            // Convert the aggregated completions into requests-per-second for the requested window. Buckets that
+            // only partially overlap the range naturally contribute their full count, which matches the behaviour
+            // expected from the mean rate (consistent with a boxcar moving average).
+            return total / window.TotalSeconds;
+        }
+
+        public double GetAverageDuration(TimeSpan window)
+        {
+            if (window <= TimeSpan.Zero)
+                return 0.0;
+
+            var windowNs = (long)(window.TotalSeconds * Clock.NanosecondsInSecond);
+            if (windowNs <= 0)
+                return 0.0;
+
+            var total = Accumulate(windowNs, out var totalDuration, out _);
+            if (total <= 0)
+                return 0.0;
+
+            return totalDuration / (double)total;
+        }
+
+        public double GetAverageDuration()
+        {
+            return GetAverageDuration(TimeSpan.FromMinutes(1));
+        }
+
+        private long Accumulate(long windowNs, out long totalDuration, out long bucketsExamined)
+        {
+            var now = _now();
+            var lowerBound = now - windowNs;
+
+            var total = 0L;
+            totalDuration = 0L;
+            bucketsExamined = 0L;
+
+            for (int i = 0; i < BucketCount; i++)
+            {
+                ref var bucket = ref _buckets[i];
+                // Skip buckets that were never initialised or fully pre-date the window. Only buckets whose
+                // quantum overlaps the requested range contribute to the final aggregates.
+                var start = Volatile.Read(ref bucket.Start);
+                if (start <= 0 || start + BucketDurationNanoseconds <= lowerBound)
+                    continue;
+
+                total += Volatile.Read(ref bucket.Count);
+                totalDuration += Volatile.Read(ref bucket.DurationSum);
+                bucketsExamined++;
+            }
+
+            return total;
         }
     }
 }

--- a/test/FastTests/Server/Metrics/RequestRouterMetricsTests.cs
+++ b/test/FastTests/Server/Metrics/RequestRouterMetricsTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Metrics
+{
+    public class RequestRouterMetricsTests(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenFact(RavenTestCategory.Core)]
+        public async Task ThroughputIsRecordedOnCompletion()
+        {
+            using var store = GetDocumentStore();
+
+            // Warm-up to make sure the database is created.
+            await store.Maintenance.SendAsync(new GetStatisticsOperation());
+
+            var database = await GetDocumentDatabaseInstanceForAsync(store.Database);
+
+            var initialCount = database.Metrics.Requests.RequestsPerSec.Count;
+
+            await store.Maintenance.SendAsync(new GetStatisticsOperation());
+
+            await AssertWaitForGreaterThanAsync(() => Task.FromResult(database.Metrics.Requests.RequestsPerSec.Count), initialCount);
+        }
+    }
+}

--- a/test/FastTests/Sparrow/MeterMetricAverageTests.cs
+++ b/test/FastTests/Sparrow/MeterMetricAverageTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Raven.Server.Utils.Metrics;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public class MeterMetricAverageTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {        
+        [RavenFact(RavenTestCategory.Core)]
+        public void AverageDurationUsesSlidingWindow()
+        {
+            long now = ToNanoseconds(1.0);
+            var meter = new MeterMetric(() => now);
+
+            // Ensure average duration is computed over the sliding window and drops back to zero once samples age out.
+            meter.Mark(1, 100);
+
+            now = ToNanoseconds(2.0);
+            meter.Mark(1, 300);
+
+            now = ToNanoseconds(3.0);
+
+            Assert.Equal(200, meter.GetAverageDuration(TimeSpan.FromSeconds(5)));
+            Assert.Equal(300, meter.GetAverageDuration(TimeSpan.FromSeconds(1)));
+
+            now = ToNanoseconds(8.0);
+            Assert.Equal(0, meter.GetAverageDuration(TimeSpan.FromSeconds(5)));
+        }
+
+        private static long ToNanoseconds(double seconds) => (long)(seconds * Clock.NanosecondsInSecond);
+    }
+}

--- a/test/FastTests/Sparrow/MeterMetricTests.cs
+++ b/test/FastTests/Sparrow/MeterMetricTests.cs
@@ -1,0 +1,80 @@
+using System;
+using Raven.Server.Utils.Metrics;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public class MeterMetricTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenFact(RavenTestCategory.Core)]        
+        public void BurstThenSilenceAgesOutToZero()
+        {
+            // Validate that a burst near the end of the ring buffer ages out cleanly and does not leak into later reads.
+            
+            // Scenario: burst near ring end, then long silence (> MaxWindow).
+            // Expectation: windowed rates return zero after silence; new traffic does not resurrect stale samples.
+            long now = ToNanoseconds(0.0);
+            long NowProvider() => now;
+            void Set(double seconds) => now = ToNanoseconds(seconds);
+
+            var meter = new MeterMetric(NowProvider);
+
+            // Burst at t = 1s
+            Set(1.0);
+            meter.Mark(100);
+
+            // Still within 1s window
+            Set(1.5);
+            Assert.True(meter.OneSecondRate > 0);
+
+            // After ~15 minutes silence: all windows should yield zero
+            Set(1.0 + 15.0 * 60.0);
+            Assert.Equal(0.0, meter.OneSecondRate);
+            Assert.Equal(0.0, meter.FiveSecondRate);
+            Assert.Equal(0.0, meter.OneMinuteRate);
+            Assert.Equal(0.0, meter.FiveMinuteRate);
+
+            // New request after silence: rates > 0 but reflect only new traffic
+            meter.Mark(1);
+            Assert.True(meter.OneSecondRate > 0, "Expected OneSecondRate > 0 after new traffic");
+            Assert.True(meter.FiveSecondRate > 0, "Expected FiveSecondRate > 0 after new traffic");
+            Assert.True(meter.OneMinuteRate > 0, "Expected OneMinuteRate > 0 after new traffic");
+        }
+        
+        [RavenFact(RavenTestCategory.Core)]        
+        public void SlidingWindowHonorsBoundaries()
+        {
+            long now = ToNanoseconds(1.0);
+            long NowProvider() => now;
+            void Advance(double seconds) => now += ToNanoseconds(seconds);
+
+            // Verify sliding-window rates respect window boundaries and drop contributions once their bucket expires.
+            var meter = new MeterMetric(NowProvider);
+
+            // t = 1s -> 10 requests
+            meter.Mark(10);
+
+            // Advance to 2s and add another 5 completions
+            Advance(1.0);
+            meter.Mark(5);
+
+            Assert.Equal(15, meter.Count);
+
+            // Evaluate rates exactly 2s after the first batch, so only it falls outside the 1s window
+            now = ToNanoseconds(3.0);
+            var oneSecondRate = meter.OneSecondRate;
+            var fiveSecondRate = meter.FiveSecondRate;
+
+            Assert.InRange(oneSecondRate, 4.9, 5.1);
+            Assert.InRange(fiveSecondRate, 2.9, 3.1);
+
+            // After 5 more seconds both buckets should age out of the 5s window.
+            now = ToNanoseconds(8.0);
+            Assert.InRange(meter.FiveSecondRate, 0.0, 0.1);
+        }
+
+        private static long ToNanoseconds(double seconds) => (long)(seconds * Clock.NanosecondsInSecond);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25355

### Additional description

The old request per second meter violated Nyquist–Shannon, counted requests on entry, and relied on a fixed-slot average that overstated steady load by 20–30%.

- Added tests that cover burst-then-silence and average-duration decay which are potential problems of the current approach.
- Switched RequestRouter from Stopwatch to Clock and pushed typed AverageDuration through the stack
- Updated dashboards, SNMP, and metrics providers so downstream consumers see the corrected duration and rate values.

**Breaking change**: request-rate dashboards and benchmarks will drop to the real numbers once this is merged.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
