### PR TITLE
RavenDB-25491 Use ppa and const value for Ubuntu 24.04

### DIFF
--- a/scripts/linux/pkg/deb/assets/build.sh
+++ b/scripts/linux/pkg/deb/assets/build.sh
@@ -16,14 +16,15 @@ export RAVENDB_VERSION_MINOR=$( egrep -o -e '^[0-9]+.[0-9]+' <<< "$RAVENDB_VERSI
 
 set -e
 
-MS_DEB_NAME="/cache/packages-microsoft-prod_${DISTRO_VERSION}.deb"
-if ! (test -f "${MS_DEB_NAME}" \
-    || wget -O "${MS_DEB_NAME}" "https://packages.microsoft.com/config/ubuntu/${DISTRO_VERSION}/packages-microsoft-prod.deb"); then
-     echo "Could not obtain packages-microsoft-prod.deb"
-     exit 1
-fi
+# MS_DEB_NAME="/cache/packages-microsoft-prod_${DISTRO_VERSION}.deb"
+# if ! (test -f "${MS_DEB_NAME}" \
+#     || wget -O "${MS_DEB_NAME}" "https://packages.microsoft.com/config/ubuntu/${DISTRO_VERSION}/packages-microsoft-prod.deb"); then
+#      echo "Could not obtain packages-microsoft-prod.deb"
+#      exit 1
+# fi
 
-dpkg -i $MS_DEB_NAME
+# dpkg -i $MS_DEB_NAME
+add-apt-repository ppa:dotnet/backports -y
 apt update
 
 DOWNLOAD_URL=${DOWNLOAD_URL:-"https://daily-builds.s3.amazonaws.com/RavenDB-${RAVENDB_VERSION}-${RAVEN_PLATFORM}.tar.bz2"}
@@ -41,7 +42,7 @@ DOTNET_VERSION_MINOR=$(egrep -o -e '^[0-9]+.[0-9]+' <<< $DOTNET_FULL_VERSION)
 export DOTNET_DEPS_VERSION="$DOTNET_FULL_VERSION"
 export DOTNET_RUNTIME_VERSION="$DOTNET_VERSION_MINOR"
 
-if [[ $release -eq 24 && $RAVEN_PLATFORM == "raspberry-pi" ]]; then
+if [[ $release -eq 24 ]]; then
     DOTNET_RUNTIME_DEPS="libicu74, libc6 (>= 2.38), libgcc-s1 (>= 3.0), liblttng-ust1t64 (>= 2.13.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)"
 else
     if [[ $release -ge 24 ]]; then
@@ -49,7 +50,7 @@ else
     else
         # Show dependencies for amd64 since that's the only platform Microsoft ships package for,
         # however the dependencies are the same at the moment.
-        DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-deps-$DOTNET_RUNTIME_VERSION:amd64"
+        DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION:amd64"
     fi
     
     # get depenencies and remove dotnet-host* dependencies


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25491 

### Additional description

`dotnet-runtime-10.0` package is not yet available in apt repository on Ubuntu 24.04 and it's available only in ppa on older OS versions.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
