### PR TITLE
RavenDB-25418 : GenAI Task: Fail to test the "Generate context objects" step

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -105,14 +105,17 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         else if (GenAiTransformation.ValidateScript(out var error) == false)
             errors.Add(error);
 
-        if (string.IsNullOrEmpty(Prompt))
-            errors.Add($"{nameof(Prompt)} must be provided");
+        if (TestMode == false)
+        {
+            if (string.IsNullOrEmpty(Prompt))
+                errors.Add($"{nameof(Prompt)} must be provided");
 
-        if (string.IsNullOrEmpty(JsonSchema) && string.IsNullOrEmpty(SampleObject))
-            errors.Add("You must provide either a JSON schema or a sample object");
+            if (string.IsNullOrEmpty(JsonSchema) && string.IsNullOrEmpty(SampleObject))
+                errors.Add("You must provide either a JSON schema or a sample object");
 
-        if (TestMode == false && string.IsNullOrEmpty(UpdateScript))
-            errors.Add("You must provide an update function");
+            if (string.IsNullOrEmpty(UpdateScript))
+                errors.Add("You must provide an update function");
+        }
 
         return errors.Count == 0;
     }
@@ -123,7 +126,6 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
         json[nameof(Identifier)] = Identifier;
         json[nameof(AiConnectorType)] = AiConnectorType;
-        json[nameof(Identifier)] = Identifier;
         json[nameof(Collection)] = Collection;
         json[nameof(Prompt)] = Prompt;
         json[nameof(SampleObject)] = SampleObject;

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDb-25418.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDb-25418.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Util;
+using Raven.Server.Documents;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi.Test;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDb_25418 : RavenTestBase
+    {
+        public RavenDb_25418(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanTestContextGenerationWhenPromptAndSchemaAreMissing(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Prompt = null;
+            config.JsonSchema = null;
+            config.SampleObject = null;
+            config.UpdateScript = null;
+            config.Collection = "Posts";
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = "ai.genContext({ Name: this.Name });"
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new { Name = "Danielle" }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            DocumentDatabase database = await GetDocumentDatabaseInstanceFor(store);
+            using IDisposable _ = database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
+
+            var operation = new TestCreateGenAiContextOperation("users/1", config);
+            GenAiTestScriptResult result = await store.Maintenance.SendAsync(context, operation);
+
+            Assert.NotNull(result);
+            Assert.NotEmpty(result.Results);
+
+            var contextOutput = result.Results[0].ContextOutput.Context;
+            Assert.NotNull(contextOutput);
+            Assert.True(contextOutput.TryGet("Name", out string name));
+            Assert.Equal("Danielle", name);
+        }
+
+        private class TestCreateGenAiContextOperation : IMaintenanceOperation<GenAiTestScriptResult>
+        {
+            private readonly TestGenAiScript _testGenAiScript;
+
+            public TestCreateGenAiContextOperation(string docId, GenAiConfiguration config)
+            {
+                _testGenAiScript = new TestGenAiScript
+                {
+                    DocumentId = docId,
+                    Configuration = config,
+                    TestStage = TestStage.CreateContextObjects
+                };
+            }
+
+            public RavenCommand<GenAiTestScriptResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new TestGenAiCommand(_testGenAiScript, conventions);
+            }
+        }
+
+        private class TestGenAiCommand(TestGenAiScript testGenAiScript, DocumentConventions conventions) : RavenCommand<GenAiTestScriptResult>
+        {
+            public override bool IsReadRequest { get; } = true;
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/admin/ai/gen-ai/test";
+                BlittableJsonReaderObject bjro = ctx.ReadObject(testGenAiScript.ToJson(), "TestGenAiCommand_payload");
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethods.Post,
+                    Content = new BlittableJsonContent(async stream => await ctx.WriteAsync(stream, bjro).ConfigureAwait(false), conventions)
+                };
+            }
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                Result = DeserializeToTestEtlScriptResult(response);
+            }
+
+            private static readonly Func<BlittableJsonReaderObject, GenAiTestScriptResult> DeserializeToTestEtlScriptResult = JsonDeserializationClient.GenerateJsonDeserializationRoutine<GenAiTestScriptResult>();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25418/GenAI-Task-Fail-to-test-the-Generate-context-objects-step

### Additional description

When the system detects a test request from the studio, it now bypasses the strict validation for the Prompt and JsonSchema or SampleObject fields.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
