### PR TITLE
RavenDB-23453 Vector search filter - Corax's part.

### DIFF
--- a/bench/Vector.Benchmark/Program.cs
+++ b/bench/Vector.Benchmark/Program.cs
@@ -35,11 +35,11 @@ void TestRecall(string path)
     var annDistances = new float[resultsCount];
     var ennMatches = new long[resultsCount];
     var ennDistances = new float[resultsCount];
-
     long results = 0;
     foreach (var file in Files)
     {
         using var txr = env.ReadTransaction();
+        using var _ = Slice.From(txr.Allocator, "wiki", out var wikiTreeName);
         var fullPath = Path.Combine(Path.GetTempPath(), "Vector.Benchmark", file);
 
         foreach (var (ids, vectors) in YieldVectors(fullPath))
@@ -48,8 +48,8 @@ void TestRecall(string path)
             {
                 var vector = new Span<float>(vectors, i * 768, 768);
                 
-                using var enn = Hnsw.ExactNearest(txr.LowLevelTransaction, "wiki", 10, MemoryMarshal.AsBytes(vector), 0f);
-                using var ann = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "wiki", 64, MemoryMarshal.AsBytes(vector), 0f);
+                using var enn = Hnsw.ExactNearest(txr.LowLevelTransaction, wikiTreeName, 10, MemoryMarshal.AsBytes(vector).ToArray(), 0f, false);
+                using var ann = Hnsw.ApproximateNearest(txr.LowLevelTransaction, wikiTreeName, 64, MemoryMarshal.AsBytes(vector).ToArray(), 0f, false);
 
                 var aRead = ann.Fill(annMatches, annDistances);
                 var eRead = enn.Fill(ennMatches, ennDistances);

--- a/bench/Voron.Benchmark/Corax/VectorSearchBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/VectorSearchBenchmark.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using Raven.Server.Documents.Indexes.VectorSearch;
+using Voron.Data.Graphs;
+
+namespace Voron.Benchmark.Corax;
+
+public class VectorSearchBenchmark
+{
+    [Params(360, 30000)]
+    public int Size;
+
+    private StorageEnvironment _env;
+    private const string Path = "D:\\temp\\corax";
+    private IndexFieldsMapping _mapping;
+    private List<string> _ids;
+
+    
+    
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _ids = new();
+        _env = new StorageEnvironment(StorageEnvironmentOptions.ForPathForTests(Path));
+        _mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, "id")
+            .AddBinding(1, "name")
+            .AddBinding(2, "vector", vectorOptions: new VectorOptions
+            {
+                NumberOfCandidates = 16, NumberOfEdges = 12, VectorEmbeddingType = VectorEmbeddingType.Single
+            })
+            .Build();
+
+        using (var indexWriter = new IndexWriter(_env, _mapping, SupportedFeatures.All))
+        {
+            for (int i = 0; i < Size; ++i)
+            {
+                var id = $"doc/{i}";
+                _ids.Add(id);
+                using var builder = indexWriter.Index(id);
+                builder.Write(0, Encoding.UTF8.GetBytes(id));
+                builder.Write(1, Encoding.UTF8.GetBytes($"name{i}"));
+                var x = MathF.Cos(i * 2 * MathF.PI / 360);
+                var y = MathF.Sin(i * 2 * MathF.PI / 360);
+                float[] vec = [x, y];
+                builder.WriteVector(2, "vector", MemoryMarshal.Cast<float, byte>(vec));
+                builder.EndWriting();
+            }
+
+            indexWriter.Commit();
+        }
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        _mapping?.Dispose();
+        _env?.Dispose();
+        Directory.Delete(Path, true);
+    }
+
+    [Benchmark]
+    public int VectorQuery()
+    {
+        using var indexSearcher = new IndexSearcher(_env, _mapping);
+        var x = MathF.Cos(180 * 2 * MathF.PI / 360);
+        var y = MathF.Sin(180 * 2 * MathF.PI / 360);
+        float[] vec = [x, y];
+        var v = GenerateEmbeddings.FromArray(indexSearcher.Allocator, vec, Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Single, Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Single);
+        var vs = indexSearcher.VectorSearch(_mapping.GetByFieldId(2).Metadata, v, 0.0f, 16, false, false);
+        Span<long> ids = stackalloc long[16];
+        var count = 0;
+        while (vs.Fill(ids) is var read and > 0)
+            count += read;
+        return count;
+    }
+}

--- a/bench/Voron.Benchmark/Corax/VectorSearchBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/VectorSearchBenchmark.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using BenchmarkDotNet.Attributes;
@@ -8,26 +9,44 @@ using Corax;
 using Corax.Indexing;
 using Corax.Mappings;
 using Corax.Querying;
+using Corax.Utils;
 using Raven.Server.Documents.Indexes.VectorSearch;
+using Sparrow.Server;
+using Sparrow.Threading;
 using Voron.Data.Graphs;
 
 namespace Voron.Benchmark.Corax;
 
 public class VectorSearchBenchmark
 {
-    [Params(360, 30000)]
+    [Params(30_000, 100_000)]
     public int Size;
 
+    [Params(16, 64, 128)]
+    public int NumberOfCandidates;
+    
     private StorageEnvironment _env;
     private const string Path = "D:\\temp\\corax";
     private IndexFieldsMapping _mapping;
     private List<string> _ids;
+    private List<string> _sources;
+    private IndexSearcher _indexSearcher;
+    private byte[] QueryVector;
+    
 
-    
-    
     [GlobalSetup]
     public void GlobalSetup()
     {
+        Random random = new(412312345);
+        {
+            var words = new List<string>();
+            var file = Directory.GetFiles(Directory.GetCurrentDirectory(), "?nglish.txt").Single();
+            foreach (var line in File.ReadAllLines(file))
+                    words.Add(line);
+            random.Shuffle(CollectionsMarshal.AsSpan(words));
+            _sources = words.Take(Size).ToList();
+        }
+
         _ids = new();
         _env = new StorageEnvironment(StorageEnvironmentOptions.ForPathForTests(Path));
         _mapping = IndexFieldsMappingBuilder.CreateForWriter(false)
@@ -41,6 +60,7 @@ public class VectorSearchBenchmark
 
         using (var indexWriter = new IndexWriter(_env, _mapping, SupportedFeatures.All))
         {
+            using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
             for (int i = 0; i < Size; ++i)
             {
                 var id = $"doc/{i}";
@@ -48,12 +68,18 @@ public class VectorSearchBenchmark
                 using var builder = indexWriter.Index(id);
                 builder.Write(0, Encoding.UTF8.GetBytes(id));
                 builder.Write(1, Encoding.UTF8.GetBytes($"name{i}"));
-                var x = MathF.Cos(i * 2 * MathF.PI / 360);
-                var y = MathF.Sin(i * 2 * MathF.PI / 360);
-                float[] vec = [x, y];
-                builder.WriteVector(2, "vector", MemoryMarshal.Cast<float, byte>(vec));
+                using var vec = GenerateEmbeddings.FromText(bsc,
+                    new Raven.Client.Documents.Indexes.Vector.VectorOptions() { DestinationEmbeddingType = Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Single, SourceEmbeddingType = Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Text },
+                    _sources[i]);
+                builder.WriteVector(2, "vector", vec.GetEmbedding());
                 builder.EndWriting();
             }
+
+            var vecToSearch = random.Next(Size);
+            using var vecToSearchVV = GenerateEmbeddings.FromText(bsc,
+                new Raven.Client.Documents.Indexes.Vector.VectorOptions() { DestinationEmbeddingType = Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Single, SourceEmbeddingType = Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Text },
+                _sources[vecToSearch]);
+            QueryVector = vecToSearchVV.GetEmbedding().ToArray();
 
             indexWriter.Commit();
         }
@@ -62,20 +88,30 @@ public class VectorSearchBenchmark
     [GlobalCleanup]
     public void GlobalCleanup()
     {
+        _ids = null;
+        _sources = null;
         _mapping?.Dispose();
         _env?.Dispose();
         Directory.Delete(Path, true);
     }
 
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _indexSearcher = new IndexSearcher(_env, _mapping);
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        _indexSearcher.Dispose();
+    }
+    
     [Benchmark]
     public int VectorQuery()
     {
-        using var indexSearcher = new IndexSearcher(_env, _mapping);
-        var x = MathF.Cos(180 * 2 * MathF.PI / 360);
-        var y = MathF.Sin(180 * 2 * MathF.PI / 360);
-        float[] vec = [x, y];
-        var v = GenerateEmbeddings.FromArray(indexSearcher.Allocator, vec, Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Single, Raven.Client.Documents.Indexes.Vector.VectorEmbeddingType.Single);
-        var vs = indexSearcher.VectorSearch(_mapping.GetByFieldId(2).Metadata, v, 0.0f, 16, false, false);
+        var v = new VectorValue(null, QueryVector);
+        var vs = _indexSearcher.VectorSearch(_mapping.GetByFieldId(2).Metadata, v, 0.0f, NumberOfCandidates, false, false);
         Span<long> ids = stackalloc long[16];
         var count = 0;
         while (vs.Fill(ids) is var read and > 0)

--- a/bench/Voron.Benchmark/Voron.Benchmark.csproj
+++ b/bench/Voron.Benchmark/Voron.Benchmark.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\src\Corax\Corax.csproj" />
     <ProjectReference Include="..\..\src\Raven.Server\Raven.Server.csproj" />
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />
+    <ProjectReference Include="..\..\tools\Voron.Dictionary.Generator\Voron.Dictionary.Generator.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsWindows64)' == 'true'">
     <None Include="..\..\libs\librvnpal\librvnpal.win.x64.dll" Link="librvnpal.win.x64.dll">

--- a/src/Corax/Indexing/IIndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IIndexEntryBuilder.cs
@@ -12,7 +12,7 @@ public interface IIndexEntryBuilder
     void WriteNonExistingMarker(int fieldId, string path);
     void Write(int fieldId, ReadOnlySpan<byte> value);
     void WriteCompound(int fieldId, ReadOnlySpan<byte> value);
-    void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value);
+    void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value, Random random = null);
     void Write(int fieldId, string path, ReadOnlySpan<byte> value);
     void Write(int fieldId, string path, string value);
     void Write(int fieldId, ReadOnlySpan<byte> value, long longValue, double dblValue);

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -296,7 +296,7 @@ public partial class IndexWriter
             ExactInsert(field, value, InserterMode.ExactInsert, forceExactInsert: true);
         }
 
-        public void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value)
+        public void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value, Random random = null)
         {
             if (value.Length <= 0)
                 return; // we don't index missing / empty vectors 
@@ -304,9 +304,9 @@ public partial class IndexWriter
 
             PortableExceptions.ThrowIfNot<InvalidOperationException>(field.HasVector, $"Field ({fieldId} , '{field.Name}') didn't have vector options but tried to write a vector. Vector length: {value.Length}");
 
-            var vectorWriter = field.GetVectorIndexer(_parent._transaction.LowLevelTransaction, value.Length);
+            var vectorWriter = field.GetVectorIndexer(_parent._transaction.LowLevelTransaction, value.Length, random);
             var vectorHash = vectorWriter.Register((long)_entryId, value);
-
+            
             //We're storing the vector hash for removal purposes
             RegisterTerm(field, vectorHash.ToSpan(), StoredFieldType.Raw);
         }

--- a/src/Corax/Indexing/IndexedField.cs
+++ b/src/Corax/Indexing/IndexedField.cs
@@ -224,14 +224,14 @@ internal sealed class IndexedField
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Hnsw.Registration GetVectorIndexer(LowLevelTransaction llt, int vectorSize = Constants.IndexWriter.Hnsw.TreeExists)
+    public Hnsw.Registration GetVectorIndexer(LowLevelTransaction llt, int vectorSize = Constants.IndexWriter.Hnsw.TreeExists, Random random = null)
     {
         if (_hnswIsCreated == false && vectorSize != Constants.IndexWriter.Hnsw.TreeExists)
             CreateHnswTree(llt, vectorSize);
 
         if (VectorIndexer == null)
         {
-            VectorIndexer = Hnsw.RegistrationFor(llt, Name);
+            VectorIndexer = Hnsw.RegistrationFor(llt, Name, random);
             if (IsVirtual)
             {
                 _parent._hnswIsCreated = true;

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -21,7 +21,12 @@ public partial class IndexSearcher
 {
     internal static class VectorSearchUtils
     {
-        public static bool ShouldScan(IndexSearcher indexSearcher, long filterMatchesCount, bool isExact, IQueryMatch filterQuery, int scanningThreshold) => filterQuery != null && (filterMatchesCount < scanningThreshold || isExact);
+        public static bool ShouldScan(IndexSearcher indexSearcher, long filterMatchesCount, bool isExact, IQueryMatch filterQuery, int scanningThreshold, int numberOfCandidates)
+        {
+            var shouldScan = filterQuery != null && (filterMatchesCount < scanningThreshold || isExact || filterMatchesCount * 0.5 < numberOfCandidates);
+
+            return shouldScan;
+        }
 
         public static GrowableBitArray LoadFilterMatches(IndexSearcher indexSearcher, ref IQueryMatch query)
         {

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -61,9 +61,10 @@ public partial class IndexSearcher
             // and then filter the documents stored in the posting list of each node individually.
             // Ideally, each node represents only a single document.
             Page p = default;
-            foreach (var docId in filterResults.Iterate(0))
+            var it = filterResults.GetIterator(0);
+            while (it.MoveNext())
             {
-                var entryTermsReader = indexSearcher.GetEntryTermsReader(docId, ref p);
+                var entryTermsReader = indexSearcher.GetEntryTermsReader(it.Current, ref p);
                 while (entryTermsReader.FindNextStored(vectorRootPage))
                 {
                     var vectorHash = entryTermsReader.StoredField.Value;

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -45,7 +45,7 @@ public partial class IndexSearcher
             return filter;
         }
 
-        public static IEnumerable<long> GetDocumentsIntoNodesRandomly(IndexSearcher indexSearcher, FieldMetadata metadata, GrowableBitArray filterResults)
+        public static IEnumerable<long> GetDocumentsIntoNodesRandomly(IndexSearcher indexSearcher, FieldMetadata metadata, GrowableBitArray filterResults, Random random = null)
         {
             var searchState = new Hnsw.SearchState(indexSearcher.Transaction.LowLevelTransaction, metadata.FieldName);
             var vectorsByHash = indexSearcher._transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
@@ -58,7 +58,7 @@ public partial class IndexSearcher
             Page p = default;
             using CompactKey key = new();
             
-            foreach (var currentDocument in GrowableBitArray.Probe(filterResults, Random.Shared))
+            foreach (var currentDocument in GrowableBitArray.Probe(filterResults, random ?? Random.Shared))
             {
                 var entryTermsReader = indexSearcher.GetEntryTermsReader(currentDocument, ref p, key);
                 while (entryTermsReader.FindNextStored(vectorRootPage))
@@ -115,9 +115,9 @@ public partial class IndexSearcher
     }
 
 
-    public VectorSearchMatch VectorSearch(in FieldMetadata metadata, in VectorValue vectorValue, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024)
+    public VectorSearchMatch VectorSearch(in FieldMetadata metadata, in VectorValue vectorValue, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024, Random random = null)
     {
-        return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
+        return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold, random);
     }
 
     public IQueryMatch VectorSearch(in FieldMetadata metadata, in string documentId, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024)
@@ -163,6 +163,6 @@ public partial class IndexSearcher
         return new MultiVectorSearchMatch(this, metadata, vectors.ToArray(), minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
     }
 
-    public MultiVectorSearchMatch MultiVectorSearch(in FieldMetadata metadata, in VectorValue[] vectorValues, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024)
-        => new(this, metadata, vectorValues, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
+    public MultiVectorSearchMatch MultiVectorSearch(in FieldMetadata metadata, in VectorValue[] vectorValues, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024, Random random = null)
+        => new(this, metadata, vectorValues, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold, random);
 }

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Corax.Indexing;
@@ -14,6 +15,7 @@ using Voron;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Graphs;
+using Voron.Data.Lookups;
 using Voron.Util;
 
 namespace Corax.Querying;
@@ -46,31 +48,130 @@ public partial class IndexSearcher
             return filter;
         }
 
-        public static IEnumerable<long> GetDocumentsIntoNodesRandomly(IndexSearcher indexSearcher, FieldMetadata metadata, GrowableBitArray filterResults, Random random = null)
+        /// <summary>
+        /// To save memory, this enumerator modifies the source during iteration to avoid materialization of the bitmap.
+        /// It restores the original state on disposal. However, it is designed in a way to not be evaluated to the end and rather for probing random nodes from document sets.
+        /// Otherwise, it's better to evaluate and perform Shuffle on the list.
+        /// </summary>
+        public struct RandomNodesFromFilterEnumerator : IEnumerator<long>
         {
-            var searchState = new Hnsw.SearchState(indexSearcher.Transaction.LowLevelTransaction, metadata.FieldName);
-            var vectorsByHash = indexSearcher._transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
-            var nodesByVectorId = searchState.NodeIdsByVectorId;
-            if (indexSearcher.TryGetRootPageByFieldName(metadata.FieldName, out var vectorRootPage) is false)
+            private List<long> _results;
+            private long _current;
+            private readonly IndexSearcher _indexSearcher;
+            private GrowableBitArray _filterResults;
+            private readonly Random _random;
+            private bool _isDone;
+            private readonly HashSet<long> _returnedDocuments = new();
+            private Page p = default;
+            private CompactKey _key;
+            private long _start = 1;
+            private long _end = 0;
+            private readonly CompactTree _vectorsByHash;
+            private readonly Lookup<Int64LookupKey> _nodesByVectorId;
+            private readonly long _vectorRootPage;
+
+            public RandomNodesFromFilterEnumerator(IndexSearcher indexSearcher, FieldMetadata metadata, GrowableBitArray filterResults, Random random = null)
             {
-                yield break;
+                _indexSearcher = indexSearcher;
+                _filterResults = filterResults;
+                _random = random ?? Random.Shared;
+                _key = new();
+                _key.Initialize(indexSearcher._transaction.LowLevelTransaction);
+                var searchState = new Hnsw.SearchState(indexSearcher.Transaction.LowLevelTransaction, metadata.FieldName);
+                _vectorsByHash = indexSearcher._transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
+                _nodesByVectorId = searchState.NodeIdsByVectorId;
+                _current = 1L;
+
+                _start = 1L;
+                _end = indexSearcher.LastEntryId;
+                
+                _isDone = 
+                    indexSearcher.TryGetRootPageByFieldName(metadata.FieldName, out _vectorRootPage) == false 
+                    || _filterResults.Count == 0;
             }
             
-            Page p = default;
-            using CompactKey key = new();
-            
-            foreach (var currentDocument in GrowableBitArray.Probe(filterResults, random ?? Random.Shared))
+            public RandomNodesFromFilterEnumerator()
             {
-                var entryTermsReader = indexSearcher.GetEntryTermsReader(currentDocument, ref p, key);
-                while (entryTermsReader.FindNextStored(vectorRootPage))
+                throw new NotSupportedException($"Default constructor is not supported for {nameof(RandomNodesFromFilterEnumerator)}");
+            }
+            
+            public void Dispose()
+            {
+                foreach (var idX in _returnedDocuments)
+                    _filterResults.Add(idX);
+                _current = -1;
+                _isDone = true;
+                _key.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                if (_isDone)
+                    return false;
+
+                if (_results is not null && _results.Count > 0)
                 {
-                    var vectorHash = entryTermsReader.StoredField.Value;
-                    var vectorExists = vectorsByHash.TryGetValue(vectorHash, out var vectorId);
-                    Debug.Assert(vectorExists, "Vector hash not found in vectors by hash tree");
-                    var nodeIdExists = nodesByVectorId.TryGetValue(vectorId, out var nodeId);
-                    Debug.Assert(nodeIdExists, "Node ID not found in nodes by vector ID tree");
-                    yield return nodeId;
+                    _current = _results[^1];
+                    _results.RemoveAt(_results.Count - 1);
+                    return true;
                 }
+
+                _current = -1L;
+                do
+                {
+                    var randomStart = _random.NextInt64(_start, _end);
+                    var it = _filterResults.GetIterator(randomStart);
+                    var anythingExists = it.MoveNext();
+                    if (anythingExists == false)
+                    {
+                        _end = randomStart;
+                        continue;
+                    }
+
+                    _returnedDocuments.Add(it.Current);
+                    _filterResults.Remove(it.Current);
+                    var entryTermsReader = _indexSearcher.GetEntryTermsReader(it.Current, ref p, _key);
+                    bool found = false;
+                    while (entryTermsReader.FindNextStored(_vectorRootPage))
+                    {
+                        var vectorHash = entryTermsReader.StoredField.Value;
+                        var vectorExists = _vectorsByHash.TryGetValue(vectorHash, out var vectorId);
+                        Debug.Assert(vectorExists, "Vector hash not found in vectors by hash tree");
+                        var nodeIdExists = _nodesByVectorId.TryGetValue(vectorId, out var nodeId);
+                        Debug.Assert(nodeIdExists, "Node ID not found in nodes by vector ID tree");
+                        found = true;
+                        if (_current == -1L)
+                        {
+                            _current = nodeId;
+                        }
+                        else
+                        {
+                            if (_results is null or { Count: 0 })
+                                _results ??= new();
+
+                            _results.Add(nodeId);
+                        }
+                    }
+
+                    if (found)
+                        return true;
+
+                } while (_start < _end && _filterResults.Count > _returnedDocuments.Count);
+
+                _isDone = true;
+                return false;
+            }
+
+            public void Reset()
+            {
+                throw new NotSupportedException($"Reset is not supported for {nameof(RandomNodesFromFilterEnumerator)}");
+            }
+
+            public long Current => _current;
+
+            object IEnumerator.Current
+            {
+                get => Current;
             }
         }
 

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -7,64 +7,129 @@ using Corax.Querying.Matches.Meta;
 using Corax.Utils;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Collections;
+using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Graphs;
+using Voron.Util;
 
 namespace Corax.Querying;
 
 public partial class IndexSearcher
 {
-    public VectorSearchMatch VectorSearch(in FieldMetadata metadata, in VectorValue vectorValue, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch)
+    internal static class VectorSearchUtils
     {
-        return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
+        public static bool ShouldScan(IndexSearcher indexSearcher, long filterMatchesCount, bool isExact, IQueryMatch filterQuery, int scanningThreshold) => filterQuery != null && (filterMatchesCount < scanningThreshold || isExact);
+
+        public static GrowableBitArray LoadFilterMatches(IndexSearcher indexSearcher, ref IQueryMatch query)
+        {
+            using var _ = indexSearcher.Allocator.Allocate(1024, out Span<long> workingBuffer);
+
+            var totalCount = 0;
+            GrowableBitArray filter = new(indexSearcher.Allocator, indexSearcher.LastEntryId);
+            while (query.Fill(workingBuffer) is var read and > 0)
+            {
+                for (int i = 0; i < read; ++i)
+                {
+                    totalCount += filter.Add(workingBuffer[i]).ToInt32();
+                }
+            }
+
+            filter.Count = totalCount;
+            return filter;
+        }
+
+        public static bool TryConvertDocumentsIdsToNodesIds(IndexSearcher indexSearcher, in FieldMetadata metadata, GrowableBitArray filterResults, out ContextBoundNativeList<long> nodesIdsToScan)
+        {
+            var searchState = new Hnsw.SearchState(indexSearcher.Transaction.LowLevelTransaction, metadata.FieldName);
+            var vectorsByHash = indexSearcher._transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
+            var nodesByVectorId = searchState.NodeIdsByVectorId;
+            if (indexSearcher.TryGetRootPageByFieldName(metadata.FieldName, out var vectorRootPage) is false)
+            {
+                nodesIdsToScan = default;
+                return false;
+            }
+
+            nodesIdsToScan = new ContextBoundNativeList<long>(indexSearcher.Allocator);
+
+            // Scan all entries from the filter to retrieve all node IDs. This is important for returning the correct number of results.
+            // To satisfy the NumberOfCandidates requirement, we need to return up to `NumberOfCandidates` posting lists with the filter applied to the query.
+            // Instead of building a mapping of nodes to matching posting lists (and distances),
+            // we reuse ExactSearch mechanisms to find the nearest nodes to the vector (so we know that each node has at least one matching document)
+            // and then filter the documents stored in the posting list of each node individually.
+            // Ideally, each node represents only a single document.
+            Page p = default;
+            foreach (var docId in filterResults.Iterate(0))
+            {
+                var entryTermsReader = indexSearcher.GetEntryTermsReader(docId, ref p);
+                while (entryTermsReader.FindNextStored(vectorRootPage))
+                {
+                    var vectorHash = entryTermsReader.StoredField.Value;
+                    if (vectorsByHash.TryGetValue(vectorHash, out var vectorId))
+                    {
+                        if (nodesByVectorId.TryGetValue(vectorId, out var nodeId))
+                            nodesIdsToScan.Add(nodeId);
+                    }
+                }
+            }
+
+            var uniqueCount = Sorting.SortAndRemoveDuplicates(nodesIdsToScan.ToSpan());
+            nodesIdsToScan.Count = uniqueCount;
+            return true;
+        }
     }
-    
-    public IQueryMatch VectorSearch(in FieldMetadata metadata, in string documentId, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch)
+
+
+    public VectorSearchMatch VectorSearch(in FieldMetadata metadata, in VectorValue vectorValue, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024)
+    {
+        return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
+    }
+
+    public IQueryMatch VectorSearch(in FieldMetadata metadata, in string documentId, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024)
     {
         var idField = _fieldsTree.CompactTreeFor(_fieldMapping.GetByFieldId(Constants.IndexWriter.PrimaryKeyFieldId).FieldName);
         string loweredDocumentId = documentId.ToLowerInvariant();
-        if (idField.TryGetValue(loweredDocumentId, out var rawId) is false || 
+        if (idField.TryGetValue(loweredDocumentId, out var rawId) is false ||
             TryGetRootPageByFieldName(metadata.FieldName, out var vectorRootPage) is false)
             return EmptyMatch();
         var vectorsByHash = _transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
         PortableExceptions.ThrowIf<InvalidOperationException>((rawId & (long)TermIdMask.EnsureIsSingleMask) != (long)TermIdMask.Single,
-            "The provided id must be a document id mapped to a single value, but got: " + documentId +", which maps to: " + rawId); 
+            "The provided id must be a document id mapped to a single value, but got: " + documentId + ", which maps to: " + rawId);
 
         Page page = default;
         var singleEntryId = EntryIdEncodings.GetContainerId(rawId);
         var reader = GetEntryTermsReader((long)singleEntryId, ref page);
 
         var searchState = new Hnsw.SearchState(_transaction.LowLevelTransaction, metadata.FieldName);
-        
+
         if (reader.FindNextStored(vectorRootPage) is false)
             return EmptyMatch();
-        
+
         PortableExceptions.ThrowIf<InvalidOperationException>(reader.IsVectorHash is false, "Expected vector field, but got " + metadata.FieldName + ", which isn't a vector");
-        
+
         Span<byte> hash = reader.StoredField.Value.ToSpan();
         if (vectorsByHash.TryGetValue(hash, out var vectorId) is false)
             return EmptyMatch();
-        
+
         var vectorSpan = Hnsw.NodeReader.ReadVector(vectorId, searchState);
-            
+
         var vectorValue = new VectorValue(null, vectorSpan.AsMemory());
         if (reader.FindNextStored(vectorRootPage) is false) // just a single vector
-            return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
+            return new VectorSearchMatch(this, metadata, vectorValue, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
 
-        List<VectorValue> vectors = [vectorValue]; 
+        List<VectorValue> vectors = [vectorValue];
         do
         {
             vectorSpan = Hnsw.NodeReader.ReadVector(vectorId, searchState);
             vectorValue = new VectorValue(null, vectorSpan.AsMemory());
             vectors.Add(vectorValue);
         } while (reader.FindNextStored(vectorRootPage));
-        
-        return new MultiVectorSearchMatch(this, metadata, vectors.ToArray(), minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
+
+        return new MultiVectorSearchMatch(this, metadata, vectors.ToArray(), minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
     }
 
-
-    public MultiVectorSearchMatch MultiVectorSearch(in FieldMetadata metadata, in VectorValue[] vectorValues, float minimumMatch, in int numberOfCandidates, bool isExact,
-        bool isSingleVectorSearch) => new MultiVectorSearchMatch(this, metadata, vectorValues, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch);
+    public MultiVectorSearchMatch MultiVectorSearch(in FieldMetadata metadata, in VectorValue[] vectorValues, float minimumMatch, in int numberOfCandidates, bool isExact, bool isSingleVectorSearch, IQueryMatch filterQuery = null, int scanningThreshold = 1024)
+        => new(this, metadata, vectorValues, minimumMatch, numberOfCandidates, isExact, isSingleVectorSearch, filterQuery, scanningThreshold);
 }

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Corax.Indexing;
 using Corax.Mappings;
 using Corax.Querying.Matches;
@@ -64,11 +65,11 @@ public partial class IndexSearcher
                 while (entryTermsReader.FindNextStored(vectorRootPage))
                 {
                     var vectorHash = entryTermsReader.StoredField.Value;
-                    if (vectorsByHash.TryGetValue(vectorHash, out var vectorId))
-                    {
-                        if (nodesByVectorId.TryGetValue(vectorId, out var nodeId))
-                            yield return nodeId;
-                    }
+                    var vectorExists = vectorsByHash.TryGetValue(vectorHash, out var vectorId);
+                    Debug.Assert(vectorExists, "Vector hash not found in vectors by hash tree");
+                    var nodeIdExists = nodesByVectorId.TryGetValue(vectorId, out var nodeId);
+                    Debug.Assert(nodeIdExists, "Node ID not found in nodes by vector ID tree");
+                    yield return nodeId;
                 }
             }
         }

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -78,7 +78,7 @@ public partial class IndexSearcher
 
             var uniqueCount = Sorting.SortAndRemoveDuplicates(nodesIdsToScan.ToSpan());
             nodesIdsToScan.Count = uniqueCount;
-            return true;
+            return nodesIdsToScan.Count > 0;
         }
     }
 

--- a/src/Corax/Querying/IndexSearcher.VectorSearch.cs
+++ b/src/Corax/Querying/IndexSearcher.VectorSearch.cs
@@ -24,7 +24,6 @@ public partial class IndexSearcher
         public static bool ShouldScan(IndexSearcher indexSearcher, long filterMatchesCount, bool isExact, IQueryMatch filterQuery, int scanningThreshold, int numberOfCandidates)
         {
             var shouldScan = filterQuery != null && (filterMatchesCount < scanningThreshold || isExact || filterMatchesCount * 0.5 < numberOfCandidates);
-
             return shouldScan;
         }
 
@@ -44,6 +43,34 @@ public partial class IndexSearcher
 
             filter.Count = totalCount;
             return filter;
+        }
+
+        public static IEnumerable<long> GetDocumentsIntoNodesRandomly(IndexSearcher indexSearcher, FieldMetadata metadata, GrowableBitArray filterResults)
+        {
+            var searchState = new Hnsw.SearchState(indexSearcher.Transaction.LowLevelTransaction, metadata.FieldName);
+            var vectorsByHash = indexSearcher._transaction.CompactTreeFor(Hnsw.VectorsIdByHashSlice);
+            var nodesByVectorId = searchState.NodeIdsByVectorId;
+            if (indexSearcher.TryGetRootPageByFieldName(metadata.FieldName, out var vectorRootPage) is false)
+            {
+                yield break;
+            }
+            
+            Page p = default;
+            using CompactKey key = new();
+            
+            foreach (var currentDocument in GrowableBitArray.Probe(filterResults, Random.Shared))
+            {
+                var entryTermsReader = indexSearcher.GetEntryTermsReader(currentDocument, ref p, key);
+                while (entryTermsReader.FindNextStored(vectorRootPage))
+                {
+                    var vectorHash = entryTermsReader.StoredField.Value;
+                    if (vectorsByHash.TryGetValue(vectorHash, out var vectorId))
+                    {
+                        if (nodesByVectorId.TryGetValue(vectorId, out var nodeId))
+                            yield return nodeId;
+                    }
+                }
+            }
         }
 
         public static bool TryConvertDocumentsIdsToNodesIds(IndexSearcher indexSearcher, in FieldMetadata metadata, GrowableBitArray filterResults, out ContextBoundNativeList<long> nodesIdsToScan)

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -155,7 +155,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         }
     }
 
-    public EntryTermsReader GetEntryTermsReader(long id, ref Page p)
+    public EntryTermsReader GetEntryTermsReader(long id, ref Page p, CompactKey key = null)
     {
         if (_entryIdToLocation.TryGetValue(id, out var locLong) == false)
             throw new InvalidOperationException("Unable to find entry id: " + id);
@@ -163,7 +163,7 @@ public sealed unsafe partial class IndexSearcher : IDisposable
         InitializeSpecialTermsMarkers();
         ContainerEntryId loc = (ContainerEntryId)locLong;
         var item = Container.MaybeGetFromSamePage(_transaction.LowLevelTransaction, ref p, loc);
-        return new EntryTermsReader(_transaction.LowLevelTransaction, _nullTermsMarkers, _nonExistingTermsMarkers, item.Address, item.Length, _dictionaryId, _vectorFieldsMarkers);
+        return new EntryTermsReader(_transaction.LowLevelTransaction, _nullTermsMarkers, _nonExistingTermsMarkers, item.Address, item.Length, _dictionaryId, _vectorFieldsMarkers, key);
     }
 
     internal void EncodeAndApplyAnalyzerForMultipleTerms(in FieldMetadata binding, ReadOnlySpan<char> term, ref ContextBoundNativeList<Slice> terms)

--- a/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
+++ b/src/Corax/Querying/Matches/BinaryMatch.Boolean.cs
@@ -66,7 +66,7 @@ namespace Corax.Querying.Matches
                     // which can be really expensive, instead, let's memoize the outer and remember that 
                     if (resultsSpan.Length == 0 && match._memoizedOuter is null)
                     {
-                        match._memoizedOuter = new MemoizationMatchProvider<TOuter>(match._indexSearcher, match._outer);
+                        match._memoizedOuter = new MemoizationMatchProvider<TOuter>(match._indexSearcher, outer);
                         match._memoizedOuter.SortingRequired();
                     }
 

--- a/src/Corax/Querying/Matches/DeduplicationMatch.cs
+++ b/src/Corax/Querying/Matches/DeduplicationMatch.cs
@@ -7,6 +7,7 @@ using Corax.Querying.Matches.Meta;
 using Corax.Utils;
 using Sparrow;
 using Sparrow.Server;
+using Sparrow.Server.Collections;
 
 namespace Corax.Querying.Matches;
 

--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -19,6 +19,7 @@ namespace Corax.Querying.Matches
         private readonly ByteStringContext _ctx;
         private readonly Querying.IndexSearcher _indexSearcher;
         private TInner _inner;
+        private bool _disposed;
 
         public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
         
@@ -64,12 +65,14 @@ namespace Corax.Querying.Matches
 
         public MemoizationMatch Replay()
         {
+            Debug.Assert(_disposed == false);
             _replayCounter++;
             return MemoizationMatch.Create(new MemoizationMatch<TInner>(this));
         }
 
         public Span<long> FillAndRetrieve()
         {
+            Debug.Assert(_disposed == false);
             if (_bufferEndIdx < 0)
                 InitializeInner();
 
@@ -202,7 +205,13 @@ namespace Corax.Querying.Matches
 
         public void Dispose()
         {
+            if (_disposed)
+                return;
+            
+            _disposed = true;
             _bufferScope.Dispose();
+            _bufferScope = default;
+            _bufferHolder = default;
         }
     }
 }

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -117,7 +117,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             {
                 _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, nodesIdsToScan),
                 true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
-                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults, _random)), 
+                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults, _random)), 
                 false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
             };
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
@@ -80,7 +82,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             _filterMatchesCount = _filterResults.Count;
         }
 
-        _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold);
+        _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold, _numberOfCandidates);
         ContextBoundNativeList<long> nodesIdsToScan = default;
         if (_scanningQuery)
         {
@@ -255,8 +257,12 @@ public struct MultiVectorSearchMatch : IQueryMatch
         return new QueryInspectionNode(nameof(MultiVectorSearchMatch),
             parameters: new Dictionary<string, string>()
             {
-                { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },
-                { nameof(Hnsw.SimilarityMethod), _vectorsRetrievers[0].SimilarityMethod.ToString() },
+                { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },                
+                { nameof(Hnsw.SimilarityMethod), _vectorsRetrievers.FirstOrDefault().SimilarityMethod?.ToString() ?? "Query not initialized." },
+                { "IsExact", _isExact.ToString() },
+                { "IsScanning", _scanningQuery.ToString() },
+                { "Minimum match", _minimumMatch.ToString(CultureInfo.InvariantCulture) },
+                { "Number of candidates", _numberOfCandidates.ToString() },
             });
     }
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -66,6 +66,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _scanningThreshold = scanningThreshold;
         IsBoosting = true;
         _singleVectorSearchDoNotSort = singleVectorSearchDoNotSortByIds;
+        _isEmpty = false;
     }
 
     private void InitializeVectorSearch()
@@ -82,7 +83,18 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold);
         ContextBoundNativeList<long> nodesIdsToScan = default;
         if (_scanningQuery)
-            IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults, out nodesIdsToScan);
+        {
+            var hasNodes = IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults, out nodesIdsToScan);
+            if (hasNodes == false)
+            {
+                _isEmpty = true;
+                nodesIdsToScan.Dispose();
+                _filterResults.Dispose();
+                foreach (var vector in _vectorsToSearch)
+                    vector.Dispose();
+                return;
+            }
+        }
 
         _vectorsRetrievers = new Hnsw.VectorSearchRetriever[_vectorsToSearch.Length];
         var llt = _indexSearcher.Transaction.LowLevelTransaction;
@@ -107,12 +119,12 @@ public struct MultiVectorSearchMatch : IQueryMatch
     {
         if (_vectorRetrieverInitialized == false)
             InitializeVectorSearch();
-
-        if (_isEmpty)
-            return 0;
         
         if (_resultsPersisted == false)
             FillAndPersistResults();
+        
+        if (_isEmpty)
+            return 0;
         
         var resultsLeft = _matches.Count - _positionOnPersistedValues;
 
@@ -129,7 +141,9 @@ public struct MultiVectorSearchMatch : IQueryMatch
     {
         Debug.Assert(_resultsPersisted == false, "Results should be persisted only once.");
         _resultsPersisted = true;
-
+        if (_isEmpty)
+            return;
+        
         _matches.Init(_indexSearcher.Allocator, 128);
         _distances.Init(_indexSearcher.Allocator, 128);
         for (var i = 0; i < _vectorsRetrievers.Length; ++i)

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -50,10 +50,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
     private GrowableBitArray _filterResults;
     private IQueryMatch _filterQuery;
-    private bool _filterQueryLoaded;
     private long _filterMatchesCount;
-
-    private bool _canStreamResults => IsBoosting == false;
 
 
     public MultiVectorSearchMatch(IndexSearcher searcher, in FieldMetadata metadata, in VectorValue[] vectorsToSearch, in float minimumMatch, in int numberOfCandidates,
@@ -71,7 +68,6 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _singleVectorSearchDoNotSort = singleVectorSearchDoNotSortByIds;
     }
 
-
     private void InitializeVectorSearch()
     {
         Debug.Assert(_vectorRetrieverInitialized == false, "Vector Retriever should be initialized only once.");
@@ -79,7 +75,6 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
         if (_filterQuery != null)
         {
-            _filterQueryLoaded = true;
             _filterResults = IndexSearcher.VectorSearchUtils.LoadFilterMatches(_indexSearcher, ref _filterQuery);
             _filterMatchesCount = _filterResults.Count;
         }

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -108,7 +108,8 @@ public struct MultiVectorSearchMatch : IQueryMatch
             {
                 _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, nodesIdsToScan),
                 true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
-                false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null)
+                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults)), 
+                false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
             };
 
             allEmpty &= _vectorsRetrievers[i].IsEmpty;

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -27,6 +27,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
     // Number of documents to be directly scanned instead of ANN / Exact on HNSW.
     private readonly int _scanningThreshold;
+    private readonly Random _random;
     private bool _scanningQuery;
 
 
@@ -56,7 +57,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
 
     public MultiVectorSearchMatch(IndexSearcher searcher, in FieldMetadata metadata, in VectorValue[] vectorsToSearch, in float minimumMatch, in int numberOfCandidates,
-        in bool isExact, in bool singleVectorSearchDoNotSortByIds, IQueryMatch filterQuery, int scanningThreshold = ScanningThreshold)
+        in bool isExact, in bool singleVectorSearchDoNotSortByIds, IQueryMatch filterQuery, int scanningThreshold = ScanningThreshold, Random random = null)
     {
         _indexSearcher = searcher;
         _metadata = metadata;
@@ -66,6 +67,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _isExact = isExact;
         _filterQuery = filterQuery;
         _scanningThreshold = scanningThreshold;
+        _random = random;
         IsBoosting = true;
         _singleVectorSearchDoNotSort = singleVectorSearchDoNotSortByIds;
         _isEmpty = false;
@@ -108,7 +110,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             {
                 _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, nodesIdsToScan),
                 true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
-                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults)), 
+                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults, _random)), 
                 false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
             };
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -4,134 +4,207 @@ using System.Diagnostics;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
+using Sparrow.Server.Collections;
 using Sparrow.Server.Utils;
 using Voron.Data.Graphs;
+using Voron.Util;
 
 namespace Corax.Querying.Matches;
 
 public struct MultiVectorSearchMatch : IQueryMatch
 {
-    private readonly IndexSearcher _searcher;
+    private const int ScanningThreshold = 1024;
+
+    private readonly IndexSearcher _indexSearcher;
     private readonly FieldMetadata _metadata;
-    private readonly bool _singleVectorSearchDoNotSortByIds;
-    private readonly Hnsw.NearestSearch[] _nearestSearches;
-    private readonly bool _isEmpty;
+    private readonly float _minimumMatch;
+    private readonly int _numberOfCandidates;
+    private readonly bool _isExact;
+    private VectorValue[] _vectorsToSearch;
+
+
+    // Number of documents to be directly scanned instead of ANN / Exact on HNSW.
+    private readonly int _scanningThreshold;
+    private bool _scanningQuery;
+
+
+    // Internal buffers used to store results from VectorSearch.
     private GrowableBuffer<long, Constant<long>> _matches;
     private GrowableBuffer<float, Constant<float>> _distances;
-    private bool _persisted = false;
-    private int _positionOnPersistedValues = 0;
 
-    private const long InitialSize = 16;
+    // Voron VectorSearch Retriever
+    private Hnsw.VectorSearchRetriever[] _vectorsRetrievers;
+    private bool _vectorRetrieverInitialized;
+
+    private bool _resultsPersisted;
+    private int _positionOnPersistedValues = 0;
+    private bool _isEmpty;
+
+
+    /// <summary>
+    /// When VectorSearch is the only condition in the WHERE statement,
+    /// do not sort to fulfill the Fill guarantees.
+    /// Otherwise, sorting is necessary as it may produce incorrect results in the upper AST statements.
+    /// </summary>
+    private readonly bool _singleVectorSearchDoNotSort;
+
+    private GrowableBitArray _filterResults;
+    private IQueryMatch _filterQuery;
+    private bool _filterQueryLoaded;
+    private long _filterMatchesCount;
+
+    private bool _canStreamResults => IsBoosting == false;
+
 
     public MultiVectorSearchMatch(IndexSearcher searcher, in FieldMetadata metadata, in VectorValue[] vectorsToSearch, in float minimumMatch, in int numberOfCandidates,
-        in bool isExact, in bool singleVectorSearchDoNotSortByIds)
+        in bool isExact, in bool singleVectorSearchDoNotSortByIds, IQueryMatch filterQuery, int scanningThreshold = ScanningThreshold)
     {
-        _searcher = searcher;
+        _indexSearcher = searcher;
         _metadata = metadata;
-        _singleVectorSearchDoNotSortByIds = singleVectorSearchDoNotSortByIds;
-        _nearestSearches = new Hnsw.NearestSearch[vectorsToSearch.Length];
-        _isEmpty = true;
-        
-        for (var i = 0; i < vectorsToSearch.Length; ++i)
-        {
-            var vectorToSearch = vectorsToSearch[i];
-            _nearestSearches[i] = isExact == false
-                ? Hnsw.ApproximateNearest(searcher.Transaction.LowLevelTransaction, metadata.FieldName, numberOfCandidates, vectorToSearch.GetEmbedding(),
-                    minimumMatch)
-                : Hnsw.ExactNearest(searcher.Transaction.LowLevelTransaction, metadata.FieldName, numberOfCandidates, vectorToSearch.GetEmbedding(),
-                    minimumMatch);
+        _minimumMatch = minimumMatch;
+        _vectorsToSearch = vectorsToSearch;
+        _numberOfCandidates = numberOfCandidates;
+        _isExact = isExact;
+        _filterQuery = filterQuery;
+        _scanningThreshold = scanningThreshold;
+        IsBoosting = true;
+        _singleVectorSearchDoNotSort = singleVectorSearchDoNotSortByIds;
+    }
 
-            _isEmpty &= _nearestSearches[i].IsEmpty;
-            vectorToSearch.Dispose();
+
+    private void InitializeVectorSearch()
+    {
+        Debug.Assert(_vectorRetrieverInitialized == false, "Vector Retriever should be initialized only once.");
+        _vectorRetrieverInitialized = true;
+
+        if (_filterQuery != null)
+        {
+            _filterQueryLoaded = true;
+            _filterResults = IndexSearcher.VectorSearchUtils.LoadFilterMatches(_indexSearcher, ref _filterQuery);
+            _filterMatchesCount = _filterResults.Count;
         }
 
-        IsBoosting = true;
+        _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold);
+        ContextBoundNativeList<long> nodesIdsToScan = default;
+        if (_scanningQuery)
+            IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults, out nodesIdsToScan);
+
+        _vectorsRetrievers = new Hnsw.VectorSearchRetriever[_vectorsToSearch.Length];
+        var llt = _indexSearcher.Transaction.LowLevelTransaction;
+        var allEmpty = true;
+        for (int i = 0; i < _vectorsRetrievers.Length; ++i)
+        {
+            var vector = _vectorsToSearch[i].GetEmbeddingMemory();
+            _vectorsRetrievers[i] = (_isExact) switch
+            {
+                _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, nodesIdsToScan),
+                true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
+                false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null)
+            };
+
+            allEmpty &= _vectorsRetrievers[i].IsEmpty;
+        }
+
+        _isEmpty = allEmpty || (_filterQuery != null && _filterResults.Count == 0);
     }
-
-    public long Count { get; private set; }
-
-    public SkipSortingResult AttemptToSkipSorting()
-    {
-        return _singleVectorSearchDoNotSortByIds
-            ? SkipSortingResult.ResultsNativelySorted
-            : SkipSortingResult.SortingIsRequired;
-    }
-
-    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
-    public bool IsBoosting { get; }
 
     public int Fill(Span<long> matches)
     {
+        if (_vectorRetrieverInitialized == false)
+            InitializeVectorSearch();
+
         if (_isEmpty)
             return 0;
-
-        if (_persisted == false)
+        
+        if (_resultsPersisted == false)
             FillAndPersistResults();
+        
+        var resultsLeft = _matches.Count - _positionOnPersistedValues;
 
-        if (_positionOnPersistedValues == _matches.Count)
+        if (resultsLeft == 0)
             return 0;
 
-        var amountToCopy = Math.Min(matches.Length, _matches.Count - _positionOnPersistedValues);
-        _matches.Results.Slice(_positionOnPersistedValues, amountToCopy).CopyTo(matches[..amountToCopy]);
+        var amountToCopy = Math.Min(resultsLeft, matches.Length);
+        _matches.Results.Slice(_positionOnPersistedValues,  amountToCopy).CopyTo(matches.Slice(0, amountToCopy));
         _positionOnPersistedValues += amountToCopy;
         return amountToCopy;
     }
 
     private void FillAndPersistResults()
     {
-        _matches.Init(_searcher.Allocator, InitialSize);
-        _distances.Init(_searcher.Allocator, InitialSize);
-        for (var i = 0; i < _nearestSearches.Length; ++i)
+        Debug.Assert(_resultsPersisted == false, "Results should be persisted only once.");
+        _resultsPersisted = true;
+
+        _matches.Init(_indexSearcher.Allocator, 128);
+        _distances.Init(_indexSearcher.Allocator, 128);
+        for (var i = 0; i < _vectorsRetrievers.Length; ++i)
         {
-            ref var nearestSearch = ref _nearestSearches[i];
-            int read = 0;
+            ref var vectorSearcher = ref _vectorsRetrievers[i];
+            int currentRead = 0;
             do
             {
                 var matchBuffer = _matches.GetSpace();
                 var distanceBuffer = _distances.GetSpace();
                 Debug.Assert(matchBuffer.Length == distanceBuffer.Length, "matchBuffer.Length == distanceBuffer.Length");
 
-                read = nearestSearch.Fill(matchBuffer, distanceBuffer);
-                _matches.AddUsage(read);
-                _distances.AddUsage(read);
-                Count += read;
-            } while (read > 0);
+                currentRead = (_filterQuery is null) switch
+                {
+                    true => vectorSearcher.Fill(matchBuffer, distanceBuffer),
+                    false => vectorSearcher.Fill(matchBuffer, distanceBuffer, _filterResults),
+                };
+                
+                _matches.AddUsage(currentRead);
+                _distances.AddUsage(currentRead);
+                Count += currentRead;
+            } while (currentRead > 0);
 
-            nearestSearch.Dispose();
+            vectorSearcher.Dispose();
+            _vectorsToSearch[i].Dispose();
         }
 
+        // Min on distances is Max on score.
         var uniqueCount = Sorting.SortAndMinOnDuplicates(_matches.Results, _distances.Results);
         _matches.Truncate(uniqueCount);
         _distances.Truncate(uniqueCount);
 
-        if (_singleVectorSearchDoNotSortByIds)
+        // Streaming query, we need to return already sorted
+        if (_singleVectorSearchDoNotSort) 
             _distances.Results.Sort(_matches.Results);
-
-        _persisted = true;
+        
+        _filterResults.Dispose();
     }
 
     public int AndWith(Span<long> buffer, int matches)
     {
+        if (_vectorRetrieverInitialized == false)
+            InitializeVectorSearch();
+
+        if (_resultsPersisted == false)
+            FillAndPersistResults();
+
         if (_isEmpty)
             return 0;
-
-        if (_persisted == false)
-            FillAndPersistResults();
 
         return MergeHelper.And(buffer, buffer[..matches], _matches.Results);
     }
 
-    public void Score(Span<long> matches, Span<float> scores, float _)
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
-        if (_persisted == false)
+        if (_resultsPersisted == false)
         {
             // BinaryMatch may skip the method call if the other node of the AND clause 
             // is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.
             return;
         }
         
-        if (_singleVectorSearchDoNotSortByIds == false)
+        if (_singleVectorSearchDoNotSort == false)
         {
+            if (_filterQuery != null)
+            {
+                ref var filterQuery = ref _filterQuery;
+                filterQuery.Score(matches, scores, boostFactor);
+            }
+
             for (int i = 0; i < matches.Length; ++i)
             {
                 var match = matches[i];
@@ -140,18 +213,33 @@ public struct MultiVectorSearchMatch : IQueryMatch
                     continue;
 
                 var distance = _distances.Results[pos];
-                scores[i] += _nearestSearches[0].DistanceToScore(distance);
+                scores[i] += boostFactor * _vectorsRetrievers[0].DistanceToScore(distance);
             }
         }
         else
         {
             _distances.Results[..scores.Length].CopyTo(scores);
-            _nearestSearches[0].DistancesToScores(scores);
+            _vectorsRetrievers[0].DistancesToScores(scores);
+            for (int i = 0; i < scores.Length; ++i)
+                scores[i] *= boostFactor;
         }
 
         _matches.Dispose();
         _distances.Dispose();
     }
+
+    public long Count { get; private set; }
+
+    public SkipSortingResult AttemptToSkipSorting()
+    {
+        return _singleVectorSearchDoNotSort
+            ? SkipSortingResult.ResultsNativelySorted
+            : SkipSortingResult.SortingIsRequired;
+    }
+
+    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
+
+    public bool IsBoosting { get; }
 
     public QueryInspectionNode Inspect()
     {
@@ -159,7 +247,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },
-                { nameof(Hnsw.SimilarityMethod), _nearestSearches[0].SimilarityMethod.ToString() },
+                { nameof(Hnsw.SimilarityMethod), _vectorsRetrievers[0].SimilarityMethod.ToString() },
             });
     }
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -82,6 +82,13 @@ public struct MultiVectorSearchMatch : IQueryMatch
         {
             _filterResults = IndexSearcher.VectorSearchUtils.LoadFilterMatches(_indexSearcher, ref _filterQuery);
             _filterMatchesCount = _filterResults.Count;
+            
+            // Shortcut for empty filter
+            if (_filterMatchesCount == 0)
+            {
+                _isEmpty = true;
+                return;
+            }
         }
 
         _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold, _numberOfCandidates);

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -199,7 +199,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
-        if (_resultsPersisted == false)
+        if (_isEmpty || _resultsPersisted == false)
         {
             // BinaryMatch may skip the method call if the other node of the AND clause 
             // is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -29,6 +29,7 @@ public struct VectorSearchMatch : IQueryMatch
     
     // Number of documents to be directly scanned instead of ANN / Exact on HNSW.
     private readonly int _scanningThreshold;
+    private readonly Random _random;
     private bool _scanningQuery;
 
     
@@ -68,7 +69,8 @@ public struct VectorSearchMatch : IQueryMatch
         in bool isExact, 
         in bool singleVectorSearchDoNotSort, 
         IQueryMatch filterQuery,
-        int scanningThreshold = ScanningThreshold)
+        int scanningThreshold = ScanningThreshold,
+        Random random = null)
     {
         _singleVectorSearchDoNotSort = singleVectorSearchDoNotSort;
         _filterQuery = filterQuery;
@@ -82,6 +84,7 @@ public struct VectorSearchMatch : IQueryMatch
         _vectorToSearch = vectorToSearch;
         _filterQueryLoaded = filterQuery is null;
         _scanningThreshold = scanningThreshold;
+        _random = random;
         _isEmpty = false;
     }
 
@@ -123,7 +126,7 @@ public struct VectorSearchMatch : IQueryMatch
         {
             _ when _scanningQuery => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
             true => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults)), 
+            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults, _random)), 
                 _ => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
         };
         

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -57,7 +57,7 @@ public struct VectorSearchMatch : IQueryMatch
     private bool _filterQueryLoaded;
     private long _filterMatchesCount;
 
-    private bool _canStreamResults => IsBoosting == false;
+    private bool CanStreamResults => IsBoosting == false && _singleVectorSearchDoNotSort;
 
     public VectorSearchMatch(IndexSearcher searcher, 
         in FieldMetadata metadata, 
@@ -84,9 +84,8 @@ public struct VectorSearchMatch : IQueryMatch
     }
 
     /// <summary>
-    /// Initialization of vector search is lazy to avoid expensive computation/IO during QueryBuilding phase.
+    /// Initialization of vector search is lazy to avoid expensive computation/IO during the QueryBuilding phase.
     /// </summary>
-    /// <param name="tmpBuffer">Used to fetch data from a filter match. This way we can spare on allocations, since the actual data will be stored in bitmap.</param>
     private void InitializeVectorSearch()
     {
         Debug.Assert(_vectorRetrieverInitialized == false, "Vector Retriever should be initialized only once.");
@@ -130,7 +129,7 @@ public struct VectorSearchMatch : IQueryMatch
         if (_isEmpty)
             return 0;
         
-        if (_canStreamResults) // case when we do not care about scores.
+        if (CanStreamResults) // case when we do not care about scores.
             return FillDiscardSimilarity(matches);
 
         if (_resultsPersisted == false)
@@ -178,6 +177,7 @@ public struct VectorSearchMatch : IQueryMatch
         
         if (read == 0)
         {
+            _returnedAllResults = true;
             _distances.Dispose();
             _distances = default;
             Dispose();

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Mappings;
@@ -99,7 +100,7 @@ public struct VectorSearchMatch : IQueryMatch
             _filterMatchesCount = _filterResults.Count;
         }
         
-        _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold);
+        _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold, _numberOfCandidates);
         var llt = _indexSearcher._transaction.LowLevelTransaction;
         var vector = _vectorToSearch.GetEmbeddingMemory();
         var fieldName = _metadata.FieldName;
@@ -297,7 +298,12 @@ public struct VectorSearchMatch : IQueryMatch
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },
-                { nameof(Hnsw.SimilarityMethod), _vectorSearchRetriever.SimilarityMethod.ToString() },
+                { nameof(Hnsw.SimilarityMethod), _vectorSearchRetriever.SimilarityMethod?.ToString() ?? "Query not initialized." },
+                { "IsExact", _isExact.ToString() },
+                { "IsScanning", _scanningQuery.ToString() },
+                { "Minimum match", _minimumMatch.ToString(CultureInfo.InvariantCulture) },
+                { "Number of candidates", _numberOfCandidates.ToString() },
+                { "Number of candidates scanned", (_vectorSearchRetriever.CandidatesProcessed).ToString()}
             });
     }
 

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -123,7 +123,8 @@ public struct VectorSearchMatch : IQueryMatch
         {
             _ when _scanningQuery => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
             true => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            false => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults)), 
+                _ => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
         };
         
 

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -133,7 +133,7 @@ public struct VectorSearchMatch : IQueryMatch
         {
             _ when _scanningQuery => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
             true => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, IndexSearcher.VectorSearchUtils.GetDocumentsIntoNodesRandomly(_indexSearcher, _metadata, _filterResults, _random)), 
+            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults, _random)), 
                 _ => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
         };
         

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -6,27 +6,44 @@ using System.Runtime.InteropServices;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
+using Sparrow.Server.Collections;
 using Sparrow.Server.Utils;
-using Sparrow.Server.Utils.VxSort;
 using Voron.Data.Graphs;
+using Voron.Util;
 
 namespace Corax.Querying.Matches;
 
 [DebuggerDisplay("{DebugView,nq}")]
 public struct VectorSearchMatch : IQueryMatch
 {
-    private Hnsw.NearestSearch _nearestSearch;
+    private const int ScanningThreshold = 1024;
+    
     private readonly IndexSearcher _indexSearcher;
     private readonly FieldMetadata _metadata;
-    public bool IsBoosting { get; init; }
+    private readonly float _minimumMatch;
+    private readonly int _numberOfCandidates;
+    private readonly bool _isExact;
+    private VectorValue _vectorToSearch;
+
     
+    // Number of documents to be directly scanned instead of ANN / Exact on HNSW.
+    private readonly int _scanningThreshold;
+    private bool _scanningQuery;
+
     
-    private bool _resultsNotPersisted = true;
-    private bool _returnedAllResults = false;
-    private int _positionOnPersistedValues = 0;
+    // Internal buffers used to store results from VectorSearch.
     private GrowableBuffer<long, Constant<long>> _matches;
     private GrowableBuffer<float, Constant<float>> _distances;
-    private readonly bool _isEmpty;
+    
+    // Voron VectorSearch Retriever
+    private Hnsw.VectorSearchRetriever _vectorSearchRetriever;
+    private bool _vectorRetrieverInitialized;
+    
+    private bool _resultsPersisted;
+    private bool _returnedAllResults = false;
+    private int _positionOnPersistedValues = 0;
+    private bool _isEmpty;
+    
     
     /// <summary>
     /// When VectorSearch is the only condition in the WHERE statement,
@@ -35,56 +52,114 @@ public struct VectorSearchMatch : IQueryMatch
     /// </summary>
     private readonly bool _singleVectorSearchDoNotSort;
 
-    public VectorSearchMatch(IndexSearcher searcher, in FieldMetadata metadata, VectorValue vectorToSearch, in float minimumMatch, in int numberOfCandidates, in bool isExact, in bool singleVectorSearchDoNotSort)
+    private GrowableBitArray _filterResults;
+    private IQueryMatch _filterQuery;
+    private bool _filterQueryLoaded;
+    private long _filterMatchesCount;
+
+    private bool _canStreamResults => IsBoosting == false;
+
+    public VectorSearchMatch(IndexSearcher searcher, 
+        in FieldMetadata metadata, 
+        VectorValue vectorToSearch,
+        in float minimumMatch, 
+        in int numberOfCandidates, 
+        in bool isExact, 
+        in bool singleVectorSearchDoNotSort, 
+        IQueryMatch filterQuery,
+        int scanningThreshold = ScanningThreshold)
     {
         _singleVectorSearchDoNotSort = singleVectorSearchDoNotSort;
+        _filterQuery = filterQuery;
         _metadata = metadata;
         _indexSearcher = searcher;
-        _nearestSearch = isExact == false
-            ? Hnsw.ApproximateNearest(searcher.Transaction.LowLevelTransaction, metadata.FieldName, numberOfCandidates, vectorToSearch.GetEmbedding(), minimumMatch)
-            : Hnsw.ExactNearest(searcher.Transaction.LowLevelTransaction, metadata.FieldName, numberOfCandidates, vectorToSearch.GetEmbedding(), minimumMatch);
+        IsBoosting = metadata.HasBoost;
+        _vectorRetrieverInitialized = false;
+        _minimumMatch = minimumMatch;
+        _numberOfCandidates = numberOfCandidates;
+        _isExact = isExact;
+        _vectorToSearch = vectorToSearch;
+        _filterQueryLoaded = filterQuery is null;
+        _scanningThreshold = scanningThreshold;
+    }
 
-        vectorToSearch.Dispose();
-        if (_nearestSearch.IsEmpty)
+    /// <summary>
+    /// Initialization of vector search is lazy to avoid expensive computation/IO during QueryBuilding phase.
+    /// </summary>
+    /// <param name="tmpBuffer">Used to fetch data from a filter match. This way we can spare on allocations, since the actual data will be stored in bitmap.</param>
+    private void InitializeVectorSearch()
+    {
+        Debug.Assert(_vectorRetrieverInitialized == false, "Vector Retriever should be initialized only once.");
+        _vectorRetrieverInitialized = true;
+
+        if (_filterQueryLoaded == false)
         {
-            _isEmpty = true;
-            return;
+            _filterQueryLoaded = true;
+            _filterResults = IndexSearcher.VectorSearchUtils.LoadFilterMatches(_indexSearcher, ref _filterQuery);
+            _filterMatchesCount = _filterResults.Count;
         }
         
-        IsBoosting = metadata.HasBoost;
+        _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold);
+        var llt = _indexSearcher._transaction.LowLevelTransaction;
+        var vector = _vectorToSearch.GetEmbeddingMemory();
+        var fieldName = _metadata.FieldName;
+        
+        ContextBoundNativeList<long> nodesIdsToScan = default;
+        if (_scanningQuery)
+            _scanningQuery = IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults, out nodesIdsToScan);
+        
+        
+        _vectorSearchRetriever = _isExact switch
+        {
+            _ when _scanningQuery => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
+            true => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            false => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+        };
+        
+
+        _isEmpty = _scanningQuery 
+            ? _filterMatchesCount == 0 || _vectorSearchRetriever.IsEmpty
+            : _vectorSearchRetriever.IsEmpty;
     }
-
-    public long Count { get; private set; }
-
-    public SkipSortingResult AttemptToSkipSorting()
-    {
-        return _singleVectorSearchDoNotSort 
-            ? SkipSortingResult.ResultsNativelySorted 
-            : SkipSortingResult.SortingIsRequired;
-    }
-
-    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
-
     
     public int Fill(Span<long> matches)
     {
+        if (_vectorRetrieverInitialized == false)
+            InitializeVectorSearch();
+        
         if (_isEmpty)
             return 0;
         
-        if (IsBoosting == false)
+        if (_canStreamResults) // case when we do not care about scores.
             return FillDiscardSimilarity(matches);
 
-        if (_resultsNotPersisted)
+        if (_resultsPersisted == false)
             FillAndPersistResults();
 
         var resultsLeft = _matches.Count - _positionOnPersistedValues;
         if (resultsLeft == 0)
+        {
             return 0;
+        }
 
         var amountToCopy = Math.Min(resultsLeft, matches.Length);
         _matches.Results.Slice(_positionOnPersistedValues,  amountToCopy).CopyTo(matches.Slice(0, amountToCopy));
         _positionOnPersistedValues += amountToCopy;
         return amountToCopy;
+    }
+    
+    public int AndWith(Span<long> buffer, int matches)
+    {
+        if (_vectorRetrieverInitialized == false)
+            InitializeVectorSearch();
+        
+        if (_isEmpty)
+            return 0;
+        
+        if (_resultsPersisted == false)
+            FillAndPersistResults();
+
+        return MergeHelper.And(buffer, buffer.Slice(0, matches), _matches.Results);
     }
 
     private int FillDiscardSimilarity(Span<long> matches)
@@ -95,18 +170,23 @@ public struct VectorSearchMatch : IQueryMatch
         if (_distances.Capacity < sizeof(float) * matches.Length)
             CreateDistanceBuffer(matches.Length);
 
-        var read = _nearestSearch.Fill(matches, _distances.GetSpace());
+        var distancesBuffer = _distances.GetSpace();
+        
+        var read = _filterQuery == null 
+            ? _vectorSearchRetriever.Fill(matches, distancesBuffer)
+            : _vectorSearchRetriever.Fill(matches, distancesBuffer, _filterResults);
+        
         if (read == 0)
         {
             _distances.Dispose();
-            _nearestSearch.Dispose(); //no more matches
-            _returnedAllResults = true;
+            _distances = default;
+            Dispose();
             return 0;
         }
         
-        // We've to sort inner batch and remove duplicates
-        Sort.Run(matches[..read]);
-        return RemoveDuplicates(matches[..read], _distances.GetSpace()[..read]);
+        Sorting.SortAndMinOnDuplicates(matches[..read], distancesBuffer[..read]);
+        distancesBuffer[..read].Sort(matches[..read]);
+        return read;
     }
 
     private void CreateDistanceBuffer(int length)
@@ -114,9 +194,12 @@ public struct VectorSearchMatch : IQueryMatch
         ref var distances = ref _distances;
         distances.Init(_indexSearcher.Allocator, length);
     }
-
+    
     private void FillAndPersistResults()
     {
+        Debug.Assert(_resultsPersisted == false, "Results should be persisted only once.");
+        _resultsPersisted = true;
+        
         ref var matches = ref _matches;
         ref var distances = ref _distances;
         
@@ -129,90 +212,33 @@ public struct VectorSearchMatch : IQueryMatch
             var dBuf = distances.GetSpace();
             Debug.Assert(mBuf.Length == dBuf.Length, "mBuf.Length == dBuf.Length");
             
-            currentRead = _nearestSearch.Fill(mBuf, dBuf);
+            currentRead = (_filterQuery is null) switch
+            {
+                true => _vectorSearchRetriever.Fill(mBuf, dBuf),
+                false => _vectorSearchRetriever.Fill(mBuf, dBuf, _filterResults)
+            };
+            
             matches.AddUsage(currentRead);
             distances.AddUsage(currentRead);
-        } while (currentRead != 0);
 
+        } while (currentRead != 0);
+        
         if (_singleVectorSearchDoNotSort == false)
         {
-            matches.Results.Sort(distances.Results);
-        
             //Truncate the buffer to the actual size
-            var matchesCount = RemoveDuplicates(matches.Results, distances.Results);
+            var matchesCount = Sorting.SortAndMinOnDuplicates(matches.Results, distances.Results);
             distances.Truncate(matchesCount);
             matches.Truncate(matchesCount);
         }
-        
-        _nearestSearch.Dispose();
-        _resultsNotPersisted = false;
-    }
-
-    /// <summary>
-    /// Deduplicates the original matches buffer and retains the lowest distance value among duplicates.
-    /// </summary>
-    /// <param name="matches">sorted matches</param>
-    /// <param name="distances">Distances buffer</param>
-    /// <returns>Unique elements.</returns>
-    internal static int RemoveDuplicates(Span<long> matches, Span<float> distances)
-    {
-        Debug.Assert(IsSorted(matches));
-        if (matches.Length <= 1)
-            return matches.Length;
-
-        var outputPos = 0;
-        ref var matchesRef = ref MemoryMarshal.GetReference(matches);
-        ref var distancesRef = ref MemoryMarshal.GetReference(distances);
-        
-        for (int i = 0; i < matches.Length - 1; ++i)
+        else if (_vectorSearchRetriever.IsSortedByDistance == false)
         {
-            var currentMatch = Unsafe.Add(ref matchesRef, i);
-            var nextMatch = Unsafe.Add(ref matchesRef, i + 1);
-            if (currentMatch == nextMatch)
-            {
-                ref var nextDistance = ref Unsafe.Add(ref distancesRef, i + 1);
-                nextDistance = MathF.Min(
-                    Unsafe.Add(ref distancesRef, i), 
-                    nextDistance);
-                continue;
-            }
-            
-            Unsafe.Add(ref matchesRef, outputPos) = currentMatch;
-            Unsafe.Add(ref distancesRef, outputPos) = Unsafe.Add(ref distancesRef, i);
-            outputPos++;
+            distances.Results.Sort(matches.Results);
         }
         
-        Unsafe.Add(ref matchesRef, outputPos) = Unsafe.Add(ref matchesRef, matches.Length - 1);
-        Unsafe.Add(ref distancesRef, outputPos) = Unsafe.Add(ref distancesRef, matches.Length - 1);
-        outputPos++;
-        
-        return outputPos;
-    }
-
-    private static bool IsSorted(Span<long> matches)
-    {
-        if (matches.Length <= 1)
-            return true;
-
-        for (int i = 1; i < matches.Length; ++i)
-        {
-            if (matches[i - 1] > matches[i])
-                return false;
-        }
-
-        return true;
+        Dispose();
     }
     
-    public int AndWith(Span<long> buffer, int matches)
-    {
-        if (_isEmpty)
-            return 0;
-        
-        if (_resultsNotPersisted)
-            FillAndPersistResults();
-
-        return MergeHelper.And(buffer, buffer.Slice(0, matches), _matches.Results);
-    }
+    
 
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
@@ -231,7 +257,10 @@ public struct VectorSearchMatch : IQueryMatch
             ref var matchesRef = ref MemoryMarshal.GetReference(matches);
             ref var scoresRef = ref MemoryMarshal.GetReference(scores);
             ref var distanceRef = ref MemoryMarshal.GetReference(_distances.Results);
-
+            if (_filterQuery != null)
+                _filterQuery.Score(matches, scores, boostFactor);
+            
+            
             for (var i = 0; i < matches.Length; ++i)
             {
                 var match = Unsafe.Add(ref matchesRef, i);
@@ -239,27 +268,27 @@ public struct VectorSearchMatch : IQueryMatch
                 if (pos < 0)
                     continue;
 
-                Unsafe.Add(ref scoresRef, i) += _nearestSearch.DistanceToScore(Unsafe.Add(ref distanceRef, pos));
+                Unsafe.Add(ref scoresRef, i) += _vectorSearchRetriever.DistanceToScore(Unsafe.Add(ref distanceRef, pos));
             }
         }
         else
         {
             _distances.Results[..scores.Length].CopyTo(scores);
-            _nearestSearch.DistancesToScores(scores);
+            _vectorSearchRetriever.DistancesToScores(scores);
         }
         
         _matches.Dispose();
         _distances.Dispose();
-        
     }
 
     public QueryInspectionNode Inspect()
     {
         return new QueryInspectionNode(nameof(VectorSearchMatch),
+            children: new List<QueryInspectionNode> { _filterQuery?.Inspect() ?? QueryInspectionNode.NotInitializedInspectionNode("Filter") },
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },
-                { nameof(Hnsw.SimilarityMethod), _nearestSearch.SimilarityMethod.ToString() },
+                { nameof(Hnsw.SimilarityMethod), _vectorSearchRetriever.SimilarityMethod.ToString() },
             });
     }
 
@@ -274,4 +303,24 @@ public struct VectorSearchMatch : IQueryMatch
     public DuplicatesOccurrence DuplicatesOccurrenceStatus => _singleVectorSearchDoNotSort || IsBoosting == false
         ? DuplicatesOccurrence.Possible 
         : DuplicatesOccurrence.NotPossible;
+    
+    public long Count { get; private set; }
+
+    public SkipSortingResult AttemptToSkipSorting()
+    {
+        return _singleVectorSearchDoNotSort 
+            ? SkipSortingResult.ResultsNativelySorted 
+            : SkipSortingResult.SortingIsRequired;
+    }
+
+    public QueryCountConfidence Confidence => QueryCountConfidence.Low;
+    
+    public bool IsBoosting { get; init; }
+
+    private void Dispose()
+    {
+        _filterResults.Dispose();
+        _vectorSearchRetriever.Dispose();
+        _vectorToSearch.Dispose();
+    }
 }

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -81,6 +81,7 @@ public struct VectorSearchMatch : IQueryMatch
         _vectorToSearch = vectorToSearch;
         _filterQueryLoaded = filterQuery is null;
         _scanningThreshold = scanningThreshold;
+        _isEmpty = false;
     }
 
     /// <summary>
@@ -105,7 +106,16 @@ public struct VectorSearchMatch : IQueryMatch
         
         ContextBoundNativeList<long> nodesIdsToScan = default;
         if (_scanningQuery)
-            _scanningQuery = IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults, out nodesIdsToScan);
+        {
+            var hasNodes = IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults, out nodesIdsToScan);
+            if (hasNodes == false)
+            {
+                _isEmpty = true;
+                _vectorToSearch.Dispose();
+                _filterResults.Dispose();
+                return;
+            }
+        }
         
         
         _vectorSearchRetriever = _isExact switch
@@ -126,15 +136,15 @@ public struct VectorSearchMatch : IQueryMatch
         if (_vectorRetrieverInitialized == false)
             InitializeVectorSearch();
         
-        if (_isEmpty)
-            return 0;
-        
         if (CanStreamResults) // case when we do not care about scores.
             return FillDiscardSimilarity(matches);
 
         if (_resultsPersisted == false)
             FillAndPersistResults();
 
+        if (_isEmpty)
+            return 0;
+        
         var resultsLeft = _matches.Count - _positionOnPersistedValues;
         if (resultsLeft == 0)
         {
@@ -163,7 +173,7 @@ public struct VectorSearchMatch : IQueryMatch
 
     private int FillDiscardSimilarity(Span<long> matches)
     {
-        if (_returnedAllResults)
+        if (_returnedAllResults || _isEmpty)
             return 0;
         
         if (_distances.Capacity < sizeof(float) * matches.Length)
@@ -238,8 +248,6 @@ public struct VectorSearchMatch : IQueryMatch
         Dispose();
     }
     
-    
-
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
         if (_resultsNotPersisted)

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -101,6 +101,13 @@ public struct VectorSearchMatch : IQueryMatch
             _filterQueryLoaded = true;
             _filterResults = IndexSearcher.VectorSearchUtils.LoadFilterMatches(_indexSearcher, ref _filterQuery);
             _filterMatchesCount = _filterResults.Count;
+
+            // Shortcut for empty filter
+            if (_filterMatchesCount == 0)
+            {
+                _isEmpty = true;
+                return;
+            }
         }
         
         _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold, _numberOfCandidates);

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -250,7 +250,7 @@ public struct VectorSearchMatch : IQueryMatch
     
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
-        if (_resultsNotPersisted)
+        if (_resultsPersisted == false)
         {
             // BinaryMatch may skip the method call if the other node of the AND clause 
             // is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -136,14 +136,15 @@ public struct VectorSearchMatch : IQueryMatch
         if (_vectorRetrieverInitialized == false)
             InitializeVectorSearch();
         
+        if (_isEmpty)
+            return 0;
+        
         if (CanStreamResults) // case when we do not care about scores.
             return FillDiscardSimilarity(matches);
 
         if (_resultsPersisted == false)
             FillAndPersistResults();
 
-        if (_isEmpty)
-            return 0;
         
         var resultsLeft = _matches.Count - _positionOnPersistedValues;
         if (resultsLeft == 0)
@@ -250,7 +251,7 @@ public struct VectorSearchMatch : IQueryMatch
     
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
-        if (_resultsPersisted == false)
+        if (_isEmpty || _resultsPersisted == false)
         {
             // BinaryMatch may skip the method call if the other node of the AND clause 
             // is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.

--- a/src/Corax/Utils/EntryTermsReader.cs
+++ b/src/Corax/Utils/EntryTermsReader.cs
@@ -102,7 +102,7 @@ public unsafe struct EntryTermsReader
     public bool IsNonExisting;
 
     //rootPages has to be sorted.
-    public EntryTermsReader(LowLevelTransaction llt, HashSet<long> nullTermsMarkers, HashSet<long> nonExistingTermsMarkers, byte* cur, int size, long dicId, long[] vectorFieldsMarkers)
+    public EntryTermsReader(LowLevelTransaction llt, HashSet<long> nullTermsMarkers, HashSet<long> nonExistingTermsMarkers, byte* cur, int size, long dicId, long[] vectorFieldsMarkers, CompactKey key = null)
     {
         _llt = llt;
         _nullTermsMarkers = nullTermsMarkers;
@@ -115,7 +115,7 @@ public unsafe struct EntryTermsReader
         _end = cur + size;
         _prevTerm = 0;
         _prevLong = 0;
-        Current = new();
+        Current = key ?? new();
         Current.Initialize(llt);
     }
 

--- a/src/Corax/Utils/VectorValue.cs
+++ b/src/Corax/Utils/VectorValue.cs
@@ -19,6 +19,11 @@ public struct VectorValue : IDisposable
         return _memory.Span.Slice(0, _length);
     }
 
+    public Memory<byte> GetEmbeddingMemory()
+    {
+        return _memory.Slice(0, _length);
+    }
+
     public VectorValue()
     {
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -68,7 +68,7 @@ internal class CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
             // nothing to do
         }
 
-        public void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value)
+        public void WriteVector(int fieldId, string path, ReadOnlySpan<byte> value, Random random = null)
         {
             // nothing to do here
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -647,7 +647,6 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                                 yield break;
                         }
 
-                        queryTimings?.SetQueryPlan(queryMatch.Inspect());
                     }
                     finally
                     {
@@ -806,9 +805,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                     } 
                     while (read != 0);
                 }
+                
+                
 
                 Done:
-
+                // Since some primitives are lazily initialized, we must call Inspect after at least one Fill call.
+                queryTimings?.SetQueryPlan(queryMatch.Inspect());
+                
                 QueryPool.Return(ids);
                 if (sortingData.IncludeScores)
                     ScorePool.Return(sortingData.ScoresBuffer);

--- a/src/Sparrow.Server/Collections/GrowableBitArray.cs
+++ b/src/Sparrow.Server/Collections/GrowableBitArray.cs
@@ -279,13 +279,13 @@ public unsafe struct GrowableBitArray : IDisposable
         }
     }
 
-    public static IEnumerable<long> Probe(GrowableBitArray filterResults, Random shared)
+    public static IEnumerable<long> Probe(GrowableBitArray filterResults, Random random)
     {
         var it = filterResults.GetIterator(0);
         HashSet<long> seen = new();
         do
         {
-            var current = shared.NextInt64(0, filterResults._capacity);
+            var current = random.NextInt64(0, filterResults._capacity);
             if (seen.Add(current) == false)
                 continue;
             if (filterResults.Contains(current) == false)

--- a/src/Sparrow.Server/Collections/GrowableBitArray.cs
+++ b/src/Sparrow.Server/Collections/GrowableBitArray.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using Sparrow.Server.Utils.VxSort;
 
 namespace Sparrow.Server.Collections;
 
@@ -11,8 +12,8 @@ public unsafe struct GrowableBitArray : IDisposable
     internal static readonly int MaxCapacityPerBitmap = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(ulong);
     internal static readonly long MaxCapacityPerBitmapInBits = MaxCapacityPerBitmap * 64L;
     private BitArray[] _bitArrays;
-    private readonly long _capacity;
-    
+    public readonly long Capacity;
+
     /// <summary>
     /// The owner must update this count manually.
     /// </summary>
@@ -23,8 +24,8 @@ public unsafe struct GrowableBitArray : IDisposable
     /// </summary>
     public GrowableBitArray(ByteStringContext allocator, long capacity)
     {
-        _capacity = capacity + 1; // ensure it's not zero and handles the last bit inclusively.
-        var numberOfUlongsToAllocate = _capacity / 64 + (_capacity % 64 == 0 ? 0 : 1);
+        Capacity = capacity + 1; // ensure it's not zero and handles the last bit inclusively.
+        var numberOfUlongsToAllocate = Capacity / 64 + (Capacity % 64 == 0 ? 0 : 1);
         var numberOfBitArrays = (int)Math.Ceiling(numberOfUlongsToAllocate / (double)MaxCapacityPerBitmap);
         _bitArrays = new BitArray[numberOfBitArrays];
         var lastChunkSize = (int)(numberOfUlongsToAllocate - (long)(numberOfBitArrays - 1) * MaxCapacityPerBitmap);
@@ -37,15 +38,15 @@ public unsafe struct GrowableBitArray : IDisposable
     }
 
     public Iterator GetIterator(long from) => new Iterator(this, from);
-    
+
     public ref struct Iterator : IEnumerator<long>
     {
         private readonly GrowableBitArray _bitArray;
-        private readonly long _from;
+        private long _from;
         private int _currentBitArrayIdx;
         private long _currentShift;
         private BitArray.Iterator _iterator;
-        
+
         public Iterator(GrowableBitArray bitArray, long from)
         {
             _bitArray = bitArray;
@@ -64,21 +65,25 @@ public unsafe struct GrowableBitArray : IDisposable
 
                 _currentShift += MaxCapacityPerBitmapInBits;
                 _currentBitArrayIdx++;
-                
+
                 if (_currentBitArrayIdx < _bitArray._bitArrays.Length)
                     _iterator = new(_bitArray._bitArrays[_currentBitArrayIdx], 0);
             }
-            
+
             return false;
         }
 
-        public void Reset()
+        public void Reset() => Reset(_from);
+
+        public void Reset(long from)
         {
+            _from = from;
+
             _currentBitArrayIdx = (int)(_from / MaxCapacityPerBitmapInBits);
             _currentShift = _currentBitArrayIdx * MaxCapacityPerBitmapInBits;
-            
+
             if (_currentBitArrayIdx <= _bitArray._bitArrays.Length)
-                _iterator = new (_bitArray._bitArrays[_currentBitArrayIdx], (int)(_from % MaxCapacityPerBitmapInBits));
+                _iterator = new(_bitArray._bitArrays[_currentBitArrayIdx], (int)(_from % MaxCapacityPerBitmapInBits));
         }
 
         public long Current => _currentShift + _iterator.Current;
@@ -87,7 +92,7 @@ public unsafe struct GrowableBitArray : IDisposable
         {
             get => Current;
         }
-        
+
         public void Dispose()
         {
             //nothing to dispose
@@ -110,12 +115,21 @@ public unsafe struct GrowableBitArray : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Add(long pos)
     {
-        if (pos >= _capacity)
-            throw new ArgumentOutOfRangeException($"Tried to modify the bit at position '{pos}', however the capacity is only {_capacity}");
+        if (pos >= Capacity)
+            throw new ArgumentOutOfRangeException($"Tried to modify the bit at position '{pos}', however the capacity is only {Capacity}");
         var bitmapIdx = (int)(pos / MaxCapacityPerBitmapInBits);
         return _bitArrays[(int)bitmapIdx].Add(pos - bitmapIdx * MaxCapacityPerBitmapInBits);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Remove(long pos)
+    {
+        if (pos >= Capacity)
+            throw new ArgumentOutOfRangeException($"Tried to modify the bit at position '{pos}', however the capacity is only {Capacity}");
+        var bitmapIdx = (int)(pos / MaxCapacityPerBitmapInBits);
+        _bitArrays[(int)bitmapIdx].Remove(pos - bitmapIdx * MaxCapacityPerBitmapInBits);
+    }
+    
     public bool Contains(long pos)
     {
         var bitmapIdx = (int)(pos / MaxCapacityPerBitmapInBits);
@@ -160,6 +174,14 @@ public unsafe struct GrowableBitArray : IDisposable
             *bucket |= mask;
             return result == 0;
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Remove(long id)
+        {
+            var mask = ~(1UL << (int)(id & 63));
+            var bucket = _bits + (int)(id >> 6);
+            *bucket &= mask;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(long id)
@@ -184,12 +206,12 @@ public unsafe struct GrowableBitArray : IDisposable
                 _array = array;
                 Reset();
             }
-            
+
             public bool MoveNext()
             {
                 if (_it >= _array._length)
                     return false;
-                
+
                 while (true)
                 {
                     if (_bitmap != 0)
@@ -203,7 +225,7 @@ public unsafe struct GrowableBitArray : IDisposable
                     _it++;
                     if (_it >= _array._length)
                         break;
-                    
+
                     _bitmap = *(_array._bits + _it);
                 }
 
@@ -215,7 +237,7 @@ public unsafe struct GrowableBitArray : IDisposable
                 _it = _from / 64;
                 _bitmap = 0;
                 _count = 0;
-                
+
                 _bitmap = *(_array._bits + _it);
                 _bitmap &= ulong.MaxValue << (_from % 64);
             }
@@ -232,7 +254,7 @@ public unsafe struct GrowableBitArray : IDisposable
                 // nothing to dispose
             }
         }
-        
+
         public unsafe IEnumerable<int> Iterate(int from)
         {
             // https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/
@@ -277,20 +299,5 @@ public unsafe struct GrowableBitArray : IDisposable
             _bits = null;
             _memoryScope = null;
         }
-    }
-
-    public static IEnumerable<long> Probe(GrowableBitArray filterResults, Random random)
-    {
-        var it = filterResults.GetIterator(0);
-        HashSet<long> seen = new();
-        do
-        {
-            var current = random.NextInt64(0, filterResults._capacity);
-            if (seen.Add(current) == false)
-                continue;
-            if (filterResults.Contains(current) == false)
-                continue;
-            yield return current;
-        } while (seen.Count < filterResults.Count);
     }
 }

--- a/src/Sparrow.Server/Collections/GrowableBitArray.cs
+++ b/src/Sparrow.Server/Collections/GrowableBitArray.cs
@@ -278,4 +278,19 @@ public unsafe struct GrowableBitArray : IDisposable
             _memoryScope = null;
         }
     }
+
+    public static IEnumerable<long> Probe(GrowableBitArray filterResults, Random shared)
+    {
+        var it = filterResults.GetIterator(0);
+        HashSet<long> seen = new();
+        do
+        {
+            var current = shared.NextInt64(0, filterResults._capacity);
+            if (seen.Add(current) == false)
+                continue;
+            if (filterResults.Contains(current) == false)
+                continue;
+            yield return current;
+        } while (seen.Count < filterResults.Count);
+    }
 }

--- a/src/Sparrow.Server/Collections/GrowableBitArray.cs
+++ b/src/Sparrow.Server/Collections/GrowableBitArray.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.CompilerServices;
+using Sparrow.Binary;
 
 namespace Sparrow.Server.Collections;
 
@@ -11,7 +14,12 @@ public unsafe struct GrowableBitArray : IDisposable
     private readonly long _capacity;
     
     /// <summary>
-    /// Creates a new bit array. It accepts when bits id are between [0, capacity]
+    /// The owner must update this count manually.
+    /// </summary>
+    public long Count;
+
+    /// <summary>
+    /// Creates a new bit array. It accepts when bits id is between [0, capacity]
     /// </summary>
     public GrowableBitArray(ByteStringContext allocator, long capacity)
     {
@@ -25,7 +33,18 @@ public unsafe struct GrowableBitArray : IDisposable
             _bitArrays[i] = new BitArray(allocator, i == numberOfBitArrays - 1
                 ? lastChunkSize
                 : MaxCapacityPerBitmap);
+        }
+    }
 
+    public IEnumerable<long> Iterate(long from)
+    {
+        for (int bitArrayIdx = (int)(from / MaxCapacityPerBitmapInBits); bitArrayIdx < _bitArrays.Length; bitArrayIdx++)
+        {
+            var shift = bitArrayIdx * MaxCapacityPerBitmapInBits;
+            foreach (var result in _bitArrays[bitArrayIdx].Iterate((int)(from % MaxCapacityPerBitmapInBits)))
+            {
+                yield return result + shift;
+            }
         }
     }
 
@@ -61,21 +80,23 @@ public unsafe struct GrowableBitArray : IDisposable
     {
         if (_bitArrays == null)
             return;
-        
+
         for (int i = 0; i < _bitArrays.Length; ++i)
             _bitArrays[i].Dispose();
-        _bitArrays  = null;
+        _bitArrays = null;
     }
 
     private struct BitArray : IDisposable
     {
         private ulong* _bits;
         private IDisposable _memoryScope;
+        private int _length;
 #if DEBUG
         public bool IsValid = true;
 #endif
         public BitArray(ByteStringContext allocator, int numberOfUlongsToAllocate)
         {
+            _length = numberOfUlongsToAllocate;
             _memoryScope = allocator.Allocate(numberOfUlongsToAllocate * sizeof(ulong), out ByteString memory);
             memory.ToSpan<ulong>().Clear();
             _bits = (ulong*)memory.Ptr;
@@ -93,7 +114,7 @@ public unsafe struct GrowableBitArray : IDisposable
             *bucket |= mask;
             return result == 0;
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Contains(long id)
         {
@@ -102,12 +123,48 @@ public unsafe struct GrowableBitArray : IDisposable
             return (*bucket & mask) != 0;
         }
 
+        //adjusted from src/Raven.Server/Documents/Queries/LuceneIntegration/FastBitArray.cs:7
+        public unsafe IEnumerable<int> Iterate(int from)
+        {
+            // https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/
+            int i = from / 64;
+            if (i >= _length)
+                yield break;
+
+            ulong bitmap;
+            unsafe
+            {
+                bitmap = *(_bits + i);
+                bitmap &= ulong.MaxValue << (from % 64);
+            }
+
+            while (true)
+            {
+                while (bitmap != 0)
+                {
+                    ulong t = bitmap & (ulong)-(long)bitmap;
+                    int count = BitOperations.TrailingZeroCount(bitmap);
+                    int setBitPos = i * 64 + count;
+                    yield return setBitPos;
+                    bitmap ^= t;
+                }
+
+                i++;
+                if (i >= _length)
+                    break;
+                unsafe
+                {
+                    bitmap = *(_bits + i);
+                }
+            }
+        }
+
         public void Dispose()
         {
 #if DEBUG
             IsValid = false;
 #endif
-            _memoryScope.Dispose();
+            _memoryScope?.Dispose();
             _bits = null;
             _memoryScope = null;
         }

--- a/src/Sparrow.Server/Collections/GrowableBitArray.cs
+++ b/src/Sparrow.Server/Collections/GrowableBitArray.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using Sparrow.Binary;
 
 namespace Sparrow.Server.Collections;
 
@@ -36,15 +36,61 @@ public unsafe struct GrowableBitArray : IDisposable
         }
     }
 
-    public IEnumerable<long> Iterate(long from)
+    public Iterator GetIterator(long from) => new Iterator(this, from);
+    
+    public ref struct Iterator : IEnumerator<long>
     {
-        for (int bitArrayIdx = (int)(from / MaxCapacityPerBitmapInBits); bitArrayIdx < _bitArrays.Length; bitArrayIdx++)
+        private readonly GrowableBitArray _bitArray;
+        private readonly long _from;
+        private int _currentBitArrayIdx;
+        private long _currentShift;
+        private BitArray.Iterator _iterator;
+        
+        public Iterator(GrowableBitArray bitArray, long from)
         {
-            var shift = bitArrayIdx * MaxCapacityPerBitmapInBits;
-            foreach (var result in _bitArrays[bitArrayIdx].Iterate((int)(from % MaxCapacityPerBitmapInBits)))
+            _bitArray = bitArray;
+            _from = from;
+            Reset();
+        }
+
+        public bool MoveNext()
+        {
+            while (_currentBitArrayIdx < _bitArray._bitArrays.Length)
             {
-                yield return result + shift;
+                if (_iterator.MoveNext())
+                {
+                    return true;
+                }
+
+                _currentShift += MaxCapacityPerBitmapInBits;
+                _currentBitArrayIdx++;
+                
+                if (_currentBitArrayIdx < _bitArray._bitArrays.Length)
+                    _iterator = new(_bitArray._bitArrays[_currentBitArrayIdx], 0);
             }
+            
+            return false;
+        }
+
+        public void Reset()
+        {
+            _currentBitArrayIdx = (int)(_from / MaxCapacityPerBitmapInBits);
+            _currentShift = _currentBitArrayIdx * MaxCapacityPerBitmapInBits;
+            
+            if (_currentBitArrayIdx <= _bitArray._bitArrays.Length)
+                _iterator = new (_bitArray._bitArrays[_currentBitArrayIdx], (int)(_from % MaxCapacityPerBitmapInBits));
+        }
+
+        public long Current => _currentShift + _iterator.Current;
+
+        object IEnumerator.Current
+        {
+            get => Current;
+        }
+        
+        public void Dispose()
+        {
+            //nothing to dispose
         }
     }
 
@@ -124,6 +170,69 @@ public unsafe struct GrowableBitArray : IDisposable
         }
 
         //adjusted from src/Raven.Server/Documents/Queries/LuceneIntegration/FastBitArray.cs:7
+        public ref struct Iterator : IEnumerator<long>
+        {
+            private int _it;
+            private ulong _bitmap = 0;
+            private int _count = 0;
+            private readonly BitArray _array;
+            private readonly int _from;
+
+            public Iterator(BitArray array, int from)
+            {
+                _from = from;
+                _array = array;
+                Reset();
+            }
+            
+            public bool MoveNext()
+            {
+                if (_it >= _array._length)
+                    return false;
+                
+                while (true)
+                {
+                    if (_bitmap != 0)
+                    {
+                        ulong t = _bitmap & (ulong)-(long)_bitmap;
+                        _count = BitOperations.TrailingZeroCount(_bitmap);
+                        _bitmap ^= t;
+                        return true;
+                    }
+
+                    _it++;
+                    if (_it >= _array._length)
+                        break;
+                    
+                    _bitmap = *(_array._bits + _it);
+                }
+
+                return false;
+            }
+
+            public void Reset()
+            {
+                _it = _from / 64;
+                _bitmap = 0;
+                _count = 0;
+                
+                _bitmap = *(_array._bits + _it);
+                _bitmap &= ulong.MaxValue << (_from % 64);
+            }
+
+            public long Current => _it * 64 + _count;
+
+            object IEnumerator.Current
+            {
+                get => Current;
+            }
+
+            public void Dispose()
+            {
+                // nothing to dispose
+            }
+        }
+        
         public unsafe IEnumerable<int> Iterate(int from)
         {
             // https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/

--- a/src/Sparrow.Server/Collections/GrowableBitArray.cs
+++ b/src/Sparrow.Server/Collections/GrowableBitArray.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Runtime.CompilerServices;
-using Sparrow.Server;
 
-namespace Corax.Utils;
+namespace Sparrow.Server.Collections;
 
-internal unsafe struct GrowableBitArray : IDisposable
+public unsafe struct GrowableBitArray : IDisposable
 {
     internal static readonly int MaxCapacityPerBitmap = (int.MaxValue - sizeof(ByteStringStorage)) / sizeof(ulong);
     internal static readonly long MaxCapacityPerBitmapInBits = MaxCapacityPerBitmap * 64L;
@@ -52,10 +51,20 @@ internal unsafe struct GrowableBitArray : IDisposable
         return _bitArrays[(int)bitmapIdx].Add(pos - bitmapIdx * MaxCapacityPerBitmapInBits);
     }
 
+    public bool Contains(long pos)
+    {
+        var bitmapIdx = (int)(pos / MaxCapacityPerBitmapInBits);
+        return _bitArrays[(int)bitmapIdx].Contains(pos - bitmapIdx * MaxCapacityPerBitmapInBits);
+    }
+
     public void Dispose()
     {
+        if (_bitArrays == null)
+            return;
+        
         for (int i = 0; i < _bitArrays.Length; ++i)
             _bitArrays[i].Dispose();
+        _bitArrays  = null;
     }
 
     private struct BitArray : IDisposable
@@ -83,6 +92,14 @@ internal unsafe struct GrowableBitArray : IDisposable
             var result = *bucket & mask;
             *bucket |= mask;
             return result == 0;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Contains(long id)
+        {
+            var mask = 1UL << (int)(id & 63);
+            var bucket = _bits + (int)(id >> 6);
+            return (*bucket & mask) != 0;
         }
 
         public void Dispose()

--- a/src/Voron/Data/Graphs/Hnsw.Constants.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Constants.cs
@@ -9,7 +9,7 @@ public partial class Hnsw
     internal static readonly Slice VectorContainerStorageSlice;
     internal static readonly Slice VectorsContainerIdSlice;
     private static readonly Slice NodeIdToLocationSlice;
-    private static readonly Slice NodesByVectorIdSlice;
+    public static readonly Slice NodesByVectorIdSlice;
     public static readonly Slice VectorsIdByHashSlice;
     internal static readonly Slice HnswGlobalConfigSlice;
     internal static readonly Slice OptionsSlice;

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -156,10 +156,13 @@ table, th, td {
 
             var path = new NativeList<int>();
             path.EnsureCapacityFor(llt.Allocator, searchState.Options.MaxLevel +1);
-            var edges = new NativeList<int>();
-            edges.EnsureCapacityFor(llt.Allocator, 16);
+            var edges = new ContextBoundNativeList<int>(llt.Allocator, 16);
             searchState.SearchNearestAcrossLevels(vector, -1, searchState.Options.MaxLevel,  ref path);
-            searchState.NearestEdges(path[0], -1, vector, 0, 8, ref edges, SearchState.NearestEdgesFlags.StartingPointAsEdge);
+            using var search = searchState.NearestSearch(path[0], new Memory<byte>(vector.ToArray()), 0, 8, edges, SearchState.NearestEdgesFlags.StartingPointAsEdge, false);
+            using var it = search.Search().GetEnumerator();
+            it.MoveNext();
+            search.TryGetCurrentCandidates(out edges);
+            
             
             for (int level = searchState.Options.MaxLevel - 1; level >= 0; level--)
             {
@@ -175,8 +178,8 @@ table, th, td {
 
                     var dist = searchState.Distance(vector, -1, nodeIdx);
                     var isPath = path[level] == nodeIdx ? "path" : "";
-                    var isResult =  level == 0 && edges.Items.Contains(nodeIdx) ? "result": "";
-                    var nextId = level == 0 ? (edges.Items.Contains(nodeIdx) ?"***": "") : $"N_{path[level - 1]}_{level - 1}";
+                    var isResult =  level == 0 && edges.Inner.Items.Contains(nodeIdx) ? "result": "";
+                    var nextId = level == 0 ? (edges.Inner.Items.Contains(nodeIdx) ?"***": "") : $"N_{path[level - 1]}_{level - 1}";
                     f.WriteLine($"<td> <table id='N_{j}_{level}'><tr><th class='{isPath} {isResult}'>N_{j}_{level} - {GetEntryId(llt,n.PostingListId)}</th>" +
                                 $"<th>{n.EdgesPerLevel[level].Count}</th><th>{dist} (<a href='#{nextId}'>{nextId}</a>)</th></tr><tr>");
                     foreach (var to in n.EdgesPerLevel[level])

--- a/src/Voron/Data/Graphs/Hnsw.Debug.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Debug.cs
@@ -154,8 +154,7 @@ table, th, td {
 
 </style><body>");
 
-            var path = new NativeList<int>();
-            path.EnsureCapacityFor(llt.Allocator, searchState.Options.MaxLevel +1);
+            var path = new ContextBoundNativeList<int>(llt.Allocator, searchState.Options.MaxLevel + 1);
             var edges = new ContextBoundNativeList<int>(llt.Allocator, 16);
             searchState.SearchNearestAcrossLevels(vector, -1, searchState.Options.MaxLevel,  ref path);
             using var search = searchState.NearestSearch(path[0], new Memory<byte>(vector.ToArray()), 0, 8, edges, SearchState.NearestEdgesFlags.StartingPointAsEdge, false);

--- a/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
@@ -25,7 +25,7 @@ public partial class Hnsw
                 return false;
             }
 
-            public void IncreaseNumberOfCandidates(int delta)
+            public void IncreaseNumberOfCandidates(int currentlyAcceptedNodes)
             {
             }
 
@@ -33,6 +33,11 @@ public partial class Hnsw
             {
                 get => 0L;
                 set => _ = value;
+            }
+
+            public bool ShouldContinueSearch(long filterDocsCount)
+            {
+                return false;
             }
 
             public int NumberOfCandidates { get; private set; } = numberOfCandidates;

--- a/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.EmptySearcher.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public partial class SearchState
+    {
+        private struct EmptySearcher(int numberOfCandidates) : IHnswSearcher
+        {
+            public void Dispose()
+            {
+            }
+
+            public IEnumerable<bool> Search()
+            {
+                yield break;
+            }
+
+            public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
+            {
+                Unsafe.SkipInit(out candidates);
+                return false;
+            }
+
+            public void IncreaseNumberOfCandidates(int delta)
+            {
+            }
+
+            public long CandidatesProcessed
+            {
+                get => 0L;
+                set => _ = value;
+            }
+
+            public int NumberOfCandidates { get; private set; } = numberOfCandidates;
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -17,13 +17,13 @@ public partial class Hnsw
             private readonly bool _hasFilterMatch;
             private ContextBoundNativeList<int> _candidates;
             private readonly ContextBoundNativeList<long>? _nodesToScan;
+            private PriorityQueue<long, float> _pq;
 
             public ExactSearcher(SearchState searchState, Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan)
             {
                 _searchState = searchState;
                 _vector = vector;
                 _hasFilterMatch = hasFilterMatch;
-                //TODO: more than int32 vectors
                 PortableExceptions.ThrowIf<NotSupportedException>(_searchState.Options.CountOfVectors >= int.MaxValue && hasFilterMatch, $"Cannot have more than {int.MaxValue} vectors and filter match");
                 
                 NumberOfCandidates = numberOfCandidates;
@@ -43,7 +43,7 @@ public partial class Hnsw
 
             public IEnumerable<bool> Search()
             {
-                var pq = new PriorityQueue<long, float>();
+                _pq = new PriorityQueue<long, float>();
                 Span<byte> vector = _vector.Span;
                 IEnumerable<long> toScan = _nodesToScan.HasValue ? _nodesToScan.Value.Iterate() : AllNodes();
                 foreach (long nodeId in toScan)
@@ -57,21 +57,21 @@ public partial class Hnsw
 
                         var curVect = reader.ReadVector(in _searchState);
                         var distance = _searchState.SimilarityCalc(vector, curVect);
-                        if (pq.Count < NumberOfCandidates || _hasFilterMatch)
+                        if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
                         {
-                            pq.Enqueue(nodeId, -distance);
+                            _pq.Enqueue(nodeId, -distance);
                         }
                         else
                         {
-                            pq.EnqueueDequeue(nodeId, -distance);
+                            _pq.EnqueueDequeue(nodeId, -distance);
                         }
                     }
                 }
 
-                while (pq.Count > 0)
+                while (_pq.Count > 0)
                 {
                     _candidates.Count = 0;
-                    while (_candidates.Count < NumberOfCandidates && pq.TryDequeue(out var nodeId, out _))
+                    while (_candidates.Count < NumberOfCandidates && _pq.TryDequeue(out var nodeId, out _))
                     {
                         _candidates.AddByRefUnsafe() = _searchState.GetNodeIndexById(nodeId);
                     }
@@ -101,11 +101,17 @@ public partial class Hnsw
                 return candidates.Count > 0;
             }
 
-            public void IncreaseNumberOfCandidates(int delta)
+            public void IncreaseNumberOfCandidates(int currentlyAcceptedNodes)
             {
             }
 
             public long CandidatesProcessed { get; set; }
+            
+            public bool ShouldContinueSearch(long filterDocsCount)
+            {
+                return _pq is {Count: > 0};
+            }
+
             public int NumberOfCandidates { get; init; }
         }
     }

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Sparrow;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public partial class SearchState
+    {
+        private class ExactSearcher : IHnswSearcher
+        {
+            private readonly SearchState _searchState;
+            private readonly Memory<byte> _vector;
+            private readonly bool _hasFilterMatch;
+            private ContextBoundNativeList<int> _candidates;
+            private readonly ContextBoundNativeList<long>? _nodesToScan;
+
+            public ExactSearcher(SearchState searchState, Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan)
+            {
+                _searchState = searchState;
+                _vector = vector;
+                _hasFilterMatch = hasFilterMatch;
+                //TODO: more than int32 vectors
+                PortableExceptions.ThrowIf<NotSupportedException>(_searchState.Options.CountOfVectors >= int.MaxValue && hasFilterMatch, "Cannot have more than int32 vectors and filter match");
+                
+                NumberOfCandidates = numberOfCandidates;
+                _nodesToScan = nodesToScan;
+
+                var candidatesCapacity = Math.Min(numberOfCandidates, (int)searchState.Options.CountOfVectors);
+                _candidates = new ContextBoundNativeList<int>(searchState.Llt.Allocator, candidatesCapacity);
+            }
+
+            public void Dispose()
+            {
+                _searchState._candidatesQ.Clear();
+                _searchState._nearestEdgesQ.Clear();
+                _candidates.Dispose();
+                _nodesToScan?.Dispose();
+            }
+
+            public IEnumerable<bool> Search()
+            {
+                var pq = new PriorityQueue<long, float>();
+                Span<byte> vector = _vector.Span;
+                IEnumerable<long> toScan = _nodesToScan.HasValue ? _nodesToScan.Value.Iterate() : AllNodes();
+                foreach (long nodeId in toScan)
+                {
+                    CandidatesProcessed++;
+                    unsafe
+                    {
+                        _searchState.ReadNode(nodeId, out var reader);
+                        if (reader.PostingListId is 0)
+                            continue; // no entries, can skip
+
+                        var curVect = reader.ReadVector(in _searchState);
+                        var distance = _searchState.SimilarityCalc(vector, curVect);
+                        if (pq.Count < NumberOfCandidates || _hasFilterMatch)
+                        {
+                            pq.Enqueue(nodeId, -distance);
+                        }
+                        else
+                        {
+                            pq.EnqueueDequeue(nodeId, -distance);
+                        }
+                    }
+                }
+
+                while (pq.Count > 0)
+                {
+                    _candidates.Count = 0;
+                    while (_candidates.Count < NumberOfCandidates && pq.TryDequeue(out var nodeId, out _))
+                    {
+                        _candidates.AddByRefUnsafe() = _searchState.GetNodeIndexById(nodeId);
+                    }
+
+                    _candidates.Inner.Reverse();
+                    yield return true;
+                }
+
+                _candidates.Count = 0;
+
+                IEnumerable<long> AllNodes()
+                {
+                    for (long nodeId = 1; nodeId <= _searchState.Options.CountOfVectors; nodeId++)
+                        yield return nodeId;
+                }
+            }
+
+            public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
+            {
+                if (_candidates.Count == 0)
+                {
+                    Unsafe.SkipInit(out candidates);
+                    return false;
+                }
+
+                candidates = _candidates;
+                return candidates.Count > 0;
+            }
+
+            public void IncreaseNumberOfCandidates(int delta)
+            {
+            }
+
+            public long CandidatesProcessed { get; set; }
+            public int NumberOfCandidates { get; init; }
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -24,7 +24,7 @@ public partial class Hnsw
                 _vector = vector;
                 _hasFilterMatch = hasFilterMatch;
                 //TODO: more than int32 vectors
-                PortableExceptions.ThrowIf<NotSupportedException>(_searchState.Options.CountOfVectors >= int.MaxValue && hasFilterMatch, "Cannot have more than int32 vectors and filter match");
+                PortableExceptions.ThrowIf<NotSupportedException>(_searchState.Options.CountOfVectors >= int.MaxValue && hasFilterMatch, $"Cannot have more than {int.MaxValue} vectors and filter match");
                 
                 NumberOfCandidates = numberOfCandidates;
                 _nodesToScan = nodesToScan;

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Sparrow;
+using Voron.Global;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
@@ -18,7 +19,8 @@ public partial class Hnsw
             private ContextBoundNativeList<int> _candidates;
             private readonly ContextBoundNativeList<long>? _nodesToScan;
             private PriorityQueue<long, float> _pq;
-
+            private long _vectorReadCounter = 0;
+            
             public ExactSearcher(SearchState searchState, Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan)
             {
                 _searchState = searchState;
@@ -49,22 +51,18 @@ public partial class Hnsw
                 foreach (long nodeId in toScan)
                 {
                     CandidatesProcessed++;
-                    unsafe
-                    {
-                        _searchState.ReadNode(nodeId, out var reader);
-                        if (reader.PostingListId is 0)
-                            continue; // no entries, can skip
+                    var nodeIndex = _searchState.GetNodeIndexById(nodeId);
+                    if ((_searchState.GetNodeByIndex(nodeIndex).PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone)
+                        continue; // no entries, can skip
 
-                        var curVect = reader.ReadVector(in _searchState);
-                        var distance = _searchState.SimilarityCalc(vector, curVect);
-                        if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
-                        {
-                            _pq.Enqueue(nodeId, -distance);
-                        }
-                        else
-                        {
-                            _pq.EnqueueDequeue(nodeId, -distance);
-                        }
+                    var distance = _searchState.QueryDistance(_vector.Span, nodeIndex, ref _vectorReadCounter);
+                    if (_pq.Count < NumberOfCandidates || _hasFilterMatch)
+                    {
+                        _pq.Enqueue(nodeId, -distance);
+                    }
+                    else
+                    {
+                        _pq.EnqueueDequeue(nodeId, -distance);
                     }
                 }
 

--- a/src/Voron/Data/Graphs/Hnsw.IndexedVectorRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.IndexedVectorRetriever.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Voron.Impl;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public class IndexedVectorsRetriever(LowLevelTransaction llt, string name) : IIndexedTermsRetriever
+    {
+        private readonly SearchState _searchState = new(llt, name);
+        private long _lastReadNodeId = 1;
+
+        public bool GetNextTerm(out ReadOnlySpan<byte> term)
+        {
+            if (_lastReadNodeId > _searchState.Options.CountOfVectors)
+            {
+                term = [];
+                return false;
+            }
+
+            _searchState.ReadNode(_lastReadNodeId, out var reader);
+            term = reader.ReadVector(in _searchState).ToReadOnlySpan();
+            _lastReadNodeId++;
+            return true;
+        }
+
+        public ConvertTo Type => ConvertTo.Base64;
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -117,7 +117,8 @@ public partial class Hnsw
                             continue; // already checked
                         next.Visited = visitedCounter;
 
-                        var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone;
+                        var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
+                            || _hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex);
 
                         float nextDist = -_searchState.QueryDistance(_vector.Span, nextIndex);
                         if (nearestEdgesQ.Count < _internalNumberOfCandidates)
@@ -187,10 +188,9 @@ public partial class Hnsw
 
                 while (_searchState._nearestEdgesQ.TryDequeue(out var edgeId, out var d))
                 {
+                    if (_hasFilterMatch)
+                        _alreadyReturnedEdges.Add(edgeId);
                     // When filtering is enabled, avoid returning the same edge more than once.
-                    if (_hasFilterMatch && _alreadyReturnedEdges.Add(edgeId) == false)
-                        continue;
-
                     _candidates.AddUnsafe(edgeId);
                 }
 

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -13,7 +13,6 @@ public partial class Hnsw
         private class NearestSearcher : IHnswSearcher
         {
             private readonly SearchState _searchState;
-            private readonly int _startingPointIndex;
             private readonly Memory<byte> _vector;
             private readonly int _level;
 
@@ -28,19 +27,19 @@ public partial class Hnsw
             private NativeList<long> _nodeIds;
             private readonly HashSet<int> _alreadyReturnedEdges;
             private long _vectorReadCounter = 0;
+            private readonly int _startingPointIndex;
+            private ContextBoundNativeList<int> _startingPointIndexes;
             
             public long CandidatesProcessed { get => _vectorReadCounter; }
-            
             public int NumberOfCandidates { get; init; }
 
-            public NearestSearcher(SearchState searchState, int startingPointIndex, Memory<byte> vector,
+            private NearestSearcher(SearchState searchState, Memory<byte> vector,
                 int level, int numberOfCandidates,
                 ContextBoundNativeList<int> candidates,
                 NearestEdgesFlags flags,
                 bool hasFilterMatch)
             {
                 _searchState = searchState;
-                _startingPointIndex = startingPointIndex;
                 _vector = vector;
                 _level = level;
                 NumberOfCandidates = numberOfCandidates;
@@ -58,10 +57,64 @@ public partial class Hnsw
                     _alreadyReturnedEdges = new();
                 }
             }
-
-            public IEnumerable<bool> Search()
+            
+            
+            public NearestSearcher(SearchState searchState, ContextBoundNativeList<int> startingPointsIndexes, Memory<byte> vector, int level, int numberOfCandidates, ContextBoundNativeList<int> candidates, NearestEdgesFlags flags) : this(searchState, vector, level, numberOfCandidates, candidates, flags, true)
             {
-                Start:
+                _startingPointIndexes = startingPointsIndexes;
+                _startingPointIndex = -1;
+            }
+
+            public NearestSearcher(SearchState searchState, int startingPointIndex, Memory<byte> vector,
+                int level, int numberOfCandidates,
+                ContextBoundNativeList<int> candidates,
+                NearestEdgesFlags flags,
+                bool hasFilterMatch) : this(searchState, vector, level, numberOfCandidates, candidates, flags, hasFilterMatch)
+            {
+                _startingPointIndex = startingPointIndex;
+            }
+
+            private void InitState(out float lowerBound, out int visitedCounter)
+            {
+                if (_startingPointIndex != -1)
+                {
+                    Deepest(out lowerBound, out visitedCounter);
+                }
+                else
+                {
+                    Multi(out lowerBound, out visitedCounter);
+                }
+            }
+
+            private void Multi(out float lowerBound, out int visitedCounter)
+            {
+                var candidatesQ = _searchState._candidatesQ;
+                var nearestEdgesQ = _searchState._nearestEdgesQ;
+
+                Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
+                Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
+
+                lowerBound = float.MaxValue;
+                visitedCounter = ++_searchState._visitsCounter;
+
+                foreach (var nodeIdx in _startingPointIndexes)
+                {
+                    ref var startingPoint = ref _searchState.GetNodeByIndex(nodeIdx);
+                    startingPoint.Visited = visitedCounter;
+                    var currentDistance = -_searchState.QueryDistance(_vector.Span, nodeIdx, ref _vectorReadCounter);
+                    lowerBound = Math.Min(lowerBound, currentDistance);
+                    candidatesQ.Enqueue(nodeIdx, -currentDistance);
+                    if (_flags.HasFlag(NearestEdgesFlags.StartingPointAsEdge) &&
+                        ((startingPoint.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) != Constants.Graphs.VectorId.Tombstone
+                         || _flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false))
+                    {
+                        nearestEdgesQ.Enqueue(nodeIdx, currentDistance);
+                    }
+                }
+            }
+
+            private void Deepest(out float lowerBound, out int visitedCounter)
+            {
                 var candidatesQ = _searchState._candidatesQ;
                 var nearestEdgesQ = _searchState._nearestEdgesQ;
                 var allocator = _searchState.Llt.Allocator;
@@ -69,8 +122,8 @@ public partial class Hnsw
                 Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
                 Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
 
-                float lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
-                var visitedCounter = ++_searchState._visitsCounter;
+                lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
+                visitedCounter = ++_searchState._visitsCounter;
                 {
                     ref var startingPoint = ref _searchState.GetNodeByIndex(_startingPointIndex);
                     startingPoint.Visited = visitedCounter;
@@ -87,6 +140,18 @@ public partial class Hnsw
                         nearestEdgesQ.Enqueue(_startingPointIndex, lowerBound);
                     }
                 }
+            }
+
+            public IEnumerable<bool> Search()
+            {
+                Start:
+                var candidatesQ = _searchState._candidatesQ;
+                var nearestEdgesQ = _searchState._nearestEdgesQ;
+                var allocator = _searchState.Llt.Allocator;
+
+                Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
+                Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
+                InitState(out float lowerBound, out int visitedCounter);
 
                 while (candidatesQ.TryDequeue(out var cur, out var curDistance))
                 {
@@ -220,6 +285,8 @@ public partial class Hnsw
 
             public void Dispose()
             {
+                if (_startingPointIndex == -1)
+                    _startingPointIndexes.Dispose();
                 _candidates.Dispose();
                 _nodeIds.Dispose(_searchState.Llt.Allocator);
                 _indexes.Dispose(_searchState.Llt.Allocator);

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -275,8 +275,8 @@ public partial class Hnsw
 
                 var max = filterDocsCount switch
                 {
-                    < 1024 => 2 * filterDocsCount, // Todo: it's hard to determine right number here. For smaller graphs it may be an issue.
-                                                        // However, for small filter set (for 1K we will force exact search anyway, therefore this probably will be used only for testing purposes.
+                    < 1024 => 2 * filterDocsCount, // It's hard to determine right number here. For smaller graphs it may be an issue.
+                    // However, for small filter set (for 1K we will force exact search anyway, therefore, this probably will be used only for testing purposes.
                     _ => Math.Min(filterDocsCount / 2, _searchState.Options.CountOfVectors / 5)
                 };
                 

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -273,8 +273,14 @@ public partial class Hnsw
                 if (_hasFilterMatch == false)
                     return false;
 
-                var nodeVisitLimit = Math.Min(filterDocsCount / 2, _searchState.Options.CountOfVectors / 5);
-                return _vectorReadCounter < nodeVisitLimit;
+                var max = filterDocsCount switch
+                {
+                    < 1024 => 2 * filterDocsCount, // Todo: it's hard to determine right number here. For smaller graphs it may be an issue.
+                                                        // However, for small filter set (for 1K we will force exact search anyway, therefore this probably will be used only for testing purposes.
+                    _ => Math.Min(filterDocsCount / 2, _searchState.Options.CountOfVectors / 5)
+                };
+                
+                return _vectorReadCounter < max;
             }
 
             private static int GetPrefetchExtendSize(int numberOfCandidates) => numberOfCandidates switch

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -30,6 +30,7 @@ public partial class Hnsw
             private readonly HashSet<int> _candidatesProcessed;
 
             public long CandidatesProcessed { get => _candidatesProcessed?.Count ?? 0; }
+            
             public int NumberOfCandidates { get; init; }
 
             public NearestSearcher(SearchState searchState, int startingPointIndex, Memory<byte> vector,
@@ -43,7 +44,10 @@ public partial class Hnsw
                 _vector = vector;
                 _level = level;
                 NumberOfCandidates = numberOfCandidates;
-                _internalNumberOfCandidates = hasFilterMatch ? (int)Math.Min((long)int.MaxValue, (2 * (long)numberOfCandidates)) : numberOfCandidates;
+
+                _internalNumberOfCandidates = hasFilterMatch == false
+                    ? numberOfCandidates
+                    : numberOfCandidates + GetPrefetchExtendSize(numberOfCandidates);
                 _candidates = candidates;
                 _flags = flags;
                 _hasFilterMatch = hasFilterMatch;
@@ -118,7 +122,7 @@ public partial class Hnsw
                         next.Visited = visitedCounter;
 
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
-                            || _hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex);
+                                        || _hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex);
 
                         float nextDist = -_searchState.QueryDistance(_vector.Span, nextIndex);
                         if (nearestEdgesQ.Count < _internalNumberOfCandidates)
@@ -161,10 +165,10 @@ public partial class Hnsw
                 return candidates.Count > 0;
             }
 
-            public void IncreaseNumberOfCandidates(int delta)
+            public void IncreaseNumberOfCandidates(int currentlyAcceptedNodes)
             {
                 Reset();
-                _internalNumberOfCandidates += delta;
+                _internalNumberOfCandidates += GetPrefetchExtendSize(_internalNumberOfCandidates);
             }
 
             // Reset the NearestSearcher state; however, it does not clear the data already stored inside SearchState.
@@ -173,8 +177,12 @@ public partial class Hnsw
             {
                 _searchState._candidatesQ.Clear();
                 _searchState._nearestEdgesQ.Clear();
+
                 for (int nodeIdx = 0; nodeIdx < _searchState._nodes.Count; nodeIdx++)
+                {
                     _searchState._nodes[nodeIdx].Visited = 0;
+                }
+
                 _searchState._visitsCounter = 0;
                 _candidates.Clear();
                 _nodeIds.Clear();
@@ -188,14 +196,46 @@ public partial class Hnsw
 
                 while (_searchState._nearestEdgesQ.TryDequeue(out var edgeId, out var d))
                 {
-                    if (_hasFilterMatch)
-                        _alreadyReturnedEdges.Add(edgeId);
                     // When filtering is enabled, avoid returning the same edge more than once.
+                    Debug.Assert(_hasFilterMatch == false || _alreadyReturnedEdges!.Contains(edgeId) == false);
+
+                    _alreadyReturnedEdges?.Add(edgeId);
                     _candidates.AddUnsafe(edgeId);
                 }
 
                 _candidates.Inner.Reverse();
             }
+            
+            public bool ShouldContinueSearch(long filterDocsCount)
+            {
+                if (_hasFilterMatch == false)
+                    return false;
+
+                const int minCount = 1_048_576;
+                const int maxCount = 8_388_608;
+                const float maxFactor = 4;
+                const float minFactor = 1.5f;
+                
+                switch (filterDocsCount)
+                {
+                    case <= minCount:
+                        return filterDocsCount * maxFactor < CandidatesProcessed;
+                    case >= maxCount:
+                        return filterDocsCount * minFactor < CandidatesProcessed;
+                }
+
+
+                var normalized = (filterDocsCount - minCount) / (float)(maxCount - minCount);
+                var t = (MathF.Cos(normalized * MathF.PI) + 1.0f) / 2f;
+                var factor = minFactor + (maxFactor - minFactor) * t;
+                return filterDocsCount * factor < CandidatesProcessed;
+            }
+
+            private static int GetPrefetchExtendSize(int numberOfCandidates) => numberOfCandidates switch
+            {
+                <= 131_072 => numberOfCandidates,
+                _ => (int)Math.Sqrt(131_072L * numberOfCandidates)
+            };
 
             public void Dispose()
             {

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -27,9 +27,9 @@ public partial class Hnsw
             private NativeList<int> _indexes;
             private NativeList<long> _nodeIds;
             private readonly HashSet<int> _alreadyReturnedEdges;
-            private readonly HashSet<int> _candidatesProcessed;
-
-            public long CandidatesProcessed { get => _candidatesProcessed?.Count ?? 0; }
+            private long _vectorReadCounter = 0;
+            
+            public long CandidatesProcessed { get => _vectorReadCounter; }
             
             public int NumberOfCandidates { get; init; }
 
@@ -56,7 +56,6 @@ public partial class Hnsw
                 if (_hasFilterMatch)
                 {
                     _alreadyReturnedEdges = new();
-                    _candidatesProcessed = new();
                 }
             }
 
@@ -70,7 +69,7 @@ public partial class Hnsw
                 Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
                 Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
 
-                float lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex);
+                float lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
                 var visitedCounter = ++_searchState._visitsCounter;
                 {
                     ref var startingPoint = ref _searchState.GetNodeByIndex(_startingPointIndex);
@@ -91,7 +90,6 @@ public partial class Hnsw
 
                 while (candidatesQ.TryDequeue(out var cur, out var curDistance))
                 {
-                    _candidatesProcessed?.Add(cur);
                     if (-curDistance < lowerBound &&
                         nearestEdgesQ.Count == _internalNumberOfCandidates)
                     {
@@ -122,9 +120,9 @@ public partial class Hnsw
                         next.Visited = visitedCounter;
 
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
-                                        || _hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex);
+                                        || (_hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex));
 
-                        float nextDist = -_searchState.QueryDistance(_vector.Span, nextIndex);
+                        float nextDist = -_searchState.QueryDistance(_vector.Span, nextIndex, ref _vectorReadCounter);
                         if (nearestEdgesQ.Count < _internalNumberOfCandidates)
                         {
                             candidatesQ.Enqueue(nextIndex, -nextDist);
@@ -196,10 +194,9 @@ public partial class Hnsw
 
                 while (_searchState._nearestEdgesQ.TryDequeue(out var edgeId, out var d))
                 {
-                    // When filtering is enabled, avoid returning the same edge more than once.
-                    Debug.Assert(_hasFilterMatch == false || _alreadyReturnedEdges!.Contains(edgeId) == false);
+                    if (_hasFilterMatch && _alreadyReturnedEdges!.Add(edgeId) == false)
+                        continue;
 
-                    _alreadyReturnedEdges?.Add(edgeId);
                     _candidates.AddUnsafe(edgeId);
                 }
 
@@ -211,29 +208,13 @@ public partial class Hnsw
                 if (_hasFilterMatch == false)
                     return false;
 
-                const int minCount = 1_048_576;
-                const int maxCount = 8_388_608;
-                const float maxFactor = 4;
-                const float minFactor = 1.5f;
-                
-                switch (filterDocsCount)
-                {
-                    case <= minCount:
-                        return filterDocsCount * maxFactor < CandidatesProcessed;
-                    case >= maxCount:
-                        return filterDocsCount * minFactor < CandidatesProcessed;
-                }
-
-
-                var normalized = (filterDocsCount - minCount) / (float)(maxCount - minCount);
-                var t = (MathF.Cos(normalized * MathF.PI) + 1.0f) / 2f;
-                var factor = minFactor + (maxFactor - minFactor) * t;
-                return filterDocsCount * factor < CandidatesProcessed;
+                var nodeVisitLimit = Math.Min(filterDocsCount / 2, _searchState.Options.CountOfVectors / 5);
+                return _vectorReadCounter < nodeVisitLimit;
             }
 
             private static int GetPrefetchExtendSize(int numberOfCandidates) => numberOfCandidates switch
             {
-                <= 131_072 => numberOfCandidates,
+                <= 131_072 =>  numberOfCandidates / 2,
                 _ => (int)Math.Sqrt(131_072L * numberOfCandidates)
             };
 

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Voron.Global;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public partial class SearchState
+    {
+        private class NearestSearcher : IHnswSearcher
+        {
+            private readonly SearchState _searchState;
+            private readonly int _startingPointIndex;
+            private readonly Memory<byte> _vector;
+            private readonly int _level;
+
+            // Actual number of candidates currently being processed. It may differ from the caller's NumberOfCandidates
+            // because we may need to over-fetch to satisfy the filter clause.
+            private int _internalNumberOfCandidates;
+
+            private ContextBoundNativeList<int> _candidates;
+            private readonly NearestEdgesFlags _flags;
+            private readonly bool _hasFilterMatch;
+            private NativeList<int> _indexes;
+            private NativeList<long> _nodeIds;
+            private readonly HashSet<int> _alreadyReturnedEdges;
+            private readonly HashSet<int> _candidatesProcessed;
+
+            public long CandidatesProcessed { get => _candidatesProcessed?.Count ?? 0; }
+            public int NumberOfCandidates { get; init; }
+
+            public NearestSearcher(SearchState searchState, int startingPointIndex, Memory<byte> vector,
+                int level, int numberOfCandidates,
+                ContextBoundNativeList<int> candidates,
+                NearestEdgesFlags flags,
+                bool hasFilterMatch)
+            {
+                _searchState = searchState;
+                _startingPointIndex = startingPointIndex;
+                _vector = vector;
+                _level = level;
+                NumberOfCandidates = numberOfCandidates;
+                _internalNumberOfCandidates = numberOfCandidates;
+                _candidates = candidates;
+                _flags = flags;
+                _hasFilterMatch = hasFilterMatch;
+                _indexes = new NativeList<int>();
+                _nodeIds = new NativeList<long>();
+                if (_hasFilterMatch)
+                {
+                    _alreadyReturnedEdges = new();
+                    _candidatesProcessed = new();
+                }
+            }
+
+            public IEnumerable<bool> Search()
+            {
+                Start:
+                var candidatesQ = _searchState._candidatesQ;
+                var nearestEdgesQ = _searchState._nearestEdgesQ;
+                var allocator = _searchState.Llt.Allocator;
+
+                Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
+                Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
+
+                float lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex);
+                var visitedCounter = ++_searchState._visitsCounter;
+                {
+                    ref var startingPoint = ref _searchState.GetNodeByIndex(_startingPointIndex);
+                    startingPoint.Visited = visitedCounter;
+                    // The candidates queue is sorted by distance, so the lowest distance
+                    // will always pop first.
+                    // The nearest-edges queue is sorted by reversed distance, so when we add a
+                    // new item to the queue, we'll pop the one with the largest distance.
+
+                    candidatesQ.Enqueue(_startingPointIndex, -lowerBound);
+                    if (_flags.HasFlag(NearestEdgesFlags.StartingPointAsEdge) &&
+                        ((startingPoint.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) != Constants.Graphs.VectorId.Tombstone
+                         || _flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false))
+                    {
+                        nearestEdgesQ.Enqueue(_startingPointIndex, lowerBound);
+                    }
+                }
+
+                while (candidatesQ.TryDequeue(out var cur, out var curDistance))
+                {
+                    _candidatesProcessed?.Add(cur);
+                    if (-curDistance < lowerBound &&
+                        nearestEdgesQ.Count == _internalNumberOfCandidates)
+                    {
+                        ProcessResults();
+                        yield return true;
+                        // If we need to fetch more, we'll start the query again with a higher NumberOfCandidates.
+                        // The SearchState keeps its state, so traversal through already visited nodes is I/O-free
+                        // because we keep distances in memory from the previous run.
+                        // This method can be greedy enough to traverse the entire graph, so it's the caller's
+                        // responsibility to enforce a stop condition.
+                        goto Start;
+                    }
+
+                    ref var candidate = ref _searchState.GetNodeByIndex(cur);
+                    candidate.Visited = visitedCounter;
+
+                    ref var edges = ref candidate.EdgesPerLevel[_level];
+
+                    _nodeIds.ResetAndCopyFrom(allocator, edges.ToSpan());
+                    _searchState.LoadNodeIndexes(ref _nodeIds, ref _indexes);
+
+                    for (int i = 0; i < _indexes.Count; i++)
+                    {
+                        var nextIndex = _indexes[i];
+                        ref var next = ref _searchState.GetNodeByIndex(nextIndex);
+                        if (next.Visited == visitedCounter)
+                            continue; // already checked
+                        next.Visited = visitedCounter;
+
+                        var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone;
+
+                        float nextDist = -_searchState.QueryDistance(_vector.Span, nextIndex);
+                        if (nearestEdgesQ.Count < _internalNumberOfCandidates)
+                        {
+                            candidatesQ.Enqueue(nextIndex, -nextDist);
+
+                            if (isDeleted == false || _flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false)
+                            {
+                                nearestEdgesQ.Enqueue(nextIndex, nextDist);
+                            }
+                        }
+                        else if (lowerBound < nextDist)
+                        {
+                            candidatesQ.Enqueue(nextIndex, -nextDist);
+
+                            if (isDeleted == false || _flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false)
+                            {
+                                nearestEdgesQ.EnqueueDequeue(nextIndex, nextDist);
+                            }
+                        }
+                        else
+                        {
+                            continue;
+                        }
+
+                        Debug.Assert(candidatesQ.Count > 0);
+                        nearestEdgesQ.TryPeek(out _, out lowerBound);
+                    }
+                }
+
+                // Nothing more to visit. Move the current results into the candidates list and finish.
+                ProcessResults();
+                candidatesQ.Clear();
+                yield return _candidates.Count > 0;
+            }
+
+            public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates)
+            {
+                candidates = _candidates;
+                return candidates.Count > 0;
+            }
+
+            public void IncreaseNumberOfCandidates(int delta)
+            {
+                Reset();
+                _internalNumberOfCandidates += delta;
+            }
+
+            // Reset the NearestSearcher state; however, it does not clear the data already stored inside SearchState.
+            // This is important because it allows us to reduce I/O pressure during over-fetching and when restarting the query.
+            private void Reset()
+            {
+                _searchState._candidatesQ.Clear();
+                _searchState._nearestEdgesQ.Clear();
+                for (int nodeIdx = 0; nodeIdx < _searchState._nodes.Count; nodeIdx++)
+                    _searchState._nodes[nodeIdx].Visited = 0;
+                _searchState._visitsCounter = 0;
+                _candidates.Clear();
+                _nodeIds.Clear();
+                _indexes.Clear();
+            }
+
+            private void ProcessResults()
+            {
+                _candidates.Clear();
+                _candidates.EnsureCapacityFor(_searchState._nearestEdgesQ.Count);
+
+                while (_searchState._nearestEdgesQ.TryDequeue(out var edgeId, out var d))
+                {
+                    // When filtering is enabled, avoid returning the same edge more than once.
+                    if (_hasFilterMatch && _alreadyReturnedEdges.Add(edgeId) == false)
+                        continue;
+
+                    _candidates.AddUnsafe(edgeId);
+                }
+
+                _candidates.Inner.Reverse();
+            }
+
+            public void Dispose()
+            {
+                _candidates.Dispose();
+                _nodeIds.Dispose(_searchState.Llt.Allocator);
+                _indexes.Dispose(_searchState.Llt.Allocator);
+                _searchState._candidatesQ.Clear();
+            }
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -43,7 +43,7 @@ public partial class Hnsw
                 _vector = vector;
                 _level = level;
                 NumberOfCandidates = numberOfCandidates;
-                _internalNumberOfCandidates = numberOfCandidates;
+                _internalNumberOfCandidates = hasFilterMatch ? (int)Math.Min((long)int.MaxValue, (2 * (long)numberOfCandidates)) : numberOfCandidates;
                 _candidates = candidates;
                 _flags = flags;
                 _hasFilterMatch = hasFilterMatch;

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using Sparrow;
+using Sparrow.Compression;
+using Sparrow.Server.Utils;
+using Voron.Data.Containers;
+using Voron.Global;
+using Voron.Impl;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public unsafe struct Node
+    {
+        public long PostingListId;
+        public long VectorId;
+        public long NodeId;
+        public NativeList<NativeList<long>> EdgesPerLevel;
+        public NativeList<NativeList<int>> EdgesIndexesPerLevel;
+        private UnmanagedSpan _vectorSpan;
+        public int Visited;
+        public float? QueryDistance;
+
+        public bool VectorLoaded => _vectorSpan.Length > 0;
+
+        public long GetVectorContainerId()
+        {
+            if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
+                return VectorId;
+
+            return VectorId & ~0xFFF;
+        }
+
+        public static NodeReader Decode(LowLevelTransaction llt, long id)
+        {
+            var span = Container.GetReadOnly(llt, new ContainerEntryId(id));
+            return Decode(llt, span);
+        }
+
+        public static NodeReader Decode(LowLevelTransaction llt, Span<byte> span)
+        {
+            var postingListId = VariableSizeEncoding.Read<long>(span, out var pos);
+            var offset = pos;
+            var vectorId = VariableSizeEncoding.Read<long>(span, out pos, offset);
+            offset += pos;
+            var countOfLevels = VariableSizeEncoding.Read<int>(span, out pos, offset);
+            offset += pos;
+
+            return new NodeReader(llt.Allocator, span[offset..]) { PostingListId = postingListId, VectorId = vectorId, CountOfLevels = countOfLevels };
+        }
+
+        public Span<byte> Encode(ref ContextBoundNativeList<byte> buffer)
+        {
+            int countOfLevels = EdgesPerLevel.Count;
+
+            // posting list id, vector id, count of levels
+            var maxSize = 3 * VariableSizeEncoding.MaximumSizeOf<long>();
+            for (int i = 0; i < countOfLevels; i++)
+            {
+                maxSize += EdgesPerLevel[i].Count * VariableSizeEncoding.MaximumSizeOf<long>();
+            }
+
+            buffer.EnsureCapacityFor(maxSize);
+
+            var bufferSpan = buffer.ToFullCapacitySpan();
+
+            var pos = VariableSizeEncoding.Write(bufferSpan, PostingListId);
+            pos += VariableSizeEncoding.Write(bufferSpan, VectorId, pos);
+            pos += VariableSizeEncoding.Write(bufferSpan, countOfLevels, pos);
+
+            for (int i = 0; i < countOfLevels; i++)
+            {
+                Span<long> span = EdgesPerLevel[i].ToSpan();
+                int len = Sorting.SortAndRemoveDuplicates(span);
+                span = span[..len];
+                long prev = 0;
+                pos += VariableSizeEncoding.Write(bufferSpan, span.Length, pos);
+                for (int j = 0; j < span.Length; j++)
+                {
+                    var delta = span[j] - prev;
+                    prev = span[j];
+                    pos += VariableSizeEncoding.Write(bufferSpan, delta, pos);
+                }
+            }
+
+            return bufferSpan[..pos];
+        }
+
+        public UnmanagedSpan GetVectorUnmanagedSpan(SearchState state)
+        {
+            if (_vectorSpan.Length > 0)
+                return _vectorSpan;
+
+            _vectorSpan = NodeReader.ReadVector(VectorId, in state);
+            return _vectorSpan;
+        }
+
+        public Span<byte> GetVector(SearchState state)
+        {
+            return GetVectorUnmanagedSpan(state).ToSpan();
+        }
+
+        internal void SetVector(SearchState searchState, UnmanagedSpan span)
+        {
+            if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
+            {
+                _vectorSpan = span;
+                return;
+            }
+
+            var count = (byte)(VectorId >> 1);
+            var offset = count * searchState.Options.VectorSizeBytes;
+            _vectorSpan = new UnmanagedSpan(span.Address + offset, searchState.Options.VectorSizeBytes);
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -13,6 +13,7 @@ public partial class Hnsw
 {
     public unsafe struct Node
     {
+        internal const long VectorIdMask = ~0xFFF;
         public long PostingListId;
         public long VectorId;
         public long NodeId;
@@ -29,7 +30,7 @@ public partial class Hnsw
             if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
                 return VectorId;
 
-            return VectorId & ~0xFFF;
+            return VectorId & VectorIdMask;
         }
 
         public static NodeReader Decode(LowLevelTransaction llt, long id)

--- a/src/Voron/Data/Graphs/Hnsw.NodeReader.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NodeReader.cs
@@ -69,7 +69,7 @@ public partial class Hnsw
             }
 
             var count = (byte)(vectorId >> 1);
-            var containerId = vectorId & ~0xFFF;
+            var containerId = vectorId & Node.VectorIdMask;
             Container.Get(state.Llt, new ContainerEntryId(containerId), out var container);
             var offset = count * state.Options.VectorSizeBytes;
             Debug.Assert(offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length, "offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length");

--- a/src/Voron/Data/Graphs/Hnsw.NodeReader.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NodeReader.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Diagnostics;
+using Sparrow;
+using Sparrow.Compression;
+using Sparrow.Server;
+using Voron.Data.Containers;
+using Voron.Global;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public unsafe ref struct NodeReader(ByteStringContext allocator, Span<byte> buffer)
+    {
+        public long PostingListId;
+        public long VectorId;
+        public int CountOfLevels;
+
+        private int _offset;
+        private readonly Span<byte> _buffer = buffer;
+
+        public void LoadInto(ref Node node)
+        {
+            node.VectorId = VectorId;
+            node.PostingListId = PostingListId;
+            node.EdgesPerLevel.EnsureCapacityFor(allocator, CountOfLevels);
+            while (NextReadEdges(out var list))
+            {
+                node.EdgesPerLevel.AddUnsafe(list);
+            }
+        }
+
+        private bool NextReadEdges(out NativeList<long> list)
+        {
+            if (_offset >= _buffer.Length)
+            {
+                list = default;
+                return false;
+            }
+
+            var count = VariableSizeEncoding.Read<int>(_buffer, out int offset, _offset);
+            _offset += offset;
+            list = new NativeList<long>();
+            list.EnsureCapacityFor(allocator, count);
+            long prev = 0;
+            for (int i = 0; i < count; i++)
+            {
+                var item = VariableSizeEncoding.Read<long>(_buffer, out offset, _offset);
+                _offset += offset;
+                prev += item;
+                Debug.Assert(prev >= 0, "prev >= 0");
+                list.AddUnsafe(prev);
+            }
+
+            return true;
+        }
+
+        public UnmanagedSpan ReadVector(in SearchState state) => ReadVector(VectorId, in state);
+
+        public static UnmanagedSpan ReadVector(long vectorId, in SearchState state)
+        {
+            if ((vectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
+            {
+                Container.Get(state.Llt, new ContainerEntryId(vectorId), out var item);
+                var vectorSpan = new UnmanagedSpan(item.Address, item.Length);
+                Debug.Assert(state.Options.VectorSizeBytes == vectorSpan.Length, "state.Options.VectorSizeBytes == vectorSpan.Length");
+                return vectorSpan;
+            }
+
+            var count = (byte)(vectorId >> 1);
+            var containerId = vectorId & ~0xFFF;
+            Container.Get(state.Llt, new ContainerEntryId(containerId), out var container);
+            var offset = count * state.Options.VectorSizeBytes;
+            Debug.Assert(offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length, "offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length");
+            return new UnmanagedSpan(container.Address + offset, state.Options.VectorSizeBytes);
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -155,9 +155,9 @@ public partial class Hnsw
                 if (_currentNode >= indexes.Count)
                 {
                     // Double the difference between accepted and searched number of candidates.
-                    _vectorsSearcher.IncreaseNumberOfCandidates(Math.Max(4, _vectorsSearcher.NumberOfCandidates - _returnedCandidates) * 2);
+                    _vectorsSearcher.IncreaseNumberOfCandidates(_vectorsSearcher.NumberOfCandidates - _returnedCandidates);
                     
-                    if (_vectorsSearcher.CandidatesProcessed > 4 * filter.Count)
+                    if (_vectorsSearcher.ShouldContinueSearch(filter.Count) == false)
                     {
                         break;
                     }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -161,8 +161,6 @@ public partial class Hnsw
                     {
                         break;
                     }
-
-                    Console.WriteLine($"CP: {_vectorsSearcher.CandidatesProcessed}");
                     
                     if (_resultsEnumerator.MoveNext() == false)
                     {
@@ -295,6 +293,7 @@ public partial class Hnsw
             _pforDecoder.Dispose();
             _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
+            _searchState.Dispose();
         }
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -39,6 +39,8 @@ public partial class Hnsw
         // We cannot do it internally since the flow is made in a streaming manner.
         public bool IsSortedByDistance = true;
         
+        public int NumberOfCandidates => _vectorsSearcher.NumberOfCandidates;
+        
         public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity)
         {
             _searchState = searchState;

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -31,7 +31,7 @@ public partial class Hnsw
         private readonly Memory<byte> _vector;
         private IEnumerator<bool> _resultsEnumerator;
 
-        public SimilarityMethod SimilarityMethod => _searchState.Options.SimilarityMethod;
+        public SimilarityMethod? SimilarityMethod => _searchState?.Options.SimilarityMethod;
         
         public bool IsEmpty => _searchState.IsEmpty;
         
@@ -40,6 +40,8 @@ public partial class Hnsw
         public bool IsSortedByDistance = true;
         
         public int NumberOfCandidates => _vectorsSearcher.NumberOfCandidates;
+
+        public long CandidatesProcessed => _vectorsSearcher?.CandidatesProcessed ?? 0;
         
         public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity)
         {
@@ -61,6 +63,7 @@ public partial class Hnsw
 
         public int Fill(Span<long> matches, Span<float> distances)
         {
+            long newVectorCount = 0;
             if (_vectorsSearcher.TryGetCurrentCandidates(out var indexes) == false)
                 return 0;
 
@@ -106,8 +109,10 @@ public partial class Hnsw
                 var nodeIdx = indexes[_currentNode];
                 ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
                 var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
-                distance = _searchState.QueryDistance(_vector.Span, nodeIdx);
-
+                
+                distance = _searchState.QueryDistance(_vector.Span, nodeIdx, ref newVectorCount);
+                Debug.Assert(newVectorCount == 0, "newVectorCount == 0");
+                
                 if (distance > _maximumDistance)
                 {
                     _currentNode++;
@@ -148,6 +153,7 @@ public partial class Hnsw
             if (_vectorsSearcher.TryGetCurrentCandidates(out var indexes) == false)
                 return 0;
 
+            long newVectorCount = 0;
             int index = 0;
             float distance = float.NaN;
             while (index < matches.Length && _returnedCandidates < _vectorsSearcher.NumberOfCandidates)
@@ -244,8 +250,10 @@ public partial class Hnsw
                 var nodeIdx = indexes[_currentNode];
                 ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
                 var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
-                distance = _searchState.QueryDistance(_vector.Span, nodeIdx);
-
+                
+                distance = _searchState.QueryDistance(_vector.Span, nodeIdx, ref newVectorCount);
+                Debug.Assert(newVectorCount == 0, "newVectorCount == 0");
+                
                 if (distance > _maximumDistance)
                 {
                     _currentNode++;

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -23,12 +23,12 @@ public partial class Hnsw
         private int _currentNode, _currentMatchesIndex;
         private ContextBoundNativeList<long> _postingListResults;
         private FastPForDecoder _pforDecoder;
-        private ByteString _vector;
         private PostingList.Iterator _postingListIterator;
         private PostingList _postingList;
         private readonly float _maximumDistance;
         private bool _foundCandidateInCurrentSmallPostingList;
         private readonly IHnswSearcher _vectorsSearcher;
+        private readonly Memory<byte> _vector;
         private IEnumerator<bool> _resultsEnumerator;
 
         public SimilarityMethod SimilarityMethod => _searchState.Options.SimilarityMethod;
@@ -43,10 +43,9 @@ public partial class Hnsw
         {
             _searchState = searchState;
             _vectorsSearcher = vectorsSearcher;
+            _vector = vector;
             _postingListResults = new(_searchState.Llt.Allocator);
             _pforDecoder = new(searchState.Llt.Allocator);
-            searchState.Llt.Allocator.AllocateDirect(vector.Length, out _vector);
-            vector.Span.CopyTo(_vector.ToSpan());
             _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
             _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();
             _resultsEnumerator.MoveNext(); //read first batch
@@ -105,7 +104,7 @@ public partial class Hnsw
                 var nodeIdx = indexes[_currentNode];
                 ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
                 var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
-                distance = _searchState.Distance(_vector.ToSpan(), -1, nodeIdx);
+                distance = _searchState.QueryDistance(_vector.Span, nodeIdx);
 
                 if (distance > _maximumDistance)
                 {
@@ -245,7 +244,7 @@ public partial class Hnsw
                 var nodeIdx = indexes[_currentNode];
                 ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
                 var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
-                distance = _searchState.Distance(_vector.ToSpan(), -1, nodeIdx);
+                distance = _searchState.QueryDistance(_vector.Span, nodeIdx);
 
                 if (distance > _maximumDistance)
                 {
@@ -292,7 +291,6 @@ public partial class Hnsw
         {
             _postingListResults.Dispose();
             _pforDecoder.Dispose();
-            _searchState.Llt.Allocator.Release(ref _vector);
             _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
         }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -1,0 +1,300 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Sparrow;
+using Sparrow.Server;
+using Sparrow.Server.Collections;
+using Voron.Data.Containers;
+using Voron.Data.PostingLists;
+using Voron.Global;
+using Voron.Util;
+using Voron.Util.PFor;
+
+namespace Voron.Data.Graphs;
+
+public partial class Hnsw
+{
+    public struct VectorSearchRetriever : IDisposable
+    {
+        private int _returnedCandidates;
+        private readonly SearchState _searchState;
+        private int _currentNode, _currentMatchesIndex;
+        private ContextBoundNativeList<long> _postingListResults;
+        private FastPForDecoder _pforDecoder;
+        private ByteString _vector;
+        private PostingList.Iterator _postingListIterator;
+        private PostingList _postingList;
+        private readonly float _maximumDistance;
+        private bool _foundCandidateInCurrentSmallPostingList;
+        private readonly IHnswSearcher _vectorsSearcher;
+        private IEnumerator<bool> _resultsEnumerator;
+
+        public SimilarityMethod SimilarityMethod => _searchState.Options.SimilarityMethod;
+        
+        public bool IsEmpty => _searchState.IsEmpty;
+        
+        // Indicates whether the results are sorted by distance or not. If not, the caller should sort them after fetching the graph.
+        // We cannot do it internally since the flow is made in a streaming manner.
+        public bool IsSortedByDistance = true;
+        
+        public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity)
+        {
+            _searchState = searchState;
+            _vectorsSearcher = vectorsSearcher;
+            _postingListResults = new(_searchState.Llt.Allocator);
+            _pforDecoder = new(searchState.Llt.Allocator);
+            searchState.Llt.Allocator.AllocateDirect(vector.Length, out _vector);
+            vector.Span.CopyTo(_vector.ToSpan());
+            _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
+            _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();
+            _resultsEnumerator.MoveNext(); //read first batch
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float DistanceToScore(float distance) => _searchState.DistanceToScore(distance);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void DistancesToScores(Span<float> distances) => _searchState.DistancesToScores(distances);
+
+        public int Fill(Span<long> matches, Span<float> distances)
+        {
+            if (_vectorsSearcher.TryGetCurrentCandidates(out var indexes) == false)
+                return 0;
+
+            int index = 0;
+            float distance = float.NaN;
+            while (index < matches.Length)
+            {
+                if (_currentNode >= indexes.Count)
+                    break;
+
+                if (_postingList != null)
+                {
+                    if (_postingListIterator.Fill(matches[index..], out var total) is false && total is 0)
+                    {
+                        _postingListIterator = default;
+                        _postingList = null;
+                        _currentNode++;
+                        continue;
+                    }
+
+                    distances.Slice(index, total).Fill(distance);
+                    index += total;
+                    continue;
+                }
+
+                if (_currentMatchesIndex < _postingListResults.Count)
+                {
+                    var copy = Math.Min(_postingListResults.Count - _currentMatchesIndex, matches.Length - index);
+                    _postingListResults.CopyTo(matches[index..], _currentMatchesIndex, copy);
+                    distances.Slice(index, copy).Fill(distance);
+                    index += copy;
+                    _currentMatchesIndex += copy;
+                    if (_currentMatchesIndex == _postingListResults.Count)
+                    {
+                        _currentMatchesIndex = 0;
+                        _postingListResults.Clear();
+                        _currentNode++;
+                    }
+
+                    continue;
+                }
+
+                var nodeIdx = indexes[_currentNode];
+                ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
+                var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
+                distance = _searchState.Distance(_vector.ToSpan(), -1, nodeIdx);
+
+                if (distance > _maximumDistance)
+                {
+                    _currentNode++;
+                    continue;
+                }
+
+                switch (node.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask)
+                {
+                    case Constants.Graphs.VectorId.Tombstone: // empty
+                        _currentNode++;
+                        continue;
+                    case Constants.Graphs.VectorId.Single: // single item posting list
+                        distances[index] = distance;
+                        matches[index++] = rawPostingListId;
+                        _currentNode++;
+                        continue;
+                    case Constants.Graphs.VectorId.SmallPostingList: // small posting list
+                        Debug.Assert(_postingListResults.Count is 0 && _currentMatchesIndex is 0);
+                        _searchState.ReadPostingList(new ContainerEntryId(rawPostingListId), ref _postingListResults, ref _pforDecoder, out _);
+                        continue;
+                    case Constants.Graphs.VectorId.PostingList: // large posting list
+                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, new(rawPostingListId));
+                        ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
+                        _postingList = new PostingList(_searchState.Llt, Slices.Empty, setState);
+                        _postingListIterator = _postingList.Iterate();
+                        continue;
+                    default:
+                        throw new ArgumentOutOfRangeException("Impossible scenario, we have only 4 options, but got: " + node.PostingListId);
+                }
+            }
+
+            Registration.InternalEntryIdToEntryId(matches.Slice(0, index));
+            return index;
+        }
+        
+        public int Fill(Span<long> matches, Span<float> distances, GrowableBitArray filter)
+        {
+            if (_vectorsSearcher.TryGetCurrentCandidates(out var indexes) == false)
+                return 0;
+
+            int index = 0;
+            float distance = float.NaN;
+            while (index < matches.Length && _returnedCandidates < _vectorsSearcher.NumberOfCandidates)
+            {
+                if (_currentNode >= indexes.Count)
+                {
+                    // Double the difference between accepted and searched number of candidates.
+                    _vectorsSearcher.IncreaseNumberOfCandidates(Math.Max(4, _vectorsSearcher.NumberOfCandidates - _returnedCandidates) * 2);
+                    
+                    if (_vectorsSearcher.CandidatesProcessed > 4 * filter.Count)
+                    {
+                        break;
+                    }
+
+                    Console.WriteLine($"CP: {_vectorsSearcher.CandidatesProcessed}");
+                    
+                    if (_resultsEnumerator.MoveNext() == false)
+                    {
+                        _resultsEnumerator = _vectorsSearcher.Search().GetEnumerator();    
+                        _resultsEnumerator.MoveNext();
+                    }
+                    
+                    // If we fetch more than once, we've no guarantee that the whole set of results are sorted by distances.
+                    // We could explore not previously seen nodes that are closer to the query vector than the ones we've already seen.
+                    IsSortedByDistance = false;
+
+                    if (_vectorsSearcher.TryGetCurrentCandidates(out indexes) == false)
+                    {
+                        // We increased the number of candidates, but we didn't get any more results,
+                        // so we end the search right here.
+                        break;
+                    }
+                    
+                    // Reset the current node index
+                    _currentNode = 0;
+                }
+
+                if (_postingList != null)
+                {
+                    if (_postingListIterator.Fill(matches[index..], out var total) is false && total is 0)
+                    {
+                        _postingListIterator = default;
+                        _postingList = null;
+
+                        _returnedCandidates += _foundCandidateInCurrentSmallPostingList.ToInt32();
+                        _foundCandidateInCurrentSmallPostingList = false;
+
+                        _currentNode++;
+                        continue;
+                    }
+
+                    //decode in bulk
+                    Registration.InternalEntryIdToEntryId(matches[index..total]);
+
+                    var currentDocIdx = index;
+                    for (; currentDocIdx < index + total; currentDocIdx++)
+                    {
+                        if (filter.Contains(matches[currentDocIdx]) == false)
+                            continue;
+
+                        _foundCandidateInCurrentSmallPostingList = true;
+                        matches[index] = matches[currentDocIdx];
+                        distances[index] = distance;
+                        index++;
+                    }
+
+                    continue;
+                }
+
+                if (_currentMatchesIndex < _postingListResults.Count)
+                {
+                    var currentFillLimit = Math.Min(_postingListResults.Count - _currentMatchesIndex, matches.Length - index);
+                    for (; _currentMatchesIndex < currentFillLimit; _currentMatchesIndex++)
+                    {
+                        if (filter.Contains(_postingListResults[_currentMatchesIndex]) == false)
+                            continue;
+
+                        matches[index] = _postingListResults[_currentMatchesIndex];
+                        distances[index] = distance;
+                        _foundCandidateInCurrentSmallPostingList = true;
+                        index++;
+                    }
+
+                    if (_currentMatchesIndex == _postingListResults.Count)
+                    {
+                        _returnedCandidates += _foundCandidateInCurrentSmallPostingList.ToInt32();
+                        _foundCandidateInCurrentSmallPostingList = false;
+                        _currentMatchesIndex = 0;
+                        _postingListResults.Clear();
+                        _currentNode++;
+                    }
+
+                    continue;
+                }
+
+                var nodeIdx = indexes[_currentNode];
+                ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
+                var rawPostingListId = node.PostingListId & Constants.Graphs.VectorId.ContainerType;
+                distance = _searchState.Distance(_vector.ToSpan(), -1, nodeIdx);
+
+                if (distance > _maximumDistance)
+                {
+                    _currentNode++;
+                    continue;
+                }
+
+                switch (node.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask)
+                {
+                    case Constants.Graphs.VectorId.Tombstone: // empty
+                        _currentNode++;
+                        continue;
+                    case Constants.Graphs.VectorId.Single: // single item posting list
+                        _currentNode++;
+                        var rawEntry = Registration.InternalEntryIdToEntryId(rawPostingListId);
+                        if (filter.Contains(rawEntry) == false)
+                            continue;
+
+                        distances[index] = distance;
+                        matches[index++] = rawEntry;
+                        _returnedCandidates++;
+                        continue;
+                    case Constants.Graphs.VectorId.SmallPostingList: // small posting list
+                        Debug.Assert(_postingListResults.Count is 0 && _currentMatchesIndex is 0 && _foundCandidateInCurrentSmallPostingList is false);
+                        _searchState.ReadPostingList(new(rawPostingListId), ref _postingListResults, ref _pforDecoder, out _);
+                        Registration.InternalEntryIdToEntryId(_postingListResults.ToSpan());
+                        continue;
+                    case Constants.Graphs.VectorId.PostingList: // large posting list
+                        Debug.Assert(_foundCandidateInCurrentSmallPostingList is false);
+                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, new(rawPostingListId));
+                        ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
+                        _postingList = new PostingList(_searchState.Llt, Slices.Empty, setState);
+                        _postingListIterator = _postingList.Iterate();
+                        continue;
+                    default:
+                        throw new ArgumentOutOfRangeException("Impossible scenario, we have only 4 options, but got: " + node.PostingListId);
+                }
+            }
+
+            return index;
+        }
+        
+        public void Dispose()
+        {
+            _postingListResults.Dispose();
+            _pforDecoder.Dispose();
+            _searchState.Llt.Allocator.Release(ref _vector);
+            _resultsEnumerator?.Dispose();
+            _vectorsSearcher?.Dispose();
+        }
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -374,7 +374,7 @@ public unsafe partial class Hnsw
             bool hasFilterMatch)
         {
             // in case of filtered match we want to over-fetch. 
-            return new NearestSearcher(this, startingPointIndex, vector, level, numberOfCandidates * (hasFilterMatch ? 2 : 1), candidates, flags, hasFilterMatch);
+            return new NearestSearcher(this, startingPointIndex, vector, level, numberOfCandidates, candidates, flags, hasFilterMatch);
         }
 
         public IHnswSearcher EmptySearch() => new EmptySearcher();

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -371,6 +371,15 @@ public unsafe partial class Hnsw
             FilterNodesWithEmptyPostingLists = 1 << 2
         }
         
+        public IHnswSearcher NearestSearch(ContextBoundNativeList<int> startingPointsIndexes, Memory<byte> vector,
+            int level, int numberOfCandidates,
+            ContextBoundNativeList<int> candidates,
+            NearestEdgesFlags flags)
+        {
+            // in case of filtered match we want to over-fetch. 
+            return new NearestSearcher(this, startingPointsIndexes, vector, level , numberOfCandidates, candidates, flags);
+        }
+        
         public IHnswSearcher NearestSearch(int startingPointIndex, Memory<byte> vector,
             int level, int numberOfCandidates,
             ContextBoundNativeList<int> candidates,
@@ -378,14 +387,57 @@ public unsafe partial class Hnsw
             bool hasFilterMatch)
         {
             // in case of filtered match we want to over-fetch. 
-            return new NearestSearcher(this, startingPointIndex, vector, level, numberOfCandidates, candidates, flags, hasFilterMatch);
+            return new NearestSearcher(this, startingPointIndex, vector, level , numberOfCandidates, candidates, flags, hasFilterMatch);
         }
 
         public IHnswSearcher EmptySearch() => new EmptySearcher();
         
         public IHnswSearcher ExactSearch(Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan) => new ExactSearcher(this, vector, hasFilterMatch, numberOfCandidates, nodesToScan);
+
+        public void SearchFilteredNearest<TNodes>(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref ContextBoundNativeList<int> nearestIndexes, TNodes nodesToProbe, int maxBest, int maxMisses)
+        where TNodes : IEnumerator<long>
+        {
+            var missed = 0;
+            PriorityQueue<int, int> nodes = new();
+            
+            // Ordered ascending
+            var negatedMinLevel = int.MinValue;
+            var limit = 512;
+            while (nodesToProbe.MoveNext() && missed < maxMisses && limit-- > 0)
+            {
+                var currentNodeIndex = nodesToProbe.Current;
+                var nodeId = GetNodeIndexById(currentNodeIndex);
+                ref var entry = ref GetNodeByIndex(nodeId);
+                var maxNodeLevel = entry.EdgesPerLevel.Count;
+
+                if (nodes.Count < maxBest)
+                {
+                    // MinPriorityQueue. First to remove is a node from lower layers
+                    nodes.Enqueue(nodeId, -maxNodeLevel);
+                    missed = 0;
+                    negatedMinLevel = Math.Max(-maxNodeLevel, negatedMinLevel);
+                    continue;
+                }
+
+
+                if (maxNodeLevel > -negatedMinLevel)
+                {
+                    nodes.EnqueueDequeue(nodeId, -maxNodeLevel);
+                    negatedMinLevel = Math.Max(-maxNodeLevel, negatedMinLevel);
+                    missed = 0;
+                }
+                else
+                {
+                    missed++;
+                }
+            }
+            
+            nearestIndexes.EnsureCapacityFor((int)nodes.Count);
+            while (nodes.TryDequeue(out var currentNodeIndex, out var _))
+                nearestIndexes.AddUnsafe(currentNodeIndex);
+        }
         
-        public void SearchNearestAcrossLevels(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref NativeList<int> nearestIndexes)
+        public void SearchNearestAcrossLevels(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref ContextBoundNativeList<int> nearestIndexes)
         {
             var visitCounter = ++_visitsCounter;
             var currentNodeIndex = GetNodeIndexById(EntryPointId);
@@ -430,7 +482,7 @@ public unsafe partial class Hnsw
 
             indexes.Dispose(Llt.Allocator);
             nodeIds.Dispose(Llt.Allocator);
-            nearestIndexes.Reverse();
+            nearestIndexes.Inner.Reverse();
         }
 
 
@@ -1018,6 +1070,24 @@ public unsafe partial class Hnsw
         var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
         return new VectorSearchRetriever(searchState,  results, vector, minimumSimilarity);
     }
+
+    public static VectorSearchRetriever ApproximateFilteredNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, IEnumerable<long> nodesToProbe)
+    {
+        var searchState = new SearchState(llt, name);
+        var startingPointsIndexes = new ContextBoundNativeList<int>(llt.Allocator);
+        var candidates = new ContextBoundNativeList<int>(llt.Allocator);
+        candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
+
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
+        
+        using var enumerator = nodesToProbe.GetEnumerator();
+        searchState.SearchFilteredNearest(vector.Span, -1, searchState.Options.MaxLevel, ref startingPointsIndexes, enumerator, 16, 16);
+        candidates.Clear();
+        var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
+            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity);
+    }
     
     public static VectorSearchRetriever ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
@@ -1027,8 +1097,8 @@ public unsafe partial class Hnsw
 
         if (searchState.Options.CountOfVectors == 0)
             return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
-
-        searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel.Inner);
+        
+        searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
         var nearest = nearestNodesByLevel[0];
         nearestNodesByLevel.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -241,7 +241,7 @@ public unsafe partial class Hnsw
         /// <summary>
         /// This accepts a list of node ids (mutable, we do destructive updates to it) and translate
         /// that to a list of the indexes in the nodes array. If needed, it will load the nodes
-        /// from the disk in a batch oriented manner. 
+        /// from the disk in a batch oriented manner.
         /// </summary>
         private void LoadNodeIndexes(ref NativeList<long> nodeIds, ref NativeList<int> indexes)
         {
@@ -314,7 +314,7 @@ public unsafe partial class Hnsw
             if (vector.IsEmpty)
             {
                 ref var from = ref GetNodeByIndex(fromIdx);
-                vector = from.GetVector(this); // note we've to make a copy here since we cannot pass this as ref into ref value
+                vector = from.GetVector(this); // Note: we have to make a copy here since we cannot pass this as ref into a ref value
             }
 
             ref var to = ref GetNodeByIndex(toIdx);
@@ -327,7 +327,7 @@ public unsafe partial class Hnsw
             return distance;
         }
 
-        //Allows storing cached distance to the queried vector. Should be used only in querying part!
+        // Allows storing cached distance to the queried vector. Should be used only in the querying part!
         public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx, ref long vectorReadCounter)
         {
             ref var to = ref GetNodeByIndex(toIdx);
@@ -376,7 +376,6 @@ public unsafe partial class Hnsw
             ContextBoundNativeList<int> candidates,
             NearestEdgesFlags flags)
         {
-            // in case of filtered match we want to over-fetch. 
             return new NearestSearcher(this, startingPointsIndexes, vector, level , numberOfCandidates, candidates, flags);
         }
         
@@ -386,7 +385,6 @@ public unsafe partial class Hnsw
             NearestEdgesFlags flags,
             bool hasFilterMatch)
         {
-            // in case of filtered match we want to over-fetch. 
             return new NearestSearcher(this, startingPointIndex, vector, level , numberOfCandidates, candidates, flags, hasFilterMatch);
         }
 
@@ -394,47 +392,54 @@ public unsafe partial class Hnsw
         
         public IHnswSearcher ExactSearch(Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan) => new ExactSearcher(this, vector, hasFilterMatch, numberOfCandidates, nodesToScan);
 
-        public void SearchFilteredNearest<TNodes>(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref ContextBoundNativeList<int> nearestIndexes, TNodes nodesToProbe, int maxBest, int maxMisses)
-        where TNodes : IEnumerator<long>
+
+        public void SearchFilteredNearest<TNodes>(ref ContextBoundNativeList<int> nearestIndexes, TNodes nodesFromFilter, int candidatesRequested, int maximumNumberOfNodesVisitedWithoutFindingBetterCandidate)
+            where TNodes : IEnumerator<long>
         {
-            var missed = 0;
-            PriorityQueue<int, int> nodes = new();
+            var numberOfNodesVisitedFromLastNewCandidate = 0;
+            PriorityQueue<int, int> nearestCandidates = new();
             
-            // Ordered ascending
-            var negatedMinLevel = int.MinValue;
-            var limit = 512;
-            while (nodesToProbe.MoveNext() && missed < maxMisses && limit-- > 0)
+            // Retrieving nodes from the filter is costly (in terms of I/O). Therefore, we limit the number of random nodes we will visit.
+            var maximumAmountOfNodesToVisit = 512;
+            
+            while (nodesFromFilter.MoveNext() 
+                   && numberOfNodesVisitedFromLastNewCandidate < maximumNumberOfNodesVisitedWithoutFindingBetterCandidate 
+                   && maximumAmountOfNodesToVisit-- > 0)
             {
-                var currentNodeIndex = nodesToProbe.Current;
+                var currentNodeIndex = nodesFromFilter.Current;
                 var nodeId = GetNodeIndexById(currentNodeIndex);
                 ref var entry = ref GetNodeByIndex(nodeId);
-                var maxNodeLevel = entry.EdgesPerLevel.Count;
+                var currentNodeMaximumLevel = entry.EdgesPerLevel.Count;
 
-                if (nodes.Count < maxBest)
+                if (nearestCandidates.Count < candidatesRequested)
                 {
-                    // MinPriorityQueue. First to remove is a node from lower layers
-                    nodes.Enqueue(nodeId, -maxNodeLevel);
-                    missed = 0;
-                    negatedMinLevel = Math.Max(-maxNodeLevel, negatedMinLevel);
+                    // The queue is still empty. We will add anything that comes from the filter.
+                    // Since we prioritize nodes that exist on higher levels,
+                    // we will negate the current node's maximum level.
+                    // This will move nodes that exist only at the bottom level to the front of the queue.
+                    nearestCandidates.Enqueue(nodeId, currentNodeMaximumLevel);
+                    numberOfNodesVisitedFromLastNewCandidate = 0;
                     continue;
                 }
-
-
-                if (maxNodeLevel > -negatedMinLevel)
+                
+                // Our queue is full, which means we will only update the queue if the currently visited node is better (based on level existence)
+                // than our worst found candidate.
+                nearestCandidates.TryPeek(out _, out var worstCandidateMaximumLevel);
+                if (currentNodeMaximumLevel > worstCandidateMaximumLevel)
                 {
-                    nodes.EnqueueDequeue(nodeId, -maxNodeLevel);
-                    negatedMinLevel = Math.Max(-maxNodeLevel, negatedMinLevel);
-                    missed = 0;
+                    nearestCandidates.EnqueueDequeue(nodeId, currentNodeMaximumLevel);
+                    numberOfNodesVisitedFromLastNewCandidate = 0;
                 }
                 else
                 {
-                    missed++;
+                    numberOfNodesVisitedFromLastNewCandidate++;
                 }
             }
             
-            nearestIndexes.EnsureCapacityFor((int)nodes.Count);
-            while (nodes.TryDequeue(out var currentNodeIndex, out var _))
+            nearestIndexes.EnsureCapacityFor((int)nearestCandidates.Count);
+            while (nearestCandidates.TryDequeue(out var currentNodeIndex, out var _))
                 nearestIndexes.AddUnsafe(currentNodeIndex);
+            nearestIndexes.Inner.Reverse(); // we want to prioritize the nodes from the higher levels
         }
         
         public void SearchNearestAcrossLevels(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref ContextBoundNativeList<int> nearestIndexes)
@@ -1082,7 +1087,7 @@ public unsafe partial class Hnsw
             return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
         
         using var enumerator = nodesToProbe.GetEnumerator();
-        searchState.SearchFilteredNearest(vector.Span, -1, searchState.Options.MaxLevel, ref startingPointsIndexes, enumerator, 16, 16);
+        searchState.SearchFilteredNearest(ref startingPointsIndexes, enumerator, numberOfCandidates, 16);
         candidates.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -328,7 +328,7 @@ public unsafe partial class Hnsw
         }
 
         //Allows storing cached distance to the queried vector. Should be used only in querying part!
-        private float QueryDistance(ReadOnlySpan<byte> vector, int toIdx)
+        public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx)
         {
             ref var to = ref GetNodeByIndex(toIdx);
             if (to.QueryDistance is not null)

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -414,19 +414,17 @@ public unsafe partial class Hnsw
                 if (nearestCandidates.Count < candidatesRequested)
                 {
                     // The queue is still empty. We will add anything that comes from the filter.
-                    // Since we prioritize nodes that exist on higher levels,
-                    // we will negate the current node's maximum level.
-                    // This will move nodes that exist only at the bottom level to the front of the queue.
                     nearestCandidates.Enqueue(nodeId, currentNodeMaximumLevel);
                     numberOfNodesVisitedFromLastNewCandidate = 0;
                     continue;
                 }
                 
-                // Our queue is full, which means we will only update the queue if the currently visited node is better (based on level existence)
+                // Our queue is full, which means we will only update the queue if the currently visited node is better (based on existence across levels)
                 // than our worst found candidate.
                 nearestCandidates.TryPeek(out _, out var worstCandidateMaximumLevel);
                 if (currentNodeMaximumLevel > worstCandidateMaximumLevel)
                 {
+                    // Replace the current worst candidate with the newly visited node since it exists on a higher level
                     nearestCandidates.EnqueueDequeue(nodeId, currentNodeMaximumLevel);
                     numberOfNodesVisitedFromLastNewCandidate = 0;
                 }
@@ -440,6 +438,7 @@ public unsafe partial class Hnsw
             while (nearestCandidates.TryDequeue(out var currentNodeIndex, out var _))
                 nearestIndexes.AddUnsafe(currentNodeIndex);
             nearestIndexes.Inner.Reverse(); // we want to prioritize the nodes from the higher levels
+            nodesFromFilter.Dispose(); // dispose the iterator to restore the state.
         }
         
         public void SearchNearestAcrossLevels(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref ContextBoundNativeList<int> nearestIndexes)
@@ -1076,7 +1075,8 @@ public unsafe partial class Hnsw
         return new VectorSearchRetriever(searchState,  results, vector, minimumSimilarity);
     }
 
-    public static VectorSearchRetriever ApproximateFilteredNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, IEnumerable<long> nodesToProbe)
+    public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
+     where TEnumerator : IEnumerator<long> 
     {
         var searchState = new SearchState(llt, name);
         var startingPointsIndexes = new ContextBoundNativeList<int>(llt.Allocator);
@@ -1086,8 +1086,7 @@ public unsafe partial class Hnsw
         if (searchState.Options.CountOfVectors == 0)
             return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
         
-        using var enumerator = nodesToProbe.GetEnumerator();
-        searchState.SearchFilteredNearest(ref startingPointsIndexes, enumerator, numberOfCandidates, 16);
+        searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
         candidates.Clear();
         var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -12,7 +12,6 @@ using Sparrow.Compression;
 using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
-using Sparrow.Server.Utils.VxSort;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
@@ -28,180 +27,12 @@ namespace Voron.Data.Graphs;
 
 public unsafe partial class Hnsw
 {
-    public ref struct NodeReader(ByteStringContext allocator, Span<byte> buffer)
-    {
-        public long PostingListId;
-        public long VectorId;
-        public int CountOfLevels;
-
-        private int _offset;
-        private readonly Span<byte> _buffer = buffer;
-
-        public void LoadInto(ref Node node)
-        {
-            node.VectorId = VectorId;
-            node.PostingListId = PostingListId;
-            node.EdgesPerLevel.EnsureCapacityFor(allocator, CountOfLevels);
-            while (NextReadEdges(out var list))
-            {
-                node.EdgesPerLevel.AddUnsafe(list);
-            }
-        }
-
-        private bool NextReadEdges(out NativeList<long> list)
-        {
-            if (_offset >= _buffer.Length)
-            {
-                list = default;
-                return false;
-            }
-
-            var count = VariableSizeEncoding.Read<int>(_buffer, out int offset, _offset);
-            _offset += offset;
-            list = new NativeList<long>();
-            list.EnsureCapacityFor(allocator, count);
-            long prev = 0;
-            for (int i = 0; i < count; i++)
-            {
-                var item = VariableSizeEncoding.Read<long>(_buffer, out offset, _offset);
-                _offset += offset;
-                prev += item;
-                Debug.Assert(prev >= 0, "prev >= 0");
-                list.AddUnsafe(prev);
-            }
-            return true;
-        }
-
-        public UnmanagedSpan ReadVector(in SearchState state) => ReadVector(VectorId, in state);
-
-        public static UnmanagedSpan ReadVector(long vectorId, in SearchState state)
-        {
-            if ((vectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
-            {
-                Container.Get(state.Llt, new ContainerEntryId(vectorId), out var item);
-                var vectorSpan = new UnmanagedSpan(item.Address, item.Length);
-                Debug.Assert(state.Options.VectorSizeBytes == vectorSpan.Length, "state.Options.VectorSizeBytes == vectorSpan.Length");
-                return vectorSpan;
-            }
-
-            var count = (byte)(vectorId >> 1);
-            var containerId = vectorId & ~0xFFF;
-            Container.Get(state.Llt, new ContainerEntryId(containerId), out var container);
-            var offset = count * state.Options.VectorSizeBytes;
-            Debug.Assert(offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length, "offset >= 0 && offset + state.Options.VectorSizeBytes <= container.Length");
-            return new UnmanagedSpan(container.Address + offset, state.Options.VectorSizeBytes);
-        }
-    }
-
-    public struct Node
-    {
-        public long PostingListId;
-        public long VectorId;
-        public long NodeId;
-        public NativeList<NativeList<long>> EdgesPerLevel;
-        public NativeList<NativeList<int>> EdgesIndexesPerLevel;
-        private UnmanagedSpan _vectorSpan;
-        public int Visited;
-
-        public bool VectorLoaded => _vectorSpan.Length > 0;
-
-        public ContainerId GetVectorContainerId()
-        {
-            if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
-                return new ContainerId(VectorId);
-
-            return new ContainerId(VectorId & ~0xFFF);
-        }
-
-        public static NodeReader Decode(LowLevelTransaction llt, long id)
-        {
-            var span = Container.GetReadOnly(llt, new ContainerEntryId(id));
-            return Decode(llt, span);
-        }
-
-        public static NodeReader Decode(LowLevelTransaction llt, Span<byte> span)
-        {
-            var postingListId = VariableSizeEncoding.Read<long>(span, out var pos);
-            var offset = pos;
-            var vectorId = VariableSizeEncoding.Read<long>(span, out pos, offset);
-            offset += pos;
-            var countOfLevels = VariableSizeEncoding.Read<int>(span, out pos, offset);
-            offset += pos;
-
-            return new NodeReader(llt.Allocator, span[offset..]) { PostingListId = postingListId, VectorId = vectorId, CountOfLevels = countOfLevels };
-        }
-
-        public Span<byte> Encode(ref ContextBoundNativeList<byte> buffer)
-        {
-            int countOfLevels = EdgesPerLevel.Count;
-
-            // posting list id, vector id, count of levels
-            var maxSize = 3 * VariableSizeEncoding.MaximumSizeOf<long>();
-            for (int i = 0; i < countOfLevels; i++)
-            {
-                maxSize += EdgesPerLevel[i].Count * VariableSizeEncoding.MaximumSizeOf<long>();
-            }
-
-            buffer.EnsureCapacityFor(maxSize);
-
-            var bufferSpan = buffer.ToFullCapacitySpan();
-
-            var pos = VariableSizeEncoding.Write(bufferSpan, PostingListId);
-            pos += VariableSizeEncoding.Write(bufferSpan, VectorId, pos);
-            pos += VariableSizeEncoding.Write(bufferSpan, countOfLevels, pos);
-
-            for (int i = 0; i < countOfLevels; i++)
-            {
-                Span<long> span = EdgesPerLevel[i].ToSpan();
-                int len = Sorting.SortAndRemoveDuplicates(span);
-                span = span[..len];
-                long prev = 0;
-                pos += VariableSizeEncoding.Write(bufferSpan, span.Length, pos);
-                for (int j = 0; j < span.Length; j++)
-                {
-                    var delta = span[j] - prev;
-                    prev = span[j];
-                    pos += VariableSizeEncoding.Write(bufferSpan, delta, pos);
-                }
-            }
-
-            return bufferSpan[..pos];
-        }
-
-        public UnmanagedSpan GetVectorUnmanagedSpan(SearchState state)
-        {
-            if (_vectorSpan.Length > 0)
-                return _vectorSpan;
-
-            _vectorSpan = NodeReader.ReadVector(VectorId, in state);
-            return _vectorSpan;
-        }
-
-        public Span<byte> GetVector(SearchState state)
-        {
-            return GetVectorUnmanagedSpan(state).ToSpan();
-        }
-
-        internal void SetVector(SearchState searchState, UnmanagedSpan span)
-        {
-            if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
-            {
-                _vectorSpan = span;
-                return;
-            }
-
-            var count = (byte)(VectorId >> 1);
-            var offset = count * searchState.Options.VectorSizeBytes;
-            _vectorSpan = new UnmanagedSpan(span.Address + offset, searchState.Options.VectorSizeBytes);
-        }
-    }
-
     public static void Create(LowLevelTransaction llt, string name, int vectorSizeBytes, int numberOfEdges, int numberOfCandidates, VectorEmbeddingType embeddingType)
     {
         using var _ = Slice.From(llt.Allocator, name, out var slice);
         Create(llt, slice, vectorSizeBytes, numberOfEdges, numberOfCandidates, embeddingType);
     }
-    
+
     public static void Create(LowLevelTransaction llt, Slice name, int vectorSizeBytes, int numberOfEdges, int numberOfCandidates, VectorEmbeddingType embeddingType)
     {
         var tree = llt.Transaction.CreateTree(name);
@@ -258,7 +89,7 @@ public unsafe partial class Hnsw
         return vectorsContainerId;
     }
 
-    public class SearchState
+    public partial class SearchState
     {
         private readonly PriorityQueue<int, float> _candidatesQ = new();
         private readonly PriorityQueue<int, float> _nearestEdgesQ = new();
@@ -271,17 +102,17 @@ public unsafe partial class Hnsw
         private int _visitsCounter;
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
-        
+
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
 
         public int CreatedNodes => _newNodes.Count;
-        
+
         public int GetCreatedNodeIndex(int index) => _newNodes[index];
 
         public Options Options;
 
-        public SearchState(LowLevelTransaction llt, string name): this(llt, SliceFromString(llt, name))
+        public SearchState(LowLevelTransaction llt, string name) : this(llt, SliceFromString(llt, name))
         {
         }
 
@@ -290,6 +121,8 @@ public unsafe partial class Hnsw
             Slice.From(llt.Allocator, name, out var slice);
             return slice;
         }
+        
+        public Lookup<Int64LookupKey> NodeIdsByVectorId => _tree.LookupFor<Int64LookupKey>(Hnsw.NodesByVectorIdSlice);
 
         public SearchState(LowLevelTransaction llt, Slice name)
         {
@@ -301,7 +134,7 @@ public unsafe partial class Hnsw
                 IsEmpty = true;
                 return;
             }
-            
+
             var options = _tree.DirectRead(OptionsSlice);
             Options = Unsafe.Read<Options>(options);
             SimilarityCalc = Options.SimilarityMethod switch
@@ -321,7 +154,7 @@ public unsafe partial class Hnsw
                 case SimilarityMethod.CosineSimilarityI8:
                     return 2f * (1.0f - minimumSimilarity);
                 case SimilarityMethod.HammingDistance:
-                    return Options.VectorSizeBytes * 8 * (1f - minimumSimilarity);  // number_of_bits * minimum_similarity
+                    return Options.VectorSizeBytes * 8 * (1f - minimumSimilarity); // number_of_bits * minimum_similarity
                 default:
                     throw new InvalidDataException($"Unknown similarity method {Options.SimilarityMethod}");
             }
@@ -336,7 +169,7 @@ public unsafe partial class Hnsw
                 case SimilarityMethod.CosineSimilarityI8:
                     return 1 - score;
                 case SimilarityMethod.HammingDistance:
-                    return ((Options.VectorSizeBytes * 8) - score) / (8f * Options.VectorSizeBytes);  // number_of_bits * minimum_similarity
+                    return ((Options.VectorSizeBytes * 8) - score) / (8f * Options.VectorSizeBytes); // number_of_bits * minimum_similarity
                 default:
                     throw new InvalidDataException($"Unknown similarity method {Options.SimilarityMethod}");
             }
@@ -358,7 +191,7 @@ public unsafe partial class Hnsw
                     throw new InvalidDataException($"Unknown similarity method {Options.SimilarityMethod}");
             }
         }
-        
+
         public void FlushOptions()
         {
             using (_tree.DirectAdd(OptionsSlice, sizeof(Options), out var dst))
@@ -366,11 +199,11 @@ public unsafe partial class Hnsw
                 Unsafe.Write(dst, Options);
             }
         }
-        
+
         public int RegisterVectorNode(long newNodeId, long vectorId)
         {
             int nodeIndex = AllocateNodeIndex(newNodeId);
-            
+
             _newNodes.Add(Llt.Allocator, nodeIndex);
             _nodes[nodeIndex].VectorId = vectorId;
 
@@ -421,7 +254,7 @@ public unsafe partial class Hnsw
                     nodeIds[i] = -1;
                 }
             }
-            
+
             if (indexes.Count == nodeIds.Count)
                 return;
 
@@ -436,8 +269,9 @@ public unsafe partial class Hnsw
                 _nodeIdToIdx[keys[i]] = nodeIdx;
                 indexes.AddUnsafe(nodeIdx);
             }
+
             _nodeIdToLocations.GetFor(keys, keys, -1);
-            
+
             var spans = Buffers.GetSpans(keys.Length);
             Container.GetAll(Llt, keys, spans, -1, Llt.PageLocator);
             for (int i = 0; i < keys.Length; i++)
@@ -453,17 +287,17 @@ public unsafe partial class Hnsw
             ref var nodeIdx = ref CollectionsMarshal.GetValueRefOrAddDefault(_nodeIdToIdx, nodeId, out var exists);
             if (exists)
                 return nodeIdx;
-            
+
             if (TryGetLocationForNode(nodeId, out var nodeLocation) is false)
                 throw new InvalidOperationException($"Unable to find node id {nodeId}");
 
-            nodeIdx =  AllocateNodeIndex(nodeId);
+            nodeIdx = AllocateNodeIndex(nodeId);
             var reader = Node.Decode(Llt, nodeLocation);
             ref var n = ref GetNodeByIndex(nodeIdx);
             reader.LoadInto(ref n);
             return nodeIdx;
         }
-        
+
         public ref Node GetNodeById(long nodeId)
         {
             int idx = GetNodeIndexById(nodeId);
@@ -484,8 +318,25 @@ public unsafe partial class Hnsw
             }
 
             ref var to = ref GetNodeByIndex(toIdx);
+            if (to.QueryDistance is not null)
+                return to.QueryDistance.Value;
+            
             Span<byte> v2 = to.GetVector(this);
             var distance = SimilarityCalc(vector, v2);
+            
+            return distance;
+        }
+
+        //Allows storing cached distance to the queried vector. Should be used only in querying part!
+        private float QueryDistance(ReadOnlySpan<byte> vector, int toIdx)
+        {
+            ref var to = ref GetNodeByIndex(toIdx);
+            if (to.QueryDistance is not null)
+                return to.QueryDistance.Value;
+            
+            Span<byte> v2 = to.GetVector(this);
+            var distance = SimilarityCalc(vector, v2);
+            to.QueryDistance = distance;
             return distance;
         }
 
@@ -498,11 +349,11 @@ public unsafe partial class Hnsw
         {
             Container.Get(llt, rawPostingListId, out var smallPostingList);
             var count = VariableSizeEncoding.Read<int>(smallPostingList.Address, out var offset);
-            
+
             var requiredSize = Math.Max(256, 256 * (int)Math.Ceiling((count + listBuffer.Count) / 256f));
             listBuffer.EnsureCapacityFor(requiredSize);
-            Debug.Assert(listBuffer.Capacity > 0 && listBuffer.Capacity % 256 ==0, "The buffer must be multiple of 256 for PForDecoder.Read");
-            
+            Debug.Assert(listBuffer.Capacity > 0 && listBuffer.Capacity % 256 == 0, "The buffer must be multiple of 256 for PForDecoder.Read");
+
             pforDecoder.Init(smallPostingList.Address + offset, smallPostingList.Length - offset);
             listBuffer.Count += pforDecoder.Read(listBuffer.RawItems + listBuffer.Count, listBuffer.Capacity - listBuffer.Count);
             postingListSize = smallPostingList.Length;
@@ -515,104 +366,21 @@ public unsafe partial class Hnsw
             StartingPointAsEdge = 1 << 1,
             FilterNodesWithEmptyPostingLists = 1 << 2
         }
-
-        public void NearestEdges(int startingPointIndex, 
-            int dstIdx, ReadOnlySpan<byte> vector, 
-            int level, int numberOfCandidates, 
-            ref NativeList<int> candidates,
-            NearestEdgesFlags flags)
+        
+        public IHnswSearcher NearestSearch(int startingPointIndex, Memory<byte> vector,
+            int level, int numberOfCandidates,
+            ContextBoundNativeList<int> candidates,
+            NearestEdgesFlags flags,
+            bool hasFilterMatch)
         {
-            Debug.Assert(_candidatesQ.Count == 0, "_candidatesQ.Count == 0");
-            Debug.Assert(_nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
-            
-            float lowerBound = -Distance(vector, dstIdx, startingPointIndex);
-            var visitedCounter = ++_visitsCounter; 
-            ref var startingPoint = ref GetNodeByIndex(startingPointIndex);
-            startingPoint.Visited = visitedCounter;
-            // candidates queue is sorted using the distance, so the lowest distance
-            // will always pop first.
-            // nearest edges is sorted using _reversed_ distance, so when we add a 
-            // new item to the queue, we'll pop the one with the largest distance
-            
-            _candidatesQ.Enqueue(startingPointIndex, -lowerBound);
-            if (flags.HasFlag(NearestEdgesFlags.StartingPointAsEdge) && 
-                    ((startingPoint.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) != Constants.Graphs.VectorId.Tombstone 
-                     || flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false))
-            {
-                _nearestEdgesQ.Enqueue(startingPointIndex, lowerBound);
-            }
-            
-            var indexes = new NativeList<int>();
-            var nodeIds = new NativeList<long>();
-            while (_candidatesQ.TryDequeue(out var cur, out var curDistance))
-            {
-                if (-curDistance < lowerBound && 
-                    _nearestEdgesQ.Count == numberOfCandidates)
-                    break;
-
-                ref var candidate = ref GetNodeByIndex(cur);
-                candidate.Visited = visitedCounter;
-             
-                ref var edges = ref candidate.EdgesPerLevel[level];
-
-                nodeIds.ResetAndCopyFrom(Llt.Allocator, edges.ToSpan());
-                LoadNodeIndexes(ref nodeIds, ref indexes);
-
-                for (int i = 0; i < indexes.Count; i++)
-                {
-                    var nextIndex = indexes[i];
-                    ref var next = ref GetNodeByIndex(nextIndex);
-                    if(next.Visited == visitedCounter)
-                        continue; // already checked it
-                    next.Visited = visitedCounter;
-                    var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone;
-
-                    float nextDist = -Distance(vector, dstIdx, nextIndex);
-                    if (_nearestEdgesQ.Count < numberOfCandidates)
-                    {
-                        _candidatesQ.Enqueue(nextIndex, -nextDist);
-                        
-                        if (nextIndex != dstIdx && 
-                            (isDeleted == false || flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false))
-                        {
-                            _nearestEdgesQ.Enqueue(nextIndex, nextDist);
-                        }
-                    }
-                    else if (lowerBound < nextDist)
-                    {
-                        _candidatesQ.Enqueue(nextIndex, -nextDist);
-                        
-                        if (nextIndex != dstIdx && 
-                            (isDeleted == false || flags.HasFlag(NearestEdgesFlags.FilterNodesWithEmptyPostingLists) is false))
-                        {
-                            _nearestEdgesQ.EnqueueDequeue(nextIndex, nextDist);
-                        }
-                    }
-                    else
-                    {
-                        continue;
-                    }
-                    
-                    Debug.Assert(_candidatesQ.Count > 0);
-                    _nearestEdgesQ.TryPeek(out _, out lowerBound);
-                }
-            }
-
-            _candidatesQ.Clear();
-            candidates.EnsureCapacityFor(Llt.Allocator, _nearestEdgesQ.Count);
-            
-            while (_nearestEdgesQ.TryDequeue(out var edgeId, out var d))
-            {
-                candidates.AddUnsafe(edgeId);
-            }
-
-            candidates.Reverse();
-            Debug.Assert(candidates.ToSpan().Contains(dstIdx) == false, "candidates.ToSpan().Contains(dstIdx) == false");
-            
-            nodeIds.Dispose(Llt.Allocator);
-            indexes.Dispose(Llt.Allocator);
+            // in case of filtered match we want to over-fetch. 
+            return new NearestSearcher(this, startingPointIndex, vector, level, numberOfCandidates * (hasFilterMatch ? 2 : 1), candidates, flags, hasFilterMatch);
         }
 
+        public IHnswSearcher EmptySearch() => new EmptySearcher();
+        
+        public IHnswSearcher ExactSearch(Memory<byte> vector, bool hasFilterMatch, int numberOfCandidates, ContextBoundNativeList<long>? nodesToScan) => new ExactSearcher(this, vector, hasFilterMatch, numberOfCandidates, nodesToScan);
+        
         public void SearchNearestAcrossLevels(ReadOnlySpan<byte> vector, int dstIdx, int maxLevel, ref NativeList<int> nearestIndexes)
         {
             var visitCounter = ++_visitsCounter;
@@ -655,62 +423,63 @@ public unsafe partial class Hnsw
                 nearestIndexes.AddUnsafe(currentNodeIndex);
                 level--;
             }
+
             indexes.Dispose(Llt.Allocator);
             nodeIds.Dispose(Llt.Allocator);
             nearestIndexes.Reverse();
         }
-        
-        
-       private static class Buffers
-       {
-           [ThreadStatic]
-           private static long[] IdsToLoad;
-           [ThreadStatic]
-           private static int[] IndexesOfIds;
-           [ThreadStatic]
-           private static long[] VectorIdsToLoad;
-           [ThreadStatic]
-           private static UnmanagedSpan[] SpansToLoad;
-           [ThreadStatic]
-           private static int[] NodeIndexes;
 
-           public static Span<UnmanagedSpan> GetSpans(int count)
-           {
-               if (IdsToLoad is null || count > IdsToLoad.Length)
-               {
-                   Allocate(count);
-               }
 
-               return SpansToLoad;
-           }
+        private static class Buffers
+        {
+            [ThreadStatic]
+            private static long[] IdsToLoad;
+            [ThreadStatic]
+            private static int[] IndexesOfIds;
+            [ThreadStatic]
+            private static long[] VectorIdsToLoad;
+            [ThreadStatic]
+            private static UnmanagedSpan[] SpansToLoad;
+            [ThreadStatic]
+            private static int[] NodeIndexes;
 
-           public static void Get(int count, out Span<long> idsToLoad, out Span<long> vectorIdsToLoad, out Span<UnmanagedSpan> spansToLoad, out Span<int> nodeIndexes, out Span<int> indexesOfIds)
-           {
-               if (IdsToLoad is null || count > IdsToLoad.Length)
-               {
-                   Allocate(count);
-               }
+            public static Span<UnmanagedSpan> GetSpans(int count)
+            {
+                if (IdsToLoad is null || count > IdsToLoad.Length)
+                {
+                    Allocate(count);
+                }
 
-               idsToLoad = IdsToLoad;
-               vectorIdsToLoad = VectorIdsToLoad;
-               spansToLoad = SpansToLoad;
-               nodeIndexes = NodeIndexes;
-               indexesOfIds = IndexesOfIds;
-           }
+                return SpansToLoad;
+            }
 
-           private static void Allocate(int count)
-           {
-               count = Bits.NextAllocationSize(count);
+            public static void Get(int count, out Span<long> idsToLoad, out Span<long> vectorIdsToLoad, out Span<UnmanagedSpan> spansToLoad, out Span<int> nodeIndexes, out Span<int> indexesOfIds)
+            {
+                if (IdsToLoad is null || count > IdsToLoad.Length)
+                {
+                    Allocate(count);
+                }
 
-               IndexesOfIds = new int[count];
-               IdsToLoad = new long[count];
-               VectorIdsToLoad = new long[count];
-               SpansToLoad = new UnmanagedSpan[count];
-               NodeIndexes = new int[count];
-           }
-       }
+                idsToLoad = IdsToLoad;
+                vectorIdsToLoad = VectorIdsToLoad;
+                spansToLoad = SpansToLoad;
+                nodeIndexes = NodeIndexes;
+                indexesOfIds = IndexesOfIds;
+            }
 
-       /// <summary>
+            private static void Allocate(int count)
+            {
+                count = Bits.NextAllocationSize(count);
+
+                IndexesOfIds = new int[count];
+                IdsToLoad = new long[count];
+                VectorIdsToLoad = new long[count];
+                SpansToLoad = new UnmanagedSpan[count];
+                NodeIndexes = new int[count];
+            }
+        }
+
+        /// <summary>
        /// Load all the _vectors_ associated with the provided node ids.
        /// Note that this actually requires us to first look up the nodes by id (loading them via batch)
        /// then load any yet unloaded vector (again using a batch) 
@@ -732,9 +501,9 @@ public unsafe partial class Hnsw
                    ref var n = ref _nodes[existingIdx];
                    if (n.VectorLoaded)
                        continue;
-                    nodeIndexes[vectorsToLoadIdx] = existingIdx;
-                    vectorIdsToLoad[vectorsToLoadIdx++] = (long)n.GetVectorContainerId();
-                    continue;
+                   nodeIndexes[vectorsToLoadIdx] = existingIdx;
+                   vectorIdsToLoad[vectorsToLoadIdx++] = n.GetVectorContainerId();
+                   continue;
                }
 
                var nodeIdx = AllocateNodeIndex(nodeId);
@@ -759,8 +528,8 @@ public unsafe partial class Hnsw
                    var nodeIndex = indexesOfIds[i];
                    ref var n = ref _nodes[nodeIndex];
                    reader.LoadInto(ref n);
-                    nodeIndexes[vectorsToLoadIdx] = nodeIndex;
-                    vectorIdsToLoad[vectorsToLoadIdx++] = (long)n.GetVectorContainerId();
+                   nodeIndexes[vectorsToLoadIdx] = nodeIndex;
+                   vectorIdsToLoad[vectorsToLoadIdx++] = n.GetVectorContainerId();
                }
            }
            if (vectorsToLoadIdx is 0)
@@ -783,7 +552,7 @@ public unsafe partial class Hnsw
            return _nodeIdToIdx.TryGetValue(nodeId, out nodeIndex);
        }
     }
-    
+
     public partial class Registration : IDisposable
     {
         public bool IsCommited { get; private set; }
@@ -797,7 +566,7 @@ public unsafe partial class Hnsw
         private PostingList _largePostingListSet;
 
         public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
-        
+
         public Registration(LowLevelTransaction llt, Slice name, Random random = null)
         {
             Random = random ?? Random.Shared;
@@ -822,7 +591,7 @@ public unsafe partial class Hnsw
 
             _searchState.Llt.Allocator.AllocateDirect(Sodium.GenericHashSize, out var hashBuffer);
             vectorHash.CopyTo(hashBuffer.ToSpan());
-            
+
             ref var postingList = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorHashCache, hashBuffer, out var exists);
             if (exists)
             {
@@ -834,12 +603,12 @@ public unsafe partial class Hnsw
 
             if (_vectorsByHash.TryGetValue(vectorHash, out var vectorId) is false)
                 PortableExceptions.Throw<InvalidOperationException>($"Unable to find the vector corresponding to the provided vector hash: base64({Convert.ToBase64String(vectorHash)}).");
-            
+
             if (_nodesByVectorId.TryGetValue(vectorId, out var nodeId) is false)
                 PortableExceptions.Throw<InvalidOperationException>($"Unable to find the node corresponding to the provided vector hash: base64({Convert.ToBase64String(vectorHash)}) and VectorId({vectorId}).");
 
             int nodeIndex = _searchState.GetNodeIndexById(nodeId);
-            postingList = (hashBuffer, nodeIndex, NativeList<long>.Create(_searchState.Llt.Allocator, entryId  | RemovalMask));
+            postingList = (hashBuffer, nodeIndex, NativeList<long>.Create(_searchState.Llt.Allocator, entryId | RemovalMask));
         }
 
         /// <summary>
@@ -853,6 +622,9 @@ public unsafe partial class Hnsw
             return entryId << 2;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static long InternalEntryIdToEntryId(long entryId) => entryId >> 2;
+
         /// <summary>
         /// During indexing, we're shifting each ID 2 bits to the left to use the two lowest bits as a mask placeholder. This is for querying decoding.
         /// </summary>
@@ -861,11 +633,11 @@ public unsafe partial class Hnsw
         {
             var entriesPos = 0;
             ref var entriesRef = ref MemoryMarshal.GetReference(entries);
-            
+
             if (AdvInstructionSet.IsAcceleratedVector512)
             {
                 var N = Vector512<long>.Count;
-                
+
                 for (; entriesPos + N < entries.Length; entriesPos += N)
                 {
                     ref var currentMemory = ref Unsafe.Add(ref entriesRef, entriesPos);
@@ -873,11 +645,11 @@ public unsafe partial class Hnsw
                     Vector512.ShiftRightLogical(current, 2).StoreUnsafe(ref currentMemory);
                 }
             }
-            
+
             if (AdvInstructionSet.IsAcceleratedVector256)
             {
                 var N = Vector256<long>.Count;
-                
+
                 for (; entriesPos + N < entries.Length; entriesPos += N)
                 {
                     ref var currentMemory = ref Unsafe.Add(ref entriesRef, entriesPos);
@@ -889,7 +661,7 @@ public unsafe partial class Hnsw
             for (; entriesPos < entries.Length; entriesPos++)
                 Unsafe.Add(ref entriesRef, entriesPos) >>= 2;
         }
-        
+
         /// <summary>
         /// Adds a vector to the graph.
         /// </summary>
@@ -906,7 +678,7 @@ public unsafe partial class Hnsw
 
             var hashBuffer = ComputeHashFor(vector);
             ref (ByteString Hash, int NodeIndex, NativeList<long> PostingList) postingList = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorHashCache, hashBuffer, out var exists);
-            if(exists)
+            if (exists)
             {
                 // already added this in the current batch
                 ref var l = ref postingList.PostingList;
@@ -923,7 +695,7 @@ public unsafe partial class Hnsw
                 vectorId = (long)vectorEntryId;
                 _vectorsByHash.Add(vectorHash, vectorId);
             }
-            
+
             if (_nodesByVectorId.TryGetValue(vectorId, out var nodeId))
             {
                 int nodeIndex = _searchState.GetNodeIndexById(nodeId);
@@ -934,11 +706,11 @@ public unsafe partial class Hnsw
             long newNodeId = ++_searchState.Options.CountOfVectors;
             int nodeIdx = _searchState.RegisterVectorNode(newNodeId, vectorId);
             _nodesByVectorId.Add(vectorId, newNodeId);
-            
+
             postingList = (hashBuffer, nodeIdx, ToPostingListTuple(entryId));
             return hashBuffer;
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         NativeList<long> ToPostingListTuple(long entryId)
         {
@@ -964,7 +736,7 @@ public unsafe partial class Hnsw
                 var sizeInBytes = _vectorBatchSizeInPages * Constants.Storage.PageSize - PageHeader.SizeOf;
                 var batchId = Container.Allocate(_searchState.Llt, _globalVectorsContainerId,
                     sizeInBytes, out var vectorStorage);
-                
+
                 Debug.Assert(vectorStorage.Length / _searchState.Options.VectorSizeBytes <= byte.MaxValue, "vectorStorage.Length / _searchState.Options.VectorSizeBytes <= byte.MaxValue");
                 Debug.Assert(((long)batchId & 0xFFF) == 0, "We allocate > 1 page, so we get the full page container id");
                 _searchState.Options.LastUsedContainerId = new ContainerId((long)batchId);
@@ -986,6 +758,7 @@ public unsafe partial class Hnsw
                 _searchState.Options.LastUsedContainerId = new ContainerId(0);
                 _searchState.Options.VectorBatchIndex = 0;
             }
+
             return id;
 
             ContainerEntryId GetVectorId(ContainerId containerId, int index)
@@ -1006,7 +779,7 @@ public unsafe partial class Hnsw
         public void Commit(CancellationToken token)
         {
             PortableExceptions.ThrowIfOnDebug<InvalidOperationException>(_searchState.Llt.Committed);
-            
+
             var pforEncoder = new FastPForEncoder(_searchState.Llt.Allocator);
             var pforDecoder = new FastPForDecoder(_searchState.Llt.Allocator);
             var listBuffer = new ContextBoundNativeList<long>(_searchState.Llt.Allocator);
@@ -1019,7 +792,7 @@ public unsafe partial class Hnsw
                 ref var node = ref nodes[nodeIndex];
                 node.PostingListId = MergePostingList(node.PostingListId, modifications);
             }
-            
+
             // Intentionally zeroing the nodes var, we may realloc the underlying array in the insert vector phase
             nodes = Span<Node>.Empty;
             _ = nodes;
@@ -1034,14 +807,14 @@ public unsafe partial class Hnsw
 
             // flush the local modifications
             _searchState.FlushOptions();
-            
+
             listBuffer.Dispose();
             byteBuffer.Dispose();
             pforEncoder.Dispose();
             pforDecoder.Dispose();
 
             IsCommited = true;
-            
+
             long MergePostingList(long postingList, NativeList<long> modifications)
             {
                 // We may have duplicates in the list.
@@ -1053,10 +826,10 @@ public unsafe partial class Hnsw
                 // - There was a removal
                 // In such case, we can just sort and remove duplicates to have unique list.
                 modifications.Shrink(Sorting.SortAndRemoveDuplicates(modifications.ToSpan()));
-                
+
                 listBuffer.Clear();
                 listBuffer.AddRange(modifications.ToSpan());
-                
+
                 int currentSize = 0;
                 bool hasSmallPostingList = false;
                 ContainerEntryId rawPostingListId = new ContainerEntryId(postingList & Constants.Graphs.VectorId.ContainerType);
@@ -1084,7 +857,7 @@ public unsafe partial class Hnsw
                 // 3) 1x Addition: New document 
                 // INFO: All other scenarios are invalid.
                 PostingList.SortModificationsAndRemoveDuplicates(ref listBuffer);
-                
+
                 if (listBuffer.Count is 0 or 1)
                 {
                     if (hasSmallPostingList)
@@ -1121,6 +894,7 @@ public unsafe partial class Hnsw
                     DeleteOldSmallPostingListIfNeeded();
                     rawPostingListId = Container.Allocate(_searchState.Llt, _searchState.Options.Container, byteBuffer.Count, out mutable);
                 }
+
                 Span<byte> span = byteBuffer.ToSpan();
                 span.CopyTo(mutable);
 
@@ -1137,7 +911,7 @@ public unsafe partial class Hnsw
                 }
             }
         }
-        
+
         public void Dispose()
         {
             //todo: we may wants to release the vector hash cache
@@ -1164,10 +938,10 @@ public unsafe partial class Hnsw
                 lists[listIdx][curIndex] = cur;
             }
 
-            var numberOfEntries = PostingList.Update(_searchState.Llt, ref postingListState, lists[0], indexes[0], 
+            var numberOfEntries = PostingList.Update(_searchState.Llt, ref postingListState, lists[0], indexes[0],
                 lists[1], indexes[1], pForEncoder, ref tempListBuffer, ref pForDecoder);
 
-            if(numberOfEntries is 0)
+            if (numberOfEntries is 0)
             {
                 _largePostingListSet ??= _searchState.Llt.Transaction.OpenPostingList(Constants.PostingList.PostingListRegister);
                 _largePostingListSet.Remove((long)postingListId);
@@ -1218,210 +992,39 @@ public unsafe partial class Hnsw
         Slice.From(llt.Allocator, name, out var slice);
         return RegistrationFor(llt, slice, random);
     }
+
     public static Registration RegistrationFor(LowLevelTransaction llt, Slice name, Random random = null)
     {
         return new Registration(llt, name, random);
     }
-
-    public static NearestSearch ExactNearest(LowLevelTransaction llt, string name, int numberOfCandidates, ReadOnlySpan<byte> vector, float minimumSimilarity)
-    {
-        Slice.From(llt.Allocator, name, out var slice);
-        return ExactNearest(llt, slice, numberOfCandidates, vector, minimumSimilarity);
-    }
-
-    public static NearestSearch ExactNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, ReadOnlySpan<byte> vector, float minimumSimilarity)
+    
+    public static VectorSearchRetriever ExactNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
     {
         var searchState = new SearchState(llt, name);
-        var pq = new PriorityQueue<long, float>();
-        for (long nodeId = 1; nodeId <= searchState.Options.CountOfVectors; nodeId++)
-        {
-            searchState.ReadNode(nodeId, out var reader);
-            if (reader.PostingListId is 0)
-                continue; // no entries, can skip
-
-            var curVect = reader.ReadVector(in searchState);
-            var distance = searchState.SimilarityCalc(vector, curVect);
-            if (pq.Count < numberOfCandidates)
-            {
-                pq.Enqueue(nodeId, -distance);
-            }
-            else
-            {
-                pq.EnqueueDequeue(nodeId, -distance);
-            }
-        }
-
-        var candidates = new ContextBoundNativeList<int>(llt.Allocator);
-        while(pq.TryDequeue(out var nodeId, out _))
-        {
-            var nodeIdx = searchState.GetNodeIndexById(nodeId);
-            candidates.Add(nodeIdx);
-        }
-        candidates.Inner.Reverse();
-        return new NearestSearch(searchState, candidates, vector, minimumSimilarity);
+        var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
+        return new VectorSearchRetriever(searchState,  results, vector, minimumSimilarity);
     }
-
-    public static NearestSearch ApproximateNearest(LowLevelTransaction llt, string name, int numberOfCandidates, ReadOnlySpan<byte> vector, float minimumSimilarity)
-    {
-        Slice.From(llt.Allocator, name, out var slice);
-        return ApproximateNearest(llt, slice, numberOfCandidates, vector, minimumSimilarity);
-    }
-
-    public static NearestSearch ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, ReadOnlySpan<byte> vector, float minimumSimilarity)
+    
+    public static VectorSearchRetriever ApproximateNearest(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
     {
         var searchState = new SearchState(llt, name);
         var nearestNodesByLevel = new ContextBoundNativeList<int>(llt.Allocator);
         nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
 
         if (searchState.Options.CountOfVectors == 0)
-            return new NearestSearch(searchState, nearestNodesByLevel, vector, minimumSimilarity);
-        
-        searchState.SearchNearestAcrossLevels(vector, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel.Inner);
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
+
+        searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel.Inner);
         var nearest = nearestNodesByLevel[0];
         nearestNodesByLevel.Clear();
-        searchState.NearestEdges(nearest, -1, vector, level: 0, numberOfCandidates: numberOfCandidates, candidates: ref nearestNodesByLevel.Inner, 
-            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
-        return new NearestSearch(searchState, nearestNodesByLevel, vector, minimumSimilarity);
+        var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
+            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity);
     }
-    
-    public class IndexedVectorsRetriever(LowLevelTransaction llt, string name) : IIndexedTermsRetriever
+
+    public static VectorSearchRetriever EmptySearch(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity)
     {
-        private readonly SearchState _searchState = new(llt, name);
-        private long _lastReadNodeId = 1;
-
-        public bool GetNextTerm(out ReadOnlySpan<byte> term)
-        {
-            if (_lastReadNodeId > _searchState.Options.CountOfVectors)
-            {
-                term = [];
-                return false;
-            }
-
-            _searchState.ReadNode(_lastReadNodeId, out var reader);
-            term = reader.ReadVector(in _searchState).ToReadOnlySpan();
-            _lastReadNodeId++;
-            return true;
-        }
-
-        public ConvertTo Type => ConvertTo.Base64;
-    }
-    
-    public struct NearestSearch : IDisposable
-    {
-        public NearestSearch(SearchState searchState, ContextBoundNativeList<int> indexes, ReadOnlySpan<byte> vector, float minimumSimilarity)
-        {
-            _searchState = searchState;
-            _indexes = indexes;
-            _postingListResults = new(_searchState.Llt.Allocator);
-            _pforDecoder = new(searchState.Llt.Allocator);
-            searchState.Llt.Allocator.AllocateDirect(vector.Length, out _vector);
-            vector.CopyTo(_vector.ToSpan());
-            _maximumDistance = searchState.MinimumSimilarityToDistance(minimumSimilarity);
-        }
-
-        private ContextBoundNativeList<int> _indexes;
-        private SearchState _searchState;
-        private int _currentNode, _currentMatchesIndex;
-        private ContextBoundNativeList<long> _postingListResults;
-        private FastPForDecoder _pforDecoder;
-        private ByteString _vector;
-        private PostingList.Iterator _postingListIterator;
-        private PostingList _postingList;
-        private readonly float _maximumDistance;
-        public SimilarityMethod SimilarityMethod => _searchState.Options.SimilarityMethod;
-        public bool IsEmpty => _searchState.IsEmpty;
-
-        public void Dispose()
-        {
-            _indexes.Dispose();
-            _postingListResults.Dispose();
-            _pforDecoder.Dispose();
-            _searchState.Llt.Allocator.Release(ref _vector);
-        }
-        
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public float DistanceToScore(float distance) => _searchState.DistanceToScore(distance);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void DistancesToScores(Span<float> distances) => _searchState.DistancesToScores(distances);
-        
-        public int Fill(Span<long> matches, Span<float> distances)
-        {
-            int index = 0;
-            float distance = float.NaN;
-            while (index < matches.Length)
-            {
-                if (_currentNode >= _indexes.Count)
-                    break;
-
-                if(_postingList != null)
-                {
-                    if (_postingListIterator.Fill(matches[index..], out var total) is false && total is 0)
-                    {
-                        _postingListIterator = default;
-                        _postingList = null;
-                        _currentNode++;
-                        continue;
-                    }
-                    distances.Slice(index, total).Fill(distance);
-                    index += total;
-                    continue;
-                }
-
-                if (_currentMatchesIndex < _postingListResults.Count)
-                {
-                    var copy = Math.Min(_postingListResults.Count - _currentMatchesIndex, matches.Length - index);
-                    _postingListResults.CopyTo(matches[index..], _currentMatchesIndex, copy);
-                    distances.Slice(index, copy).Fill(distance);
-                    index += copy;
-                    _currentMatchesIndex += copy;
-                    if(_currentMatchesIndex == _postingListResults.Count)
-                    {
-                        _currentMatchesIndex = 0;
-                        _postingListResults.Clear();
-                        _currentNode++;
-                    }
-                    continue;
-                }
-
-                var nodeIdx = _indexes[_currentNode];
-                ref var node = ref _searchState.GetNodeByIndex(nodeIdx);
-                ContainerEntryId rawPostingListId = new ContainerEntryId(node.PostingListId & Constants.Graphs.VectorId.ContainerType);
-                distance = _searchState.Distance(_vector.ToSpan(), -1, nodeIdx);
-
-                if (distance > _maximumDistance)
-                {
-                    _currentNode++;
-                    continue;
-                }
-
-                switch (node.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask)
-                {
-                    case Constants.Graphs.VectorId.Tombstone: // empty
-                        _currentNode++;
-                        continue;
-                    case Constants.Graphs.VectorId.Single: // single item posting list
-                        distances[index] = distance;
-                        matches[index++] = (long)rawPostingListId;
-                        _currentNode++;
-                        continue;
-                    case Constants.Graphs.VectorId.SmallPostingList: // small posting list
-                        Debug.Assert(_postingListResults.Count is 0 && _currentMatchesIndex is 0);
-                        _searchState.ReadPostingList(rawPostingListId, ref _postingListResults, ref _pforDecoder, out _);
-                        continue;
-                    case Constants.Graphs.VectorId.PostingList: // large posting list
-                        var setStateSpan = Container.GetReadOnly(_searchState.Llt, rawPostingListId);
-                        ref readonly var setState = ref MemoryMarshal.AsRef<PostingListState>(setStateSpan);
-                        _postingList = new PostingList(_searchState.Llt, Slices.Empty, setState);
-                        _postingListIterator = _postingList.Iterate();
-                        continue;
-                    default:
-                        throw new ArgumentOutOfRangeException("Impossible scenario, we have only 4 options, but got: " + node.PostingListId);
-                }
-            }
-
-            Registration.InternalEntryIdToEntryId(matches.Slice(0, index));
-            return index;
-        }
+        var searchState = new SearchState(llt, name);
+        return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity);
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -89,7 +89,7 @@ public unsafe partial class Hnsw
         return vectorsContainerId;
     }
 
-    public partial class SearchState
+    public partial class SearchState : IDisposable
     {
         private readonly PriorityQueue<int, float> _candidatesQ = new();
         private readonly PriorityQueue<int, float> _nearestEdgesQ = new();
@@ -550,6 +550,16 @@ public unsafe partial class Hnsw
        public bool TryGetNodeById(long nodeId, out int nodeIndex)
        {
            return _nodeIdToIdx.TryGetValue(nodeId, out nodeIndex);
+       }
+
+       public void Dispose()
+       {
+           _candidatesQ.Clear();
+           _nearestEdgesQ.Clear();
+           _newNodes.Dispose(Llt.Allocator);
+           
+           _nodes.Dispose(Llt.Allocator);
+           
        }
     }
 

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -328,15 +328,19 @@ public unsafe partial class Hnsw
         }
 
         //Allows storing cached distance to the queried vector. Should be used only in querying part!
-        public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx)
+        public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx, ref long vectorReadCounter)
         {
             ref var to = ref GetNodeByIndex(toIdx);
             if (to.QueryDistance is not null)
+            {
                 return to.QueryDistance.Value;
+            }
             
             Span<byte> v2 = to.GetVector(this);
+            vectorReadCounter++;
             var distance = SimilarityCalc(vector, v2);
             to.QueryDistance = distance;
+
             return distance;
         }
 

--- a/src/Voron/Data/Graphs/IHNSWSearcher.cs
+++ b/src/Voron/Data/Graphs/IHNSWSearcher.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+public interface IHnswSearcher : IDisposable
+{
+    // Find nodes accepted by the query vector.
+    // Guarantee: always returns previously unseen nodes.
+    // To retrieve the accepted nodes, call TryGetCurrentCandidates.
+    public IEnumerable<bool> Search();
+
+    // Retrieve IDs of nodes from the current search batch.
+    // Guarantee: always returns previously unseen nodes.
+    // If no new nodes are found, returns false.
+    public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates);
+
+    public void IncreaseNumberOfCandidates(int delta);
+
+    // Returns the number of nodes processed by the searcher as candidates. It does not count nodes that were only queued for consideration.
+    public long CandidatesProcessed { get; }
+    
+    // Number of candidates requested by the caller.
+    public int NumberOfCandidates { get; }
+}

--- a/src/Voron/Data/Graphs/IHNSWSearcher.cs
+++ b/src/Voron/Data/Graphs/IHNSWSearcher.cs
@@ -16,10 +16,12 @@ public interface IHnswSearcher : IDisposable
     // If no new nodes are found, returns false.
     public bool TryGetCurrentCandidates(out ContextBoundNativeList<int> candidates);
 
-    public void IncreaseNumberOfCandidates(int delta);
+    public void IncreaseNumberOfCandidates(int currentlyAcceptedNodes);
 
-    // Returns the number of nodes processed by the searcher as candidates. It does not count nodes that were only queued for consideration.
+    // Returns the number of nodes processed by the searcher as candidates. It does not count nodes only queued for consideration.
     public long CandidatesProcessed { get; }
+
+    public bool ShouldContinueSearch(long filterDocsCount);
     
     // Number of candidates requested by the caller.
     public int NumberOfCandidates { get; }

--- a/src/Voron/Util/ContextBoundNativeList.cs
+++ b/src/Voron/Util/ContextBoundNativeList.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Sparrow.Server;
 
 namespace Voron.Util
@@ -17,6 +18,12 @@ namespace Voron.Util
             Inner = new NativeList<T>();
             if (requestedSize > 0)
                 Inner.Initialize(ctx, requestedSize);
+        }
+
+        public IEnumerable<T> Iterate()
+        {
+            for (int i = 0; i < Count; i++)
+                yield return this[i];
         }
 
         public T* RawItems => Inner.RawItems;

--- a/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
+++ b/test/FastTests/Corax/Vectors/MultiVectorSearch.cs
@@ -168,7 +168,7 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
             var read = query.Fill(ids);
             Assert.Equal(3, read);
             Assert.Equal(new long[] { 1L, 2L, 3L }, ids[..3]);
-            query.Score(ids[..3], scores[..3], 0f);
+            query.Score(ids[..3], scores[..3], 1f);
             Assert.Equal(scores[0], 0.96f, 0.01); // doc 1
             Assert.Equal(scores[1], 1f, 0.01); // doc 2
             Assert.Equal(scores[2], 0.92f, 0.01); // doc3
@@ -178,7 +178,7 @@ public class MultiVectorSearch(ITestOutputHelper output) : StorageTest(output)
             read = query.Fill(ids);
             Assert.Equal(3, read);
             Assert.Equal((long)sourceIds[1], ids[0]);
-            query.Score(ids[..3], scores[..3], 0f);
+            query.Score(ids[..3], scores[..3], 1f);
             Assert.True(scores[0] > scores[1]);
             Assert.True(scores[1] > scores[2]);
         }

--- a/test/FastTests/Corax/Vectors/RandomNodesFromFilterEnumeratorTests.cs
+++ b/test/FastTests/Corax/Vectors/RandomNodesFromFilterEnumeratorTests.cs
@@ -1,0 +1,322 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using FastTests.Voron;
+using Sparrow.Server.Collections;
+using Tests.Infrastructure;
+using Voron.Data.Graphs;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Vectors;
+
+public class RandomNodesFromFilterEnumeratorTests(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void CanEnumerateRandomNodesFromFilterEmpty(int seed)
+    {
+        var random = new Random(seed);
+        using var indexMapping = InsertData();
+        // Test empty
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId + 1);
+
+            using var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random);
+
+            Assert.False(it.MoveNext());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void CanEnumerateRandomNodesFromFilter(int seed)
+    {
+        var random = new Random(seed);
+        using var indexMapping = InsertData();
+
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId);
+
+            var allEntries = Enumerable.Range(1, (int)indexSearcher.LastEntryId).Select(x => (long)x).ToArray();
+            random.Shuffle(allEntries.AsSpan());
+            filterResult.Count = random.Next(1, (int)indexSearcher.LastEntryId);
+
+            var toInsert = allEntries.AsSpan().Slice(0, (int)filterResult.Count);
+
+            foreach (var id in toInsert)
+                filterResult.Add(id);
+
+            List<long> results = new();
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                for (int i = 0; i < filterResult.Count; ++i)
+                {
+                    Assert.True(it.MoveNext(), i.ToString());
+                    results.Add(it.Current);
+                }
+
+                Assert.False(it.MoveNext());
+
+                for (int i = 1; i < filterResult.Capacity; ++i)
+                    Assert.False(filterResult.Contains(i));
+            }
+
+            Assert.Equal(filterResult.Count, results.Distinct().Count());
+            results.Sort();
+            toInsert.Sort();
+            Assert.Equal(toInsert, CollectionsMarshal.AsSpan(results));
+
+            foreach (var id in toInsert)
+                Assert.True(filterResult.Contains(id));
+        }
+    }
+
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    [InlineData(479664366)]
+    [InlineData(1978241581)]
+    public void CanEnumerateRandomNodesFromFilterOnlyOne(int seed)
+    {
+        var random = new Random(seed);
+        using var indexMapping = InsertData();
+
+        //First
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId + 1);
+            filterResult.Add(1);
+            filterResult.Count = 1;
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                Assert.True(it.MoveNext());
+                Assert.Equal(1, it.Current);
+                Assert.False(filterResult.Contains(it.Current));
+                Assert.False(it.MoveNext());
+                Assert.Equal(-1, it.Current);
+            }
+
+            Assert.True(filterResult.Contains(1L));
+        }
+
+
+        //Last
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId + 1);
+            filterResult.Add(indexSearcher.LastEntryId);
+            filterResult.Count = 1;
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                Assert.True(it.MoveNext());
+                Assert.Equal(indexSearcher.LastEntryId, it.Current);
+                Assert.False(filterResult.Contains(it.Current));
+                Assert.False(it.MoveNext());
+                Assert.Equal(-1, it.Current);
+            }
+
+            Assert.True(filterResult.Contains(indexSearcher.LastEntryId));
+        }
+
+        // Random
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId + 1);
+
+            var expected = random.Next(2, (int)indexSearcher.LastEntryId);
+            filterResult.Add(expected);
+            filterResult.Count = 1;
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                Assert.True(it.MoveNext());
+                Assert.Equal(expected, it.Current);
+                Assert.False(filterResult.Contains(it.Current));
+                Assert.False(it.MoveNext());
+                Assert.Equal(-1, it.Current);
+            }
+
+            Assert.True(filterResult.Contains(expected));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void CanEnumerateRandomNodesFromFilterWhenDocumentHasMultiple(int seed)
+    {
+        using var indexMapping = InsertData(true);
+        var random = new Random(seed);
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId);
+            filterResult.Add(1);
+            filterResult.Count = 1;
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                Assert.True(it.MoveNext());
+                Assert.Equal(1, it.Current);
+                Assert.True(it.MoveNext());
+                Assert.Equal(2, it.Current);
+                Assert.False(filterResult.Contains(1));
+                Assert.False(it.MoveNext());
+                Assert.Equal(-1, it.Current);
+            }
+
+            Assert.True(filterResult.Contains(1L));
+        }
+
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId);
+            filterResult.Add(indexSearcher.LastEntryId);
+            filterResult.Count = 1;
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                Assert.True(it.MoveNext());
+                Assert.Equal(2 * indexSearcher.LastEntryId - 1, it.Current);
+                Assert.True(it.MoveNext());
+                Assert.Equal(2 * indexSearcher.LastEntryId, it.Current);
+                Assert.False(filterResult.Contains(indexSearcher.LastEntryId));
+                Assert.False(it.MoveNext());
+                Assert.Equal(-1, it.Current);
+            }
+
+            Assert.True(filterResult.Contains(indexSearcher.LastEntryId));
+        }
+
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId);
+            var randomDoc = random.Next(1, (int)indexSearcher.LastEntryId + 1);
+            filterResult.Add(randomDoc);
+            filterResult.Count = 1;
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                Assert.True(it.MoveNext());
+                Assert.Equal(2 * randomDoc - 1, it.Current);
+                Assert.True(it.MoveNext());
+                Assert.Equal(2 * randomDoc, it.Current);
+                Assert.False(filterResult.Contains(randomDoc));
+                Assert.False(it.MoveNext());
+                Assert.Equal(-1, it.Current);
+            }
+
+            Assert.True(filterResult.Contains(randomDoc));
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void CanEnumerateRandomNodesFromFilterMultipleNodesPerDocument(int seed)
+    {
+        var random = new Random(seed);
+        using var indexMapping = InsertData(true);
+
+        using (var indexSearcher = new IndexSearcher(Env, indexMapping))
+        {
+            var filterResult = new GrowableBitArray(indexSearcher.Allocator, indexSearcher.LastEntryId);
+
+            var allEntries = Enumerable.Range(1, (int)indexSearcher.LastEntryId).Select(x => (long)x).ToArray();
+            random.Shuffle(allEntries.AsSpan());
+            filterResult.Count = random.Next(1, (int)indexSearcher.LastEntryId);
+
+            var toInsert = allEntries.AsSpan().Slice(0, (int)filterResult.Count);
+            var expectedResults = toInsert.ToArray().Select(x => x * 2).Concat(toInsert.ToArray().Select(x => x * 2 - 1)).ToArray();
+
+
+            foreach (var id in toInsert)
+                filterResult.Add(id);
+
+            List<long> results = new();
+
+            using (var it = new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(indexSearcher, indexMapping.GetByFieldId(1).Metadata, filterResult, random))
+            {
+                for (int i = 0; i < filterResult.Count; ++i)
+                {
+                    Assert.True(it.MoveNext());
+                    results.Add(it.Current);
+
+
+                    Assert.True(it.MoveNext());
+                    results.Add(it.Current);
+                }
+
+                Assert.False(it.MoveNext());
+
+                for (int i = 1; i < filterResult.Capacity; ++i)
+                    Assert.False(filterResult.Contains(i));
+            }
+
+            Assert.Equal(expectedResults.Length, results.Distinct().Count());
+            results.Sort();
+            expectedResults.AsSpan().Sort();
+            Assert.Equal(expectedResults, CollectionsMarshal.AsSpan(results));
+
+            foreach (var id in toInsert)
+                Assert.True(filterResult.Contains(id));
+        }
+    }
+
+    private IndexFieldsMapping InsertData(bool indexAsList = false)
+    {
+        var indexMapping = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, "id()")
+            .AddBinding(1, "Vector",
+                vectorOptions: new VectorOptions()
+                {
+                    NumberOfCandidates = 16,
+                    NumberOfEdges = 16,
+                    VectorEmbeddingType = VectorEmbeddingType.Single
+                })
+            .Build();
+
+        using (var indexWriter = new IndexWriter(Env, indexMapping, SupportedFeatures.All))
+        {
+            for (int i = 1; i <= 10; ++i)
+            {
+                using var builder = indexWriter.Index($"Dto/{i}");
+                builder.Write(0, Encoding.UTF8.GetBytes($"Dto/{i}"));
+                if (indexAsList == false)
+                {
+                    float[] vector = { (float)i * 0.1f, (float)i * 0.2f };
+                    var vectorAsBytes = MemoryMarshal.Cast<float, byte>(vector);
+                    builder.WriteVector(1, null, vectorAsBytes);
+                }
+                else
+                {
+                    builder.IncrementList();
+                    float[] vector = { (float)2 * i * 0.1f, (float)2 * i * 0.2f };
+                    var vectorAsBytes = MemoryMarshal.Cast<float, byte>(vector);
+                    builder.WriteVector(1, null, vectorAsBytes);
+
+                    vector = [(float)(2 * i + 1) * 0.1f, (float)(2 * i + 1) * 0.2f];
+                    vectorAsBytes = MemoryMarshal.Cast<float, byte>(vector);
+                    builder.WriteVector(1, null, vectorAsBytes);
+
+                    builder.DecrementList();
+                }
+
+                builder.EndWriting();
+            }
+
+            indexWriter.Commit();
+        }
+
+        return indexMapping;
+    }
+}

--- a/test/FastTests/Corax/Vectors/VectorSearchMatchTests.cs
+++ b/test/FastTests/Corax/Vectors/VectorSearchMatchTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Querying.Matches;
 using FastTests.Voron.FixedSize;
+using Sparrow.Server.Utils;
 using Sparrow.Server.Utils.VxSort;
 using Tests.Infrastructure;
 using Xunit;
@@ -17,7 +18,7 @@ public class VectorSearchMatchTests(ITestOutputHelper output) : NoDisposalNeeded
     [RavenFact(RavenTestCategory.Vector)]
     public void CanHandleEmpty()
     {
-        var result = VectorSearchMatch.RemoveDuplicates([], []);
+        var result = Sorting.SortAndMinOnDuplicates([], []);
         Assert.Equal(0, result);
     }
     
@@ -27,7 +28,7 @@ public class VectorSearchMatchTests(ITestOutputHelper output) : NoDisposalNeeded
         long[] matches = [1L];
         float[] distances = [.5f];
 
-        var result = VectorSearchMatch.RemoveDuplicates(matches, distances);
+        var result = Sorting.SortAndMinOnDuplicates(matches, distances);
         Assert.Equal(1, result);
     }
 
@@ -37,7 +38,7 @@ public class VectorSearchMatchTests(ITestOutputHelper output) : NoDisposalNeeded
         long[] matches = [1L, 1L, 1L, 1L, 1L];
         float[] distances = [0.7f, 0.1f, 0.2f, 0.3f, 0.8f];
 
-        var result = VectorSearchMatch.RemoveDuplicates(matches, distances);
+        var result = Sorting.SortAndMinOnDuplicates(matches, distances);
         Assert.Equal(1, result);
         Assert.Equal(1L, matches[0]);
         Assert.Equal(0.1f, distances[0], 0.001);
@@ -63,8 +64,7 @@ public class VectorSearchMatchTests(ITestOutputHelper output) : NoDisposalNeeded
         var originalDistances = distances.ToArray();
         var originalMatches = matches.ToArray();
         
-        matches.AsSpan().Sort(distances.AsSpan());
-        var result = VectorSearchMatch.RemoveDuplicates(matches, distances);
+        var result = Sorting.SortAndMinOnDuplicates(matches, distances);
         Assert.Equal(amount, result);
 
         originalMatches.AsSpan().Sort(originalDistances.AsSpan());
@@ -100,7 +100,7 @@ public class VectorSearchMatchTests(ITestOutputHelper output) : NoDisposalNeeded
 
         var originalMatches = matches.ToArray();
         var originalDistances = distances.ToArray();
-        var result = VectorSearchMatch.RemoveDuplicates(matches, distances);
+        var result = Sorting.SortAndMinOnDuplicates(matches, distances);
 
         Dictionary<long, float > idToSmallestDistance = new();
         for (int i = 0; i < amount; ++i)

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using FastTests.Voron.FixedSize;
 using Raven.Server.Documents.Indexes.VectorSearch;
 using Tests.Infrastructure;
+using Voron;
 using Voron.Data.Graphs;
 using Voron.Global;
 using Xunit;
@@ -20,10 +21,13 @@ namespace FastTests.Voron.Graphs;
 
 public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 {
+    private const string TreeName = "test";
+    
     [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.Vector)]
     [InlineDataWithRandomSeed]
     public void CanTransformIdsFromNormalToInternalAndReverse(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         var random = new Random(seed);
         var N512 = Vector512<long>.Count;
         var N256 = Vector256<long>.Count;
@@ -42,25 +46,27 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [RavenFact(RavenTestCategory.Voron)]
     public void CanCreateEmptyGraph()
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 16, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, 3, 12, VectorEmbeddingType.Single);
 
             txw.Commit();
         }
 
         using (var txr = Env.ReadTransaction())
         {
-            var state = new Hnsw.SearchState(txr.LowLevelTransaction, "test");
+            var state = new Hnsw.SearchState(txr.LowLevelTransaction, treeName);
             var options = state.Options;
             Assert.Equal(12, options.NumberOfCandidates);
             Assert.Equal(3, options.NumberOfEdges);
             Assert.Equal(0, options.CountOfVectors);
             float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
 
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v1), 0f);
+                MemoryMarshal.Cast<float, byte>(v1).ToArray(), 0f);
             Span<float> scores = new float[32];
             Span<long> docs = new long[32];
             var r = nearest.Fill(docs, scores);
@@ -75,6 +81,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [InlineData(1199463143)]
     public void BasicSearchBigVec(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         Random hnswRandom = new Random(seed);
 
         float[] v1 = Enumerable.Range(0, 1536).Select(_ => hnswRandom.NextSingle() * (hnswRandom.NextInt64() % 2 == 0 ? 1f : -1f)).ToArray();
@@ -92,16 +99,16 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 1536 * sizeof(float), 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 1536 * sizeof(float), 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(1, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Register(2, MemoryMarshal.Cast<float, byte>(v2));
                 registration.Commit(CancellationToken.None);
             }
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(3, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Commit(CancellationToken.None);
@@ -112,7 +119,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txr = Env.ReadTransaction())
         {
-            var state = new Hnsw.SearchState(txr.LowLevelTransaction, "test");
+            var state = new Hnsw.SearchState(txr.LowLevelTransaction, treeName);
             var options = state.Options;
             Assert.Equal(12, options.NumberOfCandidates);
             Assert.Equal(3, options.NumberOfEdges);
@@ -123,7 +130,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[8];
             Span<float> distances = new float[8];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test", numberOfCandidates: 32, MemoryMarshal.Cast<float, byte>(v3), 0f);
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName, numberOfCandidates: 32, MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             int read = nearest.Fill(matches, distances);
             Assert.Equal(3, read);
             Assert.False(distances.Slice(0, read).ToArray().Any(float.IsNaN));
@@ -139,6 +146,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [InlineDataWithRandomSeed]
     public void BasicSearch(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         Random hnswRandom = new Random(seed);
         float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
         float[] v2 = [0.15f, 0.25f, 0.35f, 0.45f];
@@ -148,16 +156,16 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 16, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(4, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Register(8, MemoryMarshal.Cast<float, byte>(v2));
                 registration.Commit(CancellationToken.None);
             }
             
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(12, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Commit(CancellationToken.None);
@@ -168,7 +176,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txr = Env.ReadTransaction())
         {
-            var state = new Hnsw.SearchState(txr.LowLevelTransaction, "test");
+            var state = new Hnsw.SearchState(txr.LowLevelTransaction, treeName);
             var options = state.Options;
             Assert.Equal(12, options.NumberOfCandidates);
             Assert.Equal(3, options.NumberOfEdges);
@@ -179,9 +187,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[8];
             Span<float> distances = new float[8];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             int read = nearest.Fill(matches, distances);
             Assert.Equal(3, read);
             Assert.Equal(8, matches[0]);
@@ -196,6 +204,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [InlineDataWithRandomSeed]
     public void CanAddAndRemove(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         Random hnswRandom = new Random(seed);
         float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
         float[] v2 = [0.15f, 0.25f, 0.35f, 0.45f];
@@ -207,16 +216,16 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 16, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 vectorHashToRemove = registration.Register(entryIdToRemove, MemoryMarshal.Cast<float, byte>(v1)).ToSpan().ToArray();
                 registration.Register(8, MemoryMarshal.Cast<float, byte>(v2));
                 registration.Commit(CancellationToken.None);
             }
             
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(12, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Commit(CancellationToken.None);
@@ -227,9 +236,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 16, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Remove(entryIdToRemove, vectorHashToRemove);
                 registration.Commit(CancellationToken.None);
@@ -242,9 +251,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[8];
             Span<float> distances = new float[8];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             int read = nearest.Fill(matches, distances);
             Assert.Equal(2, read);
             Assert.Equal(8, matches[0]);
@@ -258,6 +267,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [InlineDataWithRandomSeed]
     public void CanCalculateGoodDistances(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         var random = new Random(seed);
         var vecOpt = new VectorOptions()
         {
@@ -270,8 +280,8 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var wTx = Env.WriteTransaction())
         {
-            Hnsw.Create(wTx.LowLevelTransaction, nameof(CanCalculateGoodDistances), v1.Length, 3, 12, VectorEmbeddingType.Single);
-            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, nameof(CanCalculateGoodDistances), random))
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, v1.Length, 3, 12, VectorEmbeddingType.Single);
+            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, random))
             {
                 registration.Register(1, v1.GetEmbedding());
                 registration.Register(2, v2.GetEmbedding());
@@ -283,7 +293,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var rTx = Env.ReadTransaction())
         {
-            using var search = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, nameof(CanCalculateGoodDistances), 12, vQ.GetEmbedding(), 0f);
+            using var search = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, treeName, 12, vQ.GetEmbeddingMemory(), 0f);
             var distances = new float[16];
             var matches = new long[16];
             var read = search.Fill(matches, distances);
@@ -305,6 +315,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [InlineData(387668521)]
     public void CanHandleLargePostingLists(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         Random hnswRandom = new Random(seed);
         float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
         float[] v2 = [0.15f, 0.25f, 0.35f, 0.45f];
@@ -315,9 +326,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         List<(long entryId, byte[] vectorHash)> elementInGraph = new();
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 16, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 for (int i = 1; i <= 20_000; i++)
                 {
@@ -337,9 +348,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[500];
             Span<float> distances = new float[500];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             var read = 0;
             readFromGraph.Clear();
             do
@@ -355,7 +366,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         var toRemove = elementInGraph.ToArray()[100..];
         using (var txw = Env.WriteTransaction())
         {
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 foreach (var el in toRemove)
                     registration.Remove(el.entryId, el.vectorHash);
@@ -369,9 +380,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[500];
             Span<float> distances = new float[500];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             readFromGraph.Clear();
             var read = 0;
             do
@@ -386,7 +397,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         toRemove = elementInGraph.ToArray()[1..];
         using (var txw = Env.WriteTransaction())
         {
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 foreach (var id in toRemove)
                     registration.Remove(id.entryId, id.vectorHash);
@@ -401,9 +412,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[100];
             Span<float> distances = new float[100];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             readFromGraph.Clear();
             var read = 0;
             do
@@ -417,7 +428,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         
         using (var txw = Env.WriteTransaction())
         {
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Remove(elementInGraph[0].entryId, elementInGraph[0].vectorHash);
                 registration.Commit(CancellationToken.None);
@@ -430,9 +441,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[4];
             Span<float> distances = new float[4];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             var read = nearest.Fill(matches, distances);
             Assert.Equal(0, read);
         }
@@ -454,6 +465,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
     [InlineDataWithRandomSeed]
     public void WithLargeVectors(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
         Random hnswRandom = new Random(seed);
         float[] v1 = new float[768];
         float[] v2 = new float[768];
@@ -467,16 +479,16 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", v1.Length * 4, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, v1.Length * 4, 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(4, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Register(8, MemoryMarshal.Cast<float, byte>(v2));
                 registration.Commit(CancellationToken.None);
             }
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", hnswRandom))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, hnswRandom))
             {
                 registration.Register(12, MemoryMarshal.Cast<float, byte>(v1));
                 registration.Commit(CancellationToken.None);
@@ -487,7 +499,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
 
         using (var txr = Env.ReadTransaction())
         {
-            var state = new Hnsw.SearchState(txr.LowLevelTransaction, "test");
+            var state = new Hnsw.SearchState(txr.LowLevelTransaction, treeName);
             var options = state.Options;
             Assert.Equal(12, options.NumberOfCandidates);
             Assert.Equal(3, options.NumberOfEdges);
@@ -498,9 +510,9 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         {
             Span<long> matches = new long[8];
             Span<float> distances = new float[8];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
-                MemoryMarshal.Cast<float, byte>(v3), 0f);
+                MemoryMarshal.Cast<float, byte>(v3).ToArray(), 0f);
             int read = nearest.Fill(matches, distances);
             Assert.Equal(3, read);
         }

--- a/test/FastTests/Voron/Graphs/GraphsVectorRemovals.cs
+++ b/test/FastTests/Voron/Graphs/GraphsVectorRemovals.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using FastTests.Voron.FixedSize;
 using Sparrow.Server;
 using Tests.Infrastructure;
+using Voron;
 using Voron.Data.Graphs;
 using Xunit;
 using Xunit.Abstractions;
@@ -13,7 +14,7 @@ namespace FastTests.Voron.Graphs;
 
 public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output)
 {
-    private const string TreeName = "test";
+    private const string TreeNameConst = "test";
     private const int VectorSizeInBytes = 4 * sizeof(float);
     
     [RavenTheory(RavenTestCategory.Voron)]
@@ -22,15 +23,16 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
     [InlineDataWithRandomSeed]
     public void CanRemoveSingle(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeNameConst, out var treeName);
         Random random = new Random(seed);
         float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
-        var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1);
+        var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1).ToArray();
         var entryId = 1 << 2;
         byte[] vectorHash = default;
         using (var wTx = Env.WriteTransaction())
         {
-            Hnsw.Create(wTx.LowLevelTransaction, TreeName, VectorSizeInBytes, 3, 12, VectorEmbeddingType.Single);
-            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, TreeName, random))
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, VectorSizeInBytes, 3, 12, VectorEmbeddingType.Single);
+            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, random))
             {
                 vectorHash = registration.Register(entryId, v1AsBytes).ToSpan().ToArray();
                 registration.Commit(CancellationToken.None);
@@ -41,7 +43,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
 
         using (var rTx = Env.ReadTransaction())
         {
-            using var s = Hnsw.ExactNearest(rTx.LowLevelTransaction, TreeName, 1, v1AsBytes, 0f);
+            using var s = Hnsw.ExactNearest(rTx.LowLevelTransaction, treeName, 1, v1AsBytes, 0f, false);
             Span<long> docs = new long[4];
             Span<float> distances = new float[4];
             var r = s.Fill(docs, distances);
@@ -50,8 +52,8 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
 
         using (var wTx = Env.WriteTransaction())
         {
-            Hnsw.Create(wTx.LowLevelTransaction, TreeName, VectorSizeInBytes, 3, 12, VectorEmbeddingType.Single);
-            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, TreeName, random))
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, VectorSizeInBytes, 3, 12, VectorEmbeddingType.Single);
+            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, random))
             {
                 registration.Remove(entryId, vectorHash);
                 registration.Commit(CancellationToken.None);
@@ -62,7 +64,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
         
         using (var rTx = Env.ReadTransaction())
         {
-            using var s = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, TreeName, 12, v1AsBytes, 0f);
+            using var s = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, treeName, 12, v1AsBytes, 0f);
             Span<long> docs = new long[4];
             Span<float> distances = new float[4];
             var r = s.Fill(docs, distances);
@@ -76,11 +78,12 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
     [InlineDataWithRandomSeed]
     public void CanRemoveDoubleSingle(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeNameConst, out var treeName);
         var random = new Random(seed);
         float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
         float[] v2 = [0.2f, 0.3f, 0.4f, 0.1f];
-        var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1);
-        var v2AsBytes = MemoryMarshal.Cast<float, byte>(v2);
+        var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1).ToArray();
+        var v2AsBytes = MemoryMarshal.Cast<float, byte>(v2).ToArray();
         var entryId1 = 1 << 2;
         byte[] v1Id = default;
         var entryId2 = 2 << 2;
@@ -99,7 +102,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
     
         using (var rTx = Env.ReadTransaction())
         {
-            using var s = Hnsw.ExactNearest(rTx.LowLevelTransaction, TreeName, 2, v1AsBytes, 0f);
+            using var s = Hnsw.ExactNearest(rTx.LowLevelTransaction, treeName, 2, v1AsBytes, 0f, false);
             Span<long> docs = new long[4];
             Span<float> distances = new float[4];
             var r = s.Fill(docs, distances);
@@ -118,7 +121,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
         
         using (var rTx = Env.ReadTransaction())
         {
-            using var s = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, TreeName, 12, v1AsBytes, 0f);
+            using var s = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, treeName, 12, v1AsBytes, 0f);
             Span<long> docs = new long[4];
             Span<float> distances = new float[4];
             var r = s.Fill(docs, distances);
@@ -133,6 +136,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
     [InlineDataWithRandomSeed]
     public void CanExpandNodeFromSingleToSmallPostingList(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeNameConst, out var treeName);
         Random random = new(seed);
         var v1Id = AddElement(1, register: true);
         var v2Id = AddElement(2, register: true);
@@ -188,11 +192,11 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
         (int Read, long[] Docs, float[] Distances) Read()
         {
             float[] v1 = [0.1f, 0.2f, 0.3f, 0.4f];
-            var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1);
+            var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1).ToArray();
             
             using (var rTx = Env.ReadTransaction())
             {
-                using var s = Hnsw.ExactNearest(rTx.LowLevelTransaction, TreeName, 12, v1AsBytes, 0f);
+                using var s = Hnsw.ExactNearest(rTx.LowLevelTransaction, treeName, 12, v1AsBytes, 0f, false);
                 var docs = new long[4];
                 var distances = new float[4];
                 var r = s.Fill(docs, distances);
@@ -207,16 +211,17 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
     [InlineDataWithRandomSeed]
     public void CanRemoveBasedOnEntryIdAndVectorHashAddress(int seed)
     {
+        using var _ = Slice.From(Allocator, TreeNameConst, out var treeName);
         float[] v1 = [.4f, .4f, .4f, .4f];
-        var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1);
+        var v1AsBytes = MemoryMarshal.Cast<float, byte>(v1).ToArray();
         var entryId = 4;
         byte[] vectorTermContainer = default;
         Random random = new(seed);
         using (var txw = Env.WriteTransaction())
         {
-            Hnsw.Create(txw.LowLevelTransaction, "test", 16, 3, 12, VectorEmbeddingType.Single);
+            Hnsw.Create(txw.LowLevelTransaction, treeName, 16, 3, 12, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", random))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, random))
             {
                 vectorTermContainer = registration.Register(4, MemoryMarshal.Cast<float, byte>(v1)).ToSpan().ToArray();
                 registration.Commit(CancellationToken.None);
@@ -229,7 +234,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
         {
             Span<long> matches = new long[8];
             Span<float> distances = new float[8];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
                 v1AsBytes, 0f);
             int read = nearest.Fill(matches, distances);
@@ -238,7 +243,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
 
         using (var txw = Env.WriteTransaction())
         {
-            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "test", random))
+            using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, treeName, random))
             {
                 registration.Remove(entryId, vectorTermContainer);
                 registration.Commit(CancellationToken.None);
@@ -251,7 +256,7 @@ public class GraphsVectorRemovals(ITestOutputHelper output) : StorageTest(output
         {
             Span<long> matches = new long[8];
             Span<float> distances = new float[8];
-            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, "test",
+            using var nearest = Hnsw.ApproximateNearest(txr.LowLevelTransaction, treeName,
                 numberOfCandidates: 32,
                 v1AsBytes, 0f);
             int read = nearest.Fill(matches, distances);

--- a/test/SlowTests/Corax/GrowableBitArrayTests.cs
+++ b/test/SlowTests/Corax/GrowableBitArrayTests.cs
@@ -6,6 +6,7 @@ using Corax.Utils;
 using FastTests;
 using FastTests.Voron.FixedSize;
 using Sparrow.Server;
+using Sparrow.Server.Collections;
 using Sparrow.Threading;
 using Tests.Infrastructure;
 using Xunit;

--- a/test/SlowTests/Corax/RavenDB-23453.cs
+++ b/test/SlowTests/Corax/RavenDB-23453.cs
@@ -323,6 +323,23 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
         }
     }
 
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public void ExposedNearestSearchNumberOfCandidatesIsRespected()
+    {
+        using var mapping = GetMapping();
+        var docs = GetDocs(360).ToList();
+
+        IndexDocuments(Env, mapping, docs);
+
+        using (var rTx = Env.ReadTransaction())
+        {
+            using var vec1 = GenerateEmbeddings.FromArray(rTx.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+            using var search = Hnsw.ApproximateNearest(rTx.LowLevelTransaction, mapping.GetByFieldId(3).FieldName, 16, vec1.GetEmbeddingMemory(), 0, true);
+            
+            Assert.Equal(16, search.NumberOfCandidates); 
+        }
+    }
+
 
     private List<string> EvaluateQuery<TQueryMatch>(IndexSearcher indexSearcher, ref TQueryMatch queryMatch)
         where TQueryMatch : IQueryMatch

--- a/test/SlowTests/Corax/RavenDB-23453.cs
+++ b/test/SlowTests/Corax/RavenDB-23453.cs
@@ -10,6 +10,7 @@ using Corax.Querying.Matches.Meta;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using FastTests.Voron;
+using Org.BouncyCastle.Security;
 using Raven.Server.Documents.Indexes.VectorSearch;
 using Sparrow;
 using Tests.Infrastructure;
@@ -55,7 +56,9 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
-    [InlineData(1980969695)]
+    [InlineData(1980969695)]       
+    [InlineData(720473198)]       
+
     public void CanFilterVectorsNearestSearch(int seed)
     {
         // NearestSearch must have a more relaxed assertion since the graph structure depends on the seed. We may get all but we can get partial results, However we should (since it's not a big graph), get at least one result.  
@@ -93,7 +96,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
             {
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), 15L, 18L);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, random: random);
                 IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
                 query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
@@ -101,14 +104,14 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
             {
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
                 var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
 
             {
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false, random: random);
                 var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultsWithoutFilterQuery = EvaluateQuery(indexSearcher, ref query);
             }
@@ -181,7 +184,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 400, isExact, false);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 400, isExact, false, random: random);
                 IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
                 query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
@@ -190,7 +193,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
                 var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
@@ -198,7 +201,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
             {
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, random: random);
                 var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultsWithoutFilterQuery = EvaluateQuery(indexSearcher, ref query);
             }
@@ -208,16 +211,16 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
     }
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
-    [InlineData(false, false, Skip = "Too small set")]
-    public void FilterQueryAndWithMethodVectorSearch(bool shouldScan, bool isExact)
+    [InlineDataWithRandomSeed(true, false)]
+    [InlineDataWithRandomSeed(false, true)]
+    [InlineDataWithRandomSeed(true, true)]
+    [InlineDataWithRandomSeed(false, false, Skip = "Too small set")]
+    public void FilterQueryAndWithMethodVectorSearch(bool shouldScan, bool isExact, int seed)
     {
         using var mapping = GetMapping();
         var docs = GetDocs(360).ToList();
-
-        IndexDocuments(Env, mapping, docs);
+        var random = new Random(seed);
+        IndexDocuments(Env, mapping, docs, random);
 
         using (var indexSearcher = new IndexSearcher(Env, mapping))
         {
@@ -228,7 +231,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
             {
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
                 var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
@@ -236,7 +239,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
             {
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random);
                 var allEntries = indexSearcher.AllEntries();
                 List<long> matched = new();
                 Span<long> ids = new long[16];
@@ -266,16 +269,17 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
     }
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(true, true)]
-    [InlineData(false, false, Skip = "Too small set")]
-    public void FilterQueryAndWithMethodMultiVectorSearch(bool shouldScan, bool isExact)
+    [InlineDataWithRandomSeed(true, false)]
+    [InlineDataWithRandomSeed(false, true)]
+    [InlineDataWithRandomSeed(true, true)]
+    [InlineDataWithRandomSeed(false, false, Skip = "Too small set")]
+    public void FilterQueryAndWithMethodMultiVectorSearch(bool shouldScan, bool isExact, int seed)
     {
         using var mapping = GetMapping();
         var docs = GetDocs(360).ToList();
 
-        IndexDocuments(Env, mapping, docs);
+        Random random = new (seed);
+        IndexDocuments(Env, mapping, docs, random);
 
         using (var indexSearcher = new IndexSearcher(Env, mapping))
         {
@@ -286,7 +290,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
                 var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
@@ -295,7 +299,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
                 var allEntries = indexSearcher.AllEntries();
                 List<long> matched = new();
                 Span<long> ids = new long[16];
@@ -323,13 +327,16 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
         }
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public void ExposedNearestSearchNumberOfCandidatesIsRespected()
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    public void ExposedNearestSearchNumberOfCandidatesIsRespected(int seed)
     {
         using var mapping = GetMapping();
+        
         var docs = GetDocs(360).ToList();
 
-        IndexDocuments(Env, mapping, docs);
+        Random random = new(seed);
+        IndexDocuments(Env, mapping, docs, random);
 
         using (var rTx = Env.ReadTransaction())
         {
@@ -430,23 +437,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
 
         indexWriter.Commit();
     }
-
-    private static void IndexDocuments(StorageEnvironment env, IndexFieldsMapping mapping, IEnumerable<Doc> docs)
-    {
-        using var indexWriter = new IndexWriter(env, mapping, SupportedFeatures.All);
-        foreach (var doc in docs)
-        {
-            using var builder = indexWriter.Index(doc.Id);
-            builder.Write(0, Encodings.Utf8.GetBytes(doc.Id));
-            builder.Write(1, Encodings.Utf8.GetBytes(doc.Text));
-            builder.Write(2, Encodings.Utf8.GetBytes(doc.Numerical.ToString()), doc.Numerical, doc.Numerical);
-            builder.WriteVector(3, null, MemoryMarshal.Cast<float, byte>(doc.Vector));
-            builder.EndWriting();
-        }
-
-        indexWriter.Commit();
-    }
-
+    
     private record VectorSearchResult(string Id, float Distance, float[] Vector);
 
     private record Doc(string Id, string Text, int Numerical, float[] Vector);

--- a/test/SlowTests/Corax/RavenDB-23453.cs
+++ b/test/SlowTests/Corax/RavenDB-23453.cs
@@ -1,0 +1,436 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using Corax.Querying.Matches.Meta;
+using Corax.Querying.Matches.SortingMatches.Meta;
+using Corax.Utils;
+using FastTests.Voron;
+using Raven.Server.Documents.Indexes.VectorSearch;
+using Sparrow;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+using Xunit.Abstractions;
+using VectorOptions = Raven.Client.Documents.Indexes.Vector.VectorOptions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
+{
+    private const float MinSimilarity = 0.75f;
+    private const int TopKMulti = 32;
+    private const long FilterMin = 15L;
+    private const long FilterMax = 18L;
+
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(true, false)]
+    [InlineDataWithRandomSeed(false, true)]
+    [InlineDataWithRandomSeed(true, true)]
+    public void CanFilterVectors(bool shouldScan, bool isExact, int seed)
+    {
+        var (resultQueryContainsAllDb, resultsFromFilteredQuery, resultsWithoutFilterQuery, manualQuery, docs) = CanFilterVectorsBase(shouldScan, isExact, seed);
+        Assert.Equal(16, manualQuery.Count);
+        Assert.Equal(16, resultQueryContainsAllDb.Count);
+        Assert.Equal(16, resultsFromFilteredQuery.Count);
+
+        foreach (var doc in resultsFromFilteredQuery)
+        {
+            var docInstance = docs.Single(x => x.Id == doc);
+            Assert.True(docInstance.Numerical is >= 15 and <= 18);
+        }
+
+        Assert.Equal(16, resultsWithoutFilterQuery.Count);
+        Assert.NotEqual(0, resultsWithoutFilterQuery.Count(x => resultsFromFilteredQuery.Contains(x) == false));
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineData(1980969695)]
+    public void CanFilterVectorsNearestSearch(int seed)
+    {
+        // NearestSearch must have a more relaxed assertion since the graph structure depends on the seed. We may get all but we can get partial results, However we should (since it's not a big graph), get at least one result.  
+        var (_, resultsFromFilteredQuery, _, _, docs) = CanFilterVectorsBase(false, false, seed);
+
+        Assert.NotEmpty(resultsFromFilteredQuery);
+        foreach (var doc in resultsFromFilteredQuery)
+        {
+            var docInstance = docs.Single(x => x.Id == doc);
+            Assert.True(docInstance.Numerical is >= 15 and <= 18);
+        }
+    }
+
+    /// <summary>
+    /// ResultQueryContainsAllDb – VectorSearch scans all vectors in the index; AND operates on all vectors returned by HNSW.
+    /// ResultsFromFilteredQuery – VectorSearch uses a vector filter, limiting the number of vectors scanned (depending on query configuration).
+    /// ResultsWithoutFilterQuery – VectorSearch has no vector filter or additional filter and returns the best NoC vectors.
+    /// ManualQuery – In-memory vector search via LINQ in the test.
+    /// Docs – All indexed documents.
+    /// </summary>
+    private (List<string> ResultQueryContainsAllDb, List<string> ResultsFromFilteredQuery, List<string> ResultsWithoutFilterQuery, List<VectorSearchResult> ManualQuery, List<Doc> Docs) CanFilterVectorsBase(bool shouldScan, bool isExact, int seed)
+    {
+        using var mapping = GetMapping();
+        var docs = GetDocs(360).ToList();
+        Random random = new(seed);
+        IndexDocuments(Env, mapping, docs, random);
+
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            List<string> resultQueryContainsAllDb;
+            List<string> resultsFromFilteredQuery;
+            List<string> resultsWithoutFilterQuery;
+            var manualQuery = VectorSearchInPlace(docs, p => p.Numerical >= 15 && p.Numerical <= 18, [docs[0].Vector], MinSimilarity, TopKMulti).ToList();
+
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), 15L, 18L);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false);
+                IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
+                query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
+            }
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
+            }
+
+            {
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultsWithoutFilterQuery = EvaluateQuery(indexSearcher, ref query);
+            }
+
+            return (resultQueryContainsAllDb, resultsFromFilteredQuery, resultsWithoutFilterQuery, manualQuery, docs);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed(true, false)]
+    [InlineDataWithRandomSeed(false, true)]
+    [InlineDataWithRandomSeed(true, true)]
+    public void CanFilterMultiVectors(bool shouldScan, bool isExact, int seed)
+    {
+        var (resultQueryContainsAllDb, resultsFromFilteredQuery, resultsWithoutFilterQuery, manualQuery, docs) = CanFilterMultiVectorsBase(shouldScan, isExact, seed);
+        Assert.Equal(32, manualQuery.Count);
+        Assert.Equal(32, resultQueryContainsAllDb.Count);
+        Assert.Equal(32, resultsFromFilteredQuery.Count);
+
+        foreach (var doc in resultsFromFilteredQuery)
+        {
+            var docInstance = docs.Single(x => x.Id == doc);
+            Assert.True(docInstance.Numerical is >= 15 and <= 18);
+        }
+
+        Assert.Equal(32, resultsWithoutFilterQuery.Count);
+        Assert.NotEqual(0, resultsWithoutFilterQuery.Count(x => resultsFromFilteredQuery.Contains(x) == false));
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    [InlineDataWithRandomSeed]
+    public void CanFilterMultiVectorsNearest(int seed)
+    {
+        var (_, resultsFromFilteredQuery, _, _, docs) = CanFilterMultiVectorsBase(false, false, seed);
+
+        Assert.NotEmpty(resultsFromFilteredQuery);
+        foreach (var doc in resultsFromFilteredQuery)
+        {
+            var docInstance = docs.Single(x => x.Id == doc);
+            Assert.True(docInstance.Numerical is >= 15 and <= 18);
+        }
+
+    }
+    
+    /// <summary>
+    /// ResultQueryContainsAllDb – VectorSearch scans all vectors in the index; AND operates on all vectors returned by HNSW.
+    /// ResultsFromFilteredQuery – VectorSearch uses a vector filter, limiting the number of vectors scanned (depending on query configuration).
+    /// ResultsWithoutFilterQuery – VectorSearch has no vector filter or additional filter and returns the best NoC vectors.
+    /// ManualQuery – In-memory vector search via LINQ in the test.
+    /// Docs – All indexed documents.
+    /// </summary>
+    private (List<string> ResultQueryContainsAllDb, List<string> ResultsFromFilteredQuery, List<string> ResultsWithoutFilterQuery, List<VectorSearchResult> ManualQuery, List<Doc> Docs) CanFilterMultiVectorsBase(bool shouldScan, bool isExact, int seed)
+    {
+        using var mapping = GetMapping();
+        var docs = GetDocs(360).ToList();
+        var random = new Random(seed);
+        IndexDocuments(Env, mapping, docs, random);
+
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            List<string> resultQueryContainsAllDb;
+            List<string> resultsFromFilteredQuery;
+            List<string> resultsWithoutFilterQuery;
+            var manualQuery = VectorSearchInPlace(docs, p => p.Numerical >= 15 && p.Numerical <= 18, [docs[0].Vector, docs[180].Vector], MinSimilarity, TopKMulti).ToList();
+
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 400, isExact, false);
+                IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
+                query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
+            }
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
+            }
+
+            {
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultsWithoutFilterQuery = EvaluateQuery(indexSearcher, ref query);
+            }
+
+            return (resultQueryContainsAllDb, resultsFromFilteredQuery, resultsWithoutFilterQuery, manualQuery, docs);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false, Skip = "Too small set")]
+    public void FilterQueryAndWithMethodVectorSearch(bool shouldScan, bool isExact)
+    {
+        using var mapping = GetMapping();
+        var docs = GetDocs(360).ToList();
+
+        IndexDocuments(Env, mapping, docs);
+
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            List<string> resultsFromFilteredQuery;
+            List<string> andWithResults;
+            var manualQuery = VectorSearchInPlace(docs, p => p.Numerical >= 15 && p.Numerical <= 18, [docs[0].Vector], MinSimilarity, TopKMulti).ToList();
+
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
+            }
+
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var allEntries = indexSearcher.AllEntries();
+                List<long> matched = new();
+                Span<long> ids = new long[16];
+                while (allEntries.Fill(ids) is var read and > 0)
+                {
+                    var common = vecSearch.AndWith(ids, read);
+                    matched.AddRange(ids[..common]);
+                }
+
+                andWithResults = GetDocsIds(indexSearcher, CollectionsMarshal.AsSpan(matched));
+            }
+
+            Assert.Equal(16, manualQuery.Count);
+            Assert.Equal(16, resultsFromFilteredQuery.Count);
+
+            foreach (var doc in resultsFromFilteredQuery)
+            {
+                var docInstance = docs.Single(x => x.Id == doc);
+                Assert.True(docInstance.Numerical is >= 15 and <= 18);
+            }
+
+            resultsFromFilteredQuery.Sort();
+            andWithResults.Sort();
+            Assert.Equal(16, andWithResults.Count);
+            Assert.Equal(resultsFromFilteredQuery, andWithResults);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    [InlineData(false, false, Skip = "Too small set")]
+    public void FilterQueryAndWithMethodMultiVectorSearch(bool shouldScan, bool isExact)
+    {
+        using var mapping = GetMapping();
+        var docs = GetDocs(360).ToList();
+
+        IndexDocuments(Env, mapping, docs);
+
+        using (var indexSearcher = new IndexSearcher(Env, mapping))
+        {
+            List<string> resultsFromFilteredQuery;
+            List<string> andWithResults;
+
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
+            }
+
+            {
+                var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
+                var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
+                var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0);
+                var allEntries = indexSearcher.AllEntries();
+                List<long> matched = new();
+                Span<long> ids = new long[16];
+                while (allEntries.Fill(ids) is var read and > 0)
+                {
+                    var common = vecSearch.AndWith(ids, read);
+                    matched.AddRange(ids[..common]);
+                }
+
+                andWithResults = GetDocsIds(indexSearcher, CollectionsMarshal.AsSpan(matched));
+            }
+
+            Assert.Equal(32, resultsFromFilteredQuery.Count);
+
+            foreach (var doc in resultsFromFilteredQuery)
+            {
+                var docInstance = docs.Single(x => x.Id == doc);
+                Assert.True(docInstance.Numerical is >= 15 and <= 18);
+            }
+
+            resultsFromFilteredQuery.Sort();
+            andWithResults.Sort();
+            Assert.Equal(32, andWithResults.Count);
+            Assert.Equal(resultsFromFilteredQuery, andWithResults);
+        }
+    }
+
+
+    private List<string> EvaluateQuery<TQueryMatch>(IndexSearcher indexSearcher, ref TQueryMatch queryMatch)
+        where TQueryMatch : IQueryMatch
+    {
+        var results = new List<long>();
+        Span<long> ids = new long[16];
+        while (queryMatch.Fill(ids) is var read and > 0)
+        {
+            results.AddRange(ids[..read]);
+        }
+
+        return GetDocsIds(indexSearcher, CollectionsMarshal.AsSpan(results));
+    }
+
+    private List<string> GetDocsIds(IndexSearcher indexSearcher, Span<long> ids, string field = "id()")
+    {
+        using var termReader = indexSearcher.TermsReaderFor("id()");
+        var resultsIds = new List<string>();
+        foreach (var id in ids)
+        {
+            Assert.True(termReader.TryGetTermFor(id, out var idAsStr));
+            resultsIds.Add(idAsStr);
+        }
+
+        return resultsIds;
+    }
+
+    private IndexFieldsMapping GetMapping() => IndexFieldsMappingBuilder.CreateForWriter(false)
+        .AddBinding(0, "id()")
+        .AddBinding(1, "Text")
+        .AddBinding(2, "Numerical")
+        .AddBinding(3, "Vector", vectorOptions: new global::Corax.Mappings.VectorOptions()
+        {
+            NumberOfCandidates = 16,
+            NumberOfEdges = 12,
+            VectorEmbeddingType = VectorEmbeddingType.Single
+        })
+        .Build();
+
+    private static IEnumerable<Doc> GetDocs(int amount)
+    {
+        for (int i = 0; i < amount; ++i)
+        {
+            var x = MathF.Cos(i * 2 * MathF.PI / amount);
+            var y = MathF.Sin(i * 2 * MathF.PI / amount);
+            yield return new Doc($"doc/{i}", $"Text{i}", i % 30, [x, y]);
+        }
+    }
+
+    private IEnumerable<VectorSearchResult> VectorSearchInPlace(List<Doc> docs, Predicate<Doc> booleanClause, IEnumerable<float[]> vectors, float minimumSimilarity, int numberOfCandidates)
+    {
+        var allVectorSearch = from doc in docs
+            from vector in vectors
+            let distance = 1 - System.Numerics.Tensors.TensorPrimitives.CosineSimilarity(doc.Vector, vector)
+            where booleanClause(doc) && distance <= 2f * (1.0f - minimumSimilarity)
+            orderby distance
+            select new VectorSearchResult(doc.Id, distance, doc.Vector);
+
+        var vectorSearch = from vector in allVectorSearch
+            group vector by vector.Id
+            into g
+            select new VectorSearchResult(g.Key, g.Min(x => x.Distance), g.First().Vector);
+
+        HashSet<string> nodesReturned = new();
+
+        foreach (var doc in vectorSearch)
+        {
+            var baseOfVector = Convert.ToBase64String(MemoryMarshal.Cast<float, byte>(doc.Vector));
+            nodesReturned.Add(baseOfVector);
+            if (nodesReturned.Count > numberOfCandidates)
+                yield break;
+            yield return doc;
+        }
+    }
+
+    private static void IndexDocuments(StorageEnvironment env, IndexFieldsMapping mapping, IEnumerable<Doc> docs, Random random)
+    {
+        using var indexWriter = new IndexWriter(env, mapping, SupportedFeatures.All);
+        foreach (var doc in docs)
+        {
+            using var builder = indexWriter.Index(doc.Id);
+            builder.Write(0, Encodings.Utf8.GetBytes(doc.Id));
+            builder.Write(1, Encodings.Utf8.GetBytes(doc.Text));
+            builder.Write(2, Encodings.Utf8.GetBytes(doc.Numerical.ToString()), doc.Numerical, doc.Numerical);
+            builder.WriteVector(3, null, MemoryMarshal.Cast<float, byte>(doc.Vector), random);
+            builder.EndWriting();
+        }
+
+        indexWriter.Commit();
+    }
+
+    private static void IndexDocuments(StorageEnvironment env, IndexFieldsMapping mapping, IEnumerable<Doc> docs)
+    {
+        using var indexWriter = new IndexWriter(env, mapping, SupportedFeatures.All);
+        foreach (var doc in docs)
+        {
+            using var builder = indexWriter.Index(doc.Id);
+            builder.Write(0, Encodings.Utf8.GetBytes(doc.Id));
+            builder.Write(1, Encodings.Utf8.GetBytes(doc.Text));
+            builder.Write(2, Encodings.Utf8.GetBytes(doc.Numerical.ToString()), doc.Numerical, doc.Numerical);
+            builder.WriteVector(3, null, MemoryMarshal.Cast<float, byte>(doc.Vector));
+            builder.EndWriting();
+        }
+
+        indexWriter.Commit();
+    }
+
+    private record VectorSearchResult(string Id, float Distance, float[] Vector);
+
+    private record Doc(string Id, string Text, int Numerical, float[] Vector);
+}

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;

--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using FastTests.Voron;
 using FastTests.Voron.FixedSize;
 using Tests.Infrastructure;
+using Voron;
 using Voron.Data.Graphs;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,6 +22,7 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
     [InlineData(237493337)]
     public void CanReturnAllOfVector(int seed)
     {
+        using var _ = Slice.From(Allocator, nameof(CanReturnAllOfVector), out var treeName);
         const int vectorSize = 1536;
         const int vectorSizeInBytes = vectorSize * sizeof(float);
         const int numberOfEntries = 1024;
@@ -31,9 +33,9 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
         
         using (var wTx = Env.WriteTransaction())
         {
-            Hnsw.Create(wTx.LowLevelTransaction, nameof(CanReturnAllOfVector), vectorSizeInBytes, 3, 16, VectorEmbeddingType.Single);
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, vectorSizeInBytes, 3, 16, VectorEmbeddingType.Single);
 
-            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, nameof(CanReturnAllOfVector), random))
+            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, random))
             {
                 foreach (var (id, vector) in storage)
                     registration.Register(id, MemoryMarshal.Cast<float, byte>(vector));
@@ -47,7 +49,7 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
         using (var rTx = Env.ReadTransaction())
         {
             var qV = MemoryMarshal.Cast<float, byte>(storage[random.Next(1, storage.Count + 1)]);
-            using var nearest = Hnsw.ExactNearest(rTx.LowLevelTransaction, nameof(CanReturnAllOfVector), 1024, qV, 0f);
+            using var nearest = Hnsw.ExactNearest(rTx.LowLevelTransaction, treeName, 1024, qV.ToArray(), 0f, false);
 
             var totalReturned = 0;
             var matches = new long[64];

--- a/test/StressTests/Corax/GrowableBitArrayTests.cs
+++ b/test/StressTests/Corax/GrowableBitArrayTests.cs
@@ -2,6 +2,7 @@
 using Corax.Utils;
 using FastTests;
 using Sparrow.Server;
+using Sparrow.Server.Collections;
 using Sparrow.Threading;
 using Tests.Infrastructure;
 using Xunit;

--- a/tools/Voron.Dictionary.Generator/Voron.Dictionary.Generator.csproj
+++ b/tools/Voron.Dictionary.Generator/Voron.Dictionary.Generator.csproj
@@ -17,6 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="english.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="french.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23453

### Additional description

_Note: this PR contains only the low-level implementation of filter capabilities inside Corax and Hnsw. It does **not** integrate them into RavenDB querying yet._

This PR allows passing a filter query as a condition that the results from `VectorSearch` must satisfy.

It includes:

- **Scanning query (for certain filter sizes):** retrieves node IDs from documents and performs `ExactSearch` only on those specific nodes. This is important because we must ensure that the `NumberOfCandidates` parameter is honored.  
- **Exact:** creates a mapping of all nodes and then, since it is sorted, yields nodes from best to worst.  
- **NearestSearch:** over-fetches (by increasing `NumberOfCandidates` internally). When we need more vectors (because previous ones are rejected by the filter), we increase `NumberOfCandidates` internally and restart the whole query. Thanks to this, we don’t need to implement an evicted list and handle it manually. To make this more performant, we leverage `SearchState` and its caching capabilities and store `D(VectorQuery, Node)` inside the nodes, so when we need to visit it again, we don’t read the vector from disk or recompute the distance.

Additionally, it includes refactoring of the flow:

- `VectorSearch` is now lazily initialized, meaning it will not search until we actually call `Fill` (or `AndWith`).  
- The implementation is split into multiple files to improve readability.  
- Internal searchers are now implemented as `IEnumerable`s, which means we can easily “fetch more” results.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
