### PR TITLE
RavenDB-25067: HTTP/2 flow control windows now configurable

### DIFF
--- a/src/Raven.Server/Config/Categories/HttpConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/HttpConfiguration.cs
@@ -13,7 +13,12 @@ namespace Raven.Server.Config.Categories
     {
         public HttpConfiguration()
         {
+            Http2Profile = Http2Profile.Balanced;
             Protocols = PlatformDetails.CanUseHttp2 ? HttpProtocols.Http1AndHttp2 : HttpProtocols.Http1;
+            
+            // Prefer lower memory defaults on 32-bit runtimes to avoid address space pressure.
+            if (PlatformDetails.Is32Bits)
+                Http2Profile = Http2Profile.Conservative;
         }
 
         [Description("Set Kestrel's minimum required data rate in bytes per second. This option must be configured together with 'Http.MinDataRateGracePeriod'.")]
@@ -103,5 +108,66 @@ namespace Raven.Server.Config.Categories
         [DefaultValue(false)]
         [ConfigurationEntry("Http.AllowSynchronousIO", ConfigurationEntryScope.ServerWideOnly)]
         public bool AllowSynchronousIo { get; set; }
+
+        [Description($"HTTP/2 performance profile: {nameof(Http2Profile.Performance)} | {nameof(Http2Profile.Balanced)} | {nameof(Http2Profile.Conservative)}. {nameof(Http2Profile.Performance)}=max throughput (more memory). {nameof(Http2Profile.Balanced)}=balanced. {nameof(Http2Profile.Conservative)}=lower memory (may cap throughput on high RTT).")]
+        [DefaultValue(DefaultValueSetInConstructor)]
+        [ConfigurationEntry("Http.Http2.Profile", ConfigurationEntryScope.ServerWideOnly)]
+        public Http2Profile Http2Profile { get; set; }
+
+        [Description($"Latency hint influencing profile sizing: {nameof(Http2LatencyHint.Default)} | {nameof(Http2LatencyHint.High)}. {nameof(Http2LatencyHint.Default)}=use profile as-is for low RTT (collocated: same region/AZ). {nameof(Http2LatencyHint.High)}=2x windows for WAN/high RTT unless explicit sizes are set.")]
+        [DefaultValue(Http2LatencyHint.Default)]
+        [ConfigurationEntry("Http.Http2.LatencyHint", ConfigurationEntryScope.ServerWideOnly)]
+        public Http2LatencyHint Http2Latency { get; set; }
+
+        [Description("EXPERT: Override Kestrel HTTP/2 InitialConnectionWindowSize in KB (per-connection receive window). Prefer Profile/LatencyHint unless you understand your BDP and memory tradeoffs. See RFC-9113 for details.")]
+        [DefaultValue(null)]
+        [SizeUnit(SizeUnit.Kilobytes)]
+        [ConfigurationEntry("Http.Http2.InitialConnectionWindowSizeInKb", ConfigurationEntryScope.ServerWideOnly)]
+        public Size? InitialConnectionWindowSize { get; set; }
+
+        [Description("EXPERT: Override Kestrel HTTP/2 InitialStreamWindowSize in KB (per-stream receive window). Prefer Profile/LatencyHint unless tuning for specific concurrency/RTT. See RFC-9113 for details.")]
+        [DefaultValue(null)]
+        [SizeUnit(SizeUnit.Kilobytes)]
+        [ConfigurationEntry("Http.Http2.InitialStreamWindowSizeInKb", ConfigurationEntryScope.ServerWideOnly)]
+        public Size? InitialStreamWindowSize { get; set; }
+
+        [Description("EXPERT: Override Kestrel HTTP/2 MaxFrameSize in KB (maximum payload per frame, 16KB-16MB). Larger frames reduce overhead for bulk transfers but delay small urgent frames. See RFC-9113 Section 4.2.")]
+        [DefaultValue(null)]
+        [SizeUnit(SizeUnit.Kilobytes)]
+        [ConfigurationEntry("Http.Http2.MaxFrameSizeInKb", ConfigurationEntryScope.ServerWideOnly)]
+        public Size? MaxFrameSize { get; set; }
+    }
+
+    public enum Http2Profile
+    {
+        /// <summary>
+        /// Favor peak throughput: large HTTP/2 flow-control windows to keep high-BDP links full. Uses more memory per connection.
+        /// </summary>
+        Performance,
+        /// <summary>
+        /// Balanced defaults for most deployments: good throughput without excessive memory usage.
+        /// </summary>
+        Balanced,
+        /// <summary>
+        /// Favor lower memory usage: smaller windows. May limit throughput on high-latency or high-bandwidth links.
+        /// </summary>
+        Conservative
+    }
+
+    public enum Http2LatencyHint
+    {
+        /// <summary>
+        /// Low latency. Server and clients are collocated (same region/AZ) or on a LAN/Cluster.
+        /// Keeps the selected profile as-is. Choose this when round-trip times are short
+        /// and HTTP/2 throughput is not flattening due to flow control.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// High latency. Cross-region or internet links where round-trip times are long.
+        /// Doubles the HTTP/2 flow-control windows derived from the selected profile to
+        /// maintain smooth throughput over larger RTTs. Use when downloads plateau under HTTP/2
+        /// and improve after increasing window sizes or when forcing HTTP/1.1.
+        /// </summary>
+        High
     }
 }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -46,6 +46,7 @@ using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
+using Raven.Server.Config.Categories;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.Subscriptions;
@@ -80,7 +81,9 @@ using Sparrow.Utils;
 using Voron;
 using DateTime = System.DateTime;
 using Raven.Server.Monitoring.OpenTelemetry;
-using Constants = Raven.Server.Monitoring.OpenTelemetry.Constants;
+using Constants = Sparrow.Global.Constants;
+using TelemetryConstants = Raven.Server.Monitoring.OpenTelemetry.Constants;
+using ClientConstants = Raven.Client.Constants;
 
 namespace Raven.Server
 {
@@ -250,6 +253,57 @@ namespace Raven.Server
 
                     if (Configuration.Http.MaxStreamsPerConnection.HasValue)
                         options.Limits.Http2.MaxStreamsPerConnection = Configuration.Http.MaxStreamsPerConnection.Value;
+
+                    // HTTP/2 flow control: start from the profile, stretch for latency, respect overrides, clamp to RFC bounds.
+                    long connectionWindowBytes;
+                    long streamWindowBytes;
+                    long maxFrameSizeBytes;
+                    switch (Configuration.Http.Http2Profile)
+                    {
+                        case Http2Profile.Performance:
+                            connectionWindowBytes = 32L * Constants.Size.Megabyte;
+                            streamWindowBytes = 4L * Constants.Size.Megabyte;
+                            maxFrameSizeBytes = 1L * Constants.Size.Megabyte;
+                            break;
+                        case Http2Profile.Balanced:
+                        default:
+                            connectionWindowBytes = 16L * Constants.Size.Megabyte;
+                            streamWindowBytes = 2L * Constants.Size.Megabyte;
+                            maxFrameSizeBytes = 256L * Constants.Size.Kilobyte;
+                            break;
+                        case Http2Profile.Conservative:
+                            connectionWindowBytes = 4L * Constants.Size.Megabyte;
+                            streamWindowBytes = 1L * Constants.Size.Megabyte;
+                            maxFrameSizeBytes = 16L * Constants.Size.Kilobyte; 
+                            break;
+                    }
+
+                    if (Configuration.Http.Http2Latency == Http2LatencyHint.High)
+                    {
+                        connectionWindowBytes *= 2;
+                        streamWindowBytes *= 2;
+                    }
+
+                    connectionWindowBytes = Configuration.Http.InitialConnectionWindowSize?.GetValue(SizeUnit.Bytes) ?? connectionWindowBytes;
+                    streamWindowBytes = Configuration.Http.InitialStreamWindowSize?.GetValue(SizeUnit.Bytes) ?? streamWindowBytes;
+                    maxFrameSizeBytes = Configuration.Http.MaxFrameSize?.GetValue(SizeUnit.Bytes) ?? maxFrameSizeBytes;
+
+                    // Clamp to RFC 9113 legal ranges: Section 6.5.2 (windows), Section 4.2 (frame size)
+                    connectionWindowBytes = Math.Clamp(connectionWindowBytes, 64L * Constants.Size.Kilobyte, int.MaxValue);
+                    streamWindowBytes = Math.Clamp(streamWindowBytes, 64L * Constants.Size.Kilobyte, int.MaxValue);
+                    maxFrameSizeBytes = Math.Clamp(maxFrameSizeBytes, 16L * Constants.Size.Kilobyte, 16L * Constants.Size.Megabyte - 1);
+
+                    options.Limits.Http2.InitialConnectionWindowSize = (int)connectionWindowBytes;
+                    options.Limits.Http2.InitialStreamWindowSize = (int)streamWindowBytes;
+                    options.Limits.Http2.MaxFrameSize = (int)maxFrameSizeBytes;
+
+                    if (Logger.IsOperationsEnabled)
+                    {
+                        var connectionWindow = new Sparrow.Size(connectionWindowBytes, SizeUnit.Bytes);
+                        var streamWindow = new Sparrow.Size(streamWindowBytes, SizeUnit.Bytes);
+                        var maxFrameSize = new Sparrow.Size(maxFrameSizeBytes, SizeUnit.Bytes);
+                        Logger.Operations($"HTTP/2: Profile={Configuration.Http.Http2Profile}, ConnWindow={connectionWindow.GetDoubleValue(SizeUnit.Kilobytes):F1}KB, StreamWindow={streamWindow.GetDoubleValue(SizeUnit.Kilobytes):F1}KB, MaxFrame={maxFrameSize.GetDoubleValue(SizeUnit.Kilobytes):F1}KB, MaxStreams={options.Limits.Http2.MaxStreamsPerConnection}");
+                    }
 
                     options.ConfigureEndpointDefaults(listenOptions => listenOptions.Protocols = Configuration.Http.Protocols);
 
@@ -468,25 +522,25 @@ namespace Raven.Server
                     builder.AddRuntimeInstrumentation();
                 
                 if (configuration.GeneralEnabled)
-                    builder.AddMeter(Constants.Meters.GeneralMeter);
+                    builder.AddMeter(TelemetryConstants.Meters.GeneralMeter);
                 
                 if (configuration.Requests)
-                    builder.AddMeter(Constants.Meters.RequestsMeter);
+                    builder.AddMeter(TelemetryConstants.Meters.RequestsMeter);
 
                 if (configuration.ServerStorage)
-                    builder.AddMeter(Constants.Meters.StorageMeter);
+                    builder.AddMeter(TelemetryConstants.Meters.StorageMeter);
                 
                 if (configuration.GcEnabled)
-                    builder.AddMeter(Constants.Meters.GcMeter);
+                    builder.AddMeter(TelemetryConstants.Meters.GcMeter);
                 
                 if (configuration.TotalDatabases)
-                    builder.AddMeter(Constants.Meters.TotalDatabasesMeter);
+                    builder.AddMeter(TelemetryConstants.Meters.TotalDatabasesMeter);
                 
                 if (configuration.Resources)
-                    builder.AddMeter(Constants.Meters.Resources);
+                    builder.AddMeter(TelemetryConstants.Meters.Resources);
                 
                 if (configuration.CPUCredits)
-                    builder.AddMeter(Constants.Meters.CpuCreditsMeter);
+                    builder.AddMeter(TelemetryConstants.Meters.CpuCreditsMeter);
                 
                 if (configuration.ConsoleExporter)
                     builder.AddConsoleExporter();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25067

### Additional description

We discovered throughput was capping at around 35 Mbps per connection when testing over WAN links with 150ms RTT, regardless of how many concurrent streams we threw at it. Forcing HTTP/1.1 immediately removed the cap and saturated the link. The culprit turned out to be Kestrel's default HTTP/2 flow control window -- too conservative for high-latency or high-bandwidth paths.

HTTP/2 uses per-stream and per-connection receive windows (RFC 9113). Senders can't exceed the receiver-advertised limits, so undersized windows starve throughput when the bandwidth-delay product gets large.

Added a profile-based configuration system:
  - Performance: 32 MB connection, 4 MB stream (maximize throughput, uses more memory)
  - Default: 16 MB connection, 2 MB stream (balanced, default for 64-bit runtimes)
  - Conservative: 4 MB connection, 1 MB stream (lower memory, may cap throughput on high RTT,  default for 32-bit runtimes to conserve memory.

Added a latency hint for WAN deployments:
  - Default: Low RTT (collocated, same region/AZ) - uses profile as-is
  - High: WAN/cross-region - doubles the windows to handle larger round-trip times

For experts who understand their bandwidth-delay product and memory constraints, we added explicit overrides:
  - Http.Http2.InitialConnectionWindowSizeInKb
  - Http.Http2.InitialStreamWindowSizeInKb

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
