### PR TITLE
RavenDB-25440 - Handle implicit Span/ReadOnlySpan conversions in query expressions

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1254,19 +1254,46 @@ The recommended method is to use full text search (mark the field as Analyzed an
             }
         }
 
+        private void VisitContainsAny(MethodCallExpression expression)
+        {
+            var sourceExpression = StripSpanLikeConversion(expression.Arguments[0]);
+            var valuesExpression = StripSpanLikeConversion(expression.Arguments[1]);
+
+            var memberInfo = GetMember(sourceExpression);
+            var objects = GetValueFromExpression(valuesExpression, GetMemberType(memberInfo));
+            DocumentQuery.ContainsAny(memberInfo.Path, ((IEnumerable)objects).Cast<object>());
+        }
+
         private void VisitContains(MethodCallExpression expression)
         {
-            var memberInfo = GetMember(expression.Arguments[0]);
-            var containsArgument = expression.Arguments[1];
+            var sourceExpression = StripSpanLikeConversion(expression.Arguments[0]);
+            var valueExpression  = StripSpanLikeConversion(expression.Arguments[1]);
 
+            var memberInfo = GetMember(sourceExpression);
             DocumentQuery.WhereEquals(new WhereParams
             {
                 FieldName = memberInfo.Path,
-                Value = GetValueFromExpression(containsArgument, containsArgument.Type),
+                Value = GetValueFromExpression(valueExpression, valueExpression.Type),
                 AllowWildcards = false,
                 Exact = _insideExact
             });
+        }
 
+        private static Expression StripSpanLikeConversion(Expression expression)
+        {
+            while (expression is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary && IsSpanLike(unary.Type))
+                expression = unary.Operand; // We only need the underlying array / enumerable for query translation.
+
+            return expression;
+        }
+
+        private static bool IsSpanLike(Type type)
+        {
+            if (type.IsGenericType == false)
+                return false;
+
+            var genericType = type.GetGenericTypeDefinition();
+            return genericType == typeof(Span<>) || genericType == typeof(ReadOnlySpan<>);
         }
 
         private void VisitMemberAccess(MemberExpression memberExpression, bool boolValue)
@@ -1440,9 +1467,7 @@ The recommended method is to use full text search (mark the field as Analyzed an
             switch (expression.Method.Name)
             {
                 case nameof(RavenQueryableExtensions.ContainsAny):
-                    var memberInfo = GetMember(expression.Arguments[0]);
-                    var objects = GetValueFromExpression(expression.Arguments[1], GetMemberType(memberInfo));
-                    DocumentQuery.ContainsAny(memberInfo.Path, ((IEnumerable)objects).Cast<object>());
+                    VisitContainsAny(expression);
                     break;
                 case nameof(MemoryExtensions.Contains):
                     VisitContains(expression);

--- a/test/SlowTests/Tests/Linq/Contains.cs
+++ b/test/SlowTests/Tests/Linq/Contains.cs
@@ -68,6 +68,35 @@ namespace SlowTests.Tests.Linq
 
         [RavenTheory(RavenTestCategory.Querying)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void CanQueryArrayWithContainsAny_MemoryExtensions(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    var doc1 = new TestDoc { StringArray = new[] { "backend", "frontend", "database" } };
+                    var doc2 = new TestDoc { StringArray = new[] { "mobile", "ios", "android" } };
+                    var doc3 = new TestDoc { StringArray = new[] { "devops", "ci", "cd" } };
+
+                    session.Store(doc1);
+                    session.Store(doc2);
+                    session.Store(doc3);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var docs = session.Query<TestDoc>()
+                        .Where(doc => MemoryExtensions.ContainsAny<string>(doc.StringArray, new[] { "frontend", "mobile", "cloud" }))
+                        .ToList();
+
+                    Assert.Equal(2, docs.Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.All)]
         public void CanQueryListWithContainsAny(Options options)
         {
             using (var store = GetDocumentStore(options))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25440/Failing-on-Query-with-MemoryExtensions.ContainsAny

### Additional description

**The Issue:**
When using methods from `System.MemoryExtensions` (such as `ContainsAny` or `Contains`) on standard arrays within a LINQ query, the C# compiler generates an expression tree that includes implicit conversions to `Span<T>` or `ReadOnlySpan<T>`.

For example, the query:
```csharp
.Where(doc => MemoryExtensions.ContainsAny(doc.StringArray, new[] { "a", "b" }))
```
Is compiled into an expression tree resembling:
```
Convert(doc.StringArray, Span<string>).ContainsAny(Convert(new [] { "a", "b" }, ReadOnlySpan<string>))
```

Previously, `RavenQueryProviderProcessor` did not handle these `Convert` nodes wrapping the arguments. It failed to identify the underlying field member or the constant array value, resulting in a `System.NotSupportedException: Could not understand expression`.

**The Fix:**
I implemented a helper method `StripSpanLikeConversion` in `RavenQueryProviderProcessor`. This method detects and unwraps `Convert` or `ConvertChecked` nodes where the target type is `Span<>` or `ReadOnlySpan<>`.

By stripping these compiler-generated conversions, the LINQ provider can now correctly access the underlying array or field member, allowing `VisitContains` and `VisitContainsAny` to generate the correct RQL.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed