### PR TITLE
RavenDB-25471 - Restore fails on ongoing tasks that are unsupported by the license instead of disabling them when DisableOngoingTasks is true

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -215,7 +215,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             Result.Files.CurrentFileName = null;
 
-            DisableOngoingTasksIfNeeded(RestoreSettings.DatabaseRecord);
             SmugglerBase.EnsureProcessed(Result, skipped: false, indexesSkipped: Result.Indexes.Skipped);
             Progress.Invoke(Result.Progress);
 
@@ -581,6 +580,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     databaseRecord.DataArchival = smugglerDatabaseRecord.DataArchival;
                     databaseRecord.QueueSinks = smugglerDatabaseRecord.QueueSinks;
                     databaseRecord.SupportedFeatures = smugglerDatabaseRecord.SupportedFeatures;
+
+                    DisableOngoingTasksIfNeeded(databaseRecord);
 
                     ServerStore.Engine.StateMachine.AssertAllLicenseLimitsOnRestore(ServerStore, databaseRecord);
                 };

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
@@ -77,8 +77,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
 
         protected override async Task OnAfterRestoreAsync()
         {
-            DisableOngoingTasksIfNeeded(RestoreSettings.DatabaseRecord);
-
             Progress.Invoke(Result.Progress);
 
             // after the db for restore is done, we can safely set the db state to normal and write the DatabaseRecord

--- a/test/StressTests/Issues/RavenDB-25471.cs
+++ b/test/StressTests/Issues/RavenDB-25471.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.OLAP;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Server.Commercial;
+using Raven.Server.ServerWide.Commands;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace StressTests.Issues
+{
+    public class RavenDB_25471 : ReplicationTestBase
+    {
+        public RavenDB_25471(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.BackupExportImport)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+        public async Task DisableOlapOnRestoreWithoutLicense(Options options, BackupType backupType)
+        {
+            DoNotReuseServer();
+
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+
+            using var source = GetDocumentStore();
+            await DisableRevisionCompression(Server, source);
+            SetupLocalOlapEtl(source, script: @"
+var orderDate = new Date(this.OrderedAt);
+var year = orderDate.getFullYear();
+var month = orderDate.getMonth();
+var key = new Date(year, month);
+
+loadToOrders(partitionBy(key),
+    {
+        Company : this.Company,
+        ShipVia : this.ShipVia
+    });
+", path: NewDataPath());
+
+            var backupOperation = await source.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+            {
+                BackupType = backupType,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = backupPath
+                }
+            }));
+            await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+            await source.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(source.Database, hardDelete: true));
+
+            await PutLicense(Server, LicenseTestBase.RL_COMM);
+
+            using var store = GetDocumentStore();
+
+            using var destination = new DocumentStore { Urls = new[] { Server.WebUrl }, Database = source.Database + "_Restore" }.Initialize();
+
+            using (Backup.RestoreDatabase(destination,
+                       new RestoreBackupConfiguration
+                       {
+                           BackupLocation = Directory.GetDirectories(backupPath).First(),
+                           DatabaseName = destination.Database,
+                           DisableOngoingTasks = true // <<==
+                       })) // restore shouldnt throw
+            {
+                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(destination.Database));
+                Assert.Equal(1, record.OlapEtls.Count);
+                foreach (var olap in record.OlapEtls)
+                {
+                    Assert.True(olap.Disabled);
+                }
+            }
+        }
+
+        private void SetupLocalOlapEtl(DocumentStore store, string script, string path)
+        {
+            var connectionStringName = $"{store.Database} to local";
+            var configuration = new OlapEtlConfiguration
+            {
+                ConnectionStringName = connectionStringName,
+                RunFrequency = "* * * * *",
+                Transforms =
+            {
+                new Transformation
+                {
+                    Name = "MonthlyOrders",
+                    Collections = new List<string> {"Orders"},
+                    Script = script
+                }
+            }
+            };
+
+            var connectionString = new OlapConnectionString
+            {
+                Name = connectionStringName,
+                LocalSettings = new LocalSettings
+                {
+                    FolderPath = path
+                }
+            };
+
+            Etl.AddEtl(store, configuration, connectionString);
+        }
+
+        private static async Task PutLicense(RavenServer leader, string licenseType)
+        {
+            var license = Environment.GetEnvironmentVariable(licenseType);
+            Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
+
+            await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+        }
+
+        private static async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
+        {
+            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
+                RaftIdGenerator.NewId());
+            await leader.ServerStore.SendToLeaderAsync(command);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25471/Restore-fails-on-ongoing-tasks-that-are-unsupported-by-the-license-instead-of-disabling-them-when-DisableOngoingTasks-is-true

### Additional description

Restore shouldn't throw when restoring ongoing tasks that aren't supported by the license if DisableOngoingTasks is set to true.
The restore should simply change those tasks to disabled and continue the restore instead of failing.
Solution:
Move 'DisableOngoingTasksIfNeeded' before Restore instead of after restore - so the restore will disable the ongoing tasks instead of throwing when DisableOngoingTasks is true and the license doesn't support the ongoing tasks.
(It should throw when DisableOngoingTasks is false)


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
