### PR TITLE
RavenDB-25491 Add support for Ubuntu Noble, handle kill signals

### DIFF
--- a/docker/build-ubuntu.ps1
+++ b/docker/build-ubuntu.ps1
@@ -62,6 +62,9 @@ function SetupDebBuildEnvironment($arch, $ubuntuVersion){
         "jammy" {
             . "..\scripts\linux\pkg\deb\set-ubuntu-jammy.ps1"
         }
+        "noble" {
+            . "..\scripts\linux\pkg\deb\set-ubuntu-noble.ps1"
+        }
         Default {
             throw "ERROR: Unsupported Ubuntu version $($ubuntuVersion). Supported version: bionic, focal, jammy."
             exit 1

--- a/scripts/linux/pkg/deb/assets/build.sh
+++ b/scripts/linux/pkg/deb/assets/build.sh
@@ -42,20 +42,23 @@ DOTNET_VERSION_MINOR=$(egrep -o -e '^[0-9]+.[0-9]+' <<< $DOTNET_FULL_VERSION)
 export DOTNET_DEPS_VERSION="$DOTNET_FULL_VERSION"
 export DOTNET_RUNTIME_VERSION="$DOTNET_VERSION_MINOR"
 
-if [[ $release -eq 24 ]]; then
-    if [[ $RAVEN_PLATFORM == "raspberry-pi" ]]; then
-        DOTNET_RUNTIME_DEPS="libicu74, libc6 (>= 2.38), libgcc-s1 (>= 3.0), liblttng-ust1t64 (>= 2.13.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)"
-    else
-        DOTNET_RUNTIME_DEPS="libicu74, libbrotli1 (>= 0.6.0), libc6 (>= 2.34), libgcc-s1 (>= 3.0), liblttng-ust1 (>= 2.13.0), libssl3 (>= 3.0.0~~alpha1), libstdc++6 (>= 12), libunwind8, zlib1g (>= 1:1.2.3.4)"
-    fi
+
+# Microsoft does not provide deb package for arm32 architecture
+if [[ $RAVEN_PLATFORM == "raspberry-pi" ]]; then
+    case $release in 
+        22) DOTNET_RUNTIME_DEPS="libicu70"
+            ;;
+        24) DOTNET_RUNTIME_DEPS="libicu74"
+            ;;
+    esac
+    DOTNET_RUNTIME_DEPS+=", libc6 (>= 2.38), libgcc-s1 (>= 3.0), liblttng-ust1t64 (>= 2.13.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)"
+elif [[ $release -eq 24 ]]; then
+    # package for ubuntu 24 is not yet available in canonical apt repository
+    DOTNET_RUNTIME_DEPS="libicu74, libbrotli1 (>= 0.6.0), libc6 (>= 2.34), libgcc-s1 (>= 3.0), liblttng-ust1 (>= 2.13.0), libssl3 (>= 3.0.0~~alpha1), libstdc++6 (>= 12), libunwind8, zlib1g (>= 1:1.2.3.4)"
 else
-    if [[ $release -ge 24 ]]; then
-        DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION"
-    else
-        # Show dependencies for amd64 since that's the only platform Microsoft ships package for,
-        # however the dependencies are the same at the moment.
-        DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION:amd64"
-    fi
+    DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION"
+    # display available packages
+    apt-cache search dotnet-runtime
     
     # get depenencies and remove dotnet-host* dependencies
     DOTNET_RUNTIME_DEPS=$(apt show $DOTNET_RUNTIME_DEPS_PKG 2>/dev/null | sed -n -e 's/Depends: //p' | sed -E 's/(^|, )dotnet-host[^,]*(, |$)/\1/; s/, $//')

--- a/scripts/linux/pkg/deb/assets/build.sh
+++ b/scripts/linux/pkg/deb/assets/build.sh
@@ -43,7 +43,11 @@ export DOTNET_DEPS_VERSION="$DOTNET_FULL_VERSION"
 export DOTNET_RUNTIME_VERSION="$DOTNET_VERSION_MINOR"
 
 if [[ $release -eq 24 ]]; then
-    DOTNET_RUNTIME_DEPS="libicu74, libc6 (>= 2.38), libgcc-s1 (>= 3.0), liblttng-ust1t64 (>= 2.13.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)"
+    if [[ $RAVEN_PLATFORM == "raspberry-pi" ]]; then
+        DOTNET_RUNTIME_DEPS="libicu74, libc6 (>= 2.38), libgcc-s1 (>= 3.0), liblttng-ust1t64 (>= 2.13.0), libssl3t64 (>= 3.0.0), libstdc++6 (>= 13.1), zlib1g (>= 1:1.1.4)"
+    else
+        DOTNET_RUNTIME_DEPS="libicu74, libbrotli1 (>= 0.6.0), libc6 (>= 2.34), libgcc-s1 (>= 3.0), liblttng-ust1 (>= 2.13.0), libssl3 (>= 3.0.0~~alpha1), libstdc++6 (>= 12), libunwind8, zlib1g (>= 1:1.2.3.4)"
+    fi
 else
     if [[ $release -ge 24 ]]; then
         DOTNET_RUNTIME_DEPS_PKG="dotnet-runtime-$DOTNET_RUNTIME_VERSION"
@@ -62,7 +66,7 @@ else
 fi
 
 
-export DEB_DEPS="${DOTNET_RUNTIME_DEPS}, libc6-dev (>= 2.27)"
+export DEB_DEPS="${DOTNET_RUNTIME_DEPS}, libc6-dev (>= 2.27), adduser"
 
 echo ".NET Runtime: $DOTNET_FULL_VERSION"
 echo "Package dependencies: $DEB_DEPS"

--- a/scripts/linux/pkg/deb/ubuntu_multiarch.Dockerfile
+++ b/scripts/linux/pkg/deb/ubuntu_multiarch.Dockerfile
@@ -11,7 +11,7 @@ ARG DISTRO_VERSION
 
 RUN apt update \ 
     && apt-get -y dist-upgrade \
-    && apt install -y curl wget apt-transport-https 
+    && apt install -y curl wget apt-transport-https software-properties-common
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y dos2unix devscripts dh-make wget gettext-base lintian curl debhelper
 

--- a/scripts/linux/pkg/deb/ubuntu_native.Dockerfile
+++ b/scripts/linux/pkg/deb/ubuntu_native.Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y dos2unix devscri
 
 RUN apt update \ 
     && apt-get -y dist-upgrade \
-    && apt install -y curl wget apt-transport-https 
+    && apt install -y curl wget apt-transport-https software-properties-common
 
 ENV DEBEMAIL=support@ravendb.net DEBFULLNAME="RavenDB LTD" 
 ENV DEB_ARCHITECTURE="" DOTNET_RUNTIME_VERSION="" DOTNET_DEPS_VERSION=""

--- a/src/Raven.Server/Program.cs
+++ b/src/Raven.Server/Program.cs
@@ -50,6 +50,17 @@ namespace Raven.Server
 
         public static unsafe int Main(string[] args)
         {
+            using var termSignalRegistration =
+                PosixSignalRegistration.Create(
+                    PosixSignal.SIGTERM,
+                    (_) => Environment.Exit(0));
+
+            // Replicates the previous behavior on Windows
+            using var sigHupSignalRegistration =
+                PosixSignalRegistration.Create(
+                    PosixSignal.SIGHUP,
+                    (_) => Environment.Exit(0));
+
             bool useLegacyHttpClientFactory = false;
             var useLegacyHttpClientFactoryAsString = Environment.GetEnvironmentVariable("RAVEN_HTTP_USELEGACYHTTPCLIENTFACTORY");
             if (useLegacyHttpClientFactoryAsString != null && bool.TryParse(useLegacyHttpClientFactoryAsString, out useLegacyHttpClientFactory) == false)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25491 

### Additional description

[.NET runtime no longer provides default termination signal handlers](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/sigterm-signal-handler).
Use Ubuntu Noble for docker as this is only version dotnet provides the image we use as base.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
