### PR TITLE
RavenDB-25407 - (Remote attachments) Document view - attachments now can have remote parameters

### DIFF
--- a/src/Raven.Studio/typescript/commands/database/documents/attachments/uploadAttachmentCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/attachments/uploadAttachmentCommand.ts
@@ -2,11 +2,18 @@ import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
+interface uploadAttachmentCommandArgs {
+    id: string;
+    name: string;
+    contentType: string;
+    remoteAt?: string;
+    remoteIdentifier?: string;
+}
 class uploadAttachmentCommand extends commandBase {
 
     private xhr: XMLHttpRequest;
     
-    constructor(private file: File, private documentId: string, private db: database | string, private onProgress?: (event: ProgressEvent) => void) {
+    constructor(private file: File, private documentId: string, private db: database | string, private onProgress?: (event: ProgressEvent) => void, private remoteParameters?: Raven.Client.Documents.Operations.Attachments.RemoteAttachmentParameters) {
         super();
     }
     
@@ -17,11 +24,16 @@ class uploadAttachmentCommand extends commandBase {
     }
 
     execute(): JQueryPromise<Raven.Client.Documents.Operations.Attachments.AttachmentDetails> {
-        const args = {
+        const args: uploadAttachmentCommandArgs = {
             id: this.documentId,
             name: this.file.name,
-            contentType: this.file.type
+            contentType: this.file.type,
         };
+
+        if (this.remoteParameters) {
+            args.remoteAt = this.remoteParameters.At;
+            args.remoteIdentifier = this.remoteParameters.Identifier;
+        }
 
         const options: JQueryAjaxSettings = {
             processData: false,

--- a/src/Raven.Studio/typescript/commands/database/documents/attachments/uploadAttachmentCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/documents/attachments/uploadAttachmentCommand.ts
@@ -2,7 +2,7 @@ import commandBase = require("commands/commandBase");
 import database = require("models/resources/database");
 import endpoints = require("endpoints");
 
-interface uploadAttachmentCommandArgs {
+interface UploadAttachmentCommandArgs {
     id: string;
     name: string;
     contentType: string;
@@ -24,7 +24,7 @@ class uploadAttachmentCommand extends commandBase {
     }
 
     execute(): JQueryPromise<Raven.Client.Documents.Operations.Attachments.AttachmentDetails> {
-        const args: uploadAttachmentCommandArgs = {
+        const args: UploadAttachmentCommandArgs = {
             id: this.documentId,
             name: this.file.name,
             contentType: this.file.type,

--- a/src/Raven.Studio/typescript/components/common/Modal.scss
+++ b/src/Raven.Studio/typescript/components/common/Modal.scss
@@ -6,7 +6,7 @@
     .modal-backdrop.show:nth-of-type(#{$i}) {
         z-index: $zIndexBackdrop;
     }
-    div[role="dialog"][aria-modal="true"]:nth-of-type(#{$i}) {
+    div[role="dialog"]:nth-of-type(#{$i}) {
         z-index: $zIndexContent !important;
     }
 }

--- a/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/common/formDestinations/utils/formDestinationsMapsToDto.ts
@@ -36,7 +36,7 @@ export function mapLocalToDto(destination: LocalDestination): Raven.Client.Docum
     };
 }
 
-function mapAmazonToDto(destination: S3Destination | GlacierDestination) {
+export function mapAmazonToDto(destination: S3Destination | GlacierDestination) {
     return {
         AwsRegionName: destination.awsRegionName,
         AwsAccessKey: destination.awsAccessKey,

--- a/src/Raven.Studio/typescript/components/common/select/Select.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/Select.tsx
@@ -16,9 +16,9 @@ import classNames from "classnames";
 
 export type SelectValue = string | number | boolean;
 
-export interface SelectOption<T = string, K = string> {
+export interface SelectOption<T = string> {
     value: T;
-    label: K;
+    label: string;
     isDisabled?: boolean;
 }
 

--- a/src/Raven.Studio/typescript/components/common/select/Select.tsx
+++ b/src/Raven.Studio/typescript/components/common/select/Select.tsx
@@ -16,9 +16,9 @@ import classNames from "classnames";
 
 export type SelectValue = string | number | boolean;
 
-export interface SelectOption<T = string> {
+export interface SelectOption<T = string, K = string> {
     value: T;
-    label: string;
+    label: K;
     isDisabled?: boolean;
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.stories.tsx
@@ -14,15 +14,6 @@ export default {
             url: "https://www.figma.com/design/HDUBpGrDU7d5Bh8I0HE8Bl/Pages---Remote-attachments?node-id=17-2682&t=whTMznR6tx6dnFHi-0",
         },
     },
-    argTypes: {
-        licenseType: licenseArgType,
-        databaseAccess: databaseAccessArgType,
-    },
-    args: {
-        databaseAccess: "DatabaseAdmin",
-        licenseType: "Enterprise",
-        hasRemoteAttachments: true,
-    },
 } satisfies Meta;
 
 interface RemoteAttachmentsStoryArgs {
@@ -33,6 +24,15 @@ interface RemoteAttachmentsStoryArgs {
 
 export const DefaultRemoteAttachments: StoryObj<RemoteAttachmentsStoryArgs> = {
     name: "Remote Attachments",
+    argTypes: {
+        licenseType: licenseArgType,
+        databaseAccess: databaseAccessArgType,
+    },
+    args: {
+        databaseAccess: "DatabaseAdmin",
+        licenseType: "Enterprise",
+        hasRemoteAttachments: true,
+    },
     render: (args) => {
         const { accessManager, license, databases } = mockStore;
         const { databasesService } = mockServices;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
@@ -133,7 +133,7 @@ function DestinationsList() {
         const confirmed = await confirm({
             icon: "remote-attachment",
             actionColor: "danger",
-            title: "You're about to delete remote attachment",
+            title: `You are about to delete the remote destination: '${id}'`,
             message: "This action cannot be undone.",
             confirmText: "Delete",
         });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
@@ -1,7 +1,7 @@
 import { useAppDispatch, useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
-import { FormProvider, SubmitHandler, useForm, useFormContext, UseFormReturn } from "react-hook-form";
+import { FormProvider, SubmitHandler, useForm, useFormContext, UseFormReturn, useWatch } from "react-hook-form";
 import { useEventsCollector } from "hooks/useEventsCollector";
 import { tryHandleSubmit } from "components/utils/common";
 import { LoadingView } from "components/common/LoadingView";
@@ -32,6 +32,7 @@ import {
 import useConfirm from "components/common/ConfirmDialog";
 import { RemoteAttachmentsInfoHub } from "components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub";
 import { useViewSheet, ViewSheet } from "components/common/splitView/ViewSheet";
+import { EmptySet } from "components/common/EmptySet";
 
 export default function RemoteAttachments() {
     // TODO: Add license restrictions. I cant do that at the moment because the key is missing in `LicenseStatus`
@@ -81,7 +82,10 @@ export default function RemoteAttachments() {
         return (
             <LoadError
                 error="Unable to load remote attachments"
-                refresh={() => dispatch(remoteAttachmentsActions.fetchRemoteAttachments(databaseName))}
+                refresh={async () => {
+                    const dto = await dispatch(remoteAttachmentsActions.fetchRemoteAttachments(databaseName)).unwrap();
+                    form.reset(remoteAttachmentsUtils.mapFromDto(dto));
+                }}
             />
         );
     }
@@ -90,30 +94,28 @@ export default function RemoteAttachments() {
         <div className="content-padding position-relative h-100">
             <FormProvider {...form}>
                 <Form onSubmit={handleSubmit(handleSave)}>
-                    <Col xxl={12}>
-                        <Row className="gy-sm">
-                            <Col>
-                                <AboutViewHeading title="Remote Attachments" icon="remote-attachment" />
-                                {hasDatabaseAdminAccess && (
-                                    <ButtonWithSpinner
-                                        type="submit"
-                                        variant="primary"
-                                        className="mb-3"
-                                        disabled={!isAnyModified && !formState.isDirty}
-                                        icon="save"
-                                        isSpinning={formState.isSubmitting}
-                                    >
-                                        Save
-                                    </ButtonWithSpinner>
-                                )}
-                                <RemoteAttachmentsSettingsCard />
-                                <DestinationsList />
-                            </Col>
-                            <Col sm={12} lg={4}>
-                                <RemoteAttachmentsInfoHub />
-                            </Col>
-                        </Row>
-                    </Col>
+                    <Row className="gy-sm">
+                        <Col>
+                            <AboutViewHeading title="Remote Attachments" icon="remote-attachment" />
+                            {hasDatabaseAdminAccess && (
+                                <ButtonWithSpinner
+                                    type="submit"
+                                    variant="primary"
+                                    className="mb-3"
+                                    disabled={!isAnyModified && !formState.isDirty}
+                                    icon="save"
+                                    isSpinning={formState.isSubmitting}
+                                >
+                                    Save
+                                </ButtonWithSpinner>
+                            )}
+                            <RemoteAttachmentsSettingsCard />
+                            <DestinationsList />
+                        </Col>
+                        <Col sm={12} lg={4}>
+                            <RemoteAttachmentsInfoHub />
+                        </Col>
+                    </Row>
                 </Form>
             </FormProvider>
         </div>
@@ -137,7 +139,7 @@ function DestinationsList() {
         });
 
         if (confirmed) {
-            dispatch(remoteAttachmentsActions.removeDestination(id));
+            dispatch(remoteAttachmentsActions.destinationRemoved(id));
         }
     };
 
@@ -146,7 +148,7 @@ function DestinationsList() {
     };
 
     const toggleDestination = async (id: string) => {
-        dispatch(remoteAttachmentsActions.toggleDestinationDisabled(id));
+        dispatch(remoteAttachmentsActions.toggledDestinationDisabled(id));
     };
 
     const { open } = useViewSheet();
@@ -177,6 +179,7 @@ function DestinationsList() {
                 <Icon icon="global" />
                 Destinations
             </HrHeader>
+            {destinations.length === 0 && <EmptySet>No destinations have been defined.</EmptySet>}
             {destinations.map((field, index) => (
                 <DestinationPanel
                     {...field}
@@ -191,10 +194,9 @@ function DestinationsList() {
 }
 
 function RemoteAttachmentsSettingsCard() {
-    const { control, formState, watch } = useFormContext<RemoteAttachmentsFormData>();
+    const { control, formState } = useFormContext<RemoteAttachmentsFormData>();
     const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
-    const formValues = watch();
-
+    const formValues = useWatch({ control });
     return (
         <Card>
             <Card.Body>
@@ -287,18 +289,13 @@ function RemoteAttachmentsSettingsCard() {
     );
 }
 
-const useRemoteAttachmentsSideEffects = ({
-    watch,
-    setValue,
-    clearErrors,
-}: UseFormReturn<RemoteAttachmentsFormData>) => {
+const useRemoteAttachmentsSideEffects = ({ watch, setValue }: UseFormReturn<RemoteAttachmentsFormData>) => {
     useEffect(() => {
         const { unsubscribe } = watch((values, { name }) => {
             if (name === "isRemoteAttachmentsEnabled" && !values.isRemoteAttachmentsEnabled) {
-                setValue("isCheckFrequencyInSecEnabled", false);
-                setValue("isMaxItemsToProcessEnabled", false);
-                setValue("isConcurrentUploadsEnabled", false);
-                clearErrors(["checkFrequencyInSec", "maxItemsToProcess", "concurrentUploads"]);
+                setValue("isCheckFrequencyInSecEnabled", false, { shouldValidate: true });
+                setValue("isMaxItemsToProcessEnabled", false, { shouldValidate: true });
+                setValue("isConcurrentUploadsEnabled", false, { shouldValidate: true });
             }
         });
         return unsubscribe;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/DestinationPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/DestinationPanel.tsx
@@ -17,14 +17,14 @@ import { Icon } from "components/common/Icon";
 import { useServices } from "hooks/useServices";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { remoteAttachmentsSelectors } from "components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSliceSelectors";
-import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import { FormProvider, SubmitHandler, useForm, useWatch } from "react-hook-form";
 import {
     defaultAzureFormData,
     defaultS3FormData,
 } from "components/common/formDestinations/utils/formDestinationsMapsFromDto";
 import { useAsyncCallback } from "react-async-hook";
-import { mapAzureToDto, mapS3ToDto } from "components/common/formDestinations/utils/formDestinationsMapsToDto";
-import { useEffect } from "react";
+import { mapAzureToDto } from "components/common/formDestinations/utils/formDestinationsMapsToDto";
+import { ReactNode, useEffect } from "react";
 import { remoteAttachmentsActions } from "components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSlice";
 import { FormGroup, FormLabel, FormSelect } from "components/common/Form";
 import {
@@ -35,6 +35,9 @@ import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useViewSheet, ViewSheet } from "components/common/splitView/ViewSheet";
 import { remoteAttachmentsConstants } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsConstants";
+import { remoteAttachmentsUtils } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils";
+import { SelectOption } from "components/common/select/Select";
+import { storageClassOptions } from "components/utils/common";
 
 interface DestinationPanelProps extends RemoteAttachmentsDestinationFormData {
     onEdit: (id: string) => void;
@@ -83,8 +86,8 @@ export function DestinationPanel({
                 </RichPanelHeader>
                 <RichPanelDetails>
                     <RichPanelDetailItem size="sm" label="Destination">
-                        <Icon icon={provider === "s3" ? "aws" : "azure"} />
-                        {provider === "s3" ? "Amazon S3" : "Azure"}
+                        <Icon icon={remoteAttachmentsUtils.getProviderIcon(provider)} />
+                        {remoteAttachmentsUtils.getProviderName(provider)}
                     </RichPanelDetailItem>
                 </RichPanelDetails>
             </div>
@@ -113,29 +116,11 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
             destinations,
             currentIdentifier: editingDestinationId ?? undefined,
         },
-        defaultValues: editingDestination
-            ? {
-                  provider: editingDestination.provider,
-                  identifier: editingDestination.identifier,
-                  disabled: editingDestination.disabled,
-                  s3:
-                      editingDestination.provider === "s3"
-                          ? { ...defaultS3FormData, ...editingDestination.s3, isEnabled: true }
-                          : null,
-                  azure:
-                      editingDestination.provider === "azure"
-                          ? { ...defaultAzureFormData, ...editingDestination.azure, isEnabled: true }
-                          : null,
-              }
-            : {
-                  provider: "s3",
-                  s3: { ...defaultS3FormData, isEnabled: true },
-                  azure: defaultAzureFormData,
-              },
+        defaultValues: getDefaultValues(editingDestination),
     });
 
     const { control, watch, handleSubmit, trigger, setValue } = form;
-    const formValues = watch();
+    const formValues = useWatch({ control });
 
     const asyncTest = useAsyncCallback<Raven.Server.Web.System.NodeConnectionTestResult, []>(async () => {
         const isValid = await trigger(formValues.provider);
@@ -147,7 +132,9 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
             case "s3":
                 return manageServerService.testPeriodicBackupCredentials(
                     "S3",
-                    mapS3ToDto({ ...formValues.s3, isEnabled: true })
+                    remoteAttachmentsUtils.mapS3ToDto(
+                        formValues.s3
+                    ) as unknown as Raven.Client.Documents.Operations.Backups.AmazonSettings
                 );
             case "azure":
                 return manageServerService.testPeriodicBackupCredentials(
@@ -174,7 +161,7 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
                 };
 
                 const activeProvider = values.provider;
-                const providers = remoteAttachmentsConstants.destinationProviderList as DestinationProviderType[];
+                const providers = remoteAttachmentsConstants.destinationProviderList;
 
                 providers.forEach((p) => setProviderState(p, p === activeProvider));
             }
@@ -187,17 +174,17 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
             ...data,
             s3: data.provider === "s3" ? data.s3 : null,
             azure: data.provider === "azure" ? data.azure : null,
-        } as RemoteAttachmentsDestinationFormData;
+        };
 
         if (editingDestinationId) {
             dispatch(
-                remoteAttachmentsActions.updateDestination({
+                remoteAttachmentsActions.destinationUpdated({
                     prevId: editingDestinationId,
                     destination: destinationData,
                 })
             );
         } else {
-            dispatch(remoteAttachmentsActions.addDestination(destinationData));
+            dispatch(remoteAttachmentsActions.destinationAdded(destinationData));
         }
 
         close();
@@ -246,9 +233,38 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
     );
 }
 
+function getDefaultValues(
+    editingDestination?: RemoteAttachmentsDestinationFormData
+): RemoteAttachmentsDestinationFormData {
+    if (editingDestination) {
+        return {
+            provider: editingDestination.provider,
+            identifier: editingDestination.identifier,
+            disabled: editingDestination.disabled,
+            s3:
+                editingDestination.provider === "s3"
+                    ? {
+                          ...defaultS3FormData,
+                          ...editingDestination.s3,
+                          isEnabled: true,
+                      }
+                    : null,
+            azure:
+                editingDestination.provider === "azure"
+                    ? { ...defaultAzureFormData, ...editingDestination.azure, isEnabled: true }
+                    : null,
+        };
+    }
+
+    return {
+        provider: "s3",
+        s3: { ...defaultS3FormData, storageClass: storageClassOptions[0].value, isEnabled: true },
+        azure: defaultAzureFormData,
+    };
+}
 type DestinationProviderType = RemoteAttachmentsDestinationFormData["provider"];
 
-const providerOptions = [
+const providerOptions: SelectOption<string, ReactNode>[] = [
     {
         label: (
             <div>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/DestinationPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/DestinationPanel.tsx
@@ -23,8 +23,8 @@ import {
     defaultS3FormData,
 } from "components/common/formDestinations/utils/formDestinationsMapsFromDto";
 import { useAsyncCallback } from "react-async-hook";
-import { mapAzureToDto } from "components/common/formDestinations/utils/formDestinationsMapsToDto";
-import { ReactNode, useEffect } from "react";
+import { mapAzureToDto, mapS3ToDto } from "components/common/formDestinations/utils/formDestinationsMapsToDto";
+import { useEffect } from "react";
 import { remoteAttachmentsActions } from "components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSlice";
 import { FormGroup, FormLabel, FormSelect } from "components/common/Form";
 import {
@@ -36,7 +36,7 @@ import { accessManagerSelectors } from "components/common/shell/accessManagerSli
 import { useViewSheet, ViewSheet } from "components/common/splitView/ViewSheet";
 import { remoteAttachmentsConstants } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsConstants";
 import { remoteAttachmentsUtils } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils";
-import { SelectOption } from "components/common/select/Select";
+import { OptionWithIcon, SelectOptionWithIcon, SingleValueWithIcon } from "components/common/select/Select";
 import { storageClassOptions } from "components/utils/common";
 
 interface DestinationPanelProps extends RemoteAttachmentsDestinationFormData {
@@ -132,9 +132,7 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
             case "s3":
                 return manageServerService.testPeriodicBackupCredentials(
                     "S3",
-                    remoteAttachmentsUtils.mapS3ToDto(
-                        formValues.s3
-                    ) as unknown as Raven.Client.Documents.Operations.Backups.AmazonSettings
+                    mapS3ToDto({ ...formValues.s3, isEnabled: true })
                 );
             case "azure":
                 return manageServerService.testPeriodicBackupCredentials(
@@ -202,7 +200,15 @@ export function DestinationEditorPanel({ editingDestinationId }: CreateNewDestin
                 <ViewSheet.Body className="w-100 flex-grow-1 vstack p-4 overflow-auto">
                     <FormGroup marginClass="mb-0">
                         <FormLabel>Provider</FormLabel>
-                        <FormSelect name="provider" control={control} options={providerOptions} />
+                        <FormSelect
+                            name="provider"
+                            components={{
+                                Option: OptionWithIcon,
+                                SingleValue: SingleValueWithIcon,
+                            }}
+                            control={control}
+                            options={providerOptions}
+                        />
                     </FormGroup>
                     {formValues.provider === "s3" && <RemoteAttachmentsS3Fields asyncTest={asyncTest} />}
                     {formValues.provider === "azure" && <RemoteAttachmentsAzureFields asyncTest={asyncTest} />}
@@ -264,21 +270,15 @@ function getDefaultValues(
 }
 type DestinationProviderType = RemoteAttachmentsDestinationFormData["provider"];
 
-const providerOptions: SelectOption<string, ReactNode>[] = [
+const providerOptions: SelectOptionWithIcon[] = [
     {
-        label: (
-            <div>
-                <Icon icon="aws" /> Amazon S3
-            </div>
-        ),
+        label: "Amazon S3",
         value: "s3",
+        icon: "aws",
     },
     {
-        label: (
-            <div>
-                <Icon icon="azure" /> Azure
-            </div>
-        ),
+        label: "Azure",
         value: "azure",
+        icon: "azure",
     },
 ];

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsFields.tsx
@@ -60,7 +60,12 @@ export function RemoteAttachmentsS3Fields({ asyncTest }: RemoteAttachmentsDestin
 
             <FormGroup marginClass="mt-2 mb-3">
                 <FormLabel>Destination identifier</FormLabel>
-                <FormInput type="text" name="identifier" placeholder="Destination identifier" control={control} />
+                <FormInput
+                    type="text"
+                    name="identifier"
+                    placeholder="Enter a unique identifier for this remote destination"
+                    control={control}
+                />
             </FormGroup>
 
             <FormGroup>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsFields.tsx
@@ -186,7 +186,7 @@ export function RemoteAttachmentsAzureFields({ asyncTest }: RemoteAttachmentsDes
         <div className="mt-3">
             <FormGroup>
                 <FormLabel>Destination identifier</FormLabel>
-                <FormInput type="text" name="identifier" placeholder="Destination identifier" control={control} />
+                <FormInput type="text" name="identifier" placeholder="Enter a unique identifier for this remote destination" control={control} />
             </FormGroup>
 
             <FormGroup>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsFields.tsx
@@ -2,12 +2,12 @@ import { Icon } from "components/common/Icon";
 import React from "react";
 import { RemoteAttachmentsDestinationFormData } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsValidation";
 import { UseAsyncReturn } from "react-async-hook";
-import { useFormContext } from "react-hook-form";
-import { FormGroup, FormInput, FormLabel, FormSelectCreatable, FormSwitch } from "components/common/Form";
+import { useFormContext, useWatch } from "react-hook-form";
+import { FormGroup, FormInput, FormLabel, FormSelect, FormSelectCreatable, FormSwitch } from "components/common/Form";
 import Collapse from "react-bootstrap/Collapse";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import Badge from "react-bootstrap/Badge";
-import { availableS3Regions } from "components/utils/common";
+import { availableS3Regions, storageClassOptions } from "components/utils/common";
 import ConnectionTestResult from "components/common/connectionTests/ConnectionTestResult";
 
 interface RemoteAttachmentsDestinationFieldsProps {
@@ -15,8 +15,8 @@ interface RemoteAttachmentsDestinationFieldsProps {
 }
 
 export function RemoteAttachmentsS3Fields({ asyncTest }: RemoteAttachmentsDestinationFieldsProps) {
-    const { control, watch } = useFormContext<RemoteAttachmentsDestinationFormData>();
-    const s3Values = watch("s3");
+    const { control } = useFormContext<RemoteAttachmentsDestinationFormData>();
+    const s3Values = useWatch({ control, name: "s3" });
 
     return (
         <div className="vstack mt-3">
@@ -133,6 +133,11 @@ export function RemoteAttachmentsS3Fields({ asyncTest }: RemoteAttachmentsDestin
                     passwordPreview
                     autoComplete="off"
                 />
+            </FormGroup>
+
+            <FormGroup>
+                <FormLabel>S3 Storage Class</FormLabel>
+                <FormSelect name="s3.storageClass" control={control} options={storageClassOptions} />
             </FormGroup>
 
             {asyncTest.result?.Error && (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsConstants.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsConstants.ts
@@ -1,5 +1,5 @@
-type DestinationProvider = "s3" | "azure";
+const destinationProviderList = ["s3", "azure"] as const;
 
-const destinationProviderList: DestinationProvider[] = ["s3", "azure"];
+export type DestinationProvider = (typeof destinationProviderList)[number];
 
 export const remoteAttachmentsConstants = { destinationProviderList };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
@@ -1,5 +1,6 @@
 import RemoteAttachmentsConfiguration = Raven.Client.Documents.Attachments.RemoteAttachmentsConfiguration;
 import RemoteAttachmentsDestinationConfiguration = Raven.Client.Documents.Attachments.RemoteAttachmentsDestinationConfiguration;
+import S3StorageClass = Raven.Client.Documents.Operations.Backups.S3StorageClass;
 import {
     RemoteAttachmentsDestinationFormData,
     RemoteAttachmentsFormData,
@@ -8,7 +9,10 @@ import {
     defaultAzureFormData,
     defaultS3FormData,
 } from "components/common/formDestinations/utils/formDestinationsMapsFromDto";
-import { mapAzureToDto, mapS3ToDto } from "components/common/formDestinations/utils/formDestinationsMapsToDto";
+import { mapAmazonToDto, mapAzureToDto } from "components/common/formDestinations/utils/formDestinationsMapsToDto";
+import IconName from "../../../../../../typings/server/icons";
+import { DestinationProvider } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsConstants";
+import { S3Destination } from "components/common/formDestinations/utils/formDestinationsTypes";
 
 type RemoteAttachmentsFormDataWithDestinations = RemoteAttachmentsFormData & {
     destinations: RemoteAttachmentsDestinationFormData[];
@@ -22,11 +26,10 @@ function mapToDto(form: RemoteAttachmentsFormDataWithDestinations): RemoteAttach
         const azureSettings = dest.provider === "azure" ? mapAzureToDto({ ...dest.azure, isEnabled: true }) : undefined;
 
         destinations[dest.identifier] = {
-            Identifier: dest.identifier,
             Disabled: dest.disabled,
             S3Settings: s3Settings,
             AzureSettings: azureSettings,
-        } as RemoteAttachmentsDestinationConfiguration;
+        };
     }
 
     return {
@@ -57,45 +60,37 @@ function mapFromDto(dto: RemoteAttachmentsConfiguration): RemoteAttachmentsFormD
     if (dto.Destinations) {
         for (const [destinationIdentifier, destinationConfig] of Object.entries(dto.Destinations)) {
             if (destinationConfig.S3Settings) {
-                const {
-                    AwsAccessKey,
-                    AwsSecretKey,
-                    AwsRegionName,
-                    AwsSessionToken,
-                    RemoteFolderName,
-                    BucketName,
-                    CustomServerUrl,
-                    ForcePathStyle,
-                } = destinationConfig.S3Settings;
+                const s3Config = destinationConfig.S3Settings;
                 destinations.push({
                     provider: "s3",
                     identifier: destinationIdentifier,
                     disabled: !!destinationConfig.Disabled,
                     s3: {
                         ...defaultS3FormData,
-                        awsAccessKey: AwsAccessKey,
-                        awsSecretKey: AwsSecretKey,
-                        awsRegionName: AwsRegionName,
-                        awsSessionToken: AwsSessionToken,
-                        remoteFolderName: RemoteFolderName,
-                        bucketName: BucketName,
-                        customServerUrl: CustomServerUrl,
-                        forcePathStyle: ForcePathStyle,
+                        awsAccessKey: s3Config.AwsAccessKey,
+                        awsSecretKey: s3Config.AwsSecretKey,
+                        awsRegionName: s3Config.AwsRegionName,
+                        awsSessionToken: s3Config.AwsSessionToken,
+                        remoteFolderName: s3Config.RemoteFolderName,
+                        bucketName: s3Config.BucketName,
+                        customServerUrl: s3Config.CustomServerUrl,
+                        forcePathStyle: s3Config.ForcePathStyle,
+                        storageClass: s3Config.StorageClass,
                     },
                     azure: null,
                 });
             } else if (destinationConfig.AzureSettings) {
-                const { AccountName, AccountKey, StorageContainer, RemoteFolderName } = destinationConfig.AzureSettings;
+                const azureConfig = destinationConfig.AzureSettings;
                 destinations.push({
                     provider: "azure",
                     identifier: destinationIdentifier,
                     disabled: !!destinationConfig.Disabled,
                     azure: {
                         ...defaultAzureFormData,
-                        accountName: AccountName,
-                        accountKey: AccountKey,
-                        storageContainer: StorageContainer,
-                        remoteFolderName: RemoteFolderName,
+                        accountName: azureConfig.AccountName,
+                        accountKey: azureConfig.AccountKey,
+                        storageContainer: azureConfig.StorageContainer,
+                        remoteFolderName: azureConfig.RemoteFolderName,
                     },
                     s3: null,
                 });
@@ -115,7 +110,54 @@ function mapFromDto(dto: RemoteAttachmentsConfiguration): RemoteAttachmentsFormD
     };
 }
 
+const getProviderIcon = (provider: string): IconName => {
+    switch (provider) {
+        case "s3":
+            return "aws";
+        case "azure":
+            return "azure";
+        default:
+            return null;
+    }
+};
+
+const getProviderName = (provider: DestinationProvider) => {
+    switch (provider) {
+        case "s3":
+            return "Amazon S3";
+        case "azure":
+            return "Azure";
+        default:
+            return null;
+    }
+};
+
+interface RemoteAttachmentsS3Destination extends S3Destination {
+    storageClass?: S3StorageClass;
+}
+
+const mapS3ToDto = (
+    destination: RemoteAttachmentsS3Destination
+): Raven.Client.Documents.Attachments.RemoteAttachmentsS3Settings => {
+    const customServerUrl =
+        !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.customServerUrl : undefined;
+
+    const forcePathStyle =
+        !destination.config.isOverrideConfig && destination.isUseCustomHost ? destination.forcePathStyle : undefined;
+
+    return {
+        ...mapAmazonToDto(destination),
+        CustomServerUrl: customServerUrl,
+        ForcePathStyle: forcePathStyle,
+        BucketName: destination.bucketName,
+        StorageClass: destination.storageClass,
+    };
+};
+
 export const remoteAttachmentsUtils = {
     mapToDto,
     mapFromDto,
+    getProviderIcon,
+    getProviderName,
+    mapS3ToDto,
 };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsValidation.ts
@@ -2,44 +2,56 @@ import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { azureSchema, s3Schema } from "components/common/formDestinations/utils/formDestinationsValidation";
 import { remoteAttachmentsConstants } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsConstants";
+import { storageClassOptions } from "components/utils/common";
+
+interface RemoteAttachmentsDestinationContext {
+    destinations: { identifier: string }[];
+    currentIdentifier?: string;
+}
 
 const destinationBaseSchema = yup.object({
-    identifier: yup
-        .string()
-        .test("unique-identifier", "Identifier must be unique across all destinations", function (value) {
-            const { options } = this;
-
-            if (options.context?.destinations) {
-                const destinations = options.context.destinations as { identifier?: string }[];
-                const currentIdentifierInEdit = options.context.currentIdentifier;
-
-                const matches = destinations.filter((dest) => dest.identifier === value);
-
-                if (!currentIdentifierInEdit) {
-                    return matches.length === 0;
-                }
-
-                if (value === currentIdentifierInEdit) {
-                    return matches.length <= 1;
-                }
-
-                return matches.length === 0;
-            }
-
-            return true;
-        })
-        .required(),
+    identifier: yup.string().test("unique-identifier", "Identifier must be unique", getIsUniqueIdentifier).required(),
     disabled: yup.boolean(),
+});
+
+function getIsUniqueIdentifier(value: string, ctx: yup.TestContext<RemoteAttachmentsDestinationContext>) {
+    const { context } = ctx.options;
+
+    if (context.destinations != null) {
+        const matches = context.destinations.filter((dest) => dest.identifier === value);
+
+        if (!context.currentIdentifier) {
+            return matches.length === 0;
+        }
+
+        if (value === context.currentIdentifier) {
+            return matches.length <= 1;
+        }
+
+        return matches.length === 0;
+    }
+
+    return true;
+}
+
+const s3StorageClassSchema = yup.object({
+    storageClass: yup
+        .string()
+        .oneOf(storageClassOptions.map((x) => x.value))
+        .default("Standard"),
 });
 
 const destinationSchema = yup
     .object({
         provider: yup.string().oneOf(remoteAttachmentsConstants.destinationProviderList).required(),
-        s3: s3Schema.nullable().when("provider", {
-            is: "s3",
-            then: (schema) => schema.required(),
-            otherwise: (schema) => schema.nullable(),
-        }),
+        s3: s3Schema
+            .concat(s3StorageClassSchema)
+            .nullable()
+            .when("provider", {
+                is: "s3",
+                then: (schema) => schema.required(),
+                otherwise: (schema) => schema.nullable(),
+            }),
         azure: azureSchema.nullable().when("provider", {
             is: "azure",
             then: (schema) => schema.required(),

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSlice.ts
@@ -3,7 +3,6 @@ import { services } from "hooks/useServices";
 import { loadStatus } from "components/models/common";
 import { RemoteAttachmentsDestinationFormData, RemoteAttachmentsFormData } from "../remoteAttachmentsValidation";
 import { remoteAttachmentsUtils } from "../remoteAttachmentsUtils";
-import RemoteAttachmentsConfiguration = Raven.Client.Documents.Attachments.RemoteAttachmentsConfiguration;
 
 const destinationsAdapter = createEntityAdapter<RemoteAttachmentsDestinationFormData, string>({
     selectId: (destination) => destination.identifier,
@@ -23,23 +22,18 @@ const initialState: RemoteAttachmentsState = {
 };
 
 export const fetchRemoteAttachments = createAsyncThunk("remoteAttachments/fetch", async (databaseName: string) => {
-    const dto = await services.databasesService.getRemoteAttachmentsConfiguration(databaseName);
-    return dto as RemoteAttachmentsConfiguration;
+    return services.databasesService.getRemoteAttachmentsConfiguration(databaseName);
 });
 
 type RemoteAttachmentsPayload = RemoteAttachmentsFormData & { destinations: RemoteAttachmentsDestinationFormData[] };
 
 export const saveRemoteAttachments = createAsyncThunk(
     "remoteAttachments/save",
-    async (args: { databaseName: string; data: RemoteAttachmentsPayload }, { rejectWithValue }) => {
-        try {
-            const dto = remoteAttachmentsUtils.mapToDto(args.data);
+    async (args: { databaseName: string; data: RemoteAttachmentsPayload }) => {
+        const dto = remoteAttachmentsUtils.mapToDto(args.data);
 
-            await services.databasesService.saveRemoteAttachmentsConfiguration(args.databaseName, dto);
-            return args.data;
-        } catch (e) {
-            return rejectWithValue(e);
-        }
+        await services.databasesService.saveRemoteAttachmentsConfiguration(args.databaseName, dto);
+        return args.data;
     }
 );
 
@@ -47,25 +41,27 @@ export const remoteAttachmentsSlice = createSlice({
     name: "remoteAttachments",
     initialState,
     reducers: {
-        addDestination: (state, { payload }: PayloadAction<RemoteAttachmentsDestinationFormData>) => {
-            destinationsAdapter.addOne(state.destinations, payload);
+        destinationAdded: (state, { payload }: PayloadAction<RemoteAttachmentsDestinationFormData>) => {
+            destinationsAdapter.addOne(state.destinations, { ...payload, disabled: false });
         },
-        updateDestination: (
+        destinationUpdated: (
             state,
             { payload }: PayloadAction<{ prevId: string; destination: RemoteAttachmentsDestinationFormData }>
         ) => {
             const { prevId, destination } = payload;
             if (prevId !== destination.identifier) {
-                destinationsAdapter.removeOne(state.destinations, prevId);
-                destinationsAdapter.addOne(state.destinations, destination);
+                destinationsAdapter.updateOne(state.destinations, {
+                    id: prevId,
+                    changes: { identifier: destination.identifier },
+                });
             } else {
                 destinationsAdapter.upsertOne(state.destinations, destination);
             }
         },
-        removeDestination: (state, { payload }: PayloadAction<string>) => {
+        destinationRemoved: (state, { payload }: PayloadAction<string>) => {
             destinationsAdapter.removeOne(state.destinations, payload);
         },
-        toggleDestinationDisabled: (state, { payload }: PayloadAction<string>) => {
+        toggledDestinationDisabled: (state, { payload }: PayloadAction<string>) => {
             const entity = state.destinations.entities[payload];
             if (entity) {
                 destinationsAdapter.updateOne(state.destinations, {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/store/remoteAttachmentsSliceSelectors.ts
@@ -1,6 +1,7 @@
 import { RootState } from "components/store";
 import { destinationsSelectors, initialDestinationsSelectors } from "./remoteAttachmentsSlice";
 import { isEqual, omit } from "lodash";
+import { RemoteAttachmentsDestinationFormData } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsValidation";
 
 const loadStatus = (s: RootState) => s.remoteAttachments.loadStatus;
 
@@ -14,7 +15,8 @@ const isAnyModified = (s: RootState) => {
     return areDestinationsDifferent(current, initial);
 };
 
-const selectDestinations = (s: RootState) => destinationsSelectors.selectAll(s.remoteAttachments);
+const selectDestinations = (s: RootState): RemoteAttachmentsDestinationFormData[] =>
+    destinationsSelectors.selectAll(s.remoteAttachments);
 const selectDestinationsTotal = (s: RootState) => destinationsSelectors.selectTotal(s.remoteAttachments);
 
 const selectIsDestinationModified = (id: string) => (s: RootState) => {

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
@@ -253,7 +253,7 @@ export function DetailedDatabaseStats() {
                                                 <span className="text-muted">•</span>
                                                 <small>
                                                     <span className="text-muted">
-                                                        {data.CountOfUniqueAttachments.toLocaleString()} unique
+                                                        {data.CountOfUniqueAttachments.toLocaleString()} unique (local)
                                                     </span>
                                                 </small>
                                                 <span className="text-muted">•</span>

--- a/src/Raven.Studio/typescript/durandalPlugins/bootstrapModal.ts
+++ b/src/Raven.Studio/typescript/durandalPlugins/bootstrapModal.ts
@@ -32,7 +32,7 @@ dialog.addContext('bootstrapModal', {
                 }
             }
             
-            const host = $('<div class="modal bs3" id="bootstrapModal" tabindex="-1" role="dialog" aria-labelledby="bootstrapModal" aria-hidden="true"></div>')
+            const host = $('<div role="dialog" class="modal bs3" id="bootstrapModal" tabindex="-1" role="dialog" aria-labelledby="bootstrapModal" aria-hidden="true"></div>')
                 .appendTo(modalContainer);
             (theDialog as any).host = host.get(0);
             closeCalled = false;

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/AddAttachmentWithRemoteParametersModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/AddAttachmentWithRemoteParametersModal.tsx
@@ -18,38 +18,39 @@ import editDocumentUploader = require("viewmodels/database/documents/editDocumen
 import RemoteAttachmentParameters = Raven.Client.Documents.Operations.Attachments.RemoteAttachmentParameters;
 import RemoteAttachmentsConfiguration = Raven.Client.Documents.Attachments.RemoteAttachmentsConfiguration;
 
-const schema = yup.object({
-    file: yup.mixed().required("File is required"),
-    identifier: yup.string().required("Identifier is required"),
-    uploadDate: yup.date().required("Upload date is required")
-})
-
-type AttachmentWithRemoteParametersFormData = yup.InferType<typeof schema>;
-
 type AddAttachmentWithRemoteParametersModalProps = {
     document: KnockoutObservable<document>;
-    db: database
+    db: database;
     onUploaded: () => void;
     onClose: () => void;
 };
 
-export default function AddAttachmentWithRemoteParametersModal({ document, onClose, db, onUploaded }: AddAttachmentWithRemoteParametersModalProps) {
-    const { databasesService } = useServices()
-    const asyncGetRemoteAttachmentParametersConfig = useAsyncCallback(() => databasesService.getRemoteAttachmentsConfiguration(db.name));
+export default function AddAttachmentWithRemoteParametersModal({
+    document,
+    onClose,
+    db,
+    onUploaded,
+}: AddAttachmentWithRemoteParametersModalProps) {
+    const { databasesService } = useServices();
+    const asyncGetRemoteAttachmentParametersConfig = useAsyncCallback(() =>
+        databasesService.getRemoteAttachmentsConfiguration(db.name)
+    );
 
     const form = useForm({
         resolver: yupResolver(schema),
         defaultValues: async () => {
-                const config = await asyncGetRemoteAttachmentParametersConfig.execute();
-                return getDefaultValues(config);
-            }
-        })
+            const config = await asyncGetRemoteAttachmentParametersConfig.execute();
+            return getDefaultValues(config);
+        },
+    });
 
-    const {control, formState} = form;
+    const { control, formState } = form;
 
-    const uploader = new editDocumentUploader(document, db, onUploaded)
+    const uploader = new editDocumentUploader(document, db, onUploaded);
 
-    const asyncUploadFileWithRemoteParameters = useAsyncCallback((file: File, dto: RemoteAttachmentParameters) => uploader.uploadFileWithRemoteParameters(file, dto));
+    const asyncUploadFileWithRemoteParameters = useAsyncCallback((file: File, dto: RemoteAttachmentParameters) =>
+        uploader.uploadFileWithRemoteParameters(file, dto)
+    );
 
     const handleSubmit = async (formData: AttachmentWithRemoteParametersFormData) => {
         try {
@@ -60,7 +61,7 @@ export default function AddAttachmentWithRemoteParametersModal({ document, onClo
                 return;
             }
         }
-    }
+    };
 
     const onFileDropzoneChange = async (files: File[], field: ControllerRenderProps<FieldValues, "file">) => {
         const file = files[0];
@@ -72,7 +73,7 @@ export default function AddAttachmentWithRemoteParametersModal({ document, onClo
         }
 
         field.onChange(file);
-    }
+    };
 
     return (
         <Modal size="lg" show contentClassName="modal-border bulge-info">
@@ -89,23 +90,37 @@ export default function AddAttachmentWithRemoteParametersModal({ document, onClo
                             <Controller
                                 name="file"
                                 render={({ field }) => (
-                                <FileDropzone
-                                    {...field}
-                                    maxFiles={1}
-                                    onChange={(files) => onFileDropzoneChange(files, field)}
-                                />
-                            )} >
-                            </Controller>
+                                    <FileDropzone
+                                        {...field}
+                                        maxFiles={1}
+                                        onChange={(files) => onFileDropzoneChange(files, field)}
+                                    />
+                                )}
+                            ></Controller>
                         </FormGroup>
                         <FormGroup>
-                            <FormLabel>
-                                Remote destination identifier
-                            </FormLabel>
-                            <FormSelectAutocomplete placeholder="Select or enter a defined destination identifier" isLoading={asyncGetRemoteAttachmentParametersConfig.loading} options={getRemoteAttachmentsDestinationsOptions(asyncGetRemoteAttachmentParametersConfig.result)} name="identifier" control={control} />
+                            <FormLabel>Remote destination identifier</FormLabel>
+                            <FormSelectAutocomplete
+                                placeholder="Select or enter a defined destination identifier"
+                                isLoading={asyncGetRemoteAttachmentParametersConfig.loading}
+                                options={getRemoteAttachmentsDestinationsOptions(
+                                    asyncGetRemoteAttachmentParametersConfig.result
+                                )}
+                                name="identifier"
+                                control={control}
+                            />
                         </FormGroup>
                         <FormGroup>
                             <FormLabel>Scheduled upload time</FormLabel>
-                            <FormDatePicker placeholderText="e.g. 11/21/2025 10:57 AM" showTimeSelect minDate={new Date()} minTime={moment().subtract(29, "minutes").toDate()} maxTime={moment().endOf("day").toDate()} name="uploadDate" control={control} />
+                            <FormDatePicker
+                                placeholderText="e.g. 11/21/2025 10:57 AM"
+                                showTimeSelect
+                                minDate={new Date()}
+                                minTime={moment().subtract(29, "minutes").toDate()}
+                                maxTime={moment().endOf("day").toDate()}
+                                name="uploadDate"
+                                control={control}
+                            />
                         </FormGroup>
                     </form>
                 </Modal.Body>
@@ -125,22 +140,30 @@ export default function AddAttachmentWithRemoteParametersModal({ document, onClo
                 </Modal.Footer>
             </FormProvider>
         </Modal>
-    )
+    );
 }
+
+const schema = yup.object({
+    file: yup.mixed().required("File is required"),
+    identifier: yup.string().required("Identifier is required"),
+    uploadDate: yup.date().required("Upload date is required"),
+});
+
+type AttachmentWithRemoteParametersFormData = yup.InferType<typeof schema>;
 
 const mapToDto = (values: AttachmentWithRemoteParametersFormData): RemoteAttachmentParameters => {
     return {
         At: values.uploadDate.toISOString(),
-        Identifier: values.identifier
-    }
-}
+        Identifier: values.identifier,
+    };
+};
 
 const getRemoteAttachmentsDestinationsOptions = (remoteAttachmentsConfiguration?: RemoteAttachmentsConfiguration) => {
     if (!remoteAttachmentsConfiguration) {
         return [];
     }
-    return Object.keys(remoteAttachmentsConfiguration.Destinations).map(d => ({ label: d, value: d }));
-}
+    return Object.keys(remoteAttachmentsConfiguration.Destinations).map((d) => ({ label: d, value: d }));
+};
 
 function getDefaultValues(configResult: RemoteAttachmentsConfiguration): AttachmentWithRemoteParametersFormData {
     const options = getRemoteAttachmentsDestinationsOptions(configResult);
@@ -149,13 +172,13 @@ function getDefaultValues(configResult: RemoteAttachmentsConfiguration): Attachm
         return {
             identifier: options[0].value,
             uploadDate: new Date(),
-            file: null
+            file: null,
         };
     }
 
     return {
         identifier: null,
         uploadDate: new Date(),
-        file: null
+        file: null,
     };
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/AddAttachmentWithRemoteParametersModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/AddAttachmentWithRemoteParametersModal.tsx
@@ -101,7 +101,7 @@ export default function AddAttachmentWithRemoteParametersModal({ document, onClo
                             <FormLabel>
                                 Remote destination identifier
                             </FormLabel>
-                            <FormSelectAutocomplete placeholder="e.g. remote-attachment-1" isLoading={asyncGetRemoteAttachmentParametersConfig.loading} options={getRemoteAttachmentsDestinationsOptions(asyncGetRemoteAttachmentParametersConfig.result)} name="identifier" control={control} />
+                            <FormSelectAutocomplete placeholder="Select or enter a defined destination identifier" isLoading={asyncGetRemoteAttachmentParametersConfig.loading} options={getRemoteAttachmentsDestinationsOptions(asyncGetRemoteAttachmentParametersConfig.result)} name="identifier" control={control} />
                         </FormGroup>
                         <FormGroup>
                             <FormLabel>Scheduled upload time</FormLabel>

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/AddAttachmentWithRemoteParametersModal.tsx
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/AddAttachmentWithRemoteParametersModal.tsx
@@ -1,0 +1,161 @@
+import Modal from "components/common/Modal";
+import { Controller, ControllerRenderProps, FieldValues, FormProvider, useForm } from "react-hook-form";
+import * as yup from "yup";
+import { Icon } from "components/common/Icon";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { FormDatePicker, FormGroup, FormLabel, FormSelectAutocomplete } from "components/common/Form";
+import FileDropzone from "components/common/FileDropzone";
+import messagePublisher from "common/messagePublisher";
+import ButtonWithSpinner from "components/common/ButtonWithSpinner";
+import * as React from "react";
+import document from "models/database/documents/document";
+import database from "models/resources/database";
+import Button from "react-bootstrap/Button";
+import { useAsyncCallback } from "react-async-hook";
+import { useServices } from "hooks/useServices";
+import moment from "moment";
+import editDocumentUploader = require("viewmodels/database/documents/editDocumentUploader");
+import RemoteAttachmentParameters = Raven.Client.Documents.Operations.Attachments.RemoteAttachmentParameters;
+import RemoteAttachmentsConfiguration = Raven.Client.Documents.Attachments.RemoteAttachmentsConfiguration;
+
+const schema = yup.object({
+    file: yup.mixed().required("File is required"),
+    identifier: yup.string().required("Identifier is required"),
+    uploadDate: yup.date().required("Upload date is required")
+})
+
+type AttachmentWithRemoteParametersFormData = yup.InferType<typeof schema>;
+
+type AddAttachmentWithRemoteParametersModalProps = {
+    document: KnockoutObservable<document>;
+    db: database
+    onUploaded: () => void;
+    onClose: () => void;
+};
+
+export default function AddAttachmentWithRemoteParametersModal({ document, onClose, db, onUploaded }: AddAttachmentWithRemoteParametersModalProps) {
+    const { databasesService } = useServices()
+    const asyncGetRemoteAttachmentParametersConfig = useAsyncCallback(() => databasesService.getRemoteAttachmentsConfiguration(db.name));
+
+    const form = useForm({
+        resolver: yupResolver(schema),
+        defaultValues: async () => {
+                const config = await asyncGetRemoteAttachmentParametersConfig.execute();
+                return getDefaultValues(config);
+            }
+        })
+
+    const {control, formState} = form;
+
+    const uploader = new editDocumentUploader(document, db, onUploaded)
+
+    const asyncUploadFileWithRemoteParameters = useAsyncCallback((file: File, dto: RemoteAttachmentParameters) => uploader.uploadFileWithRemoteParameters(file, dto));
+
+    const handleSubmit = async (formData: AttachmentWithRemoteParametersFormData) => {
+        try {
+            await asyncUploadFileWithRemoteParameters.execute(formData.file as File, mapToDto(formData));
+            onClose();
+        } catch (e) {
+            if ((e as Error).message === editDocumentUploader.userCancelledErrorCode) {
+                return;
+            }
+        }
+    }
+
+    const onFileDropzoneChange = async (files: File[], field: ControllerRenderProps<FieldValues, "file">) => {
+        const file = files[0];
+
+        if (!file.name.trim()) {
+            messagePublisher.reportError("Failed to load file");
+            form.setError("file", { type: "manual", message: "Failed to load file" });
+            return;
+        }
+
+        field.onChange(file);
+    }
+
+    return (
+        <Modal size="lg" show contentClassName="modal-border bulge-info">
+            <Modal.Header onCloseClick={onClose}>
+                <h3>
+                    <Icon icon="remote-attachment" color="info" />
+                    Add attachment to remote storage
+                </h3>
+            </Modal.Header>
+            <FormProvider {...form}>
+                <Modal.Body>
+                    <form onSubmit={form.handleSubmit(handleSubmit)}>
+                        <FormGroup>
+                            <Controller
+                                name="file"
+                                render={({ field }) => (
+                                <FileDropzone
+                                    {...field}
+                                    maxFiles={1}
+                                    onChange={(files) => onFileDropzoneChange(files, field)}
+                                />
+                            )} >
+                            </Controller>
+                        </FormGroup>
+                        <FormGroup>
+                            <FormLabel>
+                                Remote destination identifier
+                            </FormLabel>
+                            <FormSelectAutocomplete placeholder="e.g. remote-attachment-1" isLoading={asyncGetRemoteAttachmentParametersConfig.loading} options={getRemoteAttachmentsDestinationsOptions(asyncGetRemoteAttachmentParametersConfig.result)} name="identifier" control={control} />
+                        </FormGroup>
+                        <FormGroup>
+                            <FormLabel>Scheduled upload time</FormLabel>
+                            <FormDatePicker placeholderText="e.g. 11/21/2025 10:57 AM" showTimeSelect minDate={new Date()} minTime={moment().subtract(29, "minutes").toDate()} maxTime={moment().endOf("day").toDate()} name="uploadDate" control={control} />
+                        </FormGroup>
+                    </form>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="link" className="text-muted" onClick={onClose}>
+                        Close
+                    </Button>
+                    <ButtonWithSpinner
+                        className="rounded-pill"
+                        variant="info"
+                        isSpinning={formState.isSubmitting}
+                        onClick={form.handleSubmit(handleSubmit)}
+                        disabled={!formState.isValid}
+                    >
+                        Save attachment with remote settings
+                    </ButtonWithSpinner>
+                </Modal.Footer>
+            </FormProvider>
+        </Modal>
+    )
+}
+
+const mapToDto = (values: AttachmentWithRemoteParametersFormData): RemoteAttachmentParameters => {
+    return {
+        At: values.uploadDate.toISOString(),
+        Identifier: values.identifier
+    }
+}
+
+const getRemoteAttachmentsDestinationsOptions = (remoteAttachmentsConfiguration?: RemoteAttachmentsConfiguration) => {
+    if (!remoteAttachmentsConfiguration) {
+        return [];
+    }
+    return Object.keys(remoteAttachmentsConfiguration.Destinations).map(d => ({ label: d, value: d }));
+}
+
+function getDefaultValues(configResult: RemoteAttachmentsConfiguration): AttachmentWithRemoteParametersFormData {
+    const options = getRemoteAttachmentsDestinationsOptions(configResult);
+    // if there is only one destination, use it as default
+    if (options.length === 1) {
+        return {
+            identifier: options[0].value,
+            uploadDate: new Date(),
+            file: null
+        };
+    }
+
+    return {
+        identifier: null,
+        uploadDate: new Date(),
+        file: null
+    };
+}

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
@@ -21,6 +21,7 @@ import editDocumentUploader = require("viewmodels/database/documents/editDocumen
 import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
 import genUtils = require("common/generalUtils");
 import _ = require("lodash")
+import AddAttachmentWithRemoteParametersModal = require("viewmodels/database/documents/AddAttachmentWithRemoteParametersModal");
 
 type connectedDocsTabs = "attachments" | "counters" | "revisions" | "related" | "recent" | "timeSeries";
 type connectedItemType = connectedDocumentItem | attachmentItem | counterItem | timeSeriesItem;
@@ -82,6 +83,17 @@ class connectedDocuments {
     
     isArtificialDocument: KnockoutComputed<boolean>;
     isHiloDocument: KnockoutComputed<boolean>;  
+
+    isAddAttachmentWithRemoteParametersModalVisible = ko.observable<boolean>(false);
+    remoteAttachmentParametersModalView: ReactInKnockout<typeof AddAttachmentWithRemoteParametersModal.default> = ko.pureComputed(() => ({
+        component: AddAttachmentWithRemoteParametersModal.default,
+        props: {
+            document: this.document,
+            db: this.db,
+            onUploaded: () => this.afterUpload(),
+            onClose: () => this.isAddAttachmentWithRemoteParametersModalVisible(false)
+        }
+    }))
 
     gridController = ko.observable<virtualGridController<connectedItemType>>();
     private columnPreview = new columnPreviewPlugin<connectedItemType>();
@@ -155,16 +167,16 @@ class connectedDocuments {
         this.revisionsColumns = [revisionColumn];
         
         this.attachmentsColumns = [
+            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters?.Flags ?? "", "Remote flags", "35px", {
+                transformValue: (x: RemoteAttachmentFlags) => x === "Remote" ? `<i class="icon-remote-attachment text-info"></i>` : `<i class="icon-attachment text-primary"></i>`,
+            }),
             new actionColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => this.downloadAttachment(x), "Name", x => x.name, "160px",
                 {
                     extraClass: () => 'btn-link',
                     title: (item: attachmentItem) => "Download file: " + item.name
                 }),
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => generalUtils.formatBytesToSize(x.size), "Size", "70px", { extraClass: () => 'filesize' }),
-            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters?.Flags ?? "", "Remote flags", "35px", {
-                transformValue: (x: RemoteAttachmentFlags) => x === "Remote" ? `<i class="icon-remote-attachment text-primary"></i>` : `<i class="icon-attachment"></i>`,
-            }),
-            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters, "Remote parameters", "50px"),
+            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters, "Remote parameters", "100px"),
             new actionColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => this.crudActionsProvider().deleteAttachment(x),
                 "Delete",
                 `<i class="icon-trash"></i>`,
@@ -177,16 +189,16 @@ class connectedDocuments {
         ];
 
         this.attachmentsInReadOnlyModeColumns = [
+            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters?.Flags ?? "", "Remote flags", "35px", {
+                transformValue: (x: RemoteAttachmentFlags) => x === "Remote" ? `<i class="icon-remote-attachment text-info"></i>` : `<i class="icon-attachment text-primary"></i>`,
+            }),
             new actionColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => this.downloadAttachment(x), "Name", x => x.name, "195px",
                 {
                     extraClass: () => 'btn-link',
                     title: () => "Download attachment"
                 }),
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => generalUtils.formatBytesToSize(x.size), "Size", "70px", { extraClass: () => 'filesize' }),
-            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters?.Flags ?? "", "Remote flags", "35px", {
-                transformValue: (x: RemoteAttachmentFlags) => x === "Remote" ? `<i class="icon-remote-attachment text-primary"></i>` : `<i class="icon-attachment"></i>`,
-            }),
-            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters, "Remote parameters", "50px"),
+            new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters, "Remote parameters", "100px"),
         ];
 
         this.countersColumns = [

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentUploader.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentUploader.ts
@@ -10,10 +10,8 @@ import attachmentUpload = require("common/notifications/models/attachmentUpload"
 class editDocumentUploader {
 
     static readonly filePickerSelector = "#uploadAttachmentFilePicker";
+    static readonly userCancelledErrorCode = "ATTACHMENT_OVERWRITE_CANCELLED";
 
-    private document: KnockoutObservable<document>;
-    private db: database;
-    private afterUpload: () => void;
     currentUpload = ko.observable<attachmentUpload>();
     
     uploadButtonText = ko.pureComputed(() => {
@@ -27,11 +25,7 @@ class editDocumentUploader {
         upload: ko.observable<boolean>(false)
     };
 
-    constructor(document: KnockoutObservable<document>, db: database, afterUpload: () => void) {
-        this.document = document;
-        this.db = db;
-        this.afterUpload = afterUpload;
-    }
+    constructor(private document: KnockoutObservable<document>, private db: database, private afterUpload: () => void) {}
 
     fileSelected(fileName: string) {
         if (fileName) {
@@ -63,7 +57,7 @@ class editDocumentUploader {
         return attachments.find(x => x.Name === name);
     }
 
-    private uploadInternal(file: File) {
+    private async uploadInternal(file: File, remoteParameters?: Raven.Client.Documents.Operations.Attachments.RemoteAttachmentParameters) {
         this.spinners.upload(true);
 
         const upload = attachmentUpload.forFile(this.db, this.document().getId(), file.name);
@@ -72,10 +66,9 @@ class editDocumentUploader {
         
         notificationCenter.instance.monitorAttachmentUpload(upload);
 
-        const command = new uploadAttachmentCommand(file, this.document().getId(), this.db, event => upload.updateProgress(event));
+        const command = new uploadAttachmentCommand(file, this.document().getId(), this.db, event => upload.updateProgress(event), remoteParameters);
         
-        command
-            .execute()
+        await command.execute()
             .done(() => {
                 this.afterUpload();
             })
@@ -90,7 +83,30 @@ class editDocumentUploader {
                 this.currentUpload(null);
             });
      
-        upload.abort = () => command.abort(); 
+        upload.abort = () => command.abort();
+    }
+
+    async uploadFileWithRemoteParameters(file: File, remoteParameters: Raven.Client.Documents.Operations.Attachments.RemoteAttachmentParameters) {
+        const nameAlreadyExists = this.findAttachment(file.name);
+
+        if (nameAlreadyExists) {
+            const confirmed = await new Promise<boolean>((resolve) => {
+                viewHelpers
+                    .confirmationMessage(
+                        `Attachment '${file.name}' already exists.`,
+                        "Do you want to overwrite existing attachment?",
+                        { buttons: ["No", "Yes, overwrite"] }
+                    )
+                    .done((result: any) => resolve(!!result?.can))
+                    .fail(() => resolve(false));
+            });
+
+            if (!confirmed) {
+                throw new Error(editDocumentUploader.userCancelledErrorCode);
+            }
+        }
+
+        await this.uploadInternal(file, remoteParameters);
     }
 }
 

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -289,7 +289,7 @@ class shell extends viewModelBase {
         this.helpAndResourcesWidgetView = ko.pureComputed(() => ({ component: HelpAndResourcesWidget.HelpAndResourcesWidget }));
 
         this.isHelpAndResourcesWidgetVisible = ko.pureComputed(() => {
-            const routesToHide: string[] = ["databases/ai/agents/edit", "databases/ai/agents/chat"];
+            const routesToHide: string[] = ["databases/ai/agents/edit", "databases/ai/agents/chat", "databases/settings/remoteAttachments"];
             const route = genUtils.getSingleRoute(router.activeInstruction()?.config?.route);
 
             return !routesToHide.includes(route);

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -550,16 +550,44 @@
 
 <script type="text/html" id="uploader-template">
     <div class="padding padding-xs margin-top margin-top-sm" data-bind="with: uploader">
-        <div class="input-group file-input">
-            <input type="file" id="uploadAttachmentFilePicker" data-bind="event: { change: _.partial(fileSelected, $element.value) }" tabindex="-1">
-            <label for="uploadAttachmentFilePicker" class="btn btn-sm btn-primary btn-block" data-bind="css: { 'btn-spinner': spinners.upload }, disable: spinners.upload">
-                <i class="icon-attachment"></i> <span data-bind="text: uploadButtonText"></span>
-            </label>
+        <div class=" file-input">
+            <input type="file" id="uploadAttachmentFilePicker"
+                   data-bind="event: { change: _.partial(fileSelected, $element.value) }" tabindex="-1">
+            <div class="btn-group w-100 d-flex">
+                <label for="uploadAttachmentFilePicker" class="btn btn-sm btn-primary flex-grow"
+                       data-bind="css: { 'btn-spinner': spinners.upload }, disable: spinners.upload">
+                    <i class="icon-attachment"></i> <span data-bind="text: uploadButtonText"></span>
+                </label>
+
+                <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown"
+                        aria-haspopup="true"
+                        data-bind="disable: spinners.upload"
+                        aria-expanded="false"
+                >
+                    <span class="caret"></span>
+                    <span class="sr-only">Toggle Dropdown</span>
+                </button>
+
+                <ul class="dropdown-menu">
+                    <li >
+                        <a href="#" data-bind="click: () => $root.connectedDocuments.isAddAttachmentWithRemoteParametersModalVisible(true)">
+                            <i class="icon-cluster"></i>
+                            <span>Add attachment to remote storage</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
         </div>
-        <div data-bind="visible: $root.remoteAttachmentsDisabled" class="bg-warning margin-top-xxs padding padding-sm"><i class="icon-warning margin-right-xxs"></i><small class="mb-0">Remote attachments feature is disabled</small></div>
+        <div data-bind="visible: $root.remoteAttachmentsDisabled" class="bg-warning margin-top-xxs padding padding-sm">
+            <i class="icon-warning margin-right-xxs"></i><small class="mb-0">Remote attachments feature is
+            disabled</small></div>
     </div>
 </script>
 
 <div class="tooltip json-preview document-items-tooltip" style="opacity: 0">
     <pre><code></code></pre>
+</div>
+
+<div data-bind="if: connectedDocuments.isAddAttachmentWithRemoteParametersModalVisible()">
+    <div data-bind="react: $root.connectedDocuments.remoteAttachmentParametersModalView"></div>
 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25407

### Additional description

Added s3 storage class to s3 fields
<img width="2534" height="1229" alt="image" src="https://github.com/user-attachments/assets/7ae54659-d2eb-4f94-a76b-c70394ae902e" />

revamped remote attachments with creation of a new attachment with remote parameters.
<img width="550" height="658" alt="image" src="https://github.com/user-attachments/assets/b3122672-5e2d-4c5f-8bda-3479618d3d4c" />

Add attachments to remote storage modal
<img width="933" height="649" alt="image" src="https://github.com/user-attachments/assets/e0ffce16-9a67-45ff-a1ae-26702aa4c6eb" />

<img width="967" height="588" alt="image" src="https://github.com/user-attachments/assets/12dd0df2-2cdb-4468-8f29-9d426b83630f" />

If we have the same attachment already in document, we display a modal asking about overwrite.
<img width="1013" height="941" alt="image" src="https://github.com/user-attachments/assets/38e3f5b4-1c8d-438c-86f5-6ffb1aed037f" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
