### PR TITLE
RavenDB-25225 license validation for Snowflake Etl

### DIFF
--- a/src/Raven.Server/Commercial/LicenseManager.cs
+++ b/src/Raven.Server/Commercial/LicenseManager.cs
@@ -17,6 +17,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.Snowflake;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.TimeSeries;
@@ -1668,14 +1669,17 @@ namespace Raven.Server.Commercial
             throw GenerateLicenseLimit(LimitType.QueueEtl, message);
         }
         
-        public void AssertCanAddSnowflakeEtl()
+        public void AssertCanAddSnowflakeEtl(SnowflakeEtlConfiguration configuration)
         {
             if (IsValid(out var licenseLimit) == false)
                 throw licenseLimit;
 
             if (LicenseStatus.HasSnowflakeEtl)
                 return;
-            
+
+            if (configuration.Disabled)
+                return;
+
             const string message = "Your current license doesn't include the Snowflake ETL feature";
             throw GenerateLicenseLimit(LimitType.SnowflakeEtl, message);
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/OngoingTasks/AbstractOngoingTasksHandlerProcessorForAddEtl.cs
@@ -84,7 +84,8 @@ namespace Raven.Server.Documents.Handlers.Processors.OngoingTasks
                     RequestHandler.ServerStore.LicenseManager.AssertCanAddQueueEtl();
                     break;
                 case EtlType.Snowflake:
-                    RequestHandler.ServerStore.LicenseManager.AssertCanAddSnowflakeEtl();
+                    var snowflakeConfiguration = Client.Json.Serialization.JsonDeserializationClient.SnowflakeEtlConfiguration(etlConfiguration);
+                    RequestHandler.ServerStore.LicenseManager.AssertCanAddSnowflakeEtl(snowflakeConfiguration);
                     break;
                 case EtlType.EmbeddingsGeneration:
                     using (RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -63,7 +63,8 @@ public sealed partial class ClusterStateMachine
         nameof(UpdateQueueSinkCommand),
         nameof(EditDataArchivalCommand),
         nameof(AddEmbeddingsGenerationCommand),
-        nameof(UpdateEmbeddingsGenerationCommand)
+        nameof(UpdateEmbeddingsGenerationCommand),
+        nameof(AddSnowflakeEtlCommand)
     };
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
@@ -1025,6 +1026,9 @@ public sealed partial class ClusterStateMachine
             return;
 
         if (databaseRecord.SnowflakeEtls.Count == 0)
+            return;
+
+        if (databaseRecord.SnowflakeEtls.All(x => x.Disabled))
             return;
 
         throw new LicenseLimitException(LimitType.SnowflakeEtl, "Your license doesn't support using the Snowflake ETL feature.");

--- a/test/SlowTests/Issues/RavenDB-25225-EmbeddingsGeneration.cs
+++ b/test/SlowTests/Issues/RavenDB-25225-EmbeddingsGeneration.cs
@@ -21,8 +21,52 @@ namespace SlowTests.Issues
     public class RavenDB_25225_EmbeddingsGeneration(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
     {
         // ----------------------------------------
-        // Tests for EmbeddingsGeneration License Limits
+        // Tests for Embeddings Generation License Limits
+        //
+        // When we import, Embeddings Generation is disabled by default.
         // ----------------------------------------
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task Prevent_License_Downgrade_Embeddings_Generation()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.AddAiIntegration(store, Server);
+
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.EmbeddingsGeneration);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.EmbeddingsGeneration);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task PreventPutEmbeddingsGenerationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await LicenseHelper.AddAiIntegration(store, Server);
+                });
+                Assert.Equal(LimitType.EmbeddingsGeneration, exception.LimitType);
+
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task PutDisabledEmbeddingsGenerationWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                await LicenseHelper.AddAiIntegration(store, Server, true);
+            }
+        }
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
         public async Task ImportingDisabledEmbeddingsGenerationWithCommunityLicense()
@@ -35,7 +79,7 @@ namespace SlowTests.Issues
                 {
                     await LicenseHelper.DisableRevisionCompression(Server, store);
 
-                    await AddAiIntegration(store, true);
+                    await LicenseHelper.AddAiIntegration(store, Server, true);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -47,16 +91,6 @@ namespace SlowTests.Issues
 
                     var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
                     await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
-
-                    var operation = new GetOngoingTaskInfoOperation(DefaultEmbeddingGenerationTaskName, OngoingTaskType.EmbeddingsGeneration);
-                    var res = store.Maintenance.Send(operation);
-
-                    var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
-                    {
-                        var command = new UpdateEmbeddingsGenerationCommand(res.TaskId, EGConfig(false, EgConnectionString()), store.Database, RaftIdGenerator.NewId());
-                        await Server.ServerStore.SendToLeaderAsync(command);
-                    });
-                    Assert.Equal(LimitType.EmbeddingsGeneration, exception.LimitType);
                 }
             }
             finally
@@ -76,7 +110,7 @@ namespace SlowTests.Issues
                 {
                     await LicenseHelper.DisableRevisionCompression(Server, store);
 
-                    await AddAiIntegration(store, true);
+                    await LicenseHelper.AddAiIntegration(store, Server, true);
 
                     var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
                     await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
@@ -94,7 +128,7 @@ namespace SlowTests.Issues
 
                     var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                     {
-                        var command = new UpdateEmbeddingsGenerationCommand(res.TaskId, EGConfig(false, EgConnectionString()), store.Database, RaftIdGenerator.NewId());
+                        var command = new UpdateEmbeddingsGenerationCommand(res.TaskId, LicenseHelper.EGConfig(false, LicenseHelper.EgConnectionString()), store.Database, RaftIdGenerator.NewId());
                         await Server.ServerStore.SendToLeaderAsync(command);
                     });
                     Assert.Equal(LimitType.EmbeddingsGeneration, exception.LimitType);
@@ -105,8 +139,6 @@ namespace SlowTests.Issues
                 File.Delete(file);
             }
         }
-
-
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai | RavenTestCategory.BackupExportImport)]
         public async Task RestoreDisabledEmbeddingsGenerationWithCommunityLicense()
@@ -119,16 +151,16 @@ namespace SlowTests.Issues
                 {
                     await LicenseHelper.DisableRevisionCompression(Server, store);
 
-                    await AddAiIntegration(store, true);
+                    await LicenseHelper.AddAiIntegration(store, Server, true);
 
-                    await RunBackup(store, backupPath);
+                    await LicenseHelper.RunBackup(store, backupPath);
                 }
 
                 using (var store = GetDocumentStore())
                 {
                     await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
 
-                    RunRestore(store, backupPath);
+                    LicenseHelper.RunRestore(store, backupPath);
                 }
             }
             finally
@@ -148,9 +180,9 @@ namespace SlowTests.Issues
                 {
                     await LicenseHelper.DisableRevisionCompression(Server, store);
 
-                    await AddAiIntegration(store);
+                    await LicenseHelper.AddAiIntegration(store, Server);
 
-                    await RunBackup(store, backupPath);
+                    await LicenseHelper.RunBackup(store, backupPath);
                 }
 
                 using (var store = GetDocumentStore())
@@ -159,7 +191,7 @@ namespace SlowTests.Issues
 
                     var exception = Assert.Throws<LicenseLimitException>(() =>
                     {
-                        RunRestore(store, backupPath);
+                        LicenseHelper.RunRestore(store, backupPath);
                     });
                     Assert.Equal(LimitType.EmbeddingsGeneration, exception.LimitType);
                 }
@@ -171,111 +203,21 @@ namespace SlowTests.Issues
         }
 
         [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
-        public async Task PreventPutEmbeddingsGenerationWithCommunityLicense()
+        public async Task EnableEmbeddingsGenerationWithCommunityLicense()
         {
             DoNotReuseServer();
             using (var store = GetDocumentStore())
             {
                 await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                var config = await LicenseHelper.AddAiIntegration(store, Server, true);
 
                 var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
                 {
-                    await AddAiIntegration(store);
+                    await LicenseHelper.UpdateAiIntegration(store, Server, config);
                 });
                 Assert.Equal(LimitType.EmbeddingsGeneration, exception.LimitType);
-
             }
-        }
-
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
-        public async Task Prevent_License_Downgrade_Embeddings_Generation()
-        {
-            DoNotReuseServer();
-            using (var store = GetDocumentStore())
-            {
-                await AddAiIntegration(store);
-
-                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.EmbeddingsGeneration);
-                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.EmbeddingsGeneration);
-                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_DEV, LimitType.EmbeddingsGeneration);
-            }
-        }
-
-        private async Task AddAiIntegration(DocumentStore store, bool disabled = false)
-        {
-            AiConnectionString connectionString = EgConnectionString();
-
-            connectionString.Identifier = connectionString.GenerateIdentifier();
-            EmbeddingsGenerationConfiguration config = EGConfig(disabled, connectionString);
-
-            var putResult = store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(connectionString));
-            Assert.NotNull(putResult.RaftCommandIndex);
-
-            var command = new AddEmbeddingsGenerationCommand(config, store.Database, RaftIdGenerator.NewId());
-            await Server.ServerStore.SendToLeaderAsync(command);
-        }
-
-        private static AiConnectionString EgConnectionString()
-        {
-            var connectionString = new AiConnectionString
-            {
-                Name = DefaultConnectionStringName,
-                OllamaSettings = new OllamaSettings
-                {
-                    Uri = "http://localhost:11434",
-                    Model = "test-model"
-                }
-            };
-            return connectionString;
-        }
-
-        private static EmbeddingsGenerationConfiguration EGConfig(bool disabled, AiConnectionString connectionString)
-        {
-            var config = new EmbeddingsGenerationConfiguration
-            {
-                Name = DefaultEmbeddingGenerationTaskName,
-                ConnectionStringName = DefaultConnectionStringName,
-                EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }],
-                Collection = "Dtos",
-                ChunkingOptionsForQuerying = DefaultChunkingOptions,
-                Disabled = disabled,
-                Connection = connectionString
-            };
-            config.Identifier = config.GenerateIdentifier();
-            return config;
-        }
-
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
-        public async Task PutDisabledEmbeddingsGenerationWithCommunityLicense()
-        {
-            DoNotReuseServer();
-            using (var store = GetDocumentStore())
-            {
-                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
-
-                await AddAiIntegration(store, true);
-            }
-        }
-
-        private void RunRestore(DocumentStore store, string backupPath)
-        {
-            var configuration = new RestoreBackupConfiguration { DatabaseName = store.Database + "1" };
-            configuration.BackupLocation = Directory.GetDirectories(backupPath).First();
-            Backup.RestoreDatabase(store, configuration);
-        }
-
-        private static async Task RunBackup(DocumentStore store, string backupPath)
-        {
-            var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
-            {
-                BackupType = BackupType.Backup,
-                LocalSettings = new LocalSettings
-                {
-                    FolderPath = backupPath
-                }
-            }));
-
-            _ = (BackupResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-25225-SnowflakeEtl.cs
+++ b/test/SlowTests/Issues/RavenDB-25225-SnowflakeEtl.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.Snowflake;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Client.Util;
+using Raven.Server.ServerWide.Commands.ETL;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25225_SnowflakeEtl : RavenTestBase
+    {
+        // ----------------------------------------
+        // Tests for Snowflake Etl License Limits
+        //
+        // When we import, Snowflake is disabled by default.
+        // ----------------------------------------
+
+        public RavenDB_25225_SnowflakeEtl(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task PreventLicenseDowngradeSnowflakeEtl()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.CreateSnowflakeEtlConfiguration(store);
+
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_COMM, LimitType.SnowflakeEtl);
+                await LicenseHelper.FailToChangeLicense(Server, LicenseTestBase.RL_PRO, LimitType.SnowflakeEtl);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task PreventPutSnowflakeEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await LicenseHelper.CreateSnowflakeEtlConfiguration(store);
+                });
+                Assert.Equal(LimitType.SnowflakeEtl, exception.LimitType);
+
+                var config = LicenseHelper.GetSnowflakeEtlConfiguration(false, LicenseHelper.GetSnowflakeConnectionString());
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    await Server.ServerStore.SendToLeaderAsync(new AddSnowflakeEtlCommand(config, store.Database, RaftIdGenerator.NewId()));
+                });
+                Assert.Equal(LimitType.SnowflakeEtl, exception.LimitType);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl)]
+        public async Task PutDisabledSnowflakeEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                await LicenseHelper.CreateSnowflakeEtlConfiguration(store, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl | RavenTestCategory.BackupExportImport)]
+        public async Task ImportingDisabledSnowflakeEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var file = GetTempFileName();
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await LicenseHelper.CreateSnowflakeEtlConfiguration(store, true);
+
+                    var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                    await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                }
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreDisabledSnowflakeEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await LicenseHelper.CreateSnowflakeEtlConfiguration(store, true);
+
+                    await LicenseHelper.RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    LicenseHelper.RunRestore(store, backupPath);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Etl | RavenTestCategory.BackupExportImport)]
+        public async Task RestoreSnowflakeEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            var backupPath = NewDataPath(suffix: "BackupFolder");
+            try
+            {
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                    await LicenseHelper.CreateSnowflakeEtlConfiguration(store);
+                    await LicenseHelper.RunBackup(store, backupPath);
+                }
+
+                using (var store = GetDocumentStore())
+                {
+                    await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+
+                    var exception = Assert.Throws<LicenseLimitException>(() =>
+                    {
+                        LicenseHelper.RunRestore(store, backupPath);
+                    });
+                    Assert.Equal(LimitType.SnowflakeEtl, exception.LimitType);
+                }
+            }
+            finally
+            {
+                Directory.Delete(backupPath, true);
+            }
+        }
+
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Ai)]
+        public async Task EnableSnowflakeEtlWithCommunityLicense()
+        {
+            DoNotReuseServer();
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.PutLicenseAndDisableRevisionCompression(Server, store, LicenseTestBase.RL_COMM);
+                var config = await LicenseHelper.CreateSnowflakeEtlConfiguration(store, true);
+                var op = new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.SnowflakeEtl);
+
+                var res = store.Maintenance.Send(op);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    config.Disabled = false;
+
+                    await store.Maintenance.SendAsync(new UpdateEtlOperation<SnowflakeConnectionString>(res.TaskId, config));
+                });
+                Assert.Equal(LimitType.SnowflakeEtl, exception.LimitType);
+
+                exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    config.Disabled = false;
+                    await Server.ServerStore.SendToLeaderAsync(new UpdateSnowflakeEtlCommand(res.TaskId, config, store.Database, RaftIdGenerator.NewId()));
+                });
+                Assert.Equal(LimitType.SnowflakeEtl, exception.LimitType);
+            }
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.License.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.License.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.Snowflake;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Exceptions.Commercial;
@@ -17,6 +22,7 @@ using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Commercial;
 using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Commands.AI;
 using Sparrow;
 using Xunit;
 
@@ -38,6 +44,10 @@ namespace FastTests
             internal const string RL_COMM = "RAVEN_LICENSE_COMMUNITY";
             internal const string RL_PRO = "RAVEN_LICENSE_PROFESSIONAL";
             internal const string RL_DEV = "RAVEN_LICENSE_DEVELOPER";
+
+            internal const string DefaultConnectionStringName = "Local AI connection";
+            internal const string DefaultEmbeddingGenerationTaskName = "localAiTask";
+            internal static readonly ChunkingOptions DefaultChunkingOptions = new ChunkingOptions() { ChunkingMethod = ChunkingMethod.PlainTextSplitLines, MaxTokensPerChunk = 2048 };
 
             internal async Task FailToChangeLicense(RavenServer leader, string licenseType, LimitType limitType)
             {
@@ -63,6 +73,27 @@ namespace FastTests
                 Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
 
                 await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
+            }
+
+            internal void RunRestore(DocumentStore store, string backupPath)
+            {
+                var configuration = new RestoreBackupConfiguration { DatabaseName = store.Database + "1" };
+                configuration.BackupLocation = Directory.GetDirectories(backupPath).First();
+                _parent.Backup.RestoreDatabase(store, configuration);
+            }
+
+            internal async Task RunBackup(DocumentStore store, string backupPath)
+            {
+                var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Backup,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
+
+                _ = (BackupResult)await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
             }
 
             internal async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
@@ -227,6 +258,104 @@ namespace FastTests
                 };
 
                 await store.Maintenance.SendAsync(new AddEtlOperation<SqlConnectionString>(config));
+            }
+
+            internal async Task<EmbeddingsGenerationConfiguration> AddAiIntegration(DocumentStore store, RavenServer server, bool disabled = false)
+            {
+                AiConnectionString connectionString = EgConnectionString();
+
+                connectionString.Identifier = connectionString.GenerateIdentifier();
+                EmbeddingsGenerationConfiguration config = EGConfig(disabled, connectionString);
+
+                var putResult = store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(connectionString));
+                Assert.NotNull(putResult.RaftCommandIndex);
+
+                var command = new AddEmbeddingsGenerationCommand(config, store.Database, RaftIdGenerator.NewId());
+                await server.ServerStore.SendToLeaderAsync(command);
+
+                return config;
+            }
+
+            internal async Task UpdateAiIntegration(DocumentStore store, RavenServer server, EmbeddingsGenerationConfiguration config)
+            {
+                var op = new GetOngoingTaskInfoOperation(DefaultEmbeddingGenerationTaskName, OngoingTaskType.EmbeddingsGeneration);
+
+                var res = store.Maintenance.Send(op);
+                config.Disabled = false;
+
+                var command = new UpdateEmbeddingsGenerationCommand(res.TaskId, config, store.Database, RaftIdGenerator.NewId());
+                await server.ServerStore.SendToLeaderAsync(command);
+            }
+
+            internal AiConnectionString EgConnectionString()
+            {
+                var connectionString = new AiConnectionString
+                {
+                    Name = DefaultConnectionStringName,
+                    OllamaSettings = new OllamaSettings
+                    {
+                        Uri = "http://localhost:11434",
+                        Model = "test-model"
+                    }
+                };
+                return connectionString;
+            }
+
+            internal EmbeddingsGenerationConfiguration EGConfig(bool disabled, AiConnectionString connectionString)
+            {
+                var config = new EmbeddingsGenerationConfiguration
+                {
+                    Name = DefaultEmbeddingGenerationTaskName,
+                    ConnectionStringName = DefaultConnectionStringName,
+                    EmbeddingsPathConfigurations = [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }],
+                    Collection = "Dtos",
+                    ChunkingOptionsForQuerying = DefaultChunkingOptions,
+                    Disabled = disabled,
+                    Connection = connectionString
+                };
+                config.Identifier = config.GenerateIdentifier();
+                return config;
+            }
+
+            internal SnowflakeConnectionString GetSnowflakeConnectionString()
+            {
+                var connection = new SnowflakeConnectionString { Name = "snowflakeConnectionString", ConnectionString = "connectionString", };
+                return connection;
+            }
+
+            internal async Task<SnowflakeEtlConfiguration> CreateSnowflakeEtlConfiguration(DocumentStore store, bool disabled = false)
+            {
+                var connectionString = GetSnowflakeConnectionString();
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<SnowflakeConnectionString>(connectionString));
+
+                SnowflakeEtlConfiguration config = GetSnowflakeEtlConfiguration(disabled, connectionString);
+
+                await store.Maintenance.SendAsync(new AddEtlOperation<SnowflakeConnectionString>(config));
+                return config;
+            }
+
+            internal SnowflakeEtlConfiguration GetSnowflakeEtlConfiguration(bool disabled, SnowflakeConnectionString connectionString)
+            {
+                var config = new SnowflakeEtlConfiguration()
+                {
+                    Name = "snowflakeEtl",
+                    ConnectionStringName = connectionString.Name,
+                    SnowflakeTables =
+                    {
+                        new SnowflakeEtlTable { TableName = "Orders", DocumentIdColumn = "Id", InsertOnlyMode = false },
+                        new SnowflakeEtlTable { TableName = "OrderLines", DocumentIdColumn = "OrderId", InsertOnlyMode = false },
+                    },
+                    Transforms = { new Transformation() { Name = "OrdersAndLines", Collections = new List<string> { "Orders" }, Script = @"var orderData = {
+Id: id(this),
+City: this.Address.City,
+TotalCost: 0
+};
+loadToOrders(orderData);"
+                    } } ,
+                    Disabled = disabled
+                };
+                return config;
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25225

### Additional description

* Check license limit when restoring snowflake Etl
* Ignore license validation for disabled features when restoring a database
* Ignore license validation for disabled features 
* added the tests from https://issues.hibernatingrhinos.com/issue/RavenDB-25476/Add-missing-license-limit-tests for snowflake Etl and embedding generation

Related PR:
https://github.com/ravendb/ravendb/pull/21690
https://github.com/ravendb/ravendb/pull/21837
https://github.com/ravendb/ravendb/pull/21917

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
