### PR TITLE
RavenDB-25430 - AiAgent Disable option

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
@@ -110,6 +110,12 @@ public class AiAgentConfiguration : IDynamicJson
     /// </value>
     public int? MaxModelIterationsPerCall { get; set; }
 
+    /// <summary>
+    /// Indicates whether the ai-agent is disabled.
+    /// </summary>
+    public bool Disabled { get; set; }
+
+
     internal AiAgentToolQuery FindQuery(string name)
     {
         foreach (AiAgentToolQuery query in Queries ?? [])
@@ -146,7 +152,8 @@ public class AiAgentConfiguration : IDynamicJson
             [nameof(Actions)] = Actions != null ? new DynamicJsonArray(Actions) : null,
             [nameof(Parameters)] = new DynamicJsonArray(Parameters),
             [nameof(ChatTrimming)] = ChatTrimming?.ToJson(),
-            [nameof(MaxModelIterationsPerCall)] = MaxModelIterationsPerCall
+            [nameof(MaxModelIterationsPerCall)] = MaxModelIterationsPerCall,
+            [nameof(Disabled)] = Disabled,
         };
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -30,6 +30,9 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             AiAgentConfiguration configuration = GetAiAgentConfiguration(agentId);
 
+            if (configuration.Disabled)
+                throw new InvalidOperationException($"The AI Agent '{configuration.Identifier}' is currently disabled. Please enable the agent before starting\\continuing a conversation.");
+
             using var _ = ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
             var body = await ReadRequestBodyAsync(context, token.Token);
             var handler = new ConversationHandler(RequestHandler.ServerStore, RequestHandler.Database)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http.Features.Authentication;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Exceptions.Commercial;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands.AI;
@@ -39,8 +40,8 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
             Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
         };
 
-        if (body.Configuration.Disabled)
-            throw new InvalidOperationException($"The AI Agent '{body.Configuration.Identifier}' is currently disabled. Please enable the agent before starting\\continuing a conversation.");
+        if (ServerStore.LicenseManager.LicenseStatus.HasAiAgent == false)
+            throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");
 
         await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, token: token);
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http.Features.Authentication;
@@ -37,6 +38,10 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         {
             Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
         };
+
+        if (body.Configuration.Disabled)
+            throw new InvalidOperationException($"The AI Agent '{body.Configuration.Identifier}' is currently disabled. Please enable the agent before starting\\continuing a conversation.");
+
         await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, token: token);
     }
 

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -403,6 +403,14 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             if (RestoreConfiguration.DisableOngoingTasks == false)
                 return;
 
+            if (databaseRecord.AiAgents != null)
+            {
+                foreach (var agent in databaseRecord.AiAgents)
+                {
+                    agent.Disabled = true;
+                }
+            }
+
             if (databaseRecord.ExternalReplications != null)
             {
                 foreach (var task in databaseRecord.ExternalReplications)

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -64,7 +64,8 @@ public sealed partial class ClusterStateMachine
         nameof(UpdateQueueSinkCommand),
         nameof(EditDataArchivalCommand),
         nameof(AddEmbeddingsGenerationCommand),
-        nameof(UpdateEmbeddingsGenerationCommand)
+        nameof(UpdateEmbeddingsGenerationCommand),
+        nameof(AddOrUpdateAiAgentCommand)
     };
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
@@ -1088,7 +1089,7 @@ public sealed partial class ClusterStateMachine
         if (licenseStatus.HasAiAgent)
             return;
 
-        if (databaseRecord.AiAgents.Count == 0)
+        if (databaseRecord.AiAgents.Any(x => x.Disabled == false) == false)
             return;
 
         throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -1089,7 +1089,7 @@ public sealed partial class ClusterStateMachine
         if (licenseStatus.HasAiAgent)
             return;
 
-        if (databaseRecord.AiAgents.Any(x => x.Disabled == false) == false)
+        if (databaseRecord.AiAgents.All(x => x.Disabled))
             return;
 
         throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");

--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
@@ -649,6 +649,7 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
 
             foreach (var config in databaseRecord.AiAgents)
             {
+                config.Disabled = true;
                 tasks.Add(_server.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(_name, config, RaftIdGenerator.DontCareId)));
             }
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/AiAgents.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/AiAgents.tsx
@@ -10,7 +10,6 @@ import { useServices } from "components/hooks/useServices";
 import { useAsync } from "react-async-hook";
 import { LoadingView } from "components/common/LoadingView";
 import Button from "react-bootstrap/Button";
-import Row from "react-bootstrap/Row";
 import { useState } from "react";
 import FeatureNotAvailable from "components/common/FeatureNotAvailable";
 import AiAgentCard from "./partials/AiAgentCard";
@@ -103,7 +102,7 @@ export default function AiAgents() {
                 </div>
             )}
             {asyncGetAiAgents.result && (
-                <Row className="mt-3">
+                <div className="grid gap-2 mt-3">
                     {asyncGetAiAgents.result
                         .filter((config) => config.Name.toLowerCase().includes(nameFilter.trim().toLowerCase()))
                         .sort((a, b) => a.Name.localeCompare(b.Name))
@@ -114,7 +113,7 @@ export default function AiAgents() {
                                 reloadAiAgents={asyncGetAiAgents.execute}
                             />
                         ))}
-                </Row>
+                </div>
             )}
         </div>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/ChatAiAgent.tsx
@@ -66,6 +66,11 @@ export default function ChatAiAgent({ queryParams }: ReactQueryParamsProps<ChatA
                         <Icon icon="ai-agents" /> {title}
                     </h2>
                     {document.data?.TotalUsage && <TotalUsageBadge usage={document.data.TotalUsage} />}
+                    {config.data?.Disabled && (
+                        <Badge bg="warning" pill>
+                            Disabled
+                        </Badge>
+                    )}
                 </div>
                 <ChatAiAgentInfoHub />
             </div>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
@@ -83,7 +83,8 @@ export default function ChatAiAgentFormBody({
         dispatch(chatAiAgentActions.isDocumentChangedSet(false));
     };
 
-    const isPromptDisabled = isLoading || isWaitingForActionToolSubmit || isDocumentDeleted || isDocumentChanged;
+    const isPromptDisabled =
+        isLoading || isWaitingForActionToolSubmit || isDocumentDeleted || isDocumentChanged || config.data?.Disabled;
     const hasPromptErrors = formState.errors.prompts?.length > 0;
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentBasicSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentBasicSection.tsx
@@ -139,6 +139,10 @@ export default function EditAiAgentBasicSection({ isEditAiAgent }: EditAiAgentBa
                             />
                         </FormGroup>
                         <FormGroup>
+                            <FormLabel>Agent State</FormLabel>
+                            <FormSelect control={control} name="state" options={stateOptions} />
+                        </FormGroup>
+                        <FormGroup>
                             <FormLabel>
                                 Connection String
                                 <PopoverWithHoverWrapper message="The selected connection string determines which LLM the agent will interact with.">
@@ -308,3 +312,8 @@ const JsonSchemaSyntaxHelp = () => {
         </div>
     );
 };
+
+const stateOptions: SelectOption[] = ["Enabled", "Disabled"].map((x) => ({
+    label: x,
+    value: x,
+}));

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
@@ -8,6 +8,7 @@ function mapFromDto(
         return {
             name: "",
             identifier: "",
+            state: "Enabled",
             connectionStringName: "",
             systemPrompt: "",
             sampleObject: "",
@@ -32,6 +33,7 @@ function mapFromDto(
     return {
         name: isClone ? "" : dto.Name,
         identifier: isClone ? "" : dto.Identifier,
+        state: dto.Disabled ? "Disabled" : "Enabled",
         connectionStringName: dto.ConnectionStringName,
         systemPrompt: dto.SystemPrompt,
         sampleObject: dto.SampleObject,
@@ -96,6 +98,7 @@ function mapToDto(formData: EditAiAgentFormData): Raven.Client.Documents.Operati
         Identifier: formData.identifier,
         ConnectionStringName: formData.connectionStringName,
         SystemPrompt: formData.systemPrompt,
+        Disabled: formData.state === "Disabled",
         OutputSchema: formData.outputSchema,
         SampleObject: formData.sampleObject,
         Parameters:
@@ -123,7 +126,6 @@ function mapToDto(formData: EditAiAgentFormData): Raven.Client.Documents.Operati
                 ParametersSchema: x.parametersSchema || null,
             })) ?? [],
         MaxModelIterationsPerCall: null,
-        Disabled: false,
         ChatTrimming:
             formData.trimming?.method != null
                 ? {

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
@@ -123,6 +123,7 @@ function mapToDto(formData: EditAiAgentFormData): Raven.Client.Documents.Operati
                 ParametersSchema: x.parametersSchema || null,
             })) ?? [],
         MaxModelIterationsPerCall: null,
+        Disabled: false,
         ChatTrimming:
             formData.trimming?.method != null
                 ? {

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
@@ -13,6 +13,7 @@ const editSchema = yup.object({
     // Basic
     name: yup.string().required(),
     identifier: yup.string().required(),
+    state: yup.string<"Disabled" | "Enabled">().required(),
     connectionStringName: yup.string().required(),
     systemPrompt: yup.string().required(),
     sampleObject: yup.string().nullable(),

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentCard.tsx
@@ -33,18 +33,9 @@ export default function AiAgentCard({ config, reloadAiAgents }: AiAgentCardProps
         onSuccess: reloadAiAgents,
     });
 
-    const asyncDisableAiAgent = useAsyncCallback(
-        () => aiAgentService.saveAiAgent(databaseName, { ...config, Disabled: true }),
-        {
-            onSuccess: reloadAiAgents,
-        }
-    );
-
-    const asyncEnableAiAgent = useAsyncCallback(
-        () => aiAgentService.saveAiAgent(databaseName, { ...config, Disabled: false }),
-        {
-            onSuccess: reloadAiAgents,
-        }
+    const asyncToggleAiAgent = useAsyncCallback(
+        (isDisabled: boolean) => aiAgentService.saveAiAgent(databaseName, { ...config, Disabled: isDisabled }),
+        { onSuccess: reloadAiAgents }
     );
 
     const handleDelete = async () => {
@@ -122,31 +113,17 @@ export default function AiAgentCard({ config, reloadAiAgents }: AiAgentCardProps
                             <Dropdown.Item href={appUrl.forEditAiAgent(databaseName, config.Identifier, true)}>
                                 <Icon icon="copy" /> Clone
                             </Dropdown.Item>
-                            {config.Disabled ? (
-                                <Dropdown.Item
-                                    onClick={asyncEnableAiAgent.execute}
-                                    disabled={asyncEnableAiAgent.loading}
-                                >
-                                    {asyncEnableAiAgent.loading ? (
-                                        <Spinner size="sm" className="me-1" />
-                                    ) : (
-                                        <Icon icon="play" />
-                                    )}
-                                    Enable
-                                </Dropdown.Item>
-                            ) : (
-                                <Dropdown.Item
-                                    onClick={asyncDisableAiAgent.execute}
-                                    disabled={asyncDisableAiAgent.loading}
-                                >
-                                    {asyncDisableAiAgent.loading ? (
-                                        <Spinner size="sm" className="me-1" />
-                                    ) : (
-                                        <Icon icon="stop" />
-                                    )}
-                                    Disable
-                                </Dropdown.Item>
-                            )}
+                            <Dropdown.Item
+                                onClick={() => asyncToggleAiAgent.execute(!config.Disabled)}
+                                disabled={asyncToggleAiAgent.loading}
+                            >
+                                {asyncToggleAiAgent.loading ? (
+                                    <Spinner size="sm" className="me-1" />
+                                ) : (
+                                    <Icon icon={config.Disabled ? "play" : "stop"} />
+                                )}
+                                {config.Disabled ? "Enable" : "Disable"}
+                            </Dropdown.Item>{" "}
                             <Dropdown.Item
                                 className="text-danger"
                                 onClick={handleDelete}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentCard.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentCard.tsx
@@ -6,12 +6,13 @@ import { useServices } from "components/hooks/useServices";
 import { useAppSelector } from "components/store";
 import { Icon } from "components/common/Icon";
 import { useAsyncCallback } from "react-async-hook";
-import Col from "react-bootstrap/Col";
 import Dropdown from "react-bootstrap/Dropdown";
 import Spinner from "react-bootstrap/Spinner";
 import copyToClipboard from "common/copyToClipboard";
 import Button from "react-bootstrap/Button";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
+import Badge from "react-bootstrap/Badge";
+import classNames from "classnames";
 
 interface AiAgentCardProps {
     config: Raven.Client.Documents.Operations.AI.Agents.AiAgentConfiguration;
@@ -31,6 +32,20 @@ export default function AiAgentCard({ config, reloadAiAgents }: AiAgentCardProps
     const asyncDeleteAiAgent = useAsyncCallback(() => aiAgentService.deleteAiAgent(databaseName, config.Identifier), {
         onSuccess: reloadAiAgents,
     });
+
+    const asyncDisableAiAgent = useAsyncCallback(
+        () => aiAgentService.saveAiAgent(databaseName, { ...config, Disabled: true }),
+        {
+            onSuccess: reloadAiAgents,
+        }
+    );
+
+    const asyncEnableAiAgent = useAsyncCallback(
+        () => aiAgentService.saveAiAgent(databaseName, { ...config, Disabled: false }),
+        {
+            onSuccess: reloadAiAgents,
+        }
+    );
 
     const handleDelete = async () => {
         const isConfirmed = await confirm({
@@ -57,64 +72,97 @@ export default function AiAgentCard({ config, reloadAiAgents }: AiAgentCardProps
     };
 
     return (
-        <Col className="p-1" sm={12} xl={6} xxl={4}>
-            <div className="panel-bg-1 p-2 rounded-2 border border-secondary">
-                <h4 className="m-0 text-truncate" title="AI Agent name">
+        <div className="panel-bg-1 p-2 rounded-2 border border-secondary g-col-12 g-col-xl-6 g-col-xxl-4">
+            <div className="hstack mb-1">
+                <h4 className="m-0 text-truncate flex-grow" title="AI Agent name">
                     {config.Name}
                 </h4>
-                <div className="d-flex">
-                    <div className="text-truncate text-muted fs-5" title="AI Agent identifier">
-                        {config.Identifier}
-                    </div>
-                    <Button
-                        onClick={() => copyToClipboard.copy(config.Identifier, "Copied agent identifier to clipboard.")}
-                        size="xs"
-                        title="Copy to clipboard"
-                        variant="link"
-                        className="p-0"
+                {config.Disabled && (
+                    <Badge bg="warning" className="ms-2 fs-6" pill>
+                        Disabled
+                    </Badge>
+                )}
+            </div>
+            <div className="d-flex">
+                <div className="text-truncate text-muted fs-5" title="AI Agent identifier">
+                    {config.Identifier}
+                </div>
+                <Button
+                    onClick={() => copyToClipboard.copy(config.Identifier, "Copied agent identifier to clipboard.")}
+                    size="xs"
+                    title="Copy to clipboard"
+                    variant="link"
+                    className="p-0"
+                >
+                    <Icon icon="copy-to-clipboard" margin="ms-1" />
+                </Button>
+            </div>
+            <div className="mt-2 text-truncate" title={config.SystemPrompt}>
+                {config.SystemPrompt}
+            </div>
+            <div className="hstack justify-content-between mt-2">
+                {hasDatabaseWriteAccess && (
+                    <a
+                        href={appUrl.forChatAiAgent(databaseName, config.Identifier)}
+                        className={classNames("btn btn-primary", { disabled: config.Disabled })}
                     >
-                        <Icon icon="copy-to-clipboard" margin="ms-1" />
-                    </Button>
-                </div>
-                <div className="mt-2 text-truncate" title={config.SystemPrompt}>
-                    {config.SystemPrompt}
-                </div>
-                <div className="hstack justify-content-between mt-2">
-                    {hasDatabaseWriteAccess && (
-                        <a href={appUrl.forChatAiAgent(databaseName, config.Identifier)} className="btn btn-primary">
-                            <Icon icon="llm" />
-                            Start new chat
-                        </a>
-                    )}
-                    {hasDatabaseAdminAccess && (
-                        <Dropdown>
-                            <Dropdown.Toggle as={CustomDropdownToggle} isCaretHidden variant="secondary">
-                                <Icon icon="more" margin="m-0" />
-                            </Dropdown.Toggle>
-                            <Dropdown.Menu>
-                                <Dropdown.Item href={appUrl.forEditAiAgent(databaseName, config.Identifier)}>
-                                    <Icon icon="edit" /> Edit agent
-                                </Dropdown.Item>
-                                <Dropdown.Item href={appUrl.forEditAiAgent(databaseName, config.Identifier, true)}>
-                                    <Icon icon="copy" /> Clone agent
-                                </Dropdown.Item>
+                        <Icon icon="llm" />
+                        Start new chat
+                    </a>
+                )}
+                {hasDatabaseAdminAccess && (
+                    <Dropdown autoClose="outside">
+                        <Dropdown.Toggle as={CustomDropdownToggle} isCaretHidden variant="secondary">
+                            <Icon icon="more" margin="m-0" />
+                        </Dropdown.Toggle>
+                        <Dropdown.Menu>
+                            <Dropdown.Item href={appUrl.forEditAiAgent(databaseName, config.Identifier)}>
+                                <Icon icon="edit" /> Edit
+                            </Dropdown.Item>
+                            <Dropdown.Item href={appUrl.forEditAiAgent(databaseName, config.Identifier, true)}>
+                                <Icon icon="copy" /> Clone
+                            </Dropdown.Item>
+                            {config.Disabled ? (
                                 <Dropdown.Item
-                                    className="text-danger"
-                                    onClick={handleDelete}
-                                    disabled={asyncDeleteAiAgent.loading}
+                                    onClick={asyncEnableAiAgent.execute}
+                                    disabled={asyncEnableAiAgent.loading}
                                 >
-                                    {asyncDeleteAiAgent.loading ? (
+                                    {asyncEnableAiAgent.loading ? (
                                         <Spinner size="sm" className="me-1" />
                                     ) : (
-                                        <Icon icon="trash" />
+                                        <Icon icon="play" />
                                     )}
-                                    Delete agent
+                                    Enable
                                 </Dropdown.Item>
-                            </Dropdown.Menu>
-                        </Dropdown>
-                    )}
-                </div>
+                            ) : (
+                                <Dropdown.Item
+                                    onClick={asyncDisableAiAgent.execute}
+                                    disabled={asyncDisableAiAgent.loading}
+                                >
+                                    {asyncDisableAiAgent.loading ? (
+                                        <Spinner size="sm" className="me-1" />
+                                    ) : (
+                                        <Icon icon="stop" />
+                                    )}
+                                    Disable
+                                </Dropdown.Item>
+                            )}
+                            <Dropdown.Item
+                                className="text-danger"
+                                onClick={handleDelete}
+                                disabled={asyncDeleteAiAgent.loading}
+                            >
+                                {asyncDeleteAiAgent.loading ? (
+                                    <Spinner size="sm" className="me-1" />
+                                ) : (
+                                    <Icon icon="trash" />
+                                )}
+                                Delete
+                            </Dropdown.Item>
+                        </Dropdown.Menu>
+                    </Dropdown>
+                )}
             </div>
-        </Col>
+        </div>
     );
 }

--- a/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
@@ -59,6 +59,7 @@ export class AiAgentStubs {
                     ],
                     ChatTrimming: null,
                     MaxModelIterationsPerCall: null,
+                    Disabled: false,
                 },
             ],
         };

--- a/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/bs5variables.scss
@@ -35,7 +35,7 @@ $enable-reduced-motion: false !default;
 $enable-smooth-scroll: true !default;
 $enable-grid-classes: true !default;
 $enable-container-classes: true !default;
-$enable-cssgrid: false !default;
+$enable-cssgrid: true !default;
 $enable-button-pointers: true !default;
 $enable-rfs: true !default;
 $enable-validation-icons: true !default;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25430.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25430.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Server.Commercial;
+using Raven.Server.ServerWide.Commands;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class RavenDB_25430 : ReplicationTestBase
+{
+    public RavenDB_25430(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Ai, Skip = "RavenDB-25471")]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+    public async Task DisableAiAgentsOnRestoreWithoutLicense(Options options, GenAiConfiguration aiConfig, BackupType backupType)
+    {
+        DoNotReuseServer();
+
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+
+        using var source = GetDocumentStore();
+        await DisableRevisionCompression(Server, source);
+
+        await source.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(aiConfig.Connection));
+        var agents = GetAgents(aiConfig);
+        foreach (var agentConfig in agents)
+        {
+            await source.AI.CreateAgentAsync(agentConfig, AiAgentBasics.OutputSchema.Instance);
+        }
+        var backupOperation = await source.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+        {
+            BackupType = backupType,
+            LocalSettings = new LocalSettings
+            {
+                FolderPath = backupPath
+            }
+        }));
+        await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+        await source.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(source.Database, hardDelete: true));
+
+        await PutLicense(Server, LicenseTestBase.RL_COMM);
+
+        using var store = GetDocumentStore();
+
+        using var destination = new DocumentStore { Urls = new[] { Server.WebUrl }, Database = GetDatabaseName() + "_Restore" }.Initialize();
+
+        foreach (var agentConfig in agents)
+        {
+            agentConfig.Disabled = true;
+        }
+
+        using (Backup.RestoreDatabase(destination,
+                   new RestoreBackupConfiguration
+                   {
+                       BackupLocation = Directory.GetDirectories(backupPath).First(),
+                       DatabaseName = destination.Database,
+                       DisableOngoingTasks = true
+                   }))
+        {
+            var destRecord = await destination.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(destination.Database));
+            var destConfigs = destRecord.AiAgents;
+            Assert.NotNull(destConfigs);
+            Assert.Equal(2, destConfigs.Count);
+            Assert.NotNull(destConfigs[0]);
+            Assert.NotNull(destConfigs[1]);
+            Assert.Equal("shopping-assistant", destConfigs[0].Identifier);
+            Assert.Equal("warehouse-manager", destConfigs[1].Identifier);
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                var converter = DocumentConventions.Default.Serialization.DefaultConverter;
+                var c0 = converter.ToBlittable(agents[0], context);
+                var d0 = converter.ToBlittable(destConfigs[0], context);
+                Assert.Equal(c0, d0);
+                var c1 = converter.ToBlittable(agents[1], context);
+                var d1 = converter.ToBlittable(destConfigs[1], context);
+                Assert.Equal(c1, d1);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai, Skip = "RavenDB-25471")]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+    public async Task ThrowAiAgentsOnRestoreWithoutLicense(Options options, GenAiConfiguration aiConfig, BackupType backupType)
+    {
+        DoNotReuseServer();
+
+        var backupPath = NewDataPath(suffix: "BackupFolder");
+
+        using var source = GetDocumentStore();
+        await DisableRevisionCompression(Server, source);
+
+        await source.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(aiConfig.Connection));
+        var agents = GetAgents(aiConfig);
+        foreach (var agentConfig in agents)
+        {
+            await source.AI.CreateAgentAsync(agentConfig, AiAgentBasics.OutputSchema.Instance);
+        }
+        var backupOperation = await source.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+        {
+            BackupType = backupType,
+            LocalSettings = new LocalSettings
+            {
+                FolderPath = backupPath
+            }
+        }));
+        await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+        foreach (var agentConfig in agents)
+        {
+            agentConfig.Disabled = true;
+            await source.AI.CreateAgentAsync(agentConfig, AiAgentBasics.OutputSchema.Instance);
+        }
+
+        await PutLicense(Server, LicenseTestBase.RL_COMM);
+
+        using var destination = new DocumentStore { Urls = new[] { Server.WebUrl }, Database = GetDatabaseName() + "_Restore" }.Initialize();
+        var e = Assert.Throws<LicenseLimitException>(() => {
+            using (Backup.RestoreDatabase(destination,
+                       new RestoreBackupConfiguration
+                       {
+                           BackupLocation = Directory.GetDirectories(backupPath).First(),
+                           DatabaseName = destination.Database,
+                       }))
+            {
+            }
+        });
+        Assert.Contains("Your license doesn't support using the AI Agent feature", e.Message);
+
+        e = await Assert.ThrowsAsync<LicenseLimitException>(async () => {
+            foreach (var agentConfig in agents)
+            {
+                agentConfig.Disabled = false;
+                await source.AI.CreateAgentAsync(agentConfig, AiAgentBasics.OutputSchema.Instance);
+            }
+        });
+        Assert.Contains("Your current license doesn't include the AI Agent feature", e.Message);
+
+        e = await Assert.ThrowsAsync<LicenseLimitException>(async () => {
+            var record = source.Maintenance.Server.Send(new GetDatabaseRecordOperation(source.Database));
+            record.AiAgents[0].Disabled = false;
+            record.DatabaseName += "_Copy";
+            await source.Maintenance.Server.SendAsync(new CreateDatabaseOperation(record));
+        });
+        Assert.Contains("Your license doesn't support using the AI Agent feature", e.Message);
+
+        var chat = source.AI.Conversation(agents[0].Identifier, "chats/",
+            new AiConversationCreationOptions()
+                .AddParameter("company", "companies/90-A"));
+
+        var ex = await Assert.ThrowsAsync<RavenException>(async () => {
+            chat.SetUserPrompt("hello");
+            await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+        });
+        Assert.Contains("The AI Agent 'shopping-assistant' is currently disabled. Please enable the agent before starting\\continuing a conversation.", ex.Message);
+    }
+
+    private static List<AiAgentConfiguration> GetAgents(GenAiConfiguration aiConfig)
+    {
+        var agent0 = new AiAgentConfiguration("shopping assistant", aiConfig.ConnectionStringName,
+            "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+        agent0.Identifier = "shopping-assistant";
+        agent0.Parameters.Add(new AiAgentParameter("company"));
+        agent0.ChatTrimming = null;
+        agent0.Queries =
+        [
+            new AiAgentToolQuery
+            {
+                Name = "ProductSearch",
+                Description = "semantic search the store product catalog",
+                Query = "from Products where vector.search(embedding.text(Name), $query)",
+                ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            },
+            new AiAgentToolQuery
+            {
+                Name = "RecentOrder",
+                Description = "Get the recent orders of the current user",
+                Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                ParametersSampleObject = "{}"
+            }
+        ];
+
+
+        var agent1 = new AiAgentConfiguration("warehouse manager", aiConfig.ConnectionStringName, "You are an AI agent managing a warehouse.");
+        agent1.Identifier = "warehouse-manager";
+        agent1.Actions =
+        [
+            new AiAgentToolAction
+            {
+                Name = "ProductSearch",
+                Description = "semantic search the store product catalog",
+                ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            },
+            new AiAgentToolAction
+            {
+                Name = "RecentOrder",
+                Description = "Get the recent orders of the current user",
+                ParametersSampleObject = "{}"
+            }
+        ];
+        agent1.ChatTrimming = null;
+        return new List<AiAgentConfiguration>() { agent0, agent1 };
+    }
+
+    private static async Task PutLicense(RavenServer leader, string licenseType)
+    {
+        var license = Environment.GetEnvironmentVariable(licenseType);
+        Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
+
+        await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+    }
+
+    private static async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
+    {
+        var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
+            RaftIdGenerator.NewId());
+        await leader.ServerStore.SendToLeaderAsync(command);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25430/AiAgent-feature-does-not-have-a-Disable-option

### Additional description
The AiAgent feature currently does not include a Disable option like other ongoing tasks.
With the new Disabled property, we can restore an AiAgent task in a disabled state, and it cannot be re-enabled until the license supports it.
Waits for:
https://issues.hibernatingrhinos.com/issue/RavenDB-25471/Restore-fails-on-ongoing-tasks-that-are-unsupported-by-the-license-instead-of-disabling-them-when-DisableOngoingTasks-is-true
So when we set `DisableOngoingTasks` to true on the restore options or toggle it on the studio, it'll complete the restore and will disable the agents instead of throwing and stopping he restore (like when `DisableOngoingTasks` is false).
This is a general issue for all ongoing tasks *AND* for the AiAgents (which are considered as ongoing tasks in restore/import and behave like them)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
