### PR TITLE
RavenDB-25516 add ai assistant license assertions

### DIFF
--- a/src/Raven.Client/Exceptions/Commercial/LimitType.cs
+++ b/src/Raven.Client/Exceptions/Commercial/LimitType.cs
@@ -61,6 +61,9 @@ namespace Raven.Client.Exceptions.Commercial
         [Description("AI Agent")]
         AiAgent,
 
+        [Description("AI Assistant")]
+        AiAssistant,
+
         [Description("Cores Limit")]
         Cores,
 

--- a/src/Raven.Server/Commercial/LicenseAttribute.cs
+++ b/src/Raven.Server/Commercial/LicenseAttribute.cs
@@ -71,5 +71,6 @@ public enum LicenseAttribute
     SnowflakeEtl,
     AiEmbeddingsGen,
     GenAi,
-    AiAgent
+    AiAgent,
+    AiAssistant
 }

--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -1741,6 +1741,18 @@ namespace Raven.Server.Commercial
             throw GenerateLicenseLimit(LimitType.AiAgent, message);
         }
 
+        public void AssertCanUseAiAssistant()
+        {
+            if (IsValid(out var licenseLimit) == false)
+                throw licenseLimit;
+
+            if (LicenseStatus.HasAiAssistant)
+                return;
+
+            const string message = "Your current license doesn't include the AI Assistant feature";
+            throw GenerateLicenseLimit(LimitType.AiAssistant, message);
+        }
+
         public void AssertCanAddConcurrentDataSubscriptions()
         {
             if (IsValid(out var licenseLimit) == false)

--- a/src/Raven.Server/Commercial/LicenseStatus.cs
+++ b/src/Raven.Server/Commercial/LicenseStatus.cs
@@ -242,6 +242,8 @@ namespace Raven.Server.Commercial
 
         public bool HasAiAgent => Enabled(LicenseAttribute.AiAgent);
 
+        public bool HasAiAssistant => true; // TODO fix it
+
         public bool HasPowerBI => Enabled(LicenseAttribute.PowerBI);
 
         public bool HasPostgreSqlIntegration => Enabled(LicenseAttribute.PostgreSqlIntegration);

--- a/src/Raven.Server/Config/Categories/AiConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/AiConfiguration.cs
@@ -54,4 +54,9 @@ public sealed class AiConfiguration : ConfigurationCategory
     [DefaultValue(10_000)]
     [ConfigurationEntry("Ai.Agent.Tools.TokenUsageThreshold", ConfigurationEntryScope.ServerWideOrPerDatabase)]
     public int ToolsTokenUsageThreshold { get; set; }
+
+    [Description("Disable the AI Assistant features.")]
+    [DefaultValue(false)]
+    [ConfigurationEntry("Ai.Assistant.Disable", ConfigurationEntryScope.ServerWideOnly)]
+    public bool DisableAiAssistant { get; set; }
 }

--- a/src/Raven.Server/Documents/AI/AiAssistant/Handlers/Processors/AiAssistantHandlerProcessorBase.cs
+++ b/src/Raven.Server/Documents/AI/AiAssistant/Handlers/Processors/AiAssistantHandlerProcessorBase.cs
@@ -17,10 +17,16 @@ internal abstract class AiAssistantHandlerProcessorBase : AbstractHandlerProcess
 
     protected AiAssistantHandlerProcessorBase([NotNull] RequestHandler requestHandler) : base(requestHandler)
     {
+
+        if (ServerStore.Configuration.Ai.DisableAiAssistant)
+            throw new InvalidOperationException("AI Assistant is disabled by the administrator.");
+
         _license = ServerStore.LoadLicense();
 
         if (_license is null)
             throw new InvalidOperationException("AI Assistant is available only for licensed instances of RavenDB. Please register your license.");
+
+        ServerStore.LicenseManager.AssertCanUseAiAssistant();
 
         _certificateThumbprint = RequestHandler.GetCurrentCertificate()?.Thumbprint;
     }

--- a/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/LicenseStubs.ts
@@ -105,6 +105,7 @@ export class LicenseStubs {
             HasEmbeddingsGeneration: true,
             HasGenAi: true,
             HasAiAgent: true,
+            HasAiAssistant: true,
             HasDocumentsCompression: true,
             HasTimeSeriesRollupsAndRetention: true,
             HasAdditionalAssembliesFromNuGet: true,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25516

### Additional description

add new license attribute for the ai assistant

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
