### PR TITLE
RavenDB-25526 Fix SqlException when using dots in field names defined in an ETL script

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/RelationalWriters/RelationalDatabaseWriter.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using NpgsqlTypes;
 using Oracle.ManagedDataAccess.Client;
@@ -24,6 +25,8 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
 {
     public sealed class RelationalDatabaseWriter : RelationalDatabaseWriterBase, IDisposable
     {
+        private static readonly Regex _invalidParamChars = new Regex(@"[^\w]", RegexOptions.Compiled);
+        
         private readonly Logger _logger;
 
         private readonly SqlEtl _etl;
@@ -415,20 +418,27 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.RelationalWriters
 
         private string GetParameterName(string paramName)
         {
+            var sanitizedParamName = SanitizeParameterName(paramName);
+            
             switch (_providerFactory.GetType().Name)
             {
                 case "SqlClientFactory":
                 case "MySqlClientFactory":
                 case "MySqlConnectorFactory":
-                    return "@" + paramName;
+                    return "@" + sanitizedParamName;
 
                 case "OracleClientFactory":
                 case "NpgsqlFactory":
-                    return ":" + paramName;
+                    return ":" + sanitizedParamName;
 
                 default:
                     throw new NotSupportedException($"Unhandled provider factory: {_providerFactory.GetType().Name}");
             }
+        }
+        
+        private string SanitizeParameterName(string paramName)
+        {
+            return _invalidParamChars.Replace(paramName, "_");
         }
 
         public SqlWriteStats Write(SqlTableWithRecords table, List<DbCommand> commands, CancellationToken token)

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -1311,6 +1311,76 @@ loadToOrders(orderData);
             }
         }
 
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
+        public async Task CanLoadFieldsWithDot_RavenDB_25526()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    CreateRdbmsSchema(connectionString, @"
+CREATE TABLE [dbo].[OrdersWithDot]
+(
+    [Id] [nvarchar](50) NOT NULL,
+    [OrderLines.Count] [int]  NULL,
+    [TotalCost] [int] NOT NULL,
+    [City] [nvarchar](50) NULL
+)
+");
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new Order
+                        {
+                            OrderLines = new List<OrderLine>
+                            {
+                                new OrderLine { Cost = 3, Product = "Milk", Quantity = 3 }, new OrderLine { Cost = 4, Product = "Bear", Quantity = 2 },
+                            }
+                        });
+                        await session.SaveChangesAsync();
+                    }
+                    
+                    WaitForUserToContinueTheTest(store);
+                    
+                    var etlDone = Etl.WaitForEtlToComplete(store);
+
+                    SetupSqlEtl(store, connectionString, @"
+var orderData = {
+    Id: id(this),
+    TotalCost: 0
+};
+
+orderData['OrderLines.Count'] = this.OrderLines.length;
+
+for (var i = 0; i < this.OrderLines.length; i++) {
+    var line = this.OrderLines[i];
+    orderData.TotalCost += line.Cost;
+}
+
+loadToOrdersWithDot(orderData);
+", tables: new List<SqlEtlTable> { new SqlEtlTable { TableName = "OrdersWithDot", DocumentIdColumn = "Id" }, });
+
+                    etlDone.Wait(TimeSpan.FromMinutes(5));
+
+                    using (var con = new SqlConnection())
+                    {
+                        con.ConnectionString = connectionString;
+                        con.Open();
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = " SELECT COUNT(*) FROM OrdersWithDot";
+                            Assert.Equal(1, dbCommand.ExecuteScalar());
+                            
+                            dbCommand.CommandText = "SELECT [OrderLines.Count] FROM [OrdersWithDot]";
+                            var count = Convert.ToInt32(dbCommand.ExecuteScalar());
+                            Assert.Equal(2, count);
+                        }
+                    }
+                }
+            }
+        }
+
         private static void AssertCounts(int ordersCount, int orderLineCounts, string connectionString)
         {
             using (var con = new SqlConnection())
@@ -1328,19 +1398,21 @@ loadToOrders(orderData);
             }
         }
 
-        protected void SetupSqlEtl(DocumentStore store, string connectionString, string script, bool insertOnly = false, List<string> collections = null)
+        protected void SetupSqlEtl(DocumentStore store, string connectionString, string script, bool insertOnly = false, List<string> collections = null, List<SqlEtlTable> tables = null)
         {
             var connectionStringName = $"{store.Database}@{store.Urls.First()} to SQL DB";
 
+            var sqlTables = tables ?? new List<SqlEtlTable> 
+            {
+                new SqlEtlTable { TableName = "Orders", DocumentIdColumn = "Id", InsertOnlyMode = insertOnly },
+                new SqlEtlTable { TableName = "OrderLines", DocumentIdColumn = "OrderId", InsertOnlyMode = insertOnly },
+            };
+            
             Etl.AddEtl(store, new SqlEtlConfiguration()
             {
                 Name = connectionStringName,
                 ConnectionStringName = connectionStringName,
-                SqlTables =
-                {
-                    new SqlEtlTable {TableName = "Orders", DocumentIdColumn = "Id", InsertOnlyMode = insertOnly},
-                    new SqlEtlTable {TableName = "OrderLines", DocumentIdColumn = "OrderId", InsertOnlyMode = insertOnly},
-                },
+                SqlTables = sqlTables,
                 Transforms =
                 {
                     new Transformation()


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25526/Dot-character-in-property-names-causes-SQL-ETL-error

### Additional description

Sanitize generated SQL parameter names by replacing dots and special characters with underscores. This prevents invalid syntax (e.g., @Order.CreatedAt) when executing INSERT commands against relational databases.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
