### PR TITLE
Raven db 24887 - Remove RefUserActions and children (sub-agent) actions from parent doc

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentActionRequest.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentActionRequest.cs
@@ -12,8 +12,6 @@ public class AiAgentActionRequest : IDynamicJson
 
     public AiAgentActionRequestType Type;
     public string SubConversation;
-    // one sub-agent call, can have multiple user actions assosiated
-    public int RefUserActions;
 
     public bool IsEqual(AiAgentActionRequest other)
     {
@@ -24,8 +22,7 @@ public class AiAgentActionRequest : IDynamicJson
             Name == other.Name &&
             Arguments == other.Arguments &&
             Type == other.Type &&
-            SubConversation == other.SubConversation &&
-            RefUserActions == other.RefUserActions;
+            SubConversation == other.SubConversation;
     }
 
     public override string ToString()
@@ -42,8 +39,7 @@ public class AiAgentActionRequest : IDynamicJson
             [nameof(ToolId)] = ToolId,
             [nameof(Arguments)] = Arguments,
             [nameof(Type)] = Type,
-            [nameof(SubConversation)] = SubConversation,
-            [nameof(RefUserActions)] = RefUserActions
+            [nameof(SubConversation)] = SubConversation
         };
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentConfiguration.cs
@@ -181,6 +181,11 @@ public class AiAgentConfiguration : IDynamicJson
         };
     }
 
+    public DynamicJsonValue ToAuditJson()
+    {
+        return ToJson();
+    }
+
     internal void AppendCapabilities(StringBuilder sb)
     {
         sb.AppendLine("Capabilities:");

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -40,7 +40,7 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
         var r = await ServerStore.SendToLeaderAsync(new AddOrUpdateAiAgentCommand(RequestHandler.DatabaseName, cfg, RequestHandler.GetRaftRequestIdFromQuery()),
             token.Token);
 
-        RequestHandler.LogTaskToAudit($"Add/Update AI Agent '{cfg.Identifier}'", r.Index, options);
+        RequestHandler.LogTaskToAudit(Web.RequestHandler.AiAgentConfiguration, r.Index, options);
 
         await RequestHandler.WaitForIndexNotificationAsync(r.Index);
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForDeleteAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForDeleteAiAgent.cs
@@ -22,7 +22,7 @@ internal class AiAgentProcessorForDeleteAiAgent<TRequestHandler, TOperationConte
         var identifier = RequestHandler.GetStringQueryString("agentId", required: true);
         var r = await ServerStore.SendToLeaderAsync(new DeleteAiAgentCommand(RequestHandler.DatabaseName, identifier, RequestHandler.GetRaftRequestIdFromQuery()), token.Token);
 
-        RequestHandler.LogTaskToAudit($"Delete AI Agent '{identifier}'", r.Index, configuration: null);
+        RequestHandler.LogTaskToAudit(Web.RequestHandler.AiAgentConfiguration, r.Index, configuration: null);
 
         await RequestHandler.WaitForIndexNotificationAsync(r.Index);
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -324,21 +324,14 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         {
             AiAgentConfiguration subAgentConfiguration = handler.GetAiAgentConfiguration(subAgent.Identifier);
             var parameters = new Dictionary<string, string>();
-            foreach (AiAgentParameter parameter in subAgentConfiguration.Parameters ?? [])
+            foreach (AiAgentParameter parameter in configuration.Parameters)
             {
                 parameters[parameter.Name] = parameter.Description;
             }
-
-            foreach (AiAgentParameter parameter in configuration.Parameters)
+            // The child parameter description overrides the parent’s, since the description must match the parameter provided to the child.
+            foreach (AiAgentParameter parameter in subAgentConfiguration.Parameters ?? [])
             {
-                if (parameters.TryAdd(parameter.Name, parameter.Description) == false && parameters[parameter.Name] != parameter.Description)
-                {
-                    throw new InvalidOperationException(
-                        $"Parameter conflict detected for '{parameter.Name}'. " +
-                        $"Parent agent '{configuration.Identifier}' defines this parameter with value '{parameter.Description}', " +
-                        $"but sub-agent '{subAgentConfiguration.Identifier}' provides a different value '{parameters[parameter.Name]}'. " +
-                        $"These values must match to ensure consistent behavior.");
-                }
+                parameters[parameter.Name] = parameter.Description;
             }
 
             var argsSampleObject = DynamicJsonValue.Convert(parameters);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -631,7 +631,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             {
                 var t = JsonDeserializationClient.ActionResponse(tool);
 
-                var split = t.ToolId.Split('$');
+                var split = SplitByFirstDollar(t.ToolId);
                 var rootToolId = split[0];
 
                 if (_document.OpenActionCalls.TryGetValue(rootToolId, out var action) == false)
@@ -694,6 +694,15 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
         return true;
 
+        static string[] SplitByFirstDollar(string s)
+        {
+            int index = s.IndexOf('$');
+            if (index == -1)
+                return new []{ s };
+
+            return new[] { s.Substring(0, index), s.Substring(index + 1) };
+        }
+
         static ServerAiAgentActionResponse GetOrAdd(Dictionary<string, ServerAiAgentActionResponse> subAgentsActions, AiAgentActionRequest parent, string parentToolId)
         {
             if (subAgentsActions.TryGetValue(parent.SubConversation, out var subAgent))
@@ -738,6 +747,9 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
 
         await ExecuteMultiAgentRequests(context, reqs);
+
+        if (_childUserCalls.Any())
+            return;
 
         List<AiToolCall> activeToolCalls = [];
         foreach (var action in _document.OpenActionCalls)
@@ -823,9 +835,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                         if (HandleSubAgentResponse(context, requestResult, currentCall) == false)
                             _document.OpenActionCalls.Remove(currentCall.Id); // Parent call
                         else
-                        {
                             cutSubAgentConversation = true;
-                        }
+                        
                         break;
                     default:
                         throw new InvalidOperationException($"'{conversationId}' responses should contain only tool calls of type AiAgentToolSubAgent but contains '{toolCall.GetType().Name}'");

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -37,7 +37,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     public const int DefaultMaxModelIterationsPerCall = 16;
     private const int DefaultMaxTokensBeforeSummarization = 32 * 1024;
     private const int DefaultMaxTokensAfterSummarization = 1024;
-    private const string QueryVirtualConversationId = "QueryTools";
+    private const string QueryVirtualConversationId = "#QueryTools";
 
     protected ConversationDocument _document;
     private string _conversationId;
@@ -411,7 +411,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         if (reqs.Count is 0)
             return;
 
-        await ExecuteMultiAgentRequests(context, reqs);
+        await ExecuteMultiAgentAndQueryRequests(context, reqs);
     }
 
     private bool HandleSubAgentResponse(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
@@ -451,7 +451,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 }
             }
 
-            return true;
+            return false;
         }
 
         _document.AddMessage(context, context.ReadObject(
@@ -463,7 +463,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 ["subConversation"] = agentConversationId,
             }, "tool-call/response"), usage: null);
 
-        return false;
+        _document.OpenActionCalls.Remove(currentCall.Id); // Parent call
+        return true;
     }
 
     private static void RemoveNonEssentialFieldsFromMetadata(BlittableJsonReaderArray queryResult)
@@ -724,14 +725,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
     }
 
-    public class ServerAiAgentActionResponse
-    {
-        public string Agent;
-        public string ParentId;
-
-        public List<AiAgentActionResponse> Responses;
-    }
-
     private async Task HandleSubAgentCalls(JsonOperationContext context, Dictionary<string, ServerAiAgentActionResponse> subAgentsActions)
     {
         if (subAgentsActions?.Count > 0 == false)
@@ -746,7 +739,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             reqs.GetOrAdd(conversationId).Add((call, r));
         }
 
-        await ExecuteMultiAgentRequests(context, reqs);
+        await ExecuteMultiAgentAndQueryRequests(context, reqs);
 
         if (_childUserCalls.Any())
             return;
@@ -791,15 +784,17 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         };
     }
 
-    private async Task ExecuteMultiAgentRequests(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
+    private async Task ExecuteMultiAgentAndQueryRequests(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
         if (reqs.TryGetValue(QueryVirtualConversationId, out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
         {
-            // Probably need to have the same behavior as in Handle (start without defaults).
             await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(queryToolReqs.Select(x => x.Req))))
             {
                 AiToolCall currentCall = queryToolReqs[i].Call;
                 var toolCall = FindToolFrom(_configuration, currentCall.Name);
+                if (toolCall == null)
+                    throw new InvalidOperationException($"Ai-Agent has no tool in name '{currentCall.Name}'");
+
                 switch (toolCall)
                 {
                     case AiAgentToolQuery:
@@ -816,33 +811,37 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
                         break;
                     default:
-                        throw new InvalidOperationException($"'QueryTools' responses should contain only tool calls of type AiAgentToolQuery but contains '{toolCall.GetType().Name}'");
+                        throw new InvalidOperationException($"Type mismatch for tool '{currentCall.Name}'. " +
+                                                            $"Expected type: '{nameof(AiAgentToolQuery)}', Actual type: '{toolCall.GetType().Name}'.");
                 }
             }
         }
 
         foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != QueryVirtualConversationId))
         {
-            // Probably need to have the same behavior as in Handle (start without defaults).
-            await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(conversationReqs.Select(x => x.Req))))
+            await ExecuteSubAgentToolCalls(context, conversationId, conversationReqs);
+        }
+    }
+
+    private async Task ExecuteSubAgentToolCalls(JsonOperationContext context, string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
+    {
+        await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
+        {
+            var currentCall = requests[i].Call;
+            var toolCall = FindToolFrom(_configuration, currentCall.Name);
+            if (toolCall == null)
+                throw new InvalidOperationException($"Ai-Agent has no tool in name '{currentCall.Name}'");
+
+            switch (toolCall)
             {
-                AiToolCall currentCall = conversationReqs[i].Call;
-                var toolCall = FindToolFrom(_configuration, currentCall.Name);
-                var cutSubAgentConversation = false;
-                switch (toolCall)
-                {
-                    case AiAgentToolSubAgent:
-                        if (HandleSubAgentResponse(context, requestResult, currentCall) == false)
-                            _document.OpenActionCalls.Remove(currentCall.Id); // Parent call
-                        else
-                            cutSubAgentConversation = true;
-                        
-                        break;
-                    default:
-                        throw new InvalidOperationException($"'{conversationId}' responses should contain only tool calls of type AiAgentToolSubAgent but contains '{toolCall.GetType().Name}'");
-                }
-                if (cutSubAgentConversation)
+                case AiAgentToolSubAgent:
+                    if (HandleSubAgentResponse(context, requestResult, currentCall) == false)
+                        return;
                     break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Type mismatch for tool '{currentCall.Name}' in sub-conversation '{conversationId}'. " + 
+                        $"Expected type: '{nameof(AiAgentToolSubAgent)}', Actual type: '{toolCall.GetType().Name}'.");
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -37,6 +37,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     public const int DefaultMaxModelIterationsPerCall = 16;
     private const int DefaultMaxTokensBeforeSummarization = 32 * 1024;
     private const int DefaultMaxTokensAfterSummarization = 1024;
+    private const string QueryVirtualConversationId = "QueryTools";
 
     protected ConversationDocument _document;
     private string _conversationId;
@@ -488,7 +489,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private void BuildQueryRequest(JsonOperationContext context, ConversationDocument document, Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs, AiAgentToolQuery q, AiToolCall call)
     {
-        reqs.GetOrAdd("QueryTools").Add((call, new DynamicJsonValue
+        reqs.GetOrAdd(QueryVirtualConversationId).Add((call, new DynamicJsonValue
             {
                 [nameof(GetRequest.Url)] = $"/databases/{database.Name}/queries",
                 [nameof(GetRequest.Query)] = null,
@@ -780,7 +781,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private async Task ExecuteMultiAgentRequests(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
-        if (reqs.TryGetValue("QueryTools", out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
+        if (reqs.TryGetValue(QueryVirtualConversationId, out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
         {
             // Probably need to have the same behavior as in Handle (start without defaults).
             await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(queryToolReqs.Select(x => x.Req))))
@@ -808,7 +809,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             }
         }
 
-        foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != "QueryTools"))
+        foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != QueryVirtualConversationId))
         {
             // Probably need to have the same behavior as in Handle (start without defaults).
             await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(conversationReqs.Select(x => x.Req))))

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -29,7 +29,6 @@ using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server.Json.Sync;
-using System.Runtime.CompilerServices;
 
 namespace Raven.Server.Documents.Handlers.AI.Agents;
 
@@ -394,19 +393,16 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         if (toolCalls == null || toolCalls.Count == 0)
             return;
 
-        DynamicJsonArray reqs = [];
-        List<AiToolCall> activeToolCalls = [];
+        Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs = [];
         foreach (var call in toolCalls)
         {
             switch (FindToolFrom(_configuration, call.Name))
             {
                 case AiAgentToolQuery q:
-                    activeToolCalls.Add(call);
                     BuildQueryRequest(context, _document, reqs, q, call);
                     break;
                 case AiAgentToolSubAgent agent:
                     BuildAgentRequest(context, _document, call, agent, reqs);
-                    activeToolCalls.Add(call);
                     break;
             }
         }
@@ -414,32 +410,10 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         if (reqs.Count is 0)
             return;
 
-        // Probably need to have the same behavior as in Handle (start without defaults).
-        await foreach (var (requestResult, i) in ExecuteMultiRequests(context, reqs))
-        {
-            AiToolCall currentCall = activeToolCalls[i];
-            switch (FindToolFrom(_configuration, currentCall.Name))
-            {
-                case AiAgentToolQuery:
-                    if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
-                        throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-
-                    _document.AddMessage(context, context.ReadObject(
-                        new DynamicJsonValue
-                        {
-                            ["tool_call_id"] = currentCall.Id,
-                            ["role"] = "tool",
-                            ["content"] = GetToolResultContent(queryResult)
-                        }, "tool-call/response"), usage: null);
-                    break;
-                case AiAgentToolSubAgent:
-                    HandleSubAgentResponse(context, requestResult, currentCall);
-                    break;
-            }
-        }
+        await ExecuteMultiAgentRequests(context, reqs);
     }
 
-    private void HandleSubAgentResponse(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
+    private bool HandleSubAgentResponse(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
     {
         if (requestResult.TryGet(nameof(ConversationResult<object>.ConversationId), out string agentConversationId) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ConversationId)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
@@ -450,20 +424,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
         if (actionRequests?.Length > 0)
         {
-            if (_document.OpenActionCalls.TryGetValue(currentCall.Id, // Parent call
-                    out var parentCall) == false)
-            {
-                parentCall = _document.OpenActionCalls[currentCall.Id] = // Parent call
-                    new AiAgentActionRequest
-                    {
-                        ToolId = currentCall.Id, // Parent call
-                        Name = currentCall.Name,
-                        Type = AiAgentActionRequestType.SubAgent,
-                        Arguments = currentCall.Arguments
-                    };
-            }
-            
-
             foreach (BlittableJsonReaderObject req in actionRequests)
             {
                 var actionRequest = JsonDeserializationClient.ActionRequest(req);
@@ -473,18 +433,13 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     Name = currentCall.Name + "/" + actionRequest.Name,
                     Type = AiAgentActionRequestType.UserAction,
                     Arguments = actionRequest.Arguments,
-                    SubConversation = agentConversationId
                 };
 
-                if (_document.OpenActionCalls.TryAdd(actionRequest.ToolId, // Sub call
-                        newActionCall))
-                {
-                    parentCall.RefUserActions++;
-                }
-                else
+                if (_childUserCalls.TryAdd(actionRequest.ToolId, // Sub call
+                        newActionCall) == false)
                 {
                     // Already exists
-                    var existingActionCall = _document.OpenActionCalls[actionRequest.ToolId];
+                    var existingActionCall = _childUserCalls[actionRequest.ToolId];
                     Debug.Assert(newActionCall.IsEqual(existingActionCall),
                         $"Mismatch detected in OpenActionCalls for key '{actionRequest.ToolId}'.\n" +
                         $"--- NEW ACTION CALL ---\n{newActionCall}\n\n" +
@@ -495,16 +450,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 }
             }
 
-            return;
-        }
-
-        if (_document.OpenActionCalls.TryGetValue(currentCall.Id, out var subAction))
-        {
-            if (subAction.RefUserActions > 0)
-                return;
-
-            // no more references, we can remove it
-            _document.OpenActionCalls.Remove(currentCall.Id);
+            return true;
         }
 
         _document.AddMessage(context, context.ReadObject(
@@ -515,6 +461,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 ["content"] = agentResult.ToString(),
                 ["subConversation"] = agentConversationId,
             }, "tool-call/response"), usage: null);
+
+        return false;
     }
 
     private static void RemoveNonEssentialFieldsFromMetadata(BlittableJsonReaderArray queryResult)
@@ -538,22 +486,22 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     }
 
 
-    private void BuildQueryRequest(JsonOperationContext context, ConversationDocument document, DynamicJsonArray reqs, AiAgentToolQuery q, AiToolCall call)
+    private void BuildQueryRequest(JsonOperationContext context, ConversationDocument document, Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs, AiAgentToolQuery q, AiToolCall call)
     {
-        reqs.Add(new DynamicJsonValue
-        {
-            [nameof(GetRequest.Url)] = $"/databases/{database.Name}/queries",
-            [nameof(GetRequest.Query)] = null,
-            [nameof(GetRequest.Method)] = "POST",
-            [nameof(GetRequest.Content)] = new DynamicJsonValue
+        reqs.GetOrAdd("QueryTools").Add((call, new DynamicJsonValue
             {
-                [nameof(IndexQuery.Query)] = q.Query,
-                [nameof(IndexQuery.QueryParameters)] = CreateParameters(context, call, document.Parameters)
-            }
-        });
+                [nameof(GetRequest.Url)] = $"/databases/{database.Name}/queries",
+                [nameof(GetRequest.Query)] = null,
+                [nameof(GetRequest.Method)] = "POST",
+                [nameof(GetRequest.Content)] = new DynamicJsonValue
+                {
+                    [nameof(IndexQuery.Query)] = q.Query,
+                    [nameof(IndexQuery.QueryParameters)] = CreateParameters(context, call, document.Parameters)
+                }
+            }));
     }
 
-    private void BuildAgentRequest(JsonOperationContext context, ConversationDocument document, AiToolCall call, AiAgentToolSubAgent agent, DynamicJsonArray reqs)
+    private void BuildAgentRequest(JsonOperationContext context, ConversationDocument document, AiToolCall call, AiAgentToolSubAgent agent, Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs)
     {
         var args = context.Sync.ReadForMemory(call.Arguments, "call/args");
         if (args.TryGet(ConversationDocument.SubAgentUserPromptKey, out string prompt) is false)
@@ -568,7 +516,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         var subConversationParamsHash = call.Name + "/" + AttachmentsStorageHelper.CalculateHash(parameters.AsSpan());
         // Unique conversation identifier for this sub-agent (includes document ID, call name, and index).
         var conversationId = document.Id + "/" + subConversationParamsHash;
-        reqs.Add(CreateAgentRequest(agent.Identifier, conversationId,
+
+        reqs.GetOrAdd(conversationId).Add((call, CreateAgentRequest(agent.Identifier, conversationId,
             prompt, Array.Empty<object>(), new DynamicJsonValue
             {
                 [nameof(AiConversationCreationOptions.Parameters)] = parameters,
@@ -577,7 +526,16 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     { } td => (int)td.TotalSeconds,
                     null => null
                 }
-            }));
+            })));
+
+        _document.OpenActionCalls.TryAdd(call.Id, new AiAgentActionRequest
+        {
+            ToolId = call.Id, // Parent call
+            Name = call.Name,
+            Type = AiAgentActionRequestType.SubAgent,
+            Arguments = call.Arguments,
+            SubConversation = conversationId
+        });
     }
 
 
@@ -656,8 +614,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return database.DocumentsStorage.DocumentPut.BuildDocumentId(id, database.DocumentsStorage.GenerateNextEtag(), out _);
     }
 
-    private record SubAgentInstance(string Agent, string ToolId, string ConversationId);
-
     private async Task<bool> TryHandleActionResponses(JsonOperationContext context)
     {
         var hasActionResponse = _request.ActionResponses is { Length: > 0 };
@@ -666,19 +622,23 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         if (hasActionResponse && hasUserPrompt)
             throw new InvalidOperationException($"Cannot have a conversation '{_conversationId}' with open action calls and user prompt.");
 
-        Dictionary<SubAgentInstance, List<AiAgentActionResponse>> subAgentsActions = null;
+        Dictionary<string, ServerAiAgentActionResponse> subAgentsActions = null;
 
         if (_request.ActionResponses != null)
         {
             foreach (BlittableJsonReaderObject tool in _request.ActionResponses)
             {
                 var t = JsonDeserializationClient.ActionResponse(tool);
-                
-                if (_document.OpenActionCalls.Remove(t.ToolId, out var action) == false)
-                    throw new InvalidOperationException($"{t.ToolId} is an unknown action ID for conversation '{_conversationId}'");
+
+                var split = t.ToolId.Split('$');
+                var rootToolId = split[0];
+
+                if (_document.OpenActionCalls.TryGetValue(rootToolId, out var action) == false)
+                    throw new InvalidOperationException($"{rootToolId} is an unknown action ID for conversation '{_conversationId}'");
 
                 if (action.SubConversation == null)
                 {
+                    _document.OpenActionCalls.Remove(rootToolId);
                     _document.AddMessage(context, context.ReadObject(
                         new DynamicJsonValue
                         {
@@ -690,22 +650,17 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 }
                 else
                 {
-                    var parent = _document.OpenActionCalls.Single(x => x.Value.ToolId == action.ToolId);
-                    Debug.Assert(parent.Value.Type == AiAgentActionRequestType.SubAgent, "parent.Value.Type != AiAgentActionRequestType.SubAgent");
+                    var childToolId = split[1];
+                    Debug.Assert(action.Type == AiAgentActionRequestType.SubAgent, "action.Type != AiAgentActionRequestType.SubAgent");
 
-                    subAgentsActions ??= new Dictionary<SubAgentInstance, List<AiAgentActionResponse>>();
+                    subAgentsActions ??= new Dictionary<string, ServerAiAgentActionResponse>();
                     // TODO we might need to change the order here to support nested sub-agents calls
                     // so it would be grand-child / child / parent instead
-                    var i = action.Name.IndexOf('/');
-                    var name = action.Name[..i];
 
-                    var agent = _configuration.FindSubAgents(name);
-                    // TODO ensure that conversation is unique, can't have two sub-agents with same conversation ID
-                    var instance = new SubAgentInstance(agent.Identifier, parent.Key, action.SubConversation);
-                    var responses = subAgentsActions.GetOrAdd(instance);
-                    responses.Add(new AiAgentActionResponse
+                    var subAgent = GetOrAdd(subAgentsActions, action, rootToolId); // get or add from subAgentsActions
+                    subAgent.Responses.Add(new AiAgentActionResponse
                     {
-                        ToolId = t.ToolId, // sub call ID
+                        ToolId = childToolId, // sub call ID
                         Content = t.Content,
                     });
                 }
@@ -714,7 +669,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             await HandleSubAgentCalls(context, subAgentsActions);
         }
 
-        if (_document.OpenActionCalls.Count > 0)
+        if (_document.OpenActionCalls.Any(x => x.Value.Type != AiAgentActionRequestType.SubAgent) || _childUserCalls.Any())
         {
             // We have pending tool-call results from the user;
             // skip reduction - persist the document now without history,
@@ -737,41 +692,55 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
 
         return true;
+
+        static ServerAiAgentActionResponse GetOrAdd(Dictionary<string, ServerAiAgentActionResponse> subAgentsActions, AiAgentActionRequest parent, string parentToolId)
+        {
+            if (subAgentsActions.TryGetValue(parent.SubConversation, out var subAgent))
+            {
+                Debug.Assert(subAgent.ParentId == parentToolId, $"subAgent.ParentId != rootToolId. subAgent.ParentId is '{subAgent.ParentId}',  rootToolId is '{parentToolId}'");
+                Debug.Assert(subAgent.Agent == parent.Name, $"subAgent.Agent != action.Name. subAgent.Agent is '{subAgent.Agent}', action.Name is '{parent.Name}'");
+            }
+            else
+            {
+                subAgent = subAgentsActions[parent.SubConversation] = new ServerAiAgentActionResponse()
+                {
+                    ParentId = parentToolId,
+                    Agent = parent.Name,
+                    Responses = new()
+                };
+            }
+
+            return subAgent;
+        }
     }
 
-    private async Task HandleSubAgentCalls(JsonOperationContext context, Dictionary<SubAgentInstance, List<AiAgentActionResponse>> subAgentsActions)
+    public class ServerAiAgentActionResponse
+    {
+        public string Agent;
+        public string ParentId;
+
+        public List<AiAgentActionResponse> Responses;
+    }
+
+    private async Task HandleSubAgentCalls(JsonOperationContext context, Dictionary<string, ServerAiAgentActionResponse> subAgentsActions)
     {
         if (subAgentsActions?.Count > 0 == false)
             return;
 
-        var reqs = new DynamicJsonArray();
+        Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs = new();
+
+        foreach (var (conversationId, subAgent) in subAgentsActions)
+        {
+            var call = new AiToolCall(subAgent.ParentId /*Parent call*/, subAgent.Agent, Arguments: null);
+            var r = CreateAgentRequest(subAgent.Agent, conversationId, prompt: null, subAgent.Responses, creationOptions: new DynamicJsonValue());
+            reqs.GetOrAdd(conversationId).Add((call, r));
+        }
+
+        await ExecuteMultiAgentRequests(context, reqs);
+
         List<AiToolCall> activeToolCalls = [];
-
-        foreach (var (subAgent, responses) in subAgentsActions)
-        {
-            activeToolCalls.Add(new AiToolCall(subAgent.ToolId /*Parent call*/, subAgent.Agent, Arguments: null));
-            reqs.Add(CreateAgentRequest(subAgent.Agent, subAgent.ConversationId, prompt: null, responses, creationOptions: new DynamicJsonValue()));
-        }
-
-        await foreach (var (requestResult, i) in ExecuteMultiRequests(context, reqs))
-        {
-            var current = activeToolCalls[i];
-            if (_document.OpenActionCalls.TryGetValue(current.Id, // Parent call
-                    out var parentCall))
-                parentCall.RefUserActions--; // the sub action has been handled
-            else
-                throw new InvalidOperationException($"Cannot find '{current.Id}' (Name: {current.Name}) on OpenActionCalls");
-            
-            HandleSubAgentResponse(context, requestResult, current);
-        }
-
-        activeToolCalls.Clear();
         foreach (var action in _document.OpenActionCalls)
         {
-            // if we have _any_ user action left, we need to close it first before continuing
-            if (action.Value.Type == AiAgentActionRequestType.UserAction)
-                return;
-
             var call = new AiToolCall(action.Key, action.Value.Name, action.Value.Arguments);
             activeToolCalls.Add(call);
         }
@@ -807,6 +776,63 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 [nameof(ConversionRequestBody.CreationOptions)] = creationOptions
             }
         };
+    }
+
+    private async Task ExecuteMultiAgentRequests(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
+    {
+        if (reqs.TryGetValue("QueryTools", out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
+        {
+            // Probably need to have the same behavior as in Handle (start without defaults).
+            await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(queryToolReqs.Select(x => x.Req))))
+            {
+                AiToolCall currentCall = queryToolReqs[i].Call;
+                var toolCall = FindToolFrom(_configuration, currentCall.Name);
+                switch (toolCall)
+                {
+                    case AiAgentToolQuery:
+                        if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
+                            throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
+
+                        _document.AddMessage(context, context.ReadObject(
+                            new DynamicJsonValue
+                            {
+                                ["tool_call_id"] = currentCall.Id,
+                                ["role"] = "tool",
+                                ["content"] = GetToolResultContent(queryResult)
+                            }, "tool-call/response"), usage: null);
+
+                        break;
+                    default:
+                        throw new InvalidOperationException($"'QueryTools' responses should contain only tool calls of type AiAgentToolQuery but contains '{toolCall.GetType().Name}'");
+                }
+            }
+        }
+
+        foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != "QueryTools"))
+        {
+            // Probably need to have the same behavior as in Handle (start without defaults).
+            await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(conversationReqs.Select(x => x.Req))))
+            {
+                AiToolCall currentCall = conversationReqs[i].Call;
+                var toolCall = FindToolFrom(_configuration, currentCall.Name);
+                var cutSubAgentConversation = false;
+                switch (toolCall)
+                {
+                    case AiAgentToolSubAgent:
+                        if (HandleSubAgentResponse(context, requestResult, currentCall) == false)
+                            _document.OpenActionCalls.Remove(currentCall.Id); // Parent call
+                        else
+                        {
+                            cutSubAgentConversation = true;
+                        }
+                        break;
+                    default:
+                        throw new InvalidOperationException($"'{conversationId}' responses should contain only tool calls of type AiAgentToolSubAgent but contains '{toolCall.GetType().Name}'");
+                }
+                if (cutSubAgentConversation)
+                    break;
+            }
+        }
     }
 
     private async IAsyncEnumerable<(BlittableJsonReaderObject, int)> ExecuteMultiRequests(JsonOperationContext context, DynamicJsonArray reqs)
@@ -910,8 +936,16 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         };
     }
 
+    private readonly Dictionary<string, AiAgentActionRequest> _childUserCalls = [];
+
     private IEnumerable<DynamicJsonValue> GetUserActions()
     {
+        foreach (var action in _childUserCalls)
+        {
+            action.Value.ToolId = $"{action.Value.ToolId}${action.Key}";
+            yield return action.Value.ToJson();
+        }
+
         foreach (var action in _document.OpenActionCalls)
         {
             if (action.Value.Type == AiAgentActionRequestType.SubAgent)
@@ -920,7 +954,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             // replace with the actual tool call ID
             // for non-sub-agent user actions, it is identical
             action.Value.ToolId = action.Key;
-
             yield return action.Value.ToJson();
         }
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -37,7 +37,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     public const int DefaultMaxModelIterationsPerCall = 16;
     private const int DefaultMaxTokensBeforeSummarization = 32 * 1024;
     private const int DefaultMaxTokensAfterSummarization = 1024;
-    private const string QueryVirtualSubConversationId = "#QueryTools";
+    private const string QueryVirtualSubConversationId = "_QueryTools_";
 
     protected ConversationDocument _document;
     private string _conversationId;
@@ -414,7 +414,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         await ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
-    private bool HandleSubAgentResponse(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
+    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
     {
         if (requestResult.TryGet(nameof(ConversationResult<object>.ConversationId), out string agentConversationId) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ConversationId)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
@@ -632,7 +632,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             {
                 var t = JsonDeserializationClient.ActionResponse(tool);
 
-                var split = SplitByFirstDollar(t.ToolId);
+                var split = t.ToolId.Split('$', 2); // split by first '$'
                 var rootToolId = split[0];
 
                 if (_document.OpenActionCalls.TryGetValue(rootToolId, out var action) == false)
@@ -671,8 +671,10 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             await HandleSubAgentCalls(context, subAgentsActions);
         }
 
-        if (_document.OpenActionCalls.Any(x => x.Value.Type != AiAgentActionRequestType.SubAgent) || _childUserCalls.Any())
+        if (_document.OpenActionCalls.Any(x => x.Value.Type != AiAgentActionRequestType.SubAgent) || _childUserCalls.Count > 0)
         {
+            Debug.Assert(_document.OpenActionCalls.Any(x => x.Value.Type == AiAgentActionRequestType.SubAgent) == _childUserCalls.Count > 0,
+                "_document.OpenActionCalls.Any(x => x.Value.Type == AiAgentActionRequestType.SubAgent) != _childUserCalls.Count > 0");
             // We have pending tool-call results from the user;
             // skip reduction - persist the document now without history,
             // ensuring we can recover if TalkAsync fails.
@@ -694,15 +696,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
 
         return true;
-
-        static string[] SplitByFirstDollar(string s)
-        {
-            int index = s.IndexOf('$');
-            if (index == -1)
-                return new []{ s };
-
-            return new[] { s.Substring(0, index), s.Substring(index + 1) };
-        }
     }
 
     private static ServerAiAgentActionResponse GetOrAddSubAgentsActionResponses(Dictionary<string, ServerAiAgentActionResponse> subAgentsActions, AiAgentActionRequest parent, string parentToolId)
@@ -786,11 +779,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private async Task ExecuteMultiAgentAndQueryRequestsAsync(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
-        if (reqs.TryGetValue(QueryVirtualSubConversationId, out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
-        {
-            await ExecuteSingleSubConversationToolCallsAsync(context, QueryVirtualSubConversationId, queryToolReqs);
-        }
-        foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != QueryVirtualSubConversationId))
+        // TODO: Execute ExecuteSingleSubConversationToolCallsAsync calls concurrently (use tasks and Task.WhenAll())
+        foreach (var (conversationId, conversationReqs) in reqs)
         {
             await ExecuteSingleSubConversationToolCallsAsync(context, conversationId, conversationReqs);
         }
@@ -808,7 +798,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             switch (toolCall)
             {
                 case AiAgentToolSubAgent:
-                    if (HandleSubAgentResponse(context, requestResult, currentCall) == false)
+                    if (TryCloseSubAgentCall(context, requestResult, currentCall) == false)
                         return;
                     break;
                 case AiAgentToolQuery:

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -37,7 +37,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     public const int DefaultMaxModelIterationsPerCall = 16;
     private const int DefaultMaxTokensBeforeSummarization = 32 * 1024;
     private const int DefaultMaxTokensAfterSummarization = 1024;
-    private const string QueryVirtualConversationId = "#QueryTools";
+    private const string QueryVirtualSubConversationId = "#QueryTools";
 
     protected ConversationDocument _document;
     private string _conversationId;
@@ -411,7 +411,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         if (reqs.Count is 0)
             return;
 
-        await ExecuteMultiAgentAndQueryRequests(context, reqs);
+        await ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
     private bool HandleSubAgentResponse(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
@@ -490,7 +490,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private void BuildQueryRequest(JsonOperationContext context, ConversationDocument document, Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs, AiAgentToolQuery q, AiToolCall call)
     {
-        reqs.GetOrAdd(QueryVirtualConversationId).Add((call, new DynamicJsonValue
+        reqs.GetOrAdd(QueryVirtualSubConversationId).Add((call, new DynamicJsonValue
             {
                 [nameof(GetRequest.Url)] = $"/databases/{database.Name}/queries",
                 [nameof(GetRequest.Query)] = null,
@@ -659,7 +659,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     // TODO we might need to change the order here to support nested sub-agents calls
                     // so it would be grand-child / child / parent instead
 
-                    var subAgent = GetOrAdd(subAgentsActions, action, rootToolId); // get or add from subAgentsActions
+                    var subAgent = GetOrAddSubAgentsActionResponses(subAgentsActions, action, rootToolId); // get or add from subAgentsActions
                     subAgent.Responses.Add(new AiAgentActionResponse
                     {
                         ToolId = childToolId, // sub call ID
@@ -703,26 +703,26 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
             return new[] { s.Substring(0, index), s.Substring(index + 1) };
         }
+    }
 
-        static ServerAiAgentActionResponse GetOrAdd(Dictionary<string, ServerAiAgentActionResponse> subAgentsActions, AiAgentActionRequest parent, string parentToolId)
+    private static ServerAiAgentActionResponse GetOrAddSubAgentsActionResponses(Dictionary<string, ServerAiAgentActionResponse> subAgentsActions, AiAgentActionRequest parent, string parentToolId)
+    {
+        if (subAgentsActions.TryGetValue(parent.SubConversation, out var subAgent))
         {
-            if (subAgentsActions.TryGetValue(parent.SubConversation, out var subAgent))
-            {
-                Debug.Assert(subAgent.ParentId == parentToolId, $"subAgent.ParentId != rootToolId. subAgent.ParentId is '{subAgent.ParentId}',  rootToolId is '{parentToolId}'");
-                Debug.Assert(subAgent.Agent == parent.Name, $"subAgent.Agent != action.Name. subAgent.Agent is '{subAgent.Agent}', action.Name is '{parent.Name}'");
-            }
-            else
-            {
-                subAgent = subAgentsActions[parent.SubConversation] = new ServerAiAgentActionResponse()
-                {
-                    ParentId = parentToolId,
-                    Agent = parent.Name,
-                    Responses = new()
-                };
-            }
-
-            return subAgent;
+            Debug.Assert(subAgent.ParentId == parentToolId, $"subAgent.ParentId != rootToolId. subAgent.ParentId is '{subAgent.ParentId}',  rootToolId is '{parentToolId}'");
+            Debug.Assert(subAgent.Agent == parent.Name, $"subAgent.Agent != action.Name. subAgent.Agent is '{subAgent.Agent}', action.Name is '{parent.Name}'");
         }
+        else
+        {
+            subAgent = subAgentsActions[parent.SubConversation] = new ServerAiAgentActionResponse()
+            {
+                ParentId = parentToolId,
+                Agent = parent.Name,
+                Responses = new()
+            };
+        }
+
+        return subAgent;
     }
 
     private async Task HandleSubAgentCalls(JsonOperationContext context, Dictionary<string, ServerAiAgentActionResponse> subAgentsActions)
@@ -739,9 +739,9 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             reqs.GetOrAdd(conversationId).Add((call, r));
         }
 
-        await ExecuteMultiAgentAndQueryRequests(context, reqs);
+        await ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
 
-        if (_childUserCalls.Any())
+        if (_childUserCalls.Count > 0)
             return;
 
         List<AiToolCall> activeToolCalls = [];
@@ -784,46 +784,19 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         };
     }
 
-    private async Task ExecuteMultiAgentAndQueryRequests(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
+    private async Task ExecuteMultiAgentAndQueryRequestsAsync(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
-        if (reqs.TryGetValue(QueryVirtualConversationId, out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
+        if (reqs.TryGetValue(QueryVirtualSubConversationId, out List<(AiToolCall Call, DynamicJsonValue Req)> queryToolReqs))
         {
-            await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(queryToolReqs.Select(x => x.Req))))
-            {
-                AiToolCall currentCall = queryToolReqs[i].Call;
-                var toolCall = FindToolFrom(_configuration, currentCall.Name);
-                if (toolCall == null)
-                    throw new InvalidOperationException($"Ai-Agent has no tool in name '{currentCall.Name}'");
-
-                switch (toolCall)
-                {
-                    case AiAgentToolQuery:
-                        if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
-                            throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-
-                        _document.AddMessage(context, context.ReadObject(
-                            new DynamicJsonValue
-                            {
-                                ["tool_call_id"] = currentCall.Id,
-                                ["role"] = "tool",
-                                ["content"] = GetToolResultContent(queryResult)
-                            }, "tool-call/response"), usage: null);
-
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Type mismatch for tool '{currentCall.Name}'. " +
-                                                            $"Expected type: '{nameof(AiAgentToolQuery)}', Actual type: '{toolCall.GetType().Name}'.");
-                }
-            }
+            await ExecuteSingleSubConversationToolCallsAsync(context, QueryVirtualSubConversationId, queryToolReqs);
         }
-
-        foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != QueryVirtualConversationId))
+        foreach (var (conversationId, conversationReqs) in reqs.Where(kvp => kvp.Key != QueryVirtualSubConversationId))
         {
-            await ExecuteSubAgentToolCalls(context, conversationId, conversationReqs);
+            await ExecuteSingleSubConversationToolCallsAsync(context, conversationId, conversationReqs);
         }
     }
 
-    private async Task ExecuteSubAgentToolCalls(JsonOperationContext context, string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
+    private async Task ExecuteSingleSubConversationToolCallsAsync(JsonOperationContext context, string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
     {
         await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
         {
@@ -838,10 +811,23 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     if (HandleSubAgentResponse(context, requestResult, currentCall) == false)
                         return;
                     break;
+                case AiAgentToolQuery:
+                    if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
+                        throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
+
+                    _document.AddMessage(context, context.ReadObject(
+                        new DynamicJsonValue
+                        {
+                            ["tool_call_id"] = currentCall.Id,
+                            ["role"] = "tool",
+                            ["content"] = GetToolResultContent(queryResult)
+                        }, "tool-call/response"), usage: null);
+
+                    break;
                 default:
                     throw new InvalidOperationException(
                         $"Type mismatch for tool '{currentCall.Name}' in sub-conversation '{conversationId}'. " + 
-                        $"Expected type: '{nameof(AiAgentToolSubAgent)}', Actual type: '{toolCall.GetType().Name}'.");
+                        $"Expected type: '{nameof(AiAgentToolSubAgent)}' or '{nameof(AiAgentToolQuery)}', Actual type: '{toolCall.GetType().Name}'.");
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ServerAiAgentActionResponse.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ServerAiAgentActionResponse.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.AI.Agents;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents
+{
+    public class ServerAiAgentActionResponse
+    {
+        public string Agent;
+        public string ParentId;
+
+        public List<AiAgentActionResponse> Responses;
+    }
+}

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -868,11 +868,15 @@ namespace Raven.Server.Web
         public const string ReadRevisionsConfigTag = "read-revisions-config";
         public const string ConflictedRevisionsConfigTag = "conflicted-revisions-config";
         public const string RevisionsBinConfigTag = "revisions-bin-config";
+        public const string AiAgentConfiguration = "ai-agent-config";
 
         private static DynamicJsonValue GetCustomConfigurationAuditJson(string name, BlittableJsonReaderObject configuration)
         {
             switch (name)
             {
+                case AiAgentConfiguration:
+                    return JsonDeserializationCluster.AiAgentConfiguration(configuration).ToAuditJson();
+                
                 case RevisionsBinConfigTag:
                     return JsonDeserializationCluster.RevisionsBinConfiguration(configuration).ToAuditJson();
                 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -61,18 +61,18 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent = new AiAgentConfiguration("user-info-agent",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             }
@@ -82,7 +82,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         var recommendationAgent = new AiAgentConfiguration("recommendation-agent",
             config.ConnectionStringName,
             "You are a User Movie Insights Agent in a movie recommendation system. " +
-            "You can retrieve details such as:" + Environment.NewLine +
+            "You can retrieve the following details:" + Environment.NewLine +
             "- The list of movies the user has watched, ordered by their ratings (highest to lowest)." + Environment.NewLine +
             "- The user’s top 3 genre affinities, ranked by score." + Environment.NewLine +
             "Always return results in a concise, structured way that can be used directly by the recommendation engine."
@@ -137,24 +137,24 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
             [
                 new AiAgentToolSubAgent
                 {
-                    Identifier = userAgentId,
+                    Identifier = recommendationAgentId,
                     Description = "Use to ask: " + Environment.NewLine +
                                   "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
                                   "- The user’s genre affinities, sorted by preference scores. "
                 },
                 new AiAgentToolSubAgent
                 {
-                    Identifier = recommendationAgentId,
-                    Description = "Use to ask about user profile, such as: user name and watched list."
+                    Identifier = userAgentId,
+                    Description = "Get the user name."
                 }
             ]
         };
-        agent.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        agent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
 
         var identifier = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent, MoviesSampleObject.Instance)).Identifier;
 
         var chat = store.AI.Conversation(identifier, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.SetUserPrompt("Whats my name and my favorite genres?");
         var r = await chat.RunAsync<MoviesSampleObject>();
         Assert.NotNull(r.Answer);
@@ -172,18 +172,18 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent = new AiAgentConfiguration("user-info-agent",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             }
@@ -260,7 +260,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        agent.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        agent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var identifier = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent, MoviesSampleObject.Instance)).Identifier;
 
         var db = await GetDatabase(store.Database);
@@ -278,7 +278,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         };
 
         var chat = store.AI.Conversation(identifier, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.SetUserPrompt("Whats my name and my favorite genres?");
         var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<MoviesSampleObject>());
         Assert.Contains("Failed to 'talk' with the agent 'movies-agent'", e.Message);
@@ -296,18 +296,18 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent3 = new AiAgentConfiguration("user-info-agent-3",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             }
@@ -318,8 +318,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent2 = new AiAgentConfiguration("user-info-agent-2",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             SubAgents =
@@ -327,7 +326,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent3Id,
-                    Description = "Use to ask about user profile, such as: user name and watched list."
+                    Description = "Use to ask about user name."
                 }
             ]
         };
@@ -337,8 +336,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             SubAgents =
@@ -346,15 +344,15 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent2Id,
-                    Description = "Use to ask about user profile, such as: user name and watched list."
+                    Description = "Use to ask about user name."
                 }
             ]
         };
-        userAgent1.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
 
         var chat = store.AI.Conversation(userAgent1Id, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.SetUserPrompt("Whats my name?");
         var r = await chat.RunAsync<MoviesSampleObject>();
         Assert.NotNull(r.Answer);
@@ -364,7 +362,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task ActionToolsOnSubAgent(Options options, GenAiConfiguration config)
+    public async Task ActionToolsOnSubAgentWithDifferentParam(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
@@ -372,18 +370,18 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent3 = new AiAgentConfiguration("user-info-agent-3",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested OR change user name."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             },
@@ -396,13 +394,12 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 },
             }
         };
-        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the requested user, not his hold Name (equals to 'currentUserId')"));
         var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
 
         var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested OR change user name."
         )
         {
             SubAgents =
@@ -410,7 +407,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent3Id,
-                    Description = "Use to ask about user profile, such as: user name and watched list. also use to change user name."
+                    Description = "Use to get user name and to change user name."
                 }
             ]
         };
@@ -419,7 +416,10 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var chat = store.AI.Conversation(userAgent1Id, "chats/1",
             new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
-        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-3/ChangeUserName", (r) => ChangeUserNameAsync(store, r));
+        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-3/ChangeUserName", async (r) =>
+        {
+            return await ChangeUserNameAsync(store, r);
+        });
 
         chat.SetUserPrompt("Can you change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
         var r = await chat.RunAsync<MoviesSampleObject>();
@@ -430,7 +430,6 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
             var name = (await session.LoadAsync<User>("Users/1")).Name;
             Assert.Equal("Aviv Rachmani", name);
         }
-
     }
 
     private static async Task<object> ChangeUserNameAsync(IDocumentStore store, ChangeUserNameSampleRequest req)
@@ -468,18 +467,18 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent3 = new AiAgentConfiguration("user-info-agent-3",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             }
@@ -490,8 +489,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent2 = new AiAgentConfiguration("user-info-agent-2",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             SubAgents =
@@ -499,9 +497,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent3Id,
-                    Description = "Use to ask: " + Environment.NewLine +
-                                  "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
-                                  "- The user’s genre affinities, sorted by preference scores. "
+                    Description = "Get the user name"
                 }
             ]
         };
@@ -511,8 +507,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             SubAgents =
@@ -520,17 +515,15 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent2Id,
-                    Description = "Use to ask: " + Environment.NewLine +
-                                  "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
-                                  "- The user’s genre affinities, sorted by preference scores. "
+                    Description =  "Get the user name"
                 }
             ]
         };
-        userAgent1.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
 
         var chat = store.AI.Conversation(userAgent1Id, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.SetUserPrompt("Whats my name?");
         var r = await chat.RunAsync<MoviesSampleObject>();
         Assert.NotNull(r.Answer);
@@ -1022,18 +1015,18 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent = new AiAgentConfiguration("user-info-agent",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             }
@@ -1099,9 +1092,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgentId,
-                    Description = "Use to ask: " + Environment.NewLine +
-                                  "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
-                                  "- The user’s genre affinities, sorted by preference scores. "
+                    Description = "Get the user name"
                 },
                 new AiAgentToolSubAgent
                 {
@@ -1110,7 +1101,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        agent.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        agent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var identifier = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent, MoviesSampleObject.Instance)).Identifier;
 
         var db = await GetDatabase(store.Database);
@@ -1130,7 +1121,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
         // chat without error
         var chat = store.AI.Conversation(identifier, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.SetUserPrompt("Whats my top 5 movies?");
         var r = await chat.RunAsync<MoviesSampleObject>();
         Assert.Equal(AiConversationResult.Done, r.Status);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -283,7 +283,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<MoviesSampleObject>());
         Assert.Contains("Failed to 'talk' with the agent 'movies-agent'", e.Message);
         Assert.True(e.Message.Contains("Failed to 'talk' with the agent 'user-info-agent'") ||
-                    e.Message.Contains("Failed to 'talk' with the agent 'recommendation-agent'"));
+                    e.Message.Contains("Failed to 'talk' with the agent 'recommendation-agent'"), e.Message);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -618,7 +618,96 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 4 and change my name from 'Aviv Rachmani' to 'Omer Adam'?");
         r = await chat.RunAsync<MoviesSampleObject>();
         Assert.Equal(AiConversationResult.Done, r.Status);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Omer Adam", u.Name);
+        }
+        Assert.Equal(Rates.Count + 2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+    }
 
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task SubAgent2OpenActionToolsAtOnce(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        var userAgent2 = new AiAgentConfiguration("user-info-agent-2",
+            config.ConnectionStringName,
+            "You are authorized to edit the user's name and to create movie-rating records associated with the user." +
+            "Use exclusively the 'ChangeUserName' tool for changing the user's name. " +
+            "Use exclusively the 'RateMovie' tool for adding a movie-rating record (rating a movie). " +
+            "Do not perform these actions in any other way."
+        )
+        {
+            Actions = new List<AiAgentToolAction>()
+            {
+                new AiAgentToolAction("ChangeUserName",
+                    "Updates the name of the current user interacting with the AI agent. have to send also the old name for validation.")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                },
+                new AiAgentToolAction("RateMovie",
+                    "Add movie rate required movie name and rate value between 0 to 5 (can be double, doesn't has to be integer)")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(RateToolSampleRequest.Instance)
+                },
+            }
+        };
+        userAgent2.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent2Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2, MoviesSampleObject.Instance)).Identifier;
+
+
+        var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent2Id,
+                    Description = "Provide BOTH the movie rating and the new username together in one call. You can't change name without rating a movie and you cant rate a movie without changing the name. you have to ask for both in the call otherwide the tool call will fail.",
+                }
+            ]
+        };
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(userAgent1Id, "chats/",
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-2/ChangeUserName", async (r) =>
+        {
+            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+        chat.Handle<RateToolSampleRequest>("user-info-agent-2/RateMovie", async (r) =>
+        {
+            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+
+        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 5 and change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Aviv Rachmani", u.Name);
+        }
+        Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+
+        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 4 and change my name from 'Aviv Rachmani' to 'Omer Adam'?");
+        r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+        
         using (var session = store.OpenAsyncSession())
         {
             var u = await session.LoadAsync<User>("Users/1");
@@ -763,14 +852,6 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         {
             Actions = new List<AiAgentToolAction>()
             {
-                // new AiAgentToolAction("ChangeUserName",
-                //     "Changes the user's name. You must always provide both the old name and the new name for validation. " +
-                //     "If the user requests multiple consecutive name changes in a single message, DO NOT answer the user between them. " +
-                //     "Instead, execute this tool once for the first change, wait for its tool response, and only then execute this tool again for the next change. " +
-                //     "Never merge multiple name changes into one call, and never reply to the user until ALL name-change operations have completed successfully.")
-                // {
-                //     ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
-                // }
                 new AiAgentToolAction("ChangeUserName",
                     "Changes the user's name. Always provide both OldUserName and NewUserName. " +
                     "This tool MUST be called strictly one time per assistant message. " +
@@ -830,7 +911,6 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         });
 
         var msg = "change my name from Shahar Hikri to Aviv Rahmani, and then change my name to Aviv Rahmani to Omer Adam";
-        // var msg = "change my name from Shahar Hikri to Aviv Rahmani";
         chat.SetUserPrompt(msg);
         var r = await chat.RunAsync<MoviesSampleObject>();
         Assert.Equal(AiConversationResult.Done, r.Status);
@@ -1061,7 +1141,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<MoviesSampleObject>());
         Assert.Contains("Failed to 'talk' with the agent 'movies-agent'", e.Message);
         Assert.True(e.Message.Contains("Failed to 'talk' with the agent 'user-info-agent'") ||
-                    e.Message.Contains("Failed to 'talk' with the agent 'recommendation-agent'"));
+                    e.Message.Contains("Failed to 'talk' with the agent 'recommendation-agent'"), e.Message);
 
         // Resume execution after an error
         throwEx = false;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -144,7 +144,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    public async Task SubAgent2OpenActionTools_DepthOf4(Options options, GenAiConfiguration config, bool level1OncePrompt, bool level0OncePrompt)
+    public async Task SubAgent2OpenActionTools_DepthOf3(Options options, GenAiConfiguration config, bool level1OncePrompt, bool level0OncePrompt)
     {
         const string atOncePrompt =
             "Provide BOTH the movie rating and the new username together in one call. You can't change name without rating a movie and you cant rate a movie without changing the name. you have to ask for both in the call otherwide the tool call will fail.";
@@ -483,6 +483,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
             userAgent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
             return (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent0, MoviesSampleObject.Instance)).Identifier;
         }
+
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -61,18 +61,18 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent3 = new AiAgentConfiguration("user-info-agent-3",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested OR change user name."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             },
@@ -85,13 +85,12 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                 },
             }
         };
-        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the requested user"));
         var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
 
         var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested OR change user name."
         )
         {
             SubAgents =
@@ -99,17 +98,16 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent3Id,
-                    Description = "Use to ask about user profile, such as: user name and watched list. also use to change user name."
+                    Description = "Use to get user name and to change user name."
                 }
             ]
         };
-        userAgent1.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
 
         var userAgent0 = new AiAgentConfiguration("user-info-agent-0",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested OR change user name."
         )
         {
             SubAgents =
@@ -117,15 +115,15 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                 new AiAgentToolSubAgent
                 {
                     Identifier = userAgent1Id,
-                    Description = "Use to ask about user profile, such as: user name and watched list. also use to change user name."
+                    Description = "Use to get user name and to change user name."
                 }
             ]
         };
-        userAgent0.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        userAgent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent0Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent0, MoviesSampleObject.Instance)).Identifier;
 
         var chat = store.AI.Conversation(userAgent0Id, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-1/user-info-agent-3/ChangeUserName", (r) => ChangeUserNameAsync(store, r));
 
         chat.SetUserPrompt("Can you change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
@@ -364,7 +362,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                     }
                 }
             };
-            changeUserNameAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            changeUserNameAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the requested user"));
             return (await store.AI.CreateAgentAsync<MoviesSampleObject>(changeUserNameAgent, MoviesSampleObject.Instance)).Identifier;
         }
 
@@ -496,23 +494,23 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
 
         var userAgent = new AiAgentConfiguration("user-info-agent",
             config.ConnectionStringName,
-            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
-            "user name and watched list."
+            "Your role responsibility is to provide the user's name when requested."
         )
         {
             Queries = new List<AiAgentToolQuery>()
             {
                 new AiAgentToolQuery
                 {
-                    Name = "GetUserProfile",
-                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Name = "GetUserName",
+                    Description = "Get the user name",
                     Query = "from Users " +
-                            "where id() = $userId",
+                            "where id() = $userId " +
+                            "select Name",
                     ParametersSampleObject = "{}"
                 },
             }
         };
-        userAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        userAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the requested user"));
 
         var recommendationAgent = new AiAgentConfiguration("recommendation-agent",
             config.ConnectionStringName,
@@ -572,19 +570,19 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
             [
                 new AiAgentToolSubAgent
                 {
-                    Identifier = userAgentId,
+                    Identifier = recommendationAgentId,
                     Description = "Use to ask: " + Environment.NewLine +
                                   "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
                                   "- The user’s genre affinities, sorted by preference scores. "
                 },
                 new AiAgentToolSubAgent
                 {
-                    Identifier = recommendationAgentId,
-                    Description = "Use to ask about user profile, such as: user name and watched list."
+                    Identifier = userAgentId,
+                    Description = "Get the user name."
                 }
             ]
         };
-        agent1.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        agent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var identifier1 = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent1, MoviesSampleObject.Instance)).Identifier;
 
         var agent0 = new AiAgentConfiguration("movies-agent-0",
@@ -609,7 +607,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        agent0.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        agent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var identifier0 = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent0, MoviesSampleObject.Instance)).Identifier;
 
         var db = await GetDatabase(store.Database);
@@ -628,7 +626,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
         };
 
         var chat = store.AI.Conversation(identifier0, "chats/1",
-            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
 
         // error
         throwEx = true;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -1,0 +1,988 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
+{
+    public record Reply
+    {
+        public string Message { get; set; }
+    }
+
+    public class Movie
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+        public int Year { get; set; }
+        public string[] Genres { get; set; }
+        public HashSet<string> Tags { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public class User
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public HashSet<string> WatchedMovies { get; set; }
+    }
+
+    public class Rating
+    {
+        public string Id { get; set; }
+        public string UserId { get; set; }
+        public string MovieId { get; set; }
+        public double RatingValue { get; set; }
+        public DateTime TimeStamp { get; set; }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task ActionToolsOnSubAgent_DepthOf3(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        var userAgent3 = new AiAgentConfiguration("user-info-agent-3",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
+            "user name and watched list."
+        )
+        {
+            Queries = new List<AiAgentToolQuery>()
+            {
+                new AiAgentToolQuery
+                {
+                    Name = "GetUserProfile",
+                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Query = "from Users " +
+                            "where id() = $userId",
+                    ParametersSampleObject = "{}"
+                },
+            },
+            Actions = new List<AiAgentToolAction>()
+            {
+                new AiAgentToolAction("ChangeUserName",
+                    "Updates the name of the current user interacting with the AI agent. have to send also the old name for validation.")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                },
+            }
+        };
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
+
+        var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
+            "user name and watched list."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent3Id,
+                    Description = "Use to ask about user profile, such as: user name and watched list. also use to change user name."
+                }
+            ]
+        };
+        userAgent1.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
+
+        var userAgent0 = new AiAgentConfiguration("user-info-agent-0",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
+            "user name and watched list."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent1Id,
+                    Description = "Use to ask about user profile, such as: user name and watched list. also use to change user name."
+                }
+            ]
+        };
+        userAgent0.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        var userAgent0Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent0, MoviesSampleObject.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(userAgent0Id, "chats/1",
+            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-1/user-info-agent-3/ChangeUserName", (r) => ChangeUserNameAsync(store, r));
+
+        chat.SetUserPrompt("Can you change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var name = (await session.LoadAsync<User>("Users/1")).Name;
+            Assert.Equal("Aviv Rachmani", name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    public async Task SubAgent2OpenActionTools_DepthOf4(Options options, GenAiConfiguration config, bool level1OncePrompt, bool level0OncePrompt)
+    {
+        const string atOncePrompt =
+            "Provide BOTH the movie rating and the new username together in one call. You can't change name without rating a movie and you cant rate a movie without changing the name. you have to ask for both in the call otherwide the tool call will fail.";
+        const string twicePrompt = "Use for adding movie rate for the current user you talking with OR changing user name (cannot ask for both at once)";
+
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        var userAgent2 = new AiAgentConfiguration("user-info-agent-2",
+            config.ConnectionStringName,
+            "You are authorized to edit the user's name and to create movie-rating records associated with the user." +
+            "Use exclusively the 'ChangeUserName' tool for changing the user's name. " +
+            "Use exclusively the 'RateMovie' tool for adding a movie-rating record (rating a movie). " +
+            "Do not perform these actions in any other way."
+        )
+        {
+            Actions = new List<AiAgentToolAction>()
+            {
+                new AiAgentToolAction("ChangeUserName",
+                    "Updates the name of the current user interacting with the AI agent. have to send also the old name for validation.")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                },
+                new AiAgentToolAction("RateMovie",
+                    "Add movie rate required movie name and rate value between 0 to 5 (can be double, doesn't has to be integer)")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(RateToolSampleRequest.Instance)
+                },
+            }
+        };
+        userAgent2.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent2Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2, MoviesSampleObject.Instance)).Identifier;
+
+        var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent2Id,
+                    Description = level1OncePrompt ? atOncePrompt : twicePrompt
+                }
+            ]
+        };
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
+
+        var userAgent0 = new AiAgentConfiguration("user-info-agent-0",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent1Id,
+                    Description = level0OncePrompt ? atOncePrompt : twicePrompt
+
+                }
+            ]
+        };
+        userAgent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent0Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent0, MoviesSampleObject.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(userAgent0Id, "chats/",
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-1/user-info-agent-2/ChangeUserName", async (r) =>
+        {
+            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+        chat.Handle<RateToolSampleRequest>("user-info-agent-1/user-info-agent-2/RateMovie", async (r) =>
+        {
+            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+
+        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 5 and change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Aviv Rachmani", u.Name);
+        }
+        Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+
+        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 4 and change my name from 'Aviv Rachmani' to 'Omer Adam'?");
+        r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Omer Adam", u.Name);
+        }
+        Assert.Equal(Rates.Count + 2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task SubAgent2OpenActionTools_Depth3and4(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        // Level3
+        var addMovieToListAgentId = await GetAddMovieToListAgent();
+
+        // Level2
+        var changeUserNameAgentId = await GetChangeUserNameAgent();
+        var rateMovieAgentId = await GetRateMovieAgent();
+        var userAgent2bId = await GetUserAgent2b(addMovieToListAgentId);
+
+        // Level1
+        var userAgent1aId = await GetUserAgent1a(changeUserNameAgentId, rateMovieAgentId);
+        var userAgent1bId = await GetUserAgent1b(addMovieToList: userAgent2bId);
+
+        // Level0
+        var userAgent0Id = await GetUserAgent0(rateOrChangeName: userAgent1aId, addMovieToList: userAgent1bId);
+
+        /*
+        UserAgent0
+            ├── UserAgent1a
+            │   ├── changeUserNameAgent
+            │   └── rateMovieAgent
+            └── UserAgent1b
+                └── userAgent2b
+                    └── addMovieToListAgent
+        */
+
+        var addMovieToListActionName = $"{userAgent1bId}/{userAgent2bId}/{addMovieToListAgentId}/AddToMovieWatchedList";
+        var changeUserNameActionName = $"{userAgent1aId}/{changeUserNameAgentId}/ChangeUserName";
+        var rateMovieActionName = $"{userAgent1aId}/{rateMovieAgentId}/RateMovie";
+
+        var chat = store.AI.Conversation(userAgent0Id, "chats/",
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+        chat.Handle<ChangeUserNameSampleRequest>(changeUserNameActionName, async (r) =>
+        {
+            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+        chat.Handle<RateToolSampleRequest>(rateMovieActionName, async (r) =>
+        {
+            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+        chat.Handle<AddMovieToWatchedListSampleRequest>(addMovieToListActionName, async (r) =>
+        {
+            var res = await AddMovieAsync(store, "Users/1", r) as ActionToolResult;
+            return res;
+        });
+
+        chat.SetUserPrompt("Please rate the movie \"Toy Story\" as 5, add the movie Nixon and Sudden Death to my watched list,and also change my name from 'Shahar Hikri' to 'Aviv Rachmani'");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Aviv Rachmani", u.Name);
+            Assert.Equal(5, u.WatchedMovies.Count);
+        }
+
+        Assert.Equal(Rates.Count + 1, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+
+        async Task<string> GetAddMovieToListAgent()
+        {
+            var addMovieToListAgent = new AiAgentConfiguration("add-movie-to-list-agent",
+                config.ConnectionStringName,
+                "You are authorized to add movies to user watched List." +
+                "Use exclusively the 'AddToMoviesWatchedList' tool for adding a movie to user's watched list. " +
+                "Do not perform these action in any other way."
+            )
+            {
+                Actions = new List<AiAgentToolAction>()
+                {
+                    new AiAgentToolAction("AddToMovieWatchedList",
+                        "Use for adding a movie to user watched list.")
+                    {
+                        ParametersSampleObject = JsonConvert.SerializeObject(AddMovieToWatchedListSampleRequest.Instance)
+                    }
+                }
+            };
+            addMovieToListAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(addMovieToListAgent, MoviesSampleObject.Instance)).Identifier;
+        }
+
+        async Task<string> GetChangeUserNameAgent()
+        {
+            var changeUserNameAgent = new AiAgentConfiguration(
+                "change-name-agent",
+                config.ConnectionStringName,
+                "You are authorized ONLY to change the user's name. " +
+                "Use exclusively the 'ChangeUserName' tool for changing the user's name. " +
+                "Do not attempt to perform movie rating or any other action."
+            )
+            {
+                Actions = new List<AiAgentToolAction>()
+                {
+                    new AiAgentToolAction(
+                        "ChangeUserName",
+                        "Updates the name of the current user interacting with the AI agent. Must include the old name for validation.")
+                    {
+                        ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                    }
+                }
+            };
+            changeUserNameAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(changeUserNameAgent, MoviesSampleObject.Instance)).Identifier;
+        }
+
+        async Task<string> GetRateMovieAgent()
+        {
+            var rateMovieAgent = new AiAgentConfiguration(
+                "rate-movie-agent",
+                config.ConnectionStringName,
+                "You are authorized ONLY to create movie-rating records for the current user. " +
+                "Use exclusively the 'RateMovie' tool for adding a movie rating. " +
+                "Do not attempt to change the user’s name or perform any unrelated action."
+            )
+            {
+                Actions = new List<AiAgentToolAction>()
+                {
+                    new AiAgentToolAction(
+                        "RateMovie",
+                        "Adds a movie rating. Requires movie name and rating value between 0 and 5 (double allowed).")
+                    {
+                        ParametersSampleObject = JsonConvert.SerializeObject(RateToolSampleRequest.Instance)
+                    }
+                }
+            };
+            rateMovieAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(rateMovieAgent, MoviesSampleObject.Instance)).Identifier;
+        }
+
+        async Task<string> GetUserAgent2b(string addMovieToListAgentIdentifier)
+        {
+            var userAgent2b = new AiAgentConfiguration("user-info-agent-2b",
+                config.ConnectionStringName,
+                "You are authorized to add movies to user watched List." +
+                "Use exclusively the 'AddToMoviesWatchedList' tool for adding a movie to user's watched list. " +
+                "Do not perform these action in any other way."
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = addMovieToListAgentIdentifier,
+                        Description = "Use for adding a movie to user watched list."
+                    }
+                ]
+            };
+            userAgent2b.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2b, MoviesSampleObject.Instance)).Identifier;
+        }
+
+        async Task<string> GetUserAgent1a(string changeUserName, string rateMovie)
+        {
+            var userAgent1a = new AiAgentConfiguration("user-info-agent-1a",
+                config.ConnectionStringName,
+                "You are a User Profile Agent on movies rating system."
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = changeUserName,
+                        Description = "Use for changing user name"
+                    },
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = rateMovie,
+                        Description = "Use for adding movie rate for changing user name"
+                    }
+                ]
+            };
+            userAgent1a.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1a, MoviesSampleObject.Instance)).Identifier;
+        }
+
+        async Task<string> GetUserAgent1b(string addMovieToList)
+        {
+            var userAgent1b = new AiAgentConfiguration("user-info-agent-1b",
+                config.ConnectionStringName,
+                "You are a User Profile Agent on movies rating system."
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = addMovieToList,
+                        Description = "Use for adding a movie to user watched list (can add one movie per request). "
+                    }
+                ]
+            };
+            userAgent1b.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1b, MoviesSampleObject.Instance)).Identifier;
+        }
+
+        async Task<string> GetUserAgent0(string rateOrChangeName, string addMovieToList)
+        {
+            var userAgent0 = new AiAgentConfiguration("user-info-agent-0",
+                config.ConnectionStringName,
+                "You are a User Profile Agent on movies rating system."
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = rateOrChangeName,
+                        Description = "Use for adding movie rate for the current user you talking with OR changing user name (cannot ask for both at once) OR adding a movie to user watched list (can add one movie per request)"
+                    },
+                    new AiAgentToolSubAgent
+                    {
+                        Identifier = addMovieToList,
+                        Description = "Use for adding a movie to user watched list (can add one movie per request). "
+                    }
+                ]
+            };
+            userAgent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+            return (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent0, MoviesSampleObject.Instance)).Identifier;
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task ResumeChatAfterError_Depth3(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        var userAgent = new AiAgentConfiguration("user-info-agent",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system. you can give the user information about user profile, such as: " +
+            "user name and watched list."
+        )
+        {
+            Queries = new List<AiAgentToolQuery>()
+            {
+                new AiAgentToolQuery
+                {
+                    Name = "GetUserProfile",
+                    Description = "Get the profile details of a specific user, including its 'WatchedMovies' list",
+                    Query = "from Users " +
+                            "where id() = $userId",
+                    ParametersSampleObject = "{}"
+                },
+            }
+        };
+        userAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+
+        var recommendationAgent = new AiAgentConfiguration("recommendation-agent",
+            config.ConnectionStringName,
+            "You are a User Movie Insights Agent in a movie recommendation system. " +
+            "You can retrieve details such as:" + Environment.NewLine +
+            "- The list of movies the user has watched, ordered by their ratings (highest to lowest)." + Environment.NewLine +
+            "- The user’s top 3 genre affinities, ranked by score." + Environment.NewLine +
+            "Always return results in a concise, structured way that can be used directly by the recommendation engine."
+        )
+        {
+            Queries = new List<AiAgentToolQuery>()
+            {
+                // watched list ordered by user rates
+                new AiAgentToolQuery
+                {
+                    Name = "GetUserWatchedMoviesRates",
+                    Description =
+                        "Get user watched list movies ordered by the user rate - descending",
+                    Query = "from Ratings as r " +
+                            "where r.UserId = $userId " +
+                            "order by r.RatingValue desc " +
+                            "select { MovieId: r.MovieId, Title: load(r.MovieId).Title, Rating: r.RatingValue}",
+                    ParametersSampleObject = "{}"
+                },
+
+                // top 3 genres for the user
+                new AiAgentToolQuery
+                {
+                    Name = "GetUserAffinitiesByGenres",
+                    Description =
+                        "Get user genre affinities sorted by score, ordered by average Score (rating) - descending",
+                    Query = "from index 'UserGenreAffinity' " +
+                            "where UserId = $userId " +
+                            "order by Score desc " +
+                            "select Genre, Score, Count " +
+                            "limit 0, 3",
+                    ParametersSampleObject = "{}"
+                }
+            }
+        };
+        recommendationAgent.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+
+        var userAgentId = (await store.AI.CreateAgentAsync(userAgent, MoviesSampleObject.Instance)).Identifier;
+        var recommendationAgentId = (await store.AI.CreateAgentAsync(recommendationAgent, MoviesSampleObject.Instance)).Identifier;
+
+        var agent1 = new AiAgentConfiguration("movies-agent-1",
+            config.ConnectionStringName,
+            "You are a User Profile Agent in a movie recommendation and rating system. " +
+            "Your purpose is to provide accurate, structured information about a specific user. " +
+            "You can retrieve details such as: " + Environment.NewLine + "- The user’s profile (including watched movies). " + Environment.NewLine +
+            "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
+            "- The user’s genre affinities, sorted by preference scores. " + Environment.NewLine +
+            "Always return results in a clear, concise, and structured way that can be used directly by the movie recommendation system"
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgentId,
+                    Description = "Use to ask: " + Environment.NewLine +
+                                  "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
+                                  "- The user’s genre affinities, sorted by preference scores. "
+                },
+                new AiAgentToolSubAgent
+                {
+                    Identifier = recommendationAgentId,
+                    Description = "Use to ask about user profile, such as: user name and watched list."
+                }
+            ]
+        };
+        agent1.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        var identifier1 = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent1, MoviesSampleObject.Instance)).Identifier;
+
+        var agent0 = new AiAgentConfiguration("movies-agent-0",
+            config.ConnectionStringName,
+            "You are a User Profile Agent in a movie recommendation and rating system. " +
+            "Your purpose is to provide accurate, structured information about a specific user. " +
+            "You can retrieve details such as: " + Environment.NewLine + "- The user’s profile (including watched movies). " + Environment.NewLine +
+            "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
+            "- The user’s genre affinities, sorted by preference scores. " + Environment.NewLine +
+            "Always return results in a clear, concise, and structured way that can be used directly by the movie recommendation system"
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = identifier1,
+                    Description = "Use to ask: " + Environment.NewLine +
+                                  "- about user profile, such as: user name and watched list.. " + Environment.NewLine +
+                                  "- The list of movies the user has rated, ordered by rating. " + Environment.NewLine +
+                                  "- The user’s genre affinities, sorted by preference scores. "
+                }
+            ]
+        };
+        agent0.Parameters.Add(new AiAgentParameter("currentUserId", "the id of the current user that you talk with"));
+        var identifier0 = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent0, MoviesSampleObject.Instance)).Identifier;
+
+        var db = await GetDatabase(store.Database);
+        bool throwEx = false;
+        db.ForTestingPurposesOnly().BeforeAiAgentTalk = document =>
+        {
+            if (document.Agent == userAgentId && throwEx)
+            {
+                // throw on sub-agent
+                throw new RefusedToAnswerException("test")
+                {
+                    RequestId = "test123"
+                };
+            }
+
+        };
+
+        var chat = store.AI.Conversation(identifier0, "chats/1",
+            new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+
+        // error
+        throwEx = true;
+        chat.SetUserPrompt("Whats my name and my favorite genres?");
+        var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<MoviesSampleObject>());
+        Assert.Contains($"Failed to 'talk' with the agent '{userAgentId}'", e.Message);
+
+        // Resume execution after an error
+        throwEx = false;
+        chat.SetUserPrompt("Whats my name and my favorite genres?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+    }
+
+    private static async Task<object> ChangeUserNameAsync(IDocumentStore store, ChangeUserNameSampleRequest req)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var user = await session.LoadAsync<User>(req.UserId);
+            if (user.Name.ToLower() != req.OldUserName.ToLower())
+            {
+                return new ActionToolResult
+                {
+                    IsSuccessful = false,
+                    Answer = $"Your old name isn't '{req.OldUserName}'"
+                };
+            }
+
+            user.Name = req.NewUserName;
+            await session.SaveChangesAsync();
+
+            return new ActionToolResult
+            {
+                IsSuccessful = true,
+                Answer = $"Name of user '{user.Id}' changed from '{req.OldUserName}' to '{req.NewUserName}'"
+            };
+        }
+    }
+
+    private static async Task<object> RateMovieAsync(IDocumentStore store, string userId, RateToolSampleRequest req)
+    {
+        if (req.RateValue < 0 || req.RateValue > 5)
+        {
+            return new ActionToolResult
+            {
+                IsSuccessful = false,
+                Answer = $"Cant rate \"{req.MovieName}\" with the rate value {req.RateValue} - rate value has to be between 0 to 5"
+            };
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var movies = await session
+                .Advanced
+                .AsyncRawQuery<Movie>("from Movies where Title = $name")
+                .AddParameter("name", req.MovieName.ToLower())
+                .ToListAsync();
+
+            if (movies == null || movies.Count == 0)
+            {
+                return new ActionToolResult
+                {
+                    IsSuccessful = false,
+                    Answer = $"Movie with the name \"{req.MovieName}\" doesn't exist on the database"
+                };
+            }
+
+            var user = await session.LoadAsync<User>(userId);
+
+            foreach (var m in movies)
+            {
+                user.WatchedMovies.Add(m.Id);
+                await session.StoreAsync(new Rating()
+                {
+                    Id = "Ratings/",
+                    MovieId = m.Id,
+                    UserId = userId,
+                    RatingValue = req.RateValue,
+                    TimeStamp = DateTime.Now
+                });
+            }
+
+            await session.SaveChangesAsync();
+
+            return new ActionToolResult
+            {
+                IsSuccessful = true,
+                Answer =
+                    $"Found {movies.Count} movies with the name '{req.MovieName}' and rated them by score '{req.RateValue}'"
+            };
+        }
+    }
+
+    private static async Task<object> AddMovieAsync(IDocumentStore store, string userId, AddMovieToWatchedListSampleRequest req)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            var movies = await session
+                .Advanced
+                .AsyncRawQuery<Movie>("from Movies where Title = $name")
+                .AddParameter("name", req.MovieName.ToLower())
+                .ToListAsync();
+
+            if (movies == null || movies.Count == 0)
+            {
+                return new ActionToolResult
+                {
+                    IsSuccessful = false,
+                    Answer = $"Movie with the name \"{req.MovieName}\" doesn't exist on the database"
+                };
+            }
+
+            var user = await session.LoadAsync<User>(userId);
+            var movieId = string.Empty;
+            foreach (var m in movies)
+            {
+                movieId = m.Id;
+                user.WatchedMovies.Add(m.Id);
+                break;
+            }
+
+            await session.SaveChangesAsync();
+
+            return new ActionToolResult
+            {
+                IsSuccessful = true,
+                Answer =
+                    $"The movie '{req.MovieName}'  (id: {movieId}) was added to user watched list"
+            };
+        }
+    }
+
+    private static async Task CreateMoviesDatabase(DocumentStore store)
+    {
+        using (var session = store.OpenAsyncSession())
+        {
+            foreach (var m in Movies)
+            {
+                await session.StoreAsync(m);
+            }
+
+            foreach (var u in Users)
+            {
+                await session.StoreAsync(u);
+            }
+
+            foreach (var r in Rates)
+            {
+                await session.StoreAsync(r);
+            }
+
+            await session.SaveChangesAsync();
+        }
+
+        await new UserGenreAffinity().ExecuteAsync(store);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var results = await session.Query<UserGenreAffinity.Result, UserGenreAffinity>()
+                .Customize(x => x.WaitForNonStaleResults()) // ✅ ensures index is caught up
+                .ToListAsync();
+        }
+    }
+
+    public class MoviesSampleObject
+    {
+        public static MoviesSampleObject Instance = new()
+        {
+            Answer = "Answer to the user question",
+            MoviesIds = ["The movies ids relevant to the query or response"],
+            MoviesNames = ["The movies names relevant to the query or response"]
+        };
+
+        public string Answer;
+
+        public List<string> MoviesIds { get; set; }
+        public List<string> MoviesNames { get; set; }
+    }
+
+    public class RateToolSampleRequest
+    {
+        public static RateToolSampleRequest Instance = new()
+        {
+            MovieName = "The name of the movie the user wants to rate",
+            RateValue = 4.5
+        };
+
+        public string MovieName { get; set; }
+        public double RateValue { get; set; }
+    }
+
+    public class AddMovieToWatchedListSampleRequest
+    {
+        public static AddMovieToWatchedListSampleRequest Instance = new()
+        {
+            MovieName = "The name of the movie the user wants to add to its watched list",
+        };
+
+        public string MovieName { get; set; }
+    }
+
+    public class ActionToolResult
+    {
+        public bool IsSuccessful { get; set; }
+        public string Answer { get; set; }
+    }
+
+    public class ChangeUserNameSampleRequest
+    {
+        public static ChangeUserNameSampleRequest Instance = new()
+        {
+            UserId = "Users/123456789",
+            OldUserName = "James Parker",
+            NewUserName = "James Smith"
+        };
+
+        public string UserId { get; set; }
+        public string NewUserName { get; set; }
+        public string OldUserName { get; set; }
+    }
+
+    private static List<Movie> Movies = new()
+    {
+        new Movie() { Id = "Movies/1", Title = "Tom and Huck", Year = 1995, Genres = new[] { "Adventure", "Children" }, Tags = new HashSet<string>() { "Library System", "based on a book", "Mark Twain", "19th century", "abandoned house" } },
+
+        new Movie() { Id = "Movies/2", Title = "Toy Story", Year = 1995, Genres = new[] { "Adventure", "Animation", "Children", "Comedy", "Fantasy" }, Tags = new HashSet<string>() { "children", "Disney", "animation", "pixar", "funny" } },
+
+        new Movie() { Id = "Movies/3", Title = "Casino", Year = 1995, Genres = new[] { "Crime", "Drama" }, Tags = new HashSet<string>() { "Martin Scorsese", "robert de niro", "Tumey's DVDs", "Documentary like", "imdb top 250" } },
+
+        new Movie() { Id = "Movies/4", Title = "Heat", Year = 1995, Genres = new[] { "Action", "Crime", "Thriller" }, Tags = new HashSet<string>() { "atmospheric", "dialogue", "Tumey's DVDs", "realistic action", "Al Pacino" } },
+
+        new Movie() { Id = "Movies/5", Title = "Four Rooms", Year = 1995, Genres = new[] { "Comedy" }, Tags = new HashSet<string>() { "multiple storylines", "Tim Roth", "Tumey's VHS", "4", "Antonio Banderas" } },
+
+        new Movie() { Id = "Movies/6", Title = "American President, The", Year = 1995, Genres = new[] { "Comedy", "Drama", "Romance" }, Tags = new HashSet<string>() { "clever dialogue", "Aaron Sorkin", "Romance", "seen more than once", "politics" } },
+
+        new Movie() { Id = "Movies/7", Title = "GoldenEye", Year = 1995, Genres = new[] { "Action", "Adventure", "Thriller" }, Tags = new HashSet<string>() { "james bond", "Tumey's DVDs", "007", "Bond", "casual sex" } },
+
+        new Movie() { Id = "Movies/8", Title = "Jumanji", Year = 1995, Genres = new[] { "Adventure", "Children", "Fantasy" }, Tags = new HashSet<string>() { "Robin Williams", "fantasy", "time travel", "animals", "childhood recaptured" } },
+
+        new Movie() { Id = "Movies/9", Title = "Nixon", Year = 1995, Genres = new[] { "Drama" }, Tags = new HashSet<string>() { "Tumey's VHS", "based on a true story", "own", "politics", "president" } },
+
+        new Movie()
+        {
+            Id = "Movies/10", Title = "Grumpier Old Men", Year = 1995, Genres = new[] { "Comedy", "Romance" }, Tags = new HashSet<string>() { "comedinha de velhinhos engraÃƒÂ§ada", "comedinha de velhinhos engraÃ§ada", "grun running", "midwest", "Minnesota" }
+        },
+
+        new Movie() { Id = "Movies/11", Title = "Sense and Sensibility", Year = 1995, Genres = new[] { "Drama", "Romance" }, Tags = new HashSet<string>() { "boring", "nothing happens", "18th century", "classic", "emotional" } },
+
+        new Movie() { Id = "Movies/12", Title = "Sudden Death", Year = 1995, Genres = new[] { "Action" }, Tags = new HashSet<string>() { "Action", "Jean-Claude Van Damme", "Can't remember", "Peter Hyams", "1990s" } },
+
+        new Movie() { Id = "Movies/13", Title = "Balto", Year = 1995, Genres = new[] { "Adventure", "Animation", "Children" }, Tags = new HashSet<string>() { "James Horner", "wolves", "dogsled", "sort of boring", "dogs" } },
+
+        new Movie() { Id = "Movies/14", Title = "Ace Ventura: When Nature Calls", Year = 1995, Genres = new[] { "Comedy" }, Tags = new HashSet<string>() { "Jim Carrey", "detective", "silly fun", "very funny", "Rhino action :D" } },
+
+        new Movie() { Id = "Movies/15", Title = "Dracula: Dead and Loving It", Year = 1995, Genres = new[] { "Comedy", "Horror" }, Tags = new HashSet<string>() { "vampire", "vampires", "Leslie Nielsen", "spoof", "funny" } },
+
+        new Movie() { Id = "Movies/16", Title = "Get Shorty", Year = 1995, Genres = new[] { "Comedy", "Crime", "Thriller" }, Tags = new HashSet<string>() { "contrived", "forgetable", "funny", "silly", "funny!" } },
+
+        new Movie() { Id = "Movies/17", Title = "Cutthroat Island", Year = 1995, Genres = new[] { "Action", "Adventure", "Romance" }, Tags = new HashSet<string>() { "adventure", "dumb but funny", "Matthew Modine", "pirates", "Renny Harlin" } },
+
+        new Movie() { Id = "Movies/18", Title = "Sabrina", Year = 1995, Genres = new[] { "Comedy", "Romance" }, Tags = new HashSet<string>() { "as good maybe better than original", "great cast", "long island", "love story", "remake" } },
+
+        new Movie() { Id = "Movies/19", Title = "Money Train", Year = 1995, Genres = new[] { "Action", "Comedy", "Crime", "Drama", "Thriller" }, Tags = new HashSet<string>() { "afternoon section", "lame", "worthwhile", "action hero", "anti hero" } },
+
+        new Movie() { Id = "Movies/20", Title = "Father of the Bride Part II", Year = 1995, Genres = new[] { "Comedy" }, Tags = new HashSet<string>() { "Fantasy", "pregnancy", "remake", "family", "Steve Martin" } },
+
+        new Movie() { Id = "Movies/21", Title = "Waiting to Exhale", Year = 1995, Genres = new[] { "Comedy", "Drama", "Romance" }, Tags = new HashSet<string>() { "characters", "slurs", "based on novel or book", "chick flick", "divorce" } },
+    };
+
+    private static List<User> Users = new()
+    {
+        new User() { Id = "Users/1", Name = "Shahar Hikri", WatchedMovies = new HashSet<string>() { "Movies/1", "Movies/2", "Movies/15" } },
+
+        new User() { Id = "Users/2", Name = "Noa Levi", WatchedMovies = new HashSet<string>() { "Movies/3", "Movies/7", "Movies/12" } },
+
+        new User() { Id = "Users/3", Name = "Itay Cohen", WatchedMovies = new HashSet<string>() { "Movies/5", "Movies/9", "Movies/13", "Movies/20" } },
+
+        new User() { Id = "Users/4", Name = "Maya Ben-David", WatchedMovies = new HashSet<string>() { "Movies/2", "Movies/8", "Movies/14", "Movies/17", "Movies/21" } },
+
+        new User() { Id = "Users/5", Name = "Yonatan Mizrahi", WatchedMovies = new HashSet<string>() { "Movies/4", "Movies/6", "Movies/8" } },
+    };
+
+    private static List<Rating> Rates = new()
+    {
+        // User 1 (Shahar Hikri) - 3 ratings
+        new Rating() { Id = "Ratings/1", UserId = "Users/1", MovieId = "Movies/1", RatingValue = 4.8, TimeStamp = new DateTime(2025, 5, 1, 10, 0, 0) },
+        new Rating() { Id = "Ratings/2", UserId = "Users/1", MovieId = "Movies/2", RatingValue = 3.6, TimeStamp = new DateTime(2025, 5, 2, 14, 30, 0) },
+        new Rating() { Id = "Ratings/3", UserId = "Users/1", MovieId = "Movies/15", RatingValue = 2.9, TimeStamp = new DateTime(2025, 5, 3, 18, 45, 0) },
+
+        // User 2 (Noa Levi) - 3 ratings
+        new Rating() { Id = "Ratings/4", UserId = "Users/2", MovieId = "Movies/3", RatingValue = 4.2, TimeStamp = new DateTime(2025, 5, 4, 9, 15, 0) },
+        new Rating() { Id = "Ratings/5", UserId = "Users/2", MovieId = "Movies/7", RatingValue = 3.1, TimeStamp = new DateTime(2025, 5, 5, 20, 0, 0) },
+        new Rating() { Id = "Ratings/6", UserId = "Users/2", MovieId = "Movies/12", RatingValue = 2.4, TimeStamp = new DateTime(2025, 5, 6, 11, 10, 0) },
+
+        // User 3 (Itay Cohen) - 4 ratings
+        new Rating() { Id = "Ratings/7", UserId = "Users/3", MovieId = "Movies/5", RatingValue = 4.5, TimeStamp = new DateTime(2025, 5, 7, 16, 50, 0) },
+        new Rating() { Id = "Ratings/8", UserId = "Users/3", MovieId = "Movies/9", RatingValue = 3.3, TimeStamp = new DateTime(2025, 5, 8, 12, 25, 0) },
+        new Rating() { Id = "Ratings/9", UserId = "Users/3", MovieId = "Movies/13", RatingValue = 1.9, TimeStamp = new DateTime(2025, 5, 9, 19, 40, 0) },
+        new Rating() { Id = "Ratings/10", UserId = "Users/3", MovieId = "Movies/20", RatingValue = 4.7, TimeStamp = new DateTime(2025, 5, 10, 15, 5, 0) },
+
+        // User 4 (Maya Ben-David) - 5 ratings
+        new Rating() { Id = "Ratings/11", UserId = "Users/4", MovieId = "Movies/2", RatingValue = 3.8, TimeStamp = new DateTime(2025, 5, 11, 10, 0, 0) },
+        new Rating() { Id = "Ratings/12", UserId = "Users/4", MovieId = "Movies/8", RatingValue = 4.1, TimeStamp = new DateTime(2025, 5, 12, 13, 45, 0) },
+        new Rating() { Id = "Ratings/13", UserId = "Users/4", MovieId = "Movies/14", RatingValue = 2.7, TimeStamp = new DateTime(2025, 5, 13, 17, 20, 0) },
+        new Rating() { Id = "Ratings/14", UserId = "Users/4", MovieId = "Movies/17", RatingValue = 4.9, TimeStamp = new DateTime(2025, 5, 14, 21, 30, 0) },
+        new Rating() { Id = "Ratings/15", UserId = "Users/4", MovieId = "Movies/21", RatingValue = 3.0, TimeStamp = new DateTime(2025, 5, 15, 8, 55, 0) },
+
+        // User 5 (Yonatan Mizrahi) - 2 ratings
+        new Rating() { Id = "Ratings/16", UserId = "Users/5", MovieId = "Movies/4", RatingValue = 4.4, TimeStamp = new DateTime(2025, 5, 16, 14, 10, 0) },
+        new Rating() { Id = "Ratings/17", UserId = "Users/5", MovieId = "Movies/6", RatingValue = 2.6, TimeStamp = new DateTime(2025, 5, 17, 18, 20, 0) },
+        new Rating() { Id = "Ratings/18", UserId = "Users/5", MovieId = "Movies/8", RatingValue = 4.3, TimeStamp = new DateTime(2025, 5, 12, 13, 45, 0) },
+    };
+
+    private class UserGenreAffinity : AbstractIndexCreationTask<Rating, UserGenreAffinity.Result>
+    {
+        public class Result
+        {
+            public string UserId { get; set; }
+            public string Genre { get; set; }
+            public int Count { get; set; }
+            public double Sum { get; set; }
+            public double Score { get; set; }
+        }
+
+        public UserGenreAffinity()
+        {
+            Map = ratings => from r in ratings
+                             let m = LoadDocument<Movie>(r.MovieId)
+                             from gnr in (m.Genres ?? Array.Empty<string>())
+                             select new
+                             {
+                                 r.UserId,
+                                 Genre = gnr,
+                                 Count = 1,
+                                 Sum = (double)r.RatingValue,
+                                 Score = (double)r.RatingValue
+                             };
+
+            Reduce = results => from r in results
+                                group r by new { r.UserId, r.Genre }
+                into g
+                                let totalCount = g.Sum(x => x.Count)
+                                let totalSum = g.Sum(x => x.Sum)
+                                select new
+                                {
+                                    UserId = g.Key.UserId,
+                                    Genre = g.Key.Genre,
+                                    Count = totalCount,
+                                    Sum = totalSum,
+                                    Score = totalSum / totalCount
+                                };
+
+            Index(x => x.UserId, FieldIndexing.Exact);
+            Index(x => x.Genre, FieldIndexing.Search);
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24887/AI-Agent-enable-multi-agent-scenario

### Additional description

Cut specific sub-agent conversation if got action-calls from it without stop other sub-agent conversations,
Preparation for multitasking when 'talking' with multiple sub agents,
remove RefUserActions and children actions from parent doc,
Add test and debug assert validations
fix LogTaskToAudit on AiAgentProcessorForAddOrUpdateAiAgent

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
