### PR TITLE
RavenDB-25553 Dynamic index exact InQuery will use ExactField

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -327,6 +327,9 @@ namespace Raven.Server.Documents.Queries
 
                 var fieldName = ExtractIndexFieldName(query, parameters, ie.Source, metadata);
                 exact = IsExact(index, exact, fieldName);
+                if (exact && metadata.IsDynamic)
+                    fieldName = new QueryFieldName(AutoIndexField.GetExactAutoIndexFieldName(fieldName.Value), fieldName.IsQuoted);
+                
                 var termType = LuceneTermType.Null;
                 var hasGotTheRealType = false;
 
@@ -341,10 +344,7 @@ namespace Raven.Server.Documents.Queries
                             termType = GetLuceneField(fieldName, value.Type).LuceneTermType;
                             hasGotTheRealType = true;
                         }
-
-                        if (exact && metadata.IsDynamic)
-                            fieldName = new QueryFieldName(AutoIndexField.GetExactAutoIndexFieldName(fieldName.Value), fieldName.IsQuoted);
-
+                        
                         allInQuery.Add(LuceneQueryHelper.Equal(fieldName, termType, value.Value, exact), Occur.MUST);
                     }
 

--- a/test/SlowTests/Issues/RavenDB_25553.cs
+++ b/test/SlowTests/Issues/RavenDB_25553.cs
@@ -1,0 +1,36 @@
+﻿using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25553(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void DynamicIndexExactInQueryWillUseExactField(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item { Name = "Tarzan" });
+            session.Store(new Item { Name = "tarzan" });
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced.DocumentQuery<Item>()
+                .WaitForNonStaleResults()
+                .WhereIn(x => x.Name, new[] { "Tarzan" }, exact: true)
+                .SingleOrDefault();
+            Assert.NotNull(results);            
+        }
+    }
+    
+    private class Item
+    {
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25553

### Additional description

Dynamic index exact InQuery will use ExactField.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
