### PR TITLE
RavenDB-25225 license validation for GenAi and AiAgent

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -15,6 +15,7 @@ using Raven.Client;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.SQL;
@@ -1717,7 +1718,7 @@ namespace Raven.Server.Commercial
             throw GenerateLicenseLimit(LimitType.EmbeddingsGeneration, message);
         }
 
-        public void AssertCanAddGenAiTask()
+        public void AssertCanAddGenAiTask(GenAiConfiguration genAiConfiguration)
         {
             if (IsValid(out var licenseLimit) == false)
                 throw licenseLimit;
@@ -1725,16 +1726,22 @@ namespace Raven.Server.Commercial
             if (LicenseStatus.HasGenAi)
                 return;
 
+            if (genAiConfiguration.Disabled)
+                return;
+
             const string message = "Your current license doesn't include the Gen AI feature";
             throw GenerateLicenseLimit(LimitType.GenAi, message);
         }
 
-        public void AssertCanAddAiAgentTask()
+        public void AssertCanAddAiAgentTask(AiAgentConfiguration  aiAgentConfiguration)
         {
             if (IsValid(out var licenseLimit) == false)
                 throw licenseLimit;
 
             if (LicenseStatus.HasAiAgent)
+                return;
+
+            if (aiAgentConfiguration.Disabled)
                 return;
 
             const string message = "Your current license doesn't include the AI Agent feature";

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForAddOrUpdateAiAgent.cs
@@ -21,13 +21,14 @@ internal class AiAgentProcessorForAddOrUpdateAiAgent<TRequestHandler, TOperation
 
     public override async ValueTask ExecuteAsync()
     {
-        RequestHandler.ServerStore.LicenseManager.AssertCanAddAiAgentTask();
-
         using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
         using var _ = ContextPool.AllocateOperationContext(out JsonOperationContext context);
         var options = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "ai/agent", token.Token);
-        
+
         var cfg = JsonDeserializationClient.AiAgentConfiguration(options);
+
+        RequestHandler.ServerStore.LicenseManager.AssertCanAddAiAgentTask(cfg);
+
         if (string.IsNullOrEmpty(cfg.Name))
             throw new ArgumentException("Ai Agent Name cannot be empty", nameof(cfg.Name));
 

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
@@ -139,9 +139,9 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                         break;
                     }
                 case EtlType.GenAi:
-                    RequestHandler.ServerStore.LicenseManager.AssertCanAddGenAiTask();
+                    var genAiConfiguration = Client.Json.Serialization.JsonDeserializationClient.AiGenConfiguration(etlConfiguration);
+                    RequestHandler.ServerStore.LicenseManager.AssertCanAddGenAiTask(genAiConfiguration);
                     break;
-
                 default:
                     throw new NotSupportedException($"Unknown ETL configuration type. Configuration: {etlConfiguration}");
             }

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -62,10 +62,12 @@ public sealed partial class ClusterStateMachine
         nameof(AddElasticSearchEtlCommand),
         nameof(AddQueueSinkCommand),
         nameof(UpdateQueueSinkCommand),
-        nameof(EditDataArchivalCommand),
         nameof(AddEmbeddingsGenerationCommand),
         nameof(UpdateEmbeddingsGenerationCommand),
-        nameof(AddOrUpdateAiAgentCommand)
+        nameof(EditDataArchivalCommand),
+        nameof(UpdateGenAiCommand),
+        nameof(AddGenAiCommand),
+        nameof(AddOrUpdateAiAgentCommand),
     };
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
@@ -180,6 +182,7 @@ public sealed partial class ClusterStateMachine
                 AssertEmbeddingsGeneration(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(AddGenAiCommand):
+            case nameof(UpdateGenAiCommand):
                 AssertGenAi(databaseRecord, serverStore.LicenseManager.LicenseStatus, context);
                 break;
             case nameof(AddOrUpdateAiAgentCommand):
@@ -252,9 +255,9 @@ public sealed partial class ClusterStateMachine
             AssertOlapEtlLicenseLimits(databaseRecord, newLicenseLimits, context);
             AssertSnowflakeEtl(databaseRecord, newLicenseLimits, context);
             AssertEmbeddingsGeneration(databaseRecord, newLicenseLimits, context);
-            AssertDocumentsCompressionLicenseLimits(databaseRecord, newLicenseLimits, context);
             AssertGenAi(databaseRecord, newLicenseLimits, context);
             AssertAiAgent(databaseRecord, newLicenseLimits, context);
+            AssertDocumentsCompressionLicenseLimits(databaseRecord, newLicenseLimits, context);
         }
     }
 
@@ -1078,6 +1081,9 @@ public sealed partial class ClusterStateMachine
         if (databaseRecord.GenAis.Count == 0)
             return;
 
+        if (databaseRecord.GenAis.All(x => x.Disabled))
+            return;
+
         throw new LicenseLimitException(LimitType.GenAi, "Your license doesn't support using the AI Generation feature.");
     }
 
@@ -1090,6 +1096,9 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (databaseRecord.AiAgents.All(x => x.Disabled))
+            return;
+
+        if (databaseRecord.AiAgents.All(x => false))
             return;
 
         throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");

--- a/test/SlowTests.Issues/Issues/RavenDB-25225-EmbeddingsGeneration.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25225-EmbeddingsGeneration.cs
@@ -192,11 +192,11 @@ namespace SlowTests.Issues
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
+                WaitForUserToContinueTheTest(store);
                 await AddAiIntegration(store);
 
                 await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.EmbeddingsGeneration);
                 await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.EmbeddingsGeneration);
-                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_DEV, LimitType.EmbeddingsGeneration);
             }
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_25225_AiAgent.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25225_AiAgent.cs
@@ -1,0 +1,177 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25225_AiAgent(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task Prevent_License_Downgrade_AiAgent()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.AddAiAgentIntegration(store);
+
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.AiAgent);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.AiAgent);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task FailToPutGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await LicenseHelper.AddAiAgentIntegration(store);
+                });
+                Assert.Equal(LimitType.AiAgent, exception.LimitType);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task PutDisabledGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                await LicenseHelper.AddAiAgentIntegration(store, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task FailToRestoreGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddAiAgentIntegration(store);
+                    await LicenseHelper.RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var exception = Assert.Throws<LicenseLimitException>(() =>
+                    {
+                        LicenseHelper.RunRestore(store, backupPath);
+                    });
+                    Assert.Equal(LimitType.AiAgent, exception.LimitType);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddAiAgentIntegration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddAiAgentIntegration(store, true);
+                    await LicenseHelper.RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    LicenseHelper.RunRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task FailedToEnableGenAiCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddAiAgentIntegration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.RunImport(Server, store, file);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        await LicenseHelper.AddAiAgentIntegration(store);
+                    });
+
+                    Assert.Equal(LimitType.AiAgent, exception.LimitType);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_25225_GenAi.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25225_GenAi.cs
@@ -1,0 +1,240 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Commands.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25225_GenAi(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        // ----------------------------------------
+        // Tests for GenAI License Limits
+        //
+        // When we import, GenAI is disabled by default.
+        // ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task PreventLicenseDowngradeGenAi()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.AddGenAiIntegration(store);
+
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.GenAi);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.GenAi);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task FailToPutGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await LicenseHelper.AddGenAiIntegration(store);
+                });
+                Assert.Equal(LimitType.GenAi, exception.LimitType);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task PutDisabledGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                await LicenseHelper.AddGenAiIntegration(store, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task FailToRestoreGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddGenAiIntegration(store);
+                    await LicenseHelper.RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var exception = Assert.Throws<LicenseLimitException>(() =>
+                    {
+                        LicenseHelper.RunRestore(store, backupPath);
+                    });
+                    Assert.Equal(LimitType.GenAi, exception.LimitType);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddGenAiIntegration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    var operation = new GetOngoingTaskInfoOperation(LicenseHelper.DefaultGenAiTaskName, OngoingTaskType.GenAi);
+                    var res = store.Maintenance.Send(operation);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var command = new UpdateGenAiCommand(res.TaskId, LicenseHelper.GenAiConfig(false), store.Database, "", RaftIdGenerator.NewId());
+                        await Server.ServerStore.SendToLeaderAsync(command);
+                    });
+                    Assert.Equal(LimitType.GenAi, exception.LimitType);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledGenAiWithProLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddGenAiIntegration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_PRO);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+
+                    var operation = new GetOngoingTaskInfoOperation(LicenseHelper.DefaultGenAiTaskName, OngoingTaskType.GenAi);
+                    var res = store.Maintenance.Send(operation);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var command = new UpdateGenAiCommand(res.TaskId, LicenseHelper.GenAiConfig(false), store.Database, "",RaftIdGenerator.NewId());
+                        await Server.ServerStore.SendToLeaderAsync(command);
+                    });
+                    Assert.Equal(LimitType.GenAi, exception.LimitType);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledGenAiWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddGenAiIntegration(store, true);
+                    await LicenseHelper.RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                    LicenseHelper.RunRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task FailedToEnableGenAiCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+                    await LicenseHelper.AddGenAiIntegration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.RunImport(Server, store, file);
+
+                    var operation = new GetOngoingTaskInfoOperation(LicenseHelper.DefaultGenAiTaskName, OngoingTaskType.GenAi);
+                    var res = store.Maintenance.Send(operation);
+
+                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                    {
+                        var command = new UpdateGenAiCommand(res.TaskId, LicenseHelper.GenAiConfig(false), store.Database, "", RaftIdGenerator.NewId());
+                        await Server.ServerStore.SendToLeaderAsync(command);
+                    });
+
+                    Assert.Equal(LimitType.GenAi, exception.LimitType);
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.License.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.License.cs
@@ -1,8 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -10,6 +15,7 @@ using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -29,7 +35,7 @@ namespace FastTests
         public class LicenseTestBase
         {
             private readonly RavenTestBase _parent;
-
+            internal string DefaultGenAiTaskName = "localGenAiTask";
             public LicenseTestBase(RavenTestBase parent)
             {
                 _parent = parent ?? throw new ArgumentNullException(nameof(parent));
@@ -84,6 +90,23 @@ namespace FastTests
                 await ChangeLicense(server, licenseType);
             }
 
+            internal async Task RunImport(RavenServer server, DocumentStore store, string file)
+            {
+                await ChangeLicenseAndDisableRevisionCompression(server, store, RL_COMM);
+                var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+            }
+
+            internal async Task<LicenseLimitException> FailedToDoImport(RavenServer server, DocumentStore store, string file)
+            {
+                await ChangeLicenseAndDisableRevisionCompression(server, store, RL_COMM);
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                });
+                return exception;
+            }
             internal void PutIndexWithAdditionalAssemblies(DocumentStore store, IndexState indexState = IndexState.Normal)
             {
                 store.Maintenance.Send(new PutIndexesOperation(new[]
@@ -227,6 +250,118 @@ namespace FastTests
                 };
 
                 await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
+            }
+
+            internal void RunRestore(DocumentStore store, string backupPath)
+            {
+                var configuration = new RestoreBackupConfiguration { DatabaseName = store.Database + "1" };
+                configuration.BackupLocation = Directory.GetDirectories(backupPath).First();
+                _parent.Backup.RestoreDatabase(store, configuration);
+            }
+
+            internal async Task RunBackup(DocumentStore store, string backupPath)
+            {
+                var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+
+                _ = (BackupResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+            }
+
+            internal AiConnectionString GetConnectionString()
+            {
+                var connectionString = new AiConnectionString
+                {
+                    Name = "test-connection",
+                    ModelType = AiModelType.Chat,
+                    OpenAiSettings = new OpenAiSettings { ApiKey = "test-key", Model = "gpt-4", Endpoint = "https://google.com/v5" }
+                };
+                connectionString.Identifier = connectionString.GenerateIdentifier();
+                return connectionString;
+            }
+
+            internal AiAgentConfiguration AiAgentConfig(AiConnectionString connectionString)
+            {
+                var agent = new AiAgentConfiguration("shopping-assistant", connectionString.Name,
+                    "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
+                agent.Identifier = "shopping-assistant";
+                agent.Parameters.Add(new AiAgentParameter("company", "The company ID"));
+                agent.SampleObject = JsonConvert.SerializeObject(new { answer = "string" });
+                agent.Queries =
+                [
+                    new AiAgentToolQuery
+                    {
+                        Name = "ProductSearch",
+                        Description = "semantic search the store product catalog",
+                        Query = "from Products where vector.search(embedding.text(Name), $query)",
+                        ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+                    },
+                    new AiAgentToolQuery
+                    {
+                        Name = "RecentOrder",
+                        Description = "Get the recent orders of the current user",
+                        Query = "from Orders where Company = $company order by OrderedAt desc limit 10",
+                        ParametersSampleObject = "{}"
+                    }
+                ];
+
+                return agent;
+            }
+
+            internal async Task AddAiAgentIntegration(DocumentStore store, bool disabled = false)
+            {
+                AiConnectionString connectionString = GetConnectionString();
+
+                var configuration = AiAgentConfig(connectionString);
+                configuration.ConnectionStringName = connectionString.Name;
+                configuration.Disabled = disabled;
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+                await store.Maintenance.SendAsync(new AddOrUpdateAiAgentOperation(configuration));
+            }
+
+            internal async Task AddGenAiIntegration(DocumentStore store, bool disabled = false)
+            {
+                AiConnectionString connectionString = GetConnectionString();
+
+                var configuration = GenAiConfig(disabled);
+                configuration.ConnectionStringName = connectionString.Name;
+                configuration.Identifier = configuration.GenerateIdentifier();
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+                await store.Maintenance.SendAsync(new AddGenAiOperation(configuration));
+            }
+
+            internal GenAiConfiguration GenAiConfig(bool disabled)
+            {
+                return new GenAiConfiguration
+                {
+                    Name = DefaultGenAiTaskName,
+                    Collection = "TestCollection",
+                    Prompt = "Test prompt",
+                    SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or ham" }),
+                    UpdateScript = @"
+const idx = this.Comments.findIndex(c => c.Id == $input.Id);
+if($output.Blocked)
+{
+    this.Comments.splice(idx, 1); // remove
+}",
+                    GenAiTransformation = new GenAiTransformation
+                    {
+                        Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+                    },
+                    Disabled = disabled
+                };
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25225

### Additional description

* Ignore license validation for disabled features when restoring a database
* Ignore license validation for disabled features 
* added the tests from https://issues.hibernatingrhinos.com/issue/RavenDB-25476/Add-missing-license-limit-tests for GenAI and AiAgent

Related PR:
https://github.com/ravendb/ravendb/pull/21690
https://github.com/ravendb/ravendb/pull/21837

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
