### PR TITLE
RavenDB-25449 Add support for loading embeddings generated from other collection.

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -641,6 +641,9 @@ namespace Raven.Client
                         
                         public const string VectorPropertyName = "$vector";
                         public const string LoadVectorPropertyName = "$loadvector";
+
+                        internal const string LoadVectorEmbeddingSourceDocumentId = "$embeddingSourceDocumentId";
+                        internal const string LoadVectorEmbeddingSourceDocumentCollectionName = "$embeddingSourceDocumentCollectionName";
                     }
                 }
 

--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -235,6 +235,10 @@ namespace Raven.Client.Documents.Indexes
         
         public object LoadVector(string path, string embeddingsGenerationTaskIdentifier) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
         
+        public object LoadVector(string path, string embeddingsGenerationTaskIdentifier, string embeddingSourceDocumentId, string sourceDocumentCollectionName) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
+        
+        public object LoadVector<TEmbeddingSourceDocument>(string path, string embeddingsGenerationTaskIdentifier, string embeddingSourceDocumentId) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
+        
         /// <summary>
         /// Executes the index creation against the specified document database using the specified conventions
         /// </summary>

--- a/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
+++ b/src/Raven.Client/Documents/Indexes/AbstractIndexCreationTask.cs
@@ -235,9 +235,9 @@ namespace Raven.Client.Documents.Indexes
         
         public object LoadVector(string path, string embeddingsGenerationTaskIdentifier) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
         
-        public object LoadVector(string path, string embeddingsGenerationTaskIdentifier, string embeddingSourceDocumentId, string sourceDocumentCollectionName) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
+        public object LoadVector(string path, string embeddingsGenerationTaskIdentifier, string embeddingsSourceDocumentId, string embeddingsSourceDocumentCollectionName) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
         
-        public object LoadVector<TEmbeddingSourceDocument>(string path, string embeddingsGenerationTaskIdentifier, string embeddingSourceDocumentId) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
+        public object LoadVector<TEmbeddingsSourceDocument>(string path, string embeddingsGenerationTaskIdentifier, string embeddingsSourceDocumentId) => throw new NotSupportedException("This method is provided solely to allow query translation on the server");
         
         /// <summary>
         /// Executes the index creation against the specified document database using the specified conventions

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -1833,6 +1833,9 @@ namespace Raven.Client.Documents.Indexes
                     case nameof(ILoadCompareExchangeApiForIndexes.LoadCompareExchangeValue):
                         Out(nameof(ILoadCompareExchangeApiForIndexes.LoadCompareExchangeValue));
                         break;
+                    case nameof(AbstractIndexCreationTask.LoadVector):
+                        Out(nameof(AbstractIndexCreationTask.LoadVector));
+                        break;
                     default:
                         Out(node.Method.Name);
                         if (node.Method.IsGenericMethod)
@@ -1939,6 +1942,25 @@ namespace Raven.Client.Documents.Indexes
                 else
                 {
                     throw new NotSupportedException($"Unknown overload of {nameof(ILoadCommonApiForIndexes.LoadDocument)} method");
+                }
+            }
+
+            if (node.Method is { Name: nameof(AbstractIndexCreationTask.LoadVector)})
+            {
+                var parameters = node.Method.GetParameters();
+
+                if (parameters.Length == 3 && node.Method.IsGenericMethod)
+                {
+                    var type = node.Method.GetGenericArguments()[0];
+                    Out($", \"");
+                    OutLiteral(_conventions.GetCollectionName(type));
+                    Out("\" ");
+                }
+                else if (parameters.Length == 4)
+                {
+                    var argument = node.Arguments[3];
+                    if (argument.NodeType != ExpressionType.Constant)
+                        throw new InvalidOperationException($"Invalid argument in {nameof(AbstractIndexCreationTask.LoadVector)}. String constant was expected but was '{argument.NodeType}' with value '{argument}'.");
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentConverter.cs
@@ -40,7 +40,7 @@ public sealed class CoraxDocumentConverter : CoraxDocumentConverterBase
                 object vector;
 
                 if (autoVectorOptions.EmbeddingsGenerationTaskIdentifier != null)
-                    vector = AbstractStaticIndexBase.LoadVectorBase(indexField.Name, autoVectorOptions.SourceFieldName, autoVectorOptions.EmbeddingsGenerationTaskIdentifier);
+                    vector = AbstractStaticIndexBase.LoadVectorBase(indexField.Name, autoVectorOptions.SourceFieldName, autoVectorOptions.EmbeddingsGenerationTaskIdentifier, null, null);
                 else
                 {
                     if (BlittableJsonTraverserHelper.TryRead(_blittableTraverser, document, autoVectorOptions.SourceFieldName, out value) == false)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -285,14 +285,32 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                     {
                         PortableExceptions.Throw<InvalidDataException>("Path field doesn't exist but is required.");
                     }
+
+                    var hasEmbeddingSourceDocumentId = obj.TryGetValue(JavaScriptFieldName.LoadVectorEmbeddingSourceDocumentId, out JsValue embeddingSourceDocumentIdJsv);
+                    var hasEmbeddingSourceDocumentCollectionName = obj.TryGetValue(JavaScriptFieldName.LoadVectorEmbeddingSourceDocumentCollectionName, out JsValue embeddingSourceDocumentCollectionNameJsv);
                     
+                    
+                    PortableExceptions.ThrowIf<ArgumentException>(hasEmbeddingSourceDocumentId && hasEmbeddingSourceDocumentCollectionName == false, "'loadVector': missing embedding source document collection name.");
+                    PortableExceptions.ThrowIf<ArgumentException>(hasEmbeddingSourceDocumentId == false && hasEmbeddingSourceDocumentCollectionName, "'loadVector': missing embedding source document id.");
                     PortableExceptions.ThrowIfNot<ArgumentException>(pathOfEmbeddingJsv.IsString(), $"'loadVector' requires a string value of the path to the vector.");
                     PortableExceptions.ThrowIfNot<ArgumentException>(nameofEmbeddingsGeneratorJsv.IsString(), $"'loadVector' requires a string AI Task of the vector.");
+                    PortableExceptions.ThrowIf<ArgumentException>(hasEmbeddingSourceDocumentCollectionName && embeddingSourceDocumentCollectionNameJsv.IsString() == false, $"'loadVector' requires a string value of the embedding source document collection.");
+                    
+                    
                     
                     var embeddingGeneratorName = nameofEmbeddingsGeneratorJsv.AsString();
                     var path = pathOfEmbeddingJsv.AsString();
+                    object embeddingSourceDocumentId = (hasEmbeddingSourceDocumentId) switch
+                    {
+                        false => null,
+                        true when embeddingSourceDocumentIdJsv.IsString() => embeddingSourceDocumentIdJsv.AsString(),
+                        true => (object)embeddingSourceDocumentIdJsv
+                    };
+                    var embeddingSourceDocumentCollectionName = hasEmbeddingSourceDocumentCollectionName 
+                        ? embeddingSourceDocumentCollectionNameJsv.AsString() 
+                        : null;
                     
-                    object objectForIndexing = AbstractStaticIndexBase.LoadVectorJs(field.Name, path, embeddingGeneratorName, out var indexField);
+                    object objectForIndexing = AbstractStaticIndexBase.LoadVectorJs(field.Name, path, embeddingGeneratorName, embeddingSourceDocumentId, embeddingSourceDocumentCollectionName, out var indexField);
 
                     if (objectForIndexing is CoraxDynamicItem dynamicItem)
                     {

--- a/src/Raven.Server/Documents/Indexes/Static/AcornimaReferencedCollectionVisitor.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/AcornimaReferencedCollectionVisitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Acornima.Ast;
+using Raven.Server.Documents.AI.Embeddings;
 using Sparrow;
 
 namespace Raven.Server.Documents.Indexes.Static
@@ -9,6 +10,9 @@ namespace Raven.Server.Documents.Indexes.Static
     {
         public readonly HashSet<CollectionName> ReferencedCollection = new HashSet<CollectionName>();
         public bool HasLoadVector { get; private set; }
+        
+        public bool LoadVectorIsUsingDefaultCollection { get; private set; }
+        
         public bool HasCreateVector { get; private set; }
         public bool HasCompareExchangeReferences { get; private set; }
 
@@ -37,9 +41,22 @@ namespace Raven.Server.Documents.Indexes.Static
                         }
                         break;
                     case JavaScriptIndex.LoadVectorMethodName:
-                        PortableExceptions.ThrowIf<ArgumentException>(callExpression.Arguments.Count != 2, $"loadVector method is expecting two arguments, the path to the vector in Embeddings Generation tasks. e.g. loadVector('embeddingsGenerationTaskIdentifier', 'path') but was invoked with {callExpression.Arguments.Count} arguments.");
-                        HasLoadVector = true;
+                        PortableExceptions.ThrowIf<ArgumentException>(callExpression.Arguments.Count is not (2 or 4), $"loadVector method is expecting two or four arguments, the path to the vector in Embeddings Generation tasks. e.g. loadVector('embeddingsGenerationTaskIdentifier', 'path') or loadVector('embeddingsGenerationTaskIdentifier', 'path', doc.SourceDocumentId, 'SourceDocumentCollectionName') but was invoked with {callExpression.Arguments.Count} arguments.");
+
+                        if (callExpression.Arguments.Count == 4)
+                        {
+                            var collection = callExpression.Arguments[3];
+                            if (collection is Literal { Value: string s })
+                            {
+                                ReferencedCollection.Add(new CollectionName(EmbeddingsHelper.GetEmbeddingDocumentCollectionName(s)));
+                            }
+                        }
+                        else
+                        {
+                            LoadVectorIsUsingDefaultCollection = true;
+                        }
                         
+                        HasLoadVector = true;
                         break;
                         
                     case JavaScriptIndex.CreateVectorMethodName:

--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -882,8 +882,6 @@ namespace Raven.Server.Documents.Indexes.Static
                         results.Add(RoslynHelper.This(nameof(StaticIndexBase.AddReferencedCollection)).Invoke(collection, rc).AsExpressionStatement());
                     }
                 }
-
-                
                 
                 if (mapRewriter.HasLoadCompareExchangeValue)
                     results.Add(RoslynHelper.This(nameof(StaticIndexBase.AddCompareExchangeReferenceToCollection)).Invoke(collection).AsExpressionStatement());

--- a/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/JavaScriptIndex.cs
@@ -126,7 +126,7 @@ function map(name, lambda) {
 
                 var referencedCollections = mapReferencedCollections[i].ReferencedCollections;
                 
-                if (mapReferencedCollections[i].HasLoadVector)
+                if (mapReferencedCollections[i].HasLoadVector && mapReferencedCollections[i].LoadVectorIsUsingDefaultCollection)
                     referencedCollections.Add(new(EmbeddingsHelper.GetEmbeddingDocumentCollectionName(mapCollection)));
 
                 if (referencedCollections.Count > 0)
@@ -390,6 +390,7 @@ function map(name, lambda) {
                 ReferencedCollections = loadVisitor.ReferencedCollection,
                 HasCompareExchangeReferences = loadVisitor.HasCompareExchangeReferences,
                 HasLoadVector = loadVisitor.HasLoadVector,
+                LoadVectorIsUsingDefaultCollection = loadVisitor.LoadVectorIsUsingDefaultCollection,
                 HasCreateVector = loadVisitor.HasCreateVector,
             };
         }
@@ -614,8 +615,12 @@ function createVector(value) {
     return { $vector: { $value: value } }
 }
 
-function loadVector(pathToEmbedding, aiTaskIdentifier) {
-    return { $loadvector: { $name: aiTaskIdentifier, $value: pathToEmbedding } }
+function loadVector(pathToEmbedding, aiTaskIdentifier, embeddingSourceDocumentId, embeddingSourceDocumentCollectionName) {
+    if (arguments.length == 2) {
+        return { $loadvector: { $name: aiTaskIdentifier, $value: pathToEmbedding } }
+    }
+    
+    return { $loadvector: { $name: aiTaskIdentifier, $value: pathToEmbedding, $embeddingSourceDocumentId: embeddingSourceDocumentId, $embeddingSourceDocumentCollectionName: embeddingSourceDocumentCollectionName } }
 }
 ";
 
@@ -644,6 +649,8 @@ function loadVector(pathToEmbedding, aiTaskIdentifier) {
             public bool HasLoadVector;
             
             public bool HasCreateVector;
+            
+            public bool LoadVectorIsUsingDefaultCollection;
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/VectorFieldRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/VectorFieldRewriter.cs
@@ -38,13 +38,14 @@ internal sealed class VectorFieldRewriter(ReferencedCollectionsRetriever referen
                 
                 IEnumerable<string> names = collectionNameRetriever switch
                 {
-                    CollectionNameRetriever cnr => cnr!.CollectionNames!.Select(EmbeddingsHelper.GetEmbeddingDocumentCollectionName),
-                    CollectionNameRetrieverBase cnrb => cnrb.Collections.Select(n => EmbeddingsHelper.GetEmbeddingDocumentCollectionName(n.CollectionName)),
+                    _ when node.ArgumentList.Arguments.Count == 4 => [((LiteralExpressionSyntax)node.ArgumentList.Arguments[^1].Expression).ToString()[1..^1]],
+                    CollectionNameRetriever cnr => cnr!.CollectionNames!,
+                    CollectionNameRetrieverBase cnrb => cnrb.Collections.Select(n => n.CollectionName),
                     _ => throw new InvalidOperationException($"Unknown collection name retriever. Got: {collectionNameRetriever.GetType().FullName}.")
                 };
 
                 referencedCollectionsRetriever.CreateReferencedCollections();
-                referencedCollectionsRetriever.ReferencedCollections.AddRange(names.Distinct());
+                referencedCollectionsRetriever.ReferencedCollections.AddRange(names.Select(EmbeddingsHelper.GetEmbeddingDocumentCollectionName).Distinct());
                 return Rewrite();
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -535,7 +536,7 @@ public partial class AbstractStaticIndexBase
         return value is null or DynamicNullObject or DynamicJsNull or JsNull;
     }
 
-    public static object LoadVectorJs(string fieldName, string path, string embeddingGeneratorTaskName, out IndexField vectorField)
+    public static object LoadVectorJs(string fieldName, string path, string embeddingGeneratorTaskName, object embeddingSourceDocumentId, string embeddingSourceDocumentCollectionName, out IndexField vectorField)
     {
         if (IsDictionaryTrainingPhase(CurrentIndexingScope.Current))
         {
@@ -543,7 +544,8 @@ public partial class AbstractStaticIndexBase
             return null;
         }
         
-        var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskName, out vectorField);
+        //todo
+        var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskName, GetStringFromObject(embeddingSourceDocumentId), embeddingSourceDocumentCollectionName, out vectorField);
 
         // for js indexes we've no choice than create dynamic field, in such cases let's assume it is single. 
         if (vectorField == null)
@@ -557,17 +559,17 @@ public partial class AbstractStaticIndexBase
             : vectors;
     }
     
-    public object LoadVector(string fieldName, string path, string embeddingGeneratorTaskIdentifier)
+    public object LoadVector(string fieldName, string path, string embeddingGeneratorTaskIdentifier, object embeddingSourceDocumentId = null, string embeddingSourceDocumentCollectionName = null)
     {
-        return LoadVectorBase(fieldName, path, embeddingGeneratorTaskIdentifier);
+        return LoadVectorBase(fieldName, path, embeddingGeneratorTaskIdentifier, GetStringFromObject(embeddingSourceDocumentId), embeddingSourceDocumentCollectionName);
     }
     
-    public static object LoadVectorBase(string fieldName, string path, string embeddingGeneratorTaskIdentifier)
+    public static object LoadVectorBase(string fieldName, string path, string embeddingGeneratorTaskIdentifier, string embeddingSourceDocumentId, string embeddingSourceDocumentCollection)
     {
         if (IsDictionaryTrainingPhase(CurrentIndexingScope.Current))
             return null;
         
-        var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskIdentifier, out var vectorField);
+        var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskIdentifier,  embeddingSourceDocumentId, embeddingSourceDocumentCollection, out var vectorField);
 
         if (vectorField == null)
             return vectors;
@@ -577,11 +579,11 @@ public partial class AbstractStaticIndexBase
             : vectors;
     }
 
-    private static object ProcessLoadVector(string fieldName, string path, string embeddingGeneratorTaskIdentifier, out IndexField indexField)
+    private static object ProcessLoadVector(string fieldName, string path, string embeddingGeneratorTaskIdentifier, string embeddingSourceDocumentId, string embeddingSourceDocumentCollection, out IndexField indexField)
     {
         var currentIndexingScope = CurrentIndexingScope.Current;
         currentIndexingScope.Index.IndexFieldsPersistence.SetEmbeddingsGenerationTaskIdentifier(fieldName, embeddingGeneratorTaskIdentifier);
-        var embeddingDocument = LoadVectorDocument(out var embeddingDocumentId) as DynamicBlittableJson;
+        var embeddingDocument = LoadVectorDocument(embeddingSourceDocumentId, embeddingSourceDocumentCollection, out var embeddingDocumentId) as DynamicBlittableJson;
         
         // no related document
         if (embeddingDocument == null
@@ -639,13 +641,13 @@ public partial class AbstractStaticIndexBase
         return NullVectorValue;
     }
     
-    private static dynamic LoadVectorDocument(out string embeddingDocument)
+    private static dynamic LoadVectorDocument(string embeddingSourceDocumentId, string embeddingSourceDocumentCollection, out string embeddingDocument)
     {
         var scope = CurrentIndexingScope.Current;
         
-        var id = (string)scope.Source.GetId().ToString();
+        var id = embeddingSourceDocumentId ?? (string)scope.Source.GetId().ToString();
         embeddingDocument = EmbeddingsHelper.GetEmbeddingDocumentId(id);
-        var collectionName = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(scope.SourceCollection);
+        var collectionName = EmbeddingsHelper.GetEmbeddingDocumentCollectionName(embeddingSourceDocumentCollection ?? scope.SourceCollection);
         return scope.LoadDocument(null, embeddingDocument, collectionName.ToLowerInvariant());
     }
 }

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
@@ -1,0 +1,627 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.ETL.Providers.AI;
+using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using System.Threading.Tasks;
+
+namespace SlowTests.Server.Documents.AI.Embeddings;
+
+public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexSingleVectorGeneratedByEtlForDifferentDocument() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByName>();
+    
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexSingleVectorGeneratedByEtlForDifferentDocumentExplicitCollectionName() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByNameExplicitCollection>();
+
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexSingleVectorGeneratedByEtlForDifferentDocumentJs() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByNameJs>();
+
+    private async Task CanIndexSingleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore();
+
+        string dtoId;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto { Name = "Joe" };
+            session.Store(dto);
+            session.SaveChanges();
+            dtoId = dto.Id;
+            var queryDto = new QueryDto { DtoId = dto.Id };
+            session.Store(queryDto);
+            session.SaveChanges();
+        }
+
+        var index = new TIndex();
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(1, nullElements);
+
+            var ex = Assert.Throws<InvalidQueryException>(()=> session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector), v => v.ByText("Joe")).ToList());
+            Assert.Contains("Couldn't find Embeddings Generation task with 'localaitask' identifier", ex.Message);
+        }
+
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+        var etlStatus = Etl.WaitForEtlToComplete(store);
+        var (config, connectionString) = AddEmbeddingsGenerationTask(store);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        AssertEmbeddingsForPath(store, config, connectionString, "Name", ["Joe"], dtoId);
+
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("joe"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Single(byVector);
+        }
+
+        var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+        var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
+
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["Joe"], dtoId);
+        etlStatus.Reset();
+        using (var session = store.OpenSession())
+        {
+            var load = session.Load<Dto>(dtoId);
+            load.Name = "sdklfjklsadjkl;assdjaskll"; // lets change it to random string just not to have similar vector to previous one
+            session.Store(load);
+            session.SaveChanges();
+        }
+
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Empty(byVector);
+        }
+
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["sdklfjklsadjkl;assdjaskll"], dtoId);
+    }
+
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexMultipleVectorGeneratedByEtlForDifferentDocumentExplicitCollectionName() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesExplicitCollection>();
+
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexMultipleVectorGeneratedByEtlForDifferentDocument() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNames>();
+    
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexMultipleVectorGeneratedByEtlForDifferentDocumentJs() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesJs>();
+
+    private async Task CanIndexMultipleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore();
+
+        string dtoId;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto { Names = ["Joe", "Jimmy"] };
+            session.Store(dto);
+            session.SaveChanges();
+            dtoId = dto.Id;
+            var dtoQuery = new QueryDto { DtoId = dto.Id };
+            session.Store(dtoQuery);
+            session.SaveChanges();
+        }
+
+        var index = new TIndex();
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(1, nullElements);
+        }
+
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+        var etlStatus = Etl.WaitForEtlToComplete(store);
+        var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }]);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Single(byVector);
+        }
+
+        var aiIntegrationIdentifier = new EmbeddingsGenerationTaskIdentifier(config.Identifier);
+        var aiConnectionStringIdentifier = new AiConnectionStringIdentifier(connectionString.Identifier);
+
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Names", ["Joe", "Jimmy"], dtoId);
+        etlStatus.Reset();
+        using (var session = store.OpenSession())
+        {
+            var load = session.Load<Dto>(dtoId);
+            load.Names = ["sdklfjklsadjkl;assdjaskll"]; // lets change it to random string just not to have similar vector to previous one
+            session.Store(load);
+            session.SaveChanges();
+        }
+
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Empty(byVector);
+        }
+
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Names", ["sdklfjklsadjkl;assdjaskll"], dtoId);
+    }
+    
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexVectorFromTwoDifferentEtlExplicitCollectionName() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsExplicitCollection>();
+
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexVectorFromTwoDifferentEtl() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFields>();
+    
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public async Task CanIndexVectorFromTwoDifferentEtlJs() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsJs>();
+
+    private async Task CanIndexVectorFromTwoDifferentEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    {
+        const string embeddingEtlName = "V1";
+        const string embeddingEtlName2 = "V2";
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var store = GetDocumentStore();
+        
+        string id;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto { Name = "Joe", Names = ["Jimmy"] };
+            session.Store(dto);
+            session.SaveChanges();
+            id = dto.Id;
+            var queryDto = new QueryDto { DtoId = dto.Id };
+            session.Store(queryDto);
+            session.SaveChanges();
+        }
+
+        var index = new TIndex();
+        await index.ExecuteAsync(store);
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(1, nullElements);
+
+            nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(1, nullElements);
+        }
+
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+        var etlStatus = Etl.WaitForEtlToComplete(store);
+        var (config, connectionString) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Name", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName);
+        
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config.Identifier), new AiConnectionStringIdentifier(connectionString.Identifier), "Name", ["Joe"], id);
+        
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
+
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(1, nullElements);
+
+            nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("Joe"))
+                .ToList();
+
+            Assert.Single(byVector);
+        }
+
+        etlStatus.Reset();
+        var (config2, connectionString2) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "Names", ChunkingOptions = DefaultChunkingOptions }], embeddingsGenerationTaskName: embeddingEtlName2);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, config2);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(0, nullElements);
+
+            nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("Joe"))
+                .ToList();
+            Assert.Single(byVector);
+
+            byVector = session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector2),
+                    v => v.ByText("Jimmy"))
+                .ToList();
+            Assert.Single(byVector);
+        }
+
+        AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config2.Identifier), new AiConnectionStringIdentifier(connectionString2.Identifier), "Names", ["Jimmy"], id);
+    }
+
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public Task CanLoadVectorsFromTwoDifferentCollections() => CanLoadVectorsFromTwoDifferentCollectionsBase<IndexByNamesFromCurrentAndDifferentCollection>();
+    
+    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public Task CanLoadVectorsFromTwoDifferentCollectionJs() => CanLoadVectorsFromTwoDifferentCollectionsBase<IndexByNamesFromCurrentAndDifferentCollectionJs>();
+    
+    private async Task CanLoadVectorsFromTwoDifferentCollectionsBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    {
+        using var store = GetDocumentStore();
+
+        string dtoId;
+        string queryDtoId;
+        using (var session = store.OpenSession())
+        {
+            var dto = new Dto { Name = "Joe" };
+            session.Store(dto);
+            session.SaveChanges();
+            dtoId = dto.Id;
+            var queryDto = new QueryDto { DtoId = dto.Id, Name = "car"};
+            session.Store(queryDto);
+            session.SaveChanges();
+            queryDtoId = queryDto.Id;
+        }
+
+        var index = new TIndex();
+        await index.ExecuteAsync(store);
+        
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            var nullElementsFromCurrentCollection = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(1, nullElements);
+            Assert.Equal(1, nullElementsFromCurrentCollection);
+
+            var ex = Assert.Throws<InvalidQueryException>(()=> session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector), v => v.ByText("Joe")).ToList());
+            var ex2 = Assert.Throws<InvalidQueryException>(()=> session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector2), v => v.ByText("car")).ToList());
+            Assert.Contains("Couldn't find Embeddings Generation task with 'localaitask' identifier", ex.Message);
+            Assert.Contains("Couldn't find Embeddings Generation task with 'querydtotask' identifier", ex2.Message);
+        }
+
+        await store.Maintenance.SendAsync(new StopIndexOperation(index.IndexName));
+        var etlStatus = Etl.WaitForEtlToComplete(store);
+        var (configDto, connectionStringDto) = AddEmbeddingsGenerationTask(store);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configDto);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        AssertEmbeddingsForPath(store, configDto, connectionStringDto, "Name", ["Joe"], dtoId);
+
+        await store.Maintenance.SendAsync(new StartIndexOperation(index.IndexName));
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(1, nullElements);
+            
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("joe"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Single(byVector);
+            var ex2 = Assert.Throws<InvalidQueryException>(()=> session.Query<QueryDto, TIndex>().VectorSearch(f => f.WithField(s => s.Vector2), v => v.ByText("car")).ToList());
+            Assert.Contains("Couldn't find Embeddings Generation task with 'querydtotask' identifier", ex2.Message);
+        }
+
+        var aiIntegrationIdentifierForDto = new EmbeddingsGenerationTaskIdentifier(configDto.Identifier);
+        var aiConnectionStringIdentifierForDto = new AiConnectionStringIdentifier(connectionStringDto.Identifier);
+
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForDto, aiConnectionStringIdentifierForDto, "Name", ["Joe"], dtoId);
+        etlStatus.Reset();
+        
+        
+        //Register embedding generation task for QueriesDto
+        var (configQueriesDto, connectionStringQueriesDto) = AddEmbeddingsGenerationTask(store, "querydtotask", "secondaiconnection", collectionName: "QueryDtos");
+        var aiIntegrationIdentifierForQueriesDto = new EmbeddingsGenerationTaskIdentifier(configQueriesDto.Identifier);
+        var aiConnectionStringIdentifierForQueriesDto = new AiConnectionStringIdentifier(connectionStringQueriesDto.Identifier);
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configDto);
+        Assert.True(queriesWorkerRegistered);
+        Assert.True(indexingWorkerRegistered);
+        AssertEmbeddingsForPath(store, configQueriesDto, connectionStringQueriesDto, "Name", ["car"], queryDtoId);
+        etlStatus.Reset();
+        await Indexes.WaitForIndexingAsync(store);
+        
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(0, nullElements);
+            
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector2),
+                    v => v.ByText("car"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Single(byVector);
+        }
+        
+        
+        using (var session = store.OpenSession())
+        {
+            var load = session.Load<Dto>(dtoId);
+            load.Name = "sdklfjklsadjkl;assdjaskll"; // lets change it to random string just not to have similar vector to previous one
+            
+            var load2 = session.Load<QueryDto>(queryDtoId);
+            load2.Name = "dsafadfae"; // lets change it to random string just not to have similar vector to previous one
+            
+            session.Store(load);
+            session.SaveChanges();
+        }
+
+        Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenSession())
+        {
+            var nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector == null);
+            Assert.Equal(0, nullElements);
+            
+            nullElements = session.Query<QueryDto, TIndex>().Count(x => x.Vector2 == null);
+            Assert.Equal(0, nullElements);
+
+            var byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector),
+                    v => v.ByText("Joe"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Empty(byVector);
+            
+            byVector = session.Query<QueryDto, TIndex>()
+                .VectorSearch(f => f.WithField(s => s.Vector2),
+                    v => v.ByText("car"), minimumSimilarity: 0.75f)
+                .ToList();
+
+            Assert.Empty(byVector);
+        }
+
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForDto, aiConnectionStringIdentifierForDto, "Name", ["sdklfjklsadjkl;assdjaskll"], dtoId);
+        
+        AssertEmbeddingsForPath(store, aiIntegrationIdentifierForQueriesDto, aiConnectionStringIdentifierForQueriesDto, "Name", ["dsafadfae"], queryDtoId);
+    }
+
+    private class IndexByName : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByName()
+        {
+            Map = dtos => from dto in dtos
+                          select new { Vector = LoadVector<Dto>("Name", "localaitask", dto.DtoId) };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class IndexByNameExplicitCollection : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByNameExplicitCollection()
+        {
+            Map = dtos => from dto in dtos
+                select new { Vector = LoadVector("Name", "localaitask", dto.DtoId, "Dtos") };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class IndexByNameJs : AbstractJavaScriptIndexCreationTask
+    {
+        public IndexByNameJs()
+        {
+            Maps = new HashSet<string>()
+            {
+                $@"map('QueryDtos', function (doc) {{
+                return {{
+                    Id: id(doc),
+                    Vector: loadVector('Name', 'localaitask', doc.DtoId, 'Dtos'),
+                }};
+            }})"
+            };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class IndexByNames : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByNames()
+        {
+            Map = queryDtos => from queryDto in queryDtos
+                          select new { Vector = LoadVector<Dto>("Names", "localaitask", queryDto.DtoId) };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class IndexByNamesFromCurrentAndDifferentCollection : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByNamesFromCurrentAndDifferentCollection()
+        {
+            Map = queryDtos => from queryDto in queryDtos
+                let x = "rewrite me"
+                select new
+                {
+                    Ignore = x,
+                    Vector = LoadVector<Dto>("Name", "localaitask", queryDto.DtoId),
+                    Vector2 = LoadVector("Name", "querydtotask")
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class IndexByNamesFromCurrentAndDifferentCollectionJs : AbstractJavaScriptIndexCreationTask
+    {
+        public IndexByNamesFromCurrentAndDifferentCollectionJs()
+        {
+            Maps = new HashSet<string>()
+            {
+                $@"map('QueryDtos', function (doc) {{
+                return {{
+                    Id: id(doc),
+                    Vector: loadVector('Name', 'localaitask', doc.DtoId, 'Dtos'),
+                    Vector2: loadVector('Name', 'querydtotask')
+                }};
+            }})"
+            };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class IndexByNamesExplicitCollection : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByNamesExplicitCollection()
+        {
+            Map = queryDtos => from queryDto in queryDtos
+                select new { Vector = LoadVector("Names", "localaitask", queryDto.DtoId, "Dtos") };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class IndexByNamesJs : AbstractJavaScriptIndexCreationTask
+    {
+        public IndexByNamesJs()
+        {
+            Maps = new HashSet<string>()
+            {
+                $@"map('QueryDtos', function (doc) {{
+                return {{
+                    Id: id(doc),
+                    Vector: loadVector('Names', 'localaitask', doc.DtoId, 'Dtos'),
+                }};
+            }})"
+            };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+
+    private class IndexByFieldTwoFields : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByFieldTwoFields()
+        {
+            Map = queryDtos => from queryDto in queryDtos
+                          select new
+                          {
+                              Vector = LoadVector<Dto>("Name", "v1", queryDto.DtoId),
+                              Vector2 = LoadVector<Dto>("Names", "v2", queryDto.DtoId)
+                          };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+    
+    private class IndexByFieldTwoFieldsExplicitCollection : AbstractIndexCreationTask<QueryDto>
+    {
+        public IndexByFieldTwoFieldsExplicitCollection()
+        {
+            Map = queryDtos => from queryDto in queryDtos
+                select new
+                {
+                    Vector = LoadVector("Name", "v1", queryDto.DtoId, "Dtos"),
+                    Vector2 = LoadVector("Names", "v2", queryDto.DtoId, "Dtos")
+                };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class IndexByFieldTwoFieldsJs : AbstractJavaScriptIndexCreationTask
+    {
+        public IndexByFieldTwoFieldsJs()
+        {
+            Maps = new HashSet<string>()
+            {
+                $@"map('QueryDtos', function (doc) {{
+                return {{
+                    Id: id(doc),
+                    Vector: loadVector('Name', 'v1', doc.DtoId, 'Dtos'),
+                    Vector2: loadVector('Names', 'v2', doc.DtoId, 'Dtos')
+                }};
+            }})"
+            };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
+    private class QueryDto
+    {
+        public string Id { get; set; }
+        public string DtoId { get; set; }
+        
+        public object Vector { get; }
+        public object Vector2 { get; }
+        public string Name { get; set; }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string[] Names { get; set; }
+
+        public object Vector { get; }
+        public object Vector2 { get; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25449

### Additional description

Introducing API which allows to use embeddings generated from other collection than indexed.

Introduced API:

- C# indexes:
Typed LoadVector:
```csharp
public object LoadVector<TEmbeddingSourceDocument>(string path, string embeddingsGenerationTaskIdentifier, string embeddingSourceDocumentId)
```

Untyped LoadVector:
```csharp
public object LoadVector(string path, string embeddingsGenerationTaskIdentifier, string embeddingSourceDocumentId, string sourceDocumentCollectionName)
```

- JavaScript indexes
```js
loadVector(path, embeddingsGenerationTaskIdentifier, embeddingSourceDocumentId, sourceDocumentCollectionName)
```

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
