### PR TITLE
RavenDB-25459 - Fix StackOverflow in reproduction test for RavenDB-25412

### DIFF
--- a/test/SlowTests/Issues/RavenDB_25412.cs
+++ b/test/SlowTests/Issues/RavenDB_25412.cs
@@ -180,6 +180,8 @@ public class RavenDB_25412 : ReplicationTestBase
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Link the caller's token with our dispose token to handle stream disposal correctly
             using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token))
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25459/Stack-overflow-SlowTests.Issues.RavenDB25412.HubSinkPullReplicationShouldReconnectWhenRemoteStopsSending

### Additional description

Fixed a `StackOverflowException` in the `SmartHangingStreamWrapper` test utility.
WinDbg Analysis: `!clrstack` revealed infinite recursion in `ReadAsync` caused by a `Task.WhenAny` loop repeatedly firing on a cancelled token.

Fix: Added `cancellationToken.ThrowIfCancellationRequested()` at the start of the method to break the cycle.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed