### PR TITLE
RavenDB-25446 abstract ai error handling

### DIFF
--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -25,6 +26,7 @@ namespace Raven.Server.Documents.AI
         public string Refusal;
         public string FinishReason;
 
+        [DoesNotReturn]
         public static void Throw(string refusal, string responseContent, string finishReason, string requestId)
         {
             throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}', response content: {responseContent}")
@@ -72,6 +74,7 @@ namespace Raven.Server.Documents.AI
             StatusCode = statusCode;
         }
 
+        [DoesNotReturn]
         public static void Throw(string message, HttpStatusCode statusCode, string requestId)
         {
             throw new UnsuccessfulRequestException($"Status Code: {statusCode}, Message: {message}", statusCode)

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -658,7 +658,7 @@ internal class ChatCompletionClient : IDisposable
             case ErrorType.TooManyTokens:
             case ErrorType.TooManyRequests:
                 var retryAfter = TimeSpan.Zero;
-                if (headers.Contains("retry-after-ms") == false && headers.Contains("retry-after") == false)
+                if (headers.Contains(Constants.Headers.RetryAfterMs) == false && headers.Contains(Constants.Headers.RetryAfter) == false)
                 {
                     throw new TooManyTokensException(message)
                     {
@@ -666,7 +666,7 @@ internal class ChatCompletionClient : IDisposable
                     };
                 }
 
-                if (headers.TryGetValues("x-ratelimit-reset-tokens", out var resetTokensValues))
+                if (headers.TryGetValues(Constants.Headers.XRateLimitResetTokens, out var resetTokensValues))
                 {
                     // TPM
                     var retryAfterAsString = resetTokensValues.FirstOrDefault();
@@ -674,7 +674,7 @@ internal class ChatCompletionClient : IDisposable
                         throw new FormatException($"Unrecognized rate-limit format: '{retryAfterAsString}'");
                 }
 
-                if (headers.TryGetValues("x-ratelimit-reset-requests", out var resetRequestsValues))
+                if (headers.TryGetValues(Constants.Headers.XRateLimitResetRequests, out var resetRequestsValues))
                 {
                     // RPM
                     var retryAfterAsString = resetRequestsValues.FirstOrDefault();
@@ -702,7 +702,7 @@ internal class ChatCompletionClient : IDisposable
 
     internal static string GetRequestId(HttpResponseHeaders headers)
     {
-        if (headers.TryGetValues(Constants.Headers.RequestId, out IEnumerable<string> values))
+        if (headers.TryGetValues(Constants.Headers.XRequestId, out IEnumerable<string> values))
         {
             return values.FirstOrDefault() ?? string.Empty;
         }
@@ -957,10 +957,11 @@ internal class ChatCompletionClient : IDisposable
 
         public static class Headers
         {
-            public const string RetryAfter = "retry-after-ms";
-            public const string TokensResetTime = "x-ratelimit-reset-tokens";
-            public const string RequestsResetTime = "x-ratelimit-reset-requests";
-            public const string RequestId = "X-Request-ID";
+            public const string RetryAfterMs = "retry-after-ms";
+            public const string RetryAfter = "retry-after";
+            public const string XRateLimitResetTokens = "x-ratelimit-reset-tokens";
+            public const string XRateLimitResetRequests = "x-ratelimit-reset-requests";
+            public const string XRequestId = "X-Request-ID";
         }
 
         public static class JsonSchemaFields

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -639,79 +639,63 @@ internal class ChatCompletionClient : IDisposable
     }
 
     [DoesNotReturn]
-    private void HandleUnsuccessfulResponse(HttpResponseMessage response, BlittableJsonReaderObject responseContent)
+    private void HandleUnsuccessfulResponse(HttpResponseMessage response, BlittableJsonReaderObject content)
     {
         var headers = response.Headers;
         var reqId = GetRequestId(headers);
 
-        if (responseContent.TryGet(Constants.ResponseFields.Error, out BlittableJsonReaderObject errBjo) is false || errBjo.TryGet(Constants.ResponseFields.Message, out string message) is false)
-            throw UnexpectedResponseException.Create(message: "Unexpected response", response, responseContent);
+        var error = _settings.ParseError(content, response);
+        var message = error.Message;
 
-        switch (response.StatusCode)
+        switch (error.ErrorType)
         {
-            case HttpStatusCode.TooManyRequests:
-
-                if (errBjo.TryGet(Constants.ResponseFields.ErrorType, out string type) == false)
-                    throw UnexpectedResponseException.Create(message: "No type specified", response, responseContent);
-
-                switch (type)
+            case ErrorType.InsufficientQuota:
+                throw new InsufficientQuotaException(message)
                 {
-                    case Constants.ResponseFields.ErrorTypeInsufficientQuota:
-                        throw new InsufficientQuotaException(message)
-                        {
-                            RequestId = reqId
-                        };
-
-                    case Constants.ResponseFields.ErrorTypeTokens:
-                    case Constants.ResponseFields.ErrorTypeRequests:
-
-                        var retryAfter = TimeSpan.Zero;
-                        if (headers.Contains(Constants.Headers.RetryAfter) == false)
-                        {
-                            throw new TooManyTokensException(message)
-                            {
-                                RequestId = reqId
-                            };
-                        }
-
-                        if (headers.TryGetValues(Constants.Headers.TokensResetTime, out var resetTokensValues))
-                        {
-                            // TPM
-                            var retryAfterAsString = resetTokensValues.FirstOrDefault();
-                            if (TryParseResetTime(retryAfterAsString, out retryAfter) == false)
-                                throw new FormatException($"Unrecognized rate-limit format: '{retryAfterAsString}'");
-                        }
-
-                        if (headers.TryGetValues(Constants.Headers.RequestsResetTime, out var resetRequestsValues))
-                        {
-                            // RPM
-                            var retryAfterAsString = resetRequestsValues.FirstOrDefault();
-                            if (TryParseResetTime(retryAfterAsString, out var retryAfterForReqs) == false)
-                                throw new FormatException($"Unrecognized rate-limit format: '{retryAfterAsString}'");
-
-                            retryAfter = retryAfterForReqs > retryAfter ? retryAfterForReqs : retryAfter;
-                        }
-
-                        // TPM/RPM - should retry only for this exception
-                        throw new
-                            RateLimitException(message)
-                            {
-                                RetryAfter = retryAfter,
-                                RequestId = reqId
-                            };
-                    default:
-                        throw new TooManyRequestsException(message)
-                        {
-                            RequestId = reqId
-                        };
+                    RequestId = reqId
+                };
+            case ErrorType.Other429:
+            case ErrorType.TooManyTokens:
+            case ErrorType.TooManyRequests:
+                var retryAfter = TimeSpan.Zero;
+                if (headers.Contains("retry-after-ms") == false && headers.Contains("retry-after") == false)
+                {
+                    throw new TooManyTokensException(message)
+                    {
+                        RequestId = reqId
+                    };
                 }
+
+                if (headers.TryGetValues("x-ratelimit-reset-tokens", out var resetTokensValues))
+                {
+                    // TPM
+                    var retryAfterAsString = resetTokensValues.FirstOrDefault();
+                    if (TryParseResetTime(retryAfterAsString, out retryAfter) == false)
+                        throw new FormatException($"Unrecognized rate-limit format: '{retryAfterAsString}'");
+                }
+
+                if (headers.TryGetValues("x-ratelimit-reset-requests", out var resetRequestsValues))
+                {
+                    // RPM
+                    var retryAfterAsString = resetRequestsValues.FirstOrDefault();
+                    if (TryParseResetTime(retryAfterAsString, out var retryAfterForReqs) == false)
+                        throw new FormatException($"Unrecognized rate-limit format: '{retryAfterAsString}'");
+
+                    retryAfter = retryAfterForReqs > retryAfter ? retryAfterForReqs : retryAfter;
+                }
+
+                // TPM/RPM - should retry only for this exception
+                throw new
+                    RateLimitException(message)
+                    {
+                        RetryAfter = retryAfter,
+                        RequestId = reqId
+                    };
+            case ErrorType.RefusedToAnswer:
+                RefusedToAnswerException.Throw(message, content.ToString(), null, reqId);
+                break;
             default:
-                if (errBjo.TryGet("code", out string errorCode) && errorCode == "content_filter")
-                {
-                    RefusedToAnswerException.Throw("content_filter", responseContent.ToString(), "content_filter", reqId);
-                }
-
-                UnsuccessfulRequestException.Throw(responseContent.ToString(), response.StatusCode, reqId);
+                UnsuccessfulRequestException.Throw(content.ToString(), response.StatusCode, reqId);
                 break;
         }
     }
@@ -955,6 +939,7 @@ internal class ChatCompletionClient : IDisposable
             public const string Refusal = "refusal";
             public const string Usage = "usage";
             public const string Error = "error";
+            public const string ErrorCode = "code";
             public const string ErrorType = "type";
             public const string ErrorTypeInsufficientQuota = "insufficient_quota";
             public const string ErrorTypeTokens = "tokens";

--- a/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
 using Raven.Client.Documents.Operations.AI;
 using Sparrow.Json;
@@ -75,4 +76,22 @@ internal abstract class AbstractChatCompletionClientSettings
             public const string OpenAiProject = "OpenAI-Project";
         }
     }
+
+    public abstract AiError ParseError(BlittableJsonReaderObject content, HttpResponseMessage response);
+}
+
+public class AiError
+{
+    public string Message { get; set; }
+    public ErrorType ErrorType { get; set; }
+}
+
+public enum ErrorType
+{
+    Unknown,
+    InsufficientQuota,
+    TooManyTokens,
+    TooManyRequests,
+    Other429,
+    RefusedToAnswer,
 }

--- a/src/Raven.Server/Documents/AI/Settings/AzureOpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AzureOpenAiChatCompletionClientSettings.cs
@@ -1,4 +1,8 @@
-﻿using Raven.Client.Documents.Operations.AI;
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using Raven.Client.Documents.Operations.AI;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI.Settings;
 
@@ -17,4 +21,54 @@ internal class AzureOpenAiChatCompletionClientSettings : AbstractOpenAiChatCompl
     public override string GetRelativeCompletionUri() => $"openai/deployments/{_settings.DeploymentName}/chat/completions?api-version={ApiVersion}";
 
     public override string GetRelativeModelsUri() => $"openai/models?api-version={ApiVersion}";
+    public override AiError ParseError(BlittableJsonReaderObject content, HttpResponseMessage response)
+    {
+        var error = AzureOpenAiErrorHolder.Deserializer(content).error;
+        ErrorType errorType;
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            errorType = error.code switch
+            {
+                "rate_limit_exceeded" or "RateLimitExceeded" => FindErrorFromMessage(error.message),
+                "rate_limit_reached" or "RateLimitReached" => FindErrorFromMessage(error.message),
+                "insufficient_quota" or "InsufficientQuota" => ErrorType.InsufficientQuota,
+                _ => ErrorType.Other429,
+            };
+        }
+        else
+        {
+            errorType = error.code switch
+            {
+                "content_filter" or "ContentFilter" => ErrorType.RefusedToAnswer,
+                _ => ErrorType.Unknown
+            };
+        }
+
+        return new AiError
+        {
+            ErrorType = errorType,
+            Message = error.message
+        };
+    }
+
+    private static ErrorType FindErrorFromMessage(string message)
+    {
+        if(message.Contains("token rate limit"))
+            return ErrorType.TooManyTokens;
+        if (message.Contains("request rate limit"))
+            return ErrorType.TooManyRequests;
+        return ErrorType.Other429;
+    }
+
+    private class AzureOpenAiErrorHolder
+    {
+        public static readonly Func<BlittableJsonReaderObject, AzureOpenAiErrorHolder> Deserializer = JsonDeserializationBase.GenerateJsonDeserializationRoutine<AzureOpenAiErrorHolder>();
+        public AzureOpenAiError error { get; set; }
+    }
+
+    private class AzureOpenAiError
+    {
+        public string code { get; set; }
+        public string message { get; set; }
+    }
 }

--- a/src/Raven.Server/Documents/AI/Settings/OllamaChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/OllamaChatCompletionClientSettings.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net;
+using System.Net.Http;
 using Raven.Client.Documents.Operations.AI;
 using Sparrow.Json;
 
@@ -17,6 +19,15 @@ internal class OllamaChatCompletionClientSettings : AbstractChatCompletionClient
     public override string GetRelativeCompletionUri() => "v1/" + base.GetRelativeCompletionUri();
 
     public override string GetRelativeModelsUri() => "v1/" + base.GetRelativeModelsUri();
+    public override AiError ParseError(BlittableJsonReaderObject content, HttpResponseMessage response)
+    {
+        // Ollama does not provide structured error responses, so we return the raw content as the error message.
+        return new AiError
+        {
+            ErrorType = ErrorType.Unknown,
+            Message = content.ToString()
+        };
+    }
 
     public override void HandleCompletionRequestPayload(AsyncBlittableJsonTextWriter writer)
     {

--- a/src/Raven.Server/Documents/AI/Settings/OpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/OpenAiChatCompletionClientSettings.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Server.Json;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI.Settings;
 
@@ -20,5 +24,41 @@ internal class OpenAiChatCompletionClientSettings : AbstractOpenAiChatCompletion
 
         if (string.IsNullOrEmpty(_settings.ProjectId) == false)
             request.Headers.TryAddWithoutValidation(Constants.Headers.OpenAiProject, _settings.ProjectId);
+    }
+
+    public override AiError ParseError(BlittableJsonReaderObject content, HttpResponseMessage response)
+    {
+        var error = OpenAiErrorHolder.Deserializer(content).error;
+
+        var errorType = ErrorType.Unknown;
+        if (response.StatusCode == HttpStatusCode.TooManyRequests)
+        {
+            errorType = error.type switch
+            {
+                "insufficient_quota" => ErrorType.InsufficientQuota,
+                "requests" => ErrorType.TooManyRequests,
+                "tokens" => ErrorType.TooManyTokens,
+                _ => ErrorType.Other429
+            };
+        }
+
+        return new AiError
+        {
+            ErrorType = errorType,
+            Message = error.message
+        };
+    }
+
+    private class OpenAiErrorHolder
+    {
+        public static readonly Func<BlittableJsonReaderObject, OpenAiErrorHolder> Deserializer = JsonDeserializationBase.GenerateJsonDeserializationRoutine<OpenAiErrorHolder>();
+
+        public OpenAiError error { get; set; }
+    }
+
+    private class OpenAiError
+    {
+        public string type { get; set; }
+        public string message { get; set; }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
@@ -50,7 +50,7 @@ public class ChatCompletionClientTests : RavenTestBase
 }";
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi ,DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.AzureOpenAI, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task GenAiClientSanityTest(Options options, GenAiConfiguration configuration)
     {
         using (var contextPool = new TransactionContextPool(RavenLogManager.Instance.CreateNullLogger(), new StorageEnvironment(StorageEnvironmentOptions.CreateMemoryOnlyForTests())))
@@ -179,7 +179,7 @@ public class ChatCompletionClientTests : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
-    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi | RavenAiIntegration.AzureOpenAI, DatabaseMode = RavenDatabaseMode.Single)]
     // Ollama Doesn't refuse
     public async Task RefuseToAnswer(Options options, GenAiConfiguration configuration)
     {

--- a/test/StressTests/Server/Documents/AI/AiAgent/RavenDB-24884.cs
+++ b/test/StressTests/Server/Documents/AI/AiAgent/RavenDB-24884.cs
@@ -28,7 +28,7 @@ public class RavenDB_24884 : RavenTestBase
 
     private static readonly string BananaPngBase64 = GetFileAsBase64("banana.png");
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Etl)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Skip = "Takes too long")]
     public async Task TextFileWithTooManyTokens(Options options, GenAiConfiguration config)
     {
@@ -139,7 +139,7 @@ ai.genContext({
     }
 
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Etl)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Skip = "Takes too long")]
     public async Task ImgOver32MbRequest(Options options, GenAiConfiguration config)
     {
@@ -276,7 +276,7 @@ else{
         return ms; // Stream contains a valid BMP file (not Base64)
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenTheory(RavenTestCategory.Ai | RavenTestCategory.Etl)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Skip = "Takes too long")]
     public async Task Over1500ImagesRequest(Options options, GenAiConfiguration config)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25446 

### Additional description

Azure open ai has a different error format than open ai.
So I've tried to normalize the errors.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
