### PR TITLE
RavenDB-25444 Adjust `GrowableBuffer` growth strategy for 32-bit platforms.

### DIFF
--- a/src/Sparrow.Server/Utils/GrowableBuffer.cs
+++ b/src/Sparrow.Server/Utils/GrowableBuffer.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Diagnostics;
+using Sparrow.Platform;
 
 namespace Sparrow.Server.Utils;
 
@@ -13,8 +15,11 @@ public readonly struct Progressive : IBufferGrowth
 {
     public int GetNewSize(in int currentSizeInBytes)
     {
+        // Slower growth on 32-bit platforms
+        float platformScalar = PlatformDetails.Is32Bits ? 1.1f : 1.5f;
+        
         var size = currentSizeInBytes > 16 * Sparrow.Global.Constants.Size.Megabyte
-            ? (int)(currentSizeInBytes * 1.5)
+            ? (int)(currentSizeInBytes * platformScalar)
             : currentSizeInBytes * 2;
 
         // Represent array as N*sizeof(long)
@@ -30,7 +35,14 @@ public readonly struct Progressive : IBufferGrowth
 
     public int GetInitialSize(in long initialSize)
     {
+        Debug.Assert(initialSize < int.MaxValue, "initialSize < int.MaxValue");
         var size = 4 * Math.Min(Math.Max(Sparrow.Global.Constants.Size.Kilobyte, (int)initialSize), 16 * Sparrow.Global.Constants.Size.Kilobyte);
+        if (size < initialSize)
+        {
+            Debug.Assert(size % sizeof(long) == 0, "size % sizeof(long) == 0");
+            return (int)initialSize;
+        }
+        
         // Represent array as N*sizeof(long)
         return size - (size % sizeof(long));
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25444

### Additional description


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
