### PR TITLE
RavenDB-25198 Generate new key pair for some test CA certificates

### DIFF
--- a/test/SlowTests/Issues/RavenDB-19148.cs
+++ b/test/SlowTests/Issues/RavenDB-19148.cs
@@ -23,7 +23,7 @@ public class RavenDB_19148 : ClusterTestBase
     {
         var suffix = Guid.NewGuid().ToString().Split('-')[0];
         var caCommonNameValue = $"auth-{suffix}";
-        var ca = CertificateUtils.CreateCertificateAuthorityCertificate(caCommonNameValue, out var caName);
+        var ca = CertificateUtils.CreateCertificateAuthorityCertificate(caCommonNameValue, out var caName, generateNewKeyPair: true);
         CertificateUtils.CreateSelfSignedCertificateBasedOnPrivateKey($"admin-{suffix}", caName, (ca.GetExportableRsaPrivateKey(), ca.GetRSAPublicKey()), true, false,
             DateTime.UtcNow.Date.AddMonths(3), out var certBytes);
         CertificateUtils.RemoveOldTestCertificatesFromOsStore(caCommonNameValue);

--- a/test/SlowTests/Issues/RavenDB-21535.cs
+++ b/test/SlowTests/Issues/RavenDB-21535.cs
@@ -121,7 +121,7 @@ namespace SlowTests.Issues
             var suffix = Guid.NewGuid().ToString().Split('-')[0];
 
             var caCommonNameValue = $"ca-{suffix}";
-            var ca = CertificateUtils.CreateCertificateAuthorityCertificate(caCommonNameValue, out _);
+            var ca = CertificateUtils.CreateCertificateAuthorityCertificate(caCommonNameValue, out _, generateNewKeyPair: true);
             var caBase64 = Convert.ToBase64String(ca.Export(X509ContentType.Cert));
             log?.AppendLine($"Created CA: {ca.GetDisplayName()} ({ca.Thumbprint})");
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25198

### Additional description

Generate new key pair for sometimes failing tests.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
