### PR TITLE
RavenDB-25325 - add proper dispose for failed stream tasks

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForBulkPostAttachment.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/AttachmentHandlerProcessorForBulkPostAttachment.cs
@@ -102,19 +102,25 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
                 // Handle exceptions
                 foreach (var streamTask in tasks)
                 {
-                    try
+                    if (streamTask.IsCompletedSuccessfully)
                     {
-                        if (streamTask.IsCompletedSuccessfully)
-                        {
-                            // dispose stream
-                            await using var stream = await streamTask;
-                        }
+                        // we want to dispose VoronStream immediately, all of those are completed since this is local and comes from Task.FromResult
+                        SafelyDisposeStream(streamTask.Result);
+                        continue;
                     }
-                    catch
+
+                    // dispose all network streams when they complete
+                    _ = streamTask.ContinueWith(t =>
                     {
-                        // Ignore errors during cleanup
-                    }
+
+                        if (t.IsCompletedSuccessfully == false)
+                            return;
+
+                        SafelyDisposeStream(t.Result);
+                    });
                 }
+
+                throw;
             }
             finally
             {
@@ -122,6 +128,18 @@ namespace Raven.Server.Documents.Handlers.Processors.Attachments
                 foreach (var kvp in downloaders)
                 {
                     kvp.Value.Dispose();
+                }
+            }
+
+            static void SafelyDisposeStream(Stream stream)
+            {
+                try
+                {
+                    stream?.Dispose();
+                }
+                catch
+                {
+                    // ignore exceptions on dispose
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25325 

### Additional description

add proper dispose for failed stream tasks

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
