### PR TITLE
RavenDB-25441 Fix handling of null values in QueryResultRetrieverBaseand add tests for queries with loads via null properties stored in the index

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -865,7 +865,9 @@ namespace Raven.Server.Documents.Queries.Results
                                         continue;
 
                                     fieldValue = ConvertType(_context, field, GetFieldType(field.Name, retrieverInput.LuceneDocument), retrieverInput.State);
-                                    _loadedDocumentIds.Add(fieldValue.ToString());
+                                    
+                                     if (fieldValue != null)
+                                        _loadedDocumentIds.Add(fieldValue.ToString());
                                 }
                             }
                             break;
@@ -881,7 +883,8 @@ namespace Raven.Server.Documents.Queries.Results
                                 }
                                 else
                                 {
-                                    _loadedDocumentIds.Add(fieldValue?.ToString());
+                                    if (fieldValue != null)
+                                        _loadedDocumentIds.Add(fieldValue.ToString());
                                 }
                             }
                             break;

--- a/test/SlowTests/Issues/RavenDB_25441.cs
+++ b/test/SlowTests/Issues/RavenDB_25441.cs
@@ -1,0 +1,157 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25441 : RavenTestBase
+    {
+        public RavenDB_25441(ITestOutputHelper output) : base(output)
+        {
+        }
+        
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task QueryWithLoadOnNullPropertyThatIsStoredInIndex(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var customerId = "customers/1";
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Customer { Name = "Test Customer" }, customerId);
+                    
+                    session.Store(new Training
+                    {
+                        OrganizationId = "organizations/1",
+                        CustomerId = customerId
+                    });
+                    
+                    session.SaveChanges();
+                }
+                
+                var index = new Trainings_Index_StorePackageIdField();
+               
+                await index.ExecuteAsync(store);
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                var rql = $@"
+                    from index '{index.IndexName}' as t
+                    where t.OrganizationId == 'organizations/1'
+                    load t.PurchasedPackageId as p
+                    select {{
+                        TrainingId: id(t),
+                        PackageType: p.Type
+                    }}";
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var query = session.Advanced
+                        .AsyncRawQuery<TrainingReport>(rql).ToListAsync();
+                    
+                    var current = (await query).Single();
+                    
+                    Assert.NotNull(current);
+                    Assert.Null(current.PackageType);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public async Task QueryWithLoadOnPropertyThatIsStoredInIndex(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var customerId = "customers/1";
+                var packageId = "packages/1";
+                
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Customer { Name = "Test Customer" }, customerId);
+                    session.Store(new PurchasedPackage { Type = "Test Package" }, packageId);
+                    
+                    session.Store(new Training
+                    {
+                        OrganizationId = "organizations/1",
+                        CustomerId = customerId,
+                        PurchasedPackageId = packageId
+                    });
+                    
+                    session.SaveChanges();
+                }
+                
+                var index = new Trainings_Index_StorePackageIdField();
+               
+                await index.ExecuteAsync(store);
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                var rql = $@"
+                    from index '{index.IndexName}' as t
+                    where t.OrganizationId == 'organizations/1'
+                    load t.PurchasedPackageId as p
+                    select {{
+                        TrainingId: id(t),
+                        PackageType: p.Type
+                    }}";
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var query = session.Advanced
+                        .AsyncRawQuery<TrainingReport>(rql).ToListAsync();
+                    
+                    var current = (await query).Single();
+                    
+                    Assert.NotNull(current);
+                    Assert.Equal("Test Package", current.PackageType);
+                }
+            }
+        }
+        
+        private class Customer
+        {
+            public string Name { get; set; }
+        }
+        
+        private class PurchasedPackage
+        {
+            public string Type { get; set; }
+        }
+        
+        private class Training
+        {
+            public string OrganizationId { get; set; }
+            public string CustomerId { get; set; }
+            public string PurchasedPackageId { get; set; }
+        }
+
+        private class TrainingReport
+        {
+            public string TrainingId { get; set; }
+            public string CustomerName { get; set; }
+            public string PackageType { get; set; }
+        }
+        
+        private class Trainings_Index_StorePackageIdField : AbstractIndexCreationTask<Training>
+        {
+            public Trainings_Index_StorePackageIdField()
+            {
+                Map = trainings => from training in trainings
+                    select new
+                    {
+                        training.OrganizationId,
+                        training.PurchasedPackageId
+                    };
+                
+                Store(x => x.PurchasedPackageId, FieldStorage.Yes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25441/NRE-when-loading-a-document-via-null-property-but-its-stored-in-index

### Additional description

It fixes NRE when using Lucene search engine. Corax impl was fine but I modified it a bit for consistency with implementation for Lucene - also I don't think we should add `null` there.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
