### PR TITLE
RavenDB-25453 Set the maximum number of order by statements in Corax to 16 and added better exception on attempt to use more

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1386,7 +1386,10 @@ public static class CoraxQueryBuilder
         }
 
         int sortIndex = 0;
-        var sortArray = new OrderMetadata[8];
+        var sortArray = new OrderMetadata[16];
+
+        if (orderByFields.Length > sortArray.Length)
+            throw new InvalidOperationException($"Corax does not support ordering by more than {sortArray.Length} properties.");
 
         foreach (var field in orderByFields)
         {

--- a/test/SlowTests/Issues/RavenDB-25453.cs
+++ b/test/SlowTests/Issues/RavenDB-25453.cs
@@ -1,0 +1,148 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25453 : RavenTestBase
+{
+    public RavenDB_25453(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void OrderingByUpTo16PropertiesShouldWork(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto() { 
+                    Name1 = "a",  
+                    Name2 = "b", 
+                    Name3 = "c", 
+                    Name4 = "d", 
+                    Name5 = "e", 
+                    Name6 = "f", 
+                    Name7 = "g", 
+                    Name8 = "h", 
+                    Name9 = "i" ,
+                    Name10 = "j",
+                    Name11 = "k",
+                    Name12 = "l",
+                    Name13 = "m",
+                    Name14 = "n",
+                    Name15 = "o",
+                    Name16 = "p",
+                    Name17 = "r"
+                };
+                
+                session.Store(dto);
+                session.SaveChanges();
+                
+                var result = session.Query<Dto>()
+                    .OrderBy(x => x.Name1)
+                    .ThenBy(x => x.Name2)
+                    .ThenBy(x => x.Name3)
+                    .ThenBy(x => x.Name4)
+                    .ThenBy(x => x.Name5)
+                    .ThenBy(x => x.Name6)
+                    .ThenBy(x => x.Name7)
+                    .ThenBy(x => x.Name8)
+                    .ThenBy(x => x.Name9)
+                    .ThenBy(x => x.Name10)
+                    .ThenBy(x => x.Name11)
+                    .ThenBy(x => x.Name12)
+                    .ThenBy(x => x.Name13)
+                    .ThenBy(x => x.Name14)
+                    .ThenBy(x => x.Name15)
+                    .ThenBy(x => x.Name16)
+                    .ToList();
+                
+                Assert.Single(result);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void OrderingByOver16PropertiesShouldThrowOnCorax(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var dto = new Dto()
+                {
+                    Name1 = "a",
+                    Name2 = "b",
+                    Name3 = "c",
+                    Name4 = "d",
+                    Name5 = "e",
+                    Name6 = "f",
+                    Name7 = "g",
+                    Name8 = "h",
+                    Name9 = "i",
+                    Name10 = "j",
+                    Name11 = "k",
+                    Name12 = "l",
+                    Name13 = "m",
+                    Name14 = "n",
+                    Name15 = "o",
+                    Name16 = "p",
+                    Name17 = "r"
+                };
+
+                session.Store(dto);
+                session.SaveChanges();
+
+                var exception = Assert.Throws<RavenException>(() => session.Query<Dto>()
+                    .OrderBy(x => x.Name1)
+                    .ThenBy(x => x.Name2)
+                    .ThenBy(x => x.Name3)
+                    .ThenBy(x => x.Name4)
+                    .ThenBy(x => x.Name5)
+                    .ThenBy(x => x.Name6)
+                    .ThenBy(x => x.Name7)
+                    .ThenBy(x => x.Name8)
+                    .ThenBy(x => x.Name9)
+                    .ThenBy(x => x.Name10)
+                    .ThenBy(x => x.Name11)
+                    .ThenBy(x => x.Name12)
+                    .ThenBy(x => x.Name13)
+                    .ThenBy(x => x.Name14)
+                    .ThenBy(x => x.Name15)
+                    .ThenBy(x => x.Name16)
+                    .ThenBy(x => x.Name17)
+                    .ToList());
+
+                Assert.Contains("Corax does not support ordering by more than 16 properties.", exception.Message);
+            }
+        }
+    }
+
+    private class Dto
+    {
+        public string Name1 { get; set; }
+        public string Name2 { get; set; }
+        public string Name3 { get; set; }
+        public string Name4 { get; set; }
+        public string Name5 { get; set; }
+        public string Name6 { get; set; }
+        public string Name7 { get; set; }
+        public string Name8 { get; set; }
+        public string Name9 { get; set; }
+        public string Name10 { get; set; }
+        public string Name11 { get; set; }
+        public string Name12 { get; set; }
+        public string Name13 { get; set; }
+        public string Name14 { get; set; }
+        public string Name15 { get; set; }
+        public string Name16 { get; set; }
+        public string Name17 { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25453/IndexOutOfRangeException-when-using-multiple-OrderBy-clauses-in-Corax

### Additional description

Set the maximum number of order by statements in Corax to 16 and added better exception on attempt to use more. Previously it resulted in `IndexOutOfRangeException`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
