### PR TITLE
RavenDB-25548 Remote attachments: Small fix to "About this view"

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub.tsx
@@ -34,8 +34,8 @@ export function RemoteAttachmentsInfoHub() {
                         <li>Enable or disable the Remote Attachments feature.</li>
                         <li className="mt-1">
                             Configure remote destinations, including connection details and credentials. Supported
-                            destinations include <strong>Amazon S3</strong> and
-                            <strong>Azure Storage</strong>.
+                            destinations include <strong>Azure Blob Storage</strong>, <strong>Amazon S3</strong>, or any
+                            other <strong>S3-compatible</strong> storage service.
                         </li>
                         <li className="mt-1">
                             Fine-tune background processing behavior by setting:


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25548/Remote-attachments-Small-fix-to-About-this-view

### Additional description
Current text:
`Supported destinations include Amazon S3 and Azure Storage.`
Modify to:
`Supported destinations include Azure Blob Storage, Amazon S3, or any other S3-compatible storage service.`

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
