### PR TITLE
RavenDB-25535 - Make collection name validation case-insensitive

### DIFF
--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -42,7 +42,7 @@ public class SchemaValidatorCache : IDisposable
 
         Dictionary<string, SchemaValidator> newSchemaValidators = null;
         
-        foreach ((string collection, Client.Documents.Operations.SchemaValidation.SchemaDefinition validator) in configuration.ValidatorsPerCollection)
+        foreach ((string collection, SchemaDefinition validator) in configuration.ValidatorsPerCollection)
         {
             if (_schemaValidatorsPerCollection.TryGetValue(collection, out var existingValidator)
                 && validator.Schema.Equals(existingValidator.SchemaDefinition))
@@ -78,7 +78,7 @@ public class SchemaValidatorCache : IDisposable
         }
 
         if (newSchemaValidators != null)
-            _schemaValidatorsPerCollection = newSchemaValidators.ToFrozenDictionary();
+            _schemaValidatorsPerCollection = newSchemaValidators.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
     }
 
     private void EnsureMetadataIsValid(ref BlittableJsonReaderObject blittable)

--- a/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
@@ -14,8 +14,10 @@ public class SchemaValidationBasicTests : RavenTestBase
 {
     public SchemaValidationBasicTests(ITestOutputHelper output) : base(output) { }
 
-    [RavenFact(RavenTestCategory.ClientApi)]
-    public async Task Store()
+    [RavenTheory(RavenTestCategory.ClientApi)]
+    [InlineData("Users")]
+    [InlineData("users")]
+    public async Task Store(string collection)
     {
         var schema = JsonSchema.FromType<User>();
         var schemaData = schema.ToJson();
@@ -26,7 +28,7 @@ public class SchemaValidationBasicTests : RavenTestBase
             {
                 ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>()
                 {
-                    {"Users", new SchemaDefinition
+                    {collection, new SchemaDefinition
                     {
                         Schema = schemaData
                     }}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25535/Schema-validation-No-validation-when-collection-name-is-lowercased

### Additional description

Make collection name validation case-insensitive.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
