### PR TITLE
RavenDB-25509 reintroduced HardResetToPassive and added a test

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -1954,6 +1954,10 @@ namespace Raven.Server.Rachis
             }
         }
 
+        /// <summary>
+        /// This method is public via https://docs.ravendb.net/7.1/studio/server/debug/admin-js-console/#methods
+        /// DO NOT RENAME
+        /// </summary>
         public void FoundAboutHigherTerm(long term, string reason)
         {
             if (term <= CurrentTerm)
@@ -2086,6 +2090,10 @@ namespace Raven.Server.Rachis
             return true;
         }
 
+        /// <summary>
+        /// This method is public via https://docs.ravendb.net/7.1/studio/server/debug/admin-js-console/#methods
+        /// DO NOT RENAME
+        /// </summary>
         public string HardResetToNewCluster(string nodeTag = "A")
         {
             return HardResetToNewClusterAsync(nodeTag).GetAwaiter().GetResult();
@@ -2118,6 +2126,15 @@ namespace Raven.Server.Rachis
             // TODO: Run 'LeaderCanCecedeFromClusterAndNewLeaderWillBeElected' 10_000 times
 
             return topologyId;
+        }
+
+        /// <summary>
+        /// This method is public via https://docs.ravendb.net/7.1/studio/server/debug/admin-js-console/#methods
+        /// DO NOT RENAME
+        /// </summary>
+        public void HardResetToPassive(string topologyId = null)
+        {
+            HardResetToPassiveAsync(topologyId).GetAwaiter().GetResult();
         }
 
         public Task HardResetToPassiveAsync(string topologyId = null)

--- a/test/FastTests/Issues/RavenDB_25509.cs
+++ b/test/FastTests/Issues/RavenDB_25509.cs
@@ -1,0 +1,21 @@
+﻿using Raven.Server.Rachis;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_25509 : NoDisposalNeeded
+{
+    public RavenDB_25509(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Codebase)]
+    public void Assert_Method_Names()
+    {
+        Assert.Equal("HardResetToPassive", nameof(RachisConsensus.HardResetToPassive));
+        Assert.Equal("HardResetToNewCluster", nameof(RachisConsensus.HardResetToNewCluster));
+        Assert.Equal("FoundAboutHigherTerm", nameof(RachisConsensus.FoundAboutHigherTerm));
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25509

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
