### PR TITLE
RavenDB-25537 & RavenDB-25523 - Enforce case-insensitive uniqueness for identifiers, fix for Custom server URL

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils.ts
@@ -73,6 +73,7 @@ function mapFromDto(dto: RemoteAttachmentsConfiguration): RemoteAttachmentsFormD
                         awsSessionToken: s3Config.AwsSessionToken,
                         remoteFolderName: s3Config.RemoteFolderName,
                         bucketName: s3Config.BucketName,
+                        isUseCustomHost: s3Config.CustomServerUrl != null,
                         customServerUrl: s3Config.CustomServerUrl,
                         forcePathStyle: s3Config.ForcePathStyle,
                         storageClass: s3Config.StorageClass,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/remoteAttachmentsValidation.ts
@@ -18,7 +18,7 @@ function getIsUniqueIdentifier(value: string, ctx: yup.TestContext<RemoteAttachm
     const { context } = ctx.options;
 
     if (context.destinations != null) {
-        const matches = context.destinations.filter((dest) => dest.identifier === value);
+        const matches = context.destinations.filter((dest) => dest.identifier.toLowerCase() === value.toLowerCase());
 
         if (!context.currentIdentifier) {
             return matches.length === 0;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25537
https://issues.hibernatingrhinos.com/issue/RavenDB-25523
### Additional description

<img width="1609" height="891" alt="image" src="https://github.com/user-attachments/assets/86a3f7c0-e24b-45f1-8934-c3410b4931d7" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
