### PR TITLE
[Backport to 7.2] RavenDB-25320 Prevent deadlock by catching exceptions in finally block

### DIFF
--- a/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
+++ b/src/Raven.Server/Rachis/Remote/RemoteConnection.cs
@@ -106,11 +106,32 @@ namespace Raven.Server.Rachis.Remote
 
         private void Send(JsonOperationContext context, BlittableJsonReaderObject msg, Action afterFlush = null)
         {
-            using (_disposerLock.EnsureNotDisposed())
-            using (var writer = new RachisBlittableJsonTextWriter(context, _stream, afterFlush))
+            var disposerLock = _disposerLock.EnsureNotDisposed();
+            try
             {
-                context.Write(writer, msg);
-                _info.LastSent = DateTime.UtcNow;
+                var writer = new RachisBlittableJsonTextWriter(context, _stream, afterFlush);
+                try
+                {
+                    context.Write(writer, msg);
+                    _info.LastSent = DateTime.UtcNow;
+                }
+                finally
+                {
+                    try
+                    {
+                        writer.Dispose();
+                    }
+                    catch
+                    {
+                        // Suppress exception from Dispose() thrown in the finalizer so it will ensure
+                        // the outer 'finally' (which releases the lock) will be executed. Failure to do so causes a deadlock.
+                        // This is the workaround for .NET 10 issue - https://github.com/dotnet/runtime/issues/121578
+                    }
+                }
+            }
+            finally
+            {
+                disposerLock?.Dispose();
             }
         }
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25320

### Additional description

Backport of https://github.com/ravendb/ravendb/pull/21772 to v7.2 since it's also on .NET 10 and [the fix](https://github.com/dotnet/runtime/issues/121578) was not released yet (not part of .NET 10.0.1)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
