### PR TITLE
RavenDB-25450 Fix z-index and scroll in databases view

### DIFF
--- a/src/Raven.Studio/scripts/setup_jest.js
+++ b/src/Raven.Studio/scripts/setup_jest.js
@@ -56,17 +56,19 @@ global.define = function() {};
 
 Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
     configurable: true,
-    value: 500,
+    value: 800,
 });
-
-Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
-    configurable: true,
-    value: 500,
-});
-
 Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
     configurable: true,
-    value: 500,
+    value: 800,
+});
+Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    value: 1000,
+});
+Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    value: 1000,
 });
 
 if (!window.ResizeObserver) {

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/DatabasesPage.tsx
@@ -19,7 +19,6 @@ import { Icon } from "components/common/Icon";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import CreateDatabase, { CreateDatabaseMode } from "./partials/create/CreateDatabase";
 import Button from "react-bootstrap/Button";
-import SizeGetter from "components/common/SizeGetter";
 import DatabasesList from "./partials/DatabasesList";
 
 interface DatabasesPageProps {
@@ -107,8 +106,8 @@ export function DatabasesPage({ queryParams }: ReactQueryParamsProps<DatabasesPa
     const [createDatabaseMode, setCreateDatabaseMode] = useState<CreateDatabaseMode>(null);
 
     return (
-        <div className="h-100 vstack">
-            <div className="d-flex flex-wrap gap-3 align-items-end px-4 pt-4">
+        <div className="h-100 vstack py-4">
+            <div className="d-flex flex-wrap gap-3 align-items-end px-4">
                 {isOperatorOrAbove && (
                     <>
                         <Button
@@ -144,23 +143,17 @@ export function DatabasesPage({ queryParams }: ReactQueryParamsProps<DatabasesPa
                 selectedDatabases={selectedDatabases}
                 setSelectedDatabaseNames={setSelectedDatabaseNames}
             />
-            {databases.length > 0 ? (
-                <div className="flex-grow-1">
-                    <SizeGetter
-                        isHeighRequired
-                        render={({ height }) => (
-                            <DatabasesList
-                                maxHeight={height}
-                                filteredDatabaseNames={filteredDatabaseNames}
-                                selectedDatabaseNames={selectedDatabaseNames}
-                                toggleSelection={toggleSelection}
-                            />
-                        )}
+            <div className="flex-grow-1 overflow-hidden pt-2">
+                {databases.length > 0 ? (
+                    <DatabasesList
+                        filteredDatabaseNames={filteredDatabaseNames}
+                        selectedDatabaseNames={selectedDatabaseNames}
+                        toggleSelection={toggleSelection}
                     />
-                </div>
-            ) : (
-                <NoDatabases />
-            )}
+                ) : (
+                    <NoDatabases />
+                )}
+            </div>
         </div>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesList.tsx
@@ -3,14 +3,12 @@ import { useRef } from "react";
 import { DatabasePanel } from "./DatabasePanel";
 
 interface DatabasesListProps {
-    maxHeight: number;
     filteredDatabaseNames: string[];
     selectedDatabaseNames: string[];
     toggleSelection: (dbName: string) => void;
 }
 
 export default function DatabasesList({
-    maxHeight,
     filteredDatabaseNames,
     selectedDatabaseNames,
     toggleSelection,
@@ -29,7 +27,7 @@ export default function DatabasesList({
     });
 
     return (
-        <div ref={listRef} style={{ overflow: "auto", height: maxHeight }} className="px-4">
+        <div ref={listRef} className="h-100 overflow-auto px-4">
             <div style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}>
                 {virtualizer.getVirtualItems().map((virtualRow) => {
                     const dbName = filteredDatabaseNames[virtualRow.index];
@@ -46,7 +44,7 @@ export default function DatabasesList({
                                 width: "100%",
                                 transform: `translateY(${virtualRow.start}px)`,
                             }}
-                            className="pb-2 pt-1"
+                            className="pb-2 pt-1 virtual-item"
                         >
                             <DatabasePanel
                                 key={dbName}

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/DatabasesSelectActions.tsx
@@ -111,7 +111,7 @@ export function DatabasesSelectActions({
     };
 
     return (
-        <div className="position-relative px-4 py-3">
+        <div className="position-relative px-4 pt-3">
             <Checkbox
                 selected={selectionState === "AllSelected"}
                 indeterminate={selectionState === "SomeSelected"}

--- a/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_bs5extend.scss
@@ -354,6 +354,11 @@ select {
     }
 }
 
+// Ensure dropdown menus are not clipped by sibling items in virtualized lists
+.virtual-item:has(.dropdown.show) {
+    z-index: 1;
+}
+
 // remove padding top from modal footer
 .modal-footer {
     padding-top: 0;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25450/z-index-issue-on-databases-view

### Additional description

- remove size getter (just use height 100% with flex-grow)
- fix paddings and scroll
- fix z-index for dropdown in virtual-list

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
