### PR TITLE
* RavenDB-25517 - In changes API fix

### DIFF
--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
@@ -86,6 +86,9 @@ internal abstract class AbstractDatabaseConnectionState
     {
         lock (_eventLock)
         {
+            if (_disposed)
+                return;
+
             onChangeNotification += changeHandler;
             OnError += errorHandler;
         }
@@ -95,15 +98,24 @@ internal abstract class AbstractDatabaseConnectionState
     {
         lock (_eventLock)
         {
+            if (_disposed)  // already disposed
+                return;
+
             onChangeNotification -= changeHandler;
             OnError -= errorHandler;
         }
     }
 
+    private volatile bool _disposed;
+
     public virtual void Dispose()
     {
         lock (_eventLock)
         {
+            if (_disposed)
+                return;
+
+            _disposed = true;
             if (_connected?.Exception == null)
                 Set(Task.FromException(new ObjectDisposedException(nameof(DatabaseConnectionState))));
 

--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
@@ -43,17 +43,19 @@ internal abstract class AbstractDatabaseConnectionState
         _connected = connection;
     }
 
-    public void Inc()
+    public int Inc()
     {
-        Interlocked.Increment(ref _value);
+        return Interlocked.Increment(ref _value);
     }
 
-    public void Dec()
+    public int Dec()
     {
-        if (Interlocked.Decrement(ref _value) == 0)
+        var val = Interlocked.Decrement(ref _value);
+        if (val == 0)
         {
             Set(_onDisconnect());
         }
+        return val;
     }
 
     public void Error(Exception e)

--- a/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/AbstractDatabaseConnectionState.cs
@@ -16,6 +16,7 @@ internal abstract class AbstractDatabaseConnectionState
 
     private readonly TaskCompletionSource<object> _firstSet = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private Task _connected;
+    protected readonly object _eventLock = new object();
 
     protected AbstractDatabaseConnectionState(Func<Task> onConnect, Func<Task> onDisconnect)
     {
@@ -70,10 +71,43 @@ internal abstract class AbstractDatabaseConnectionState
         return _connected ?? _firstSet.Task;
     }
 
+    protected void CallEventInternal<T>(Action<T> changeHandler, T change)
+    {
+        Action<T> handler;
+        lock (_eventLock)
+        {
+            handler = changeHandler;
+        }
+
+        handler?.Invoke(change);
+    }
+
+    protected void RegisterEventsInternal<T>(ref Action<T> onChangeNotification, Action<T> changeHandler, Action<Exception> errorHandler)
+    {
+        lock (_eventLock)
+        {
+            onChangeNotification += changeHandler;
+            OnError += errorHandler;
+        }
+    }
+
+    protected void UnregisterEventsInternal<T>(ref Action<T> onChangeNotification, Action<T> changeHandler, Action<Exception> errorHandler)
+    {
+        lock (_eventLock)
+        {
+            onChangeNotification -= changeHandler;
+            OnError -= errorHandler;
+        }
+    }
+
     public virtual void Dispose()
     {
-        if(_connected?.Exception == null)
-            Set(Task.FromException(new ObjectDisposedException(nameof(DatabaseConnectionState))));
-        OnError = null;
+        lock (_eventLock)
+        {
+            if (_connected?.Exception == null)
+                Set(Task.FromException(new ObjectDisposedException(nameof(DatabaseConnectionState))));
+
+            OnError = null;
+        }
     }
 }

--- a/src/Raven.Client/Documents/Changes/ChangesObservable.cs
+++ b/src/Raven.Client/Documents/Changes/ChangesObservable.cs
@@ -38,8 +38,7 @@ namespace Raven.Client.Documents.Changes
             {
                 _connectionState.Inc();
                 // first subscriber, register to the connection state events
-                _connectionState.OnChangeNotification += Send;
-                _connectionState.OnError += Error;
+                _connectionState.RegisterEvents(Send, Error);
             }
             else if (_subscribers.TryAdd(observer))
             {
@@ -60,8 +59,7 @@ namespace Raven.Client.Documents.Changes
             if (count == 0)
             {
                 // last subscriber gone, unregister from the connection state events
-                _connectionState.OnChangeNotification -= Send;
-                _connectionState.OnError -= Error;
+                _connectionState.UnregisterEvents(Send, Error);
             }
         }
 

--- a/src/Raven.Client/Documents/Changes/ChangesObservable.cs
+++ b/src/Raven.Client/Documents/Changes/ChangesObservable.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Util;
 using Sparrow.Collections;
@@ -9,7 +10,7 @@ namespace Raven.Client.Documents.Changes
     {
         private readonly TConnectionState _connectionState;
         private readonly Func<T, bool> _filter;
-        private readonly ConcurrentSet<IObserver<T>> _subscribers = new ConcurrentSet<IObserver<T>>();
+        private ConcurrentSet<IObserver<T>> _subscribers = new ConcurrentSet<IObserver<T>>();
 
         internal ChangesObservable(
             TConnectionState connectionState,
@@ -19,21 +20,49 @@ namespace Raven.Client.Documents.Changes
             _filter = filter;
         }
 
+        private bool TryRegisterFirstObserver(IObserver<T> observer)
+        {
+            var current = _subscribers;
+            if (current.IsEmpty)
+            {
+                var firstConnection = new ConcurrentSet<IObserver<T>> { observer };
+                return Interlocked.CompareExchange(ref _subscribers, firstConnection, current) == current;
+            }
+
+            return false;
+        }
+
         public IDisposable Subscribe(IObserver<T> observer)
         {
-            _connectionState.OnChangeNotification += Send;
-            _connectionState.OnError += Error;
-
-            _connectionState.Inc();
-            _subscribers.TryAdd(observer);
-            return new DisposableAction(() =>
+            if (TryRegisterFirstObserver(observer))
             {
-                _connectionState.Dec();
-                _subscribers.TryRemove(observer);
+                _connectionState.Inc();
+                // first subscriber, register to the connection state events
+                _connectionState.OnChangeNotification += Send;
+                _connectionState.OnError += Error;
+            }
+            else if (_subscribers.TryAdd(observer))
+            {
+                // the first subscriber, has already registered to the connection state events, we only Inc the count
+                _connectionState.Inc();
+            }
 
+
+            return new DisposableAction(() => DisposeInternal(observer));
+        }
+
+        private void DisposeInternal(IObserver<T> observer)
+        {
+            if (_subscribers.TryRemove(observer) == false)
+                return;
+
+            var count = _connectionState.Dec();
+            if (count == 0)
+            {
+                // last subscriber gone, unregister from the connection state events
                 _connectionState.OnChangeNotification -= Send;
                 _connectionState.OnError -= Error;
-            });
+            }
         }
 
         public void Send(T msg)

--- a/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/DatabaseConnectionState.cs
@@ -18,87 +18,114 @@ namespace Raven.Client.Documents.Changes
 
         private event Action<TimeSeriesChange> OnTimeSeriesChangeNotification;
 
-        public DatabaseConnectionState(Func<Task> onConnect, Func<Task> onDisconnect) 
+        public DatabaseConnectionState(Func<Task> onConnect, Func<Task> onDisconnect)
             : base(onConnect, onDisconnect)
         {
         }
 
         public void Send(DocumentChange documentChange)
         {
-            OnDocumentChangeNotification?.Invoke(documentChange);
+            CallEventInternal(OnDocumentChangeNotification, documentChange);
         }
 
         public void Send(CounterChange counterChange)
         {
-            OnCounterChangeNotification?.Invoke(counterChange);
+            CallEventInternal(OnCounterChangeNotification, counterChange);
         }
 
         public void Send(TimeSeriesChange timeSeriesChange)
         {
-            OnTimeSeriesChangeNotification?.Invoke(timeSeriesChange);
+            CallEventInternal(OnTimeSeriesChangeNotification, timeSeriesChange);
         }
 
         public void Send(IndexChange indexChange)
         {
-            OnIndexChangeNotification?.Invoke(indexChange);
+            CallEventInternal(OnIndexChangeNotification, indexChange);
         }
 
         public void Send(OperationStatusChange operationStatusChange)
         {
-            OnOperationStatusChangeNotification?.Invoke(operationStatusChange);
+            CallEventInternal(OnOperationStatusChangeNotification, operationStatusChange);
         }
 
         public void Send(AggressiveCacheChange aggressiveCacheChange)
         {
-            OnAggressiveCacheChangeNotification?.Invoke(aggressiveCacheChange);
+            CallEventInternal(OnAggressiveCacheChangeNotification, aggressiveCacheChange);
         }
 
-        event Action<TimeSeriesChange> IChangesConnectionState<TimeSeriesChange>.OnChangeNotification
+        void IChangesConnectionState<TimeSeriesChange>.RegisterEvents(Action<TimeSeriesChange> onChangeNotification, Action<Exception> onError)
         {
-            add => OnTimeSeriesChangeNotification += value;
-            remove => OnTimeSeriesChangeNotification -= value;
+            RegisterEventsInternal(ref OnTimeSeriesChangeNotification, onChangeNotification, onError);
         }
 
-        event Action<CounterChange> IChangesConnectionState<CounterChange>.OnChangeNotification
+        void IChangesConnectionState<TimeSeriesChange>.UnregisterEvents(Action<TimeSeriesChange> onChangeNotification, Action<Exception> onError)
         {
-            add => OnCounterChangeNotification += value;
-            remove => OnCounterChangeNotification -= value;
+            UnregisterEventsInternal(ref OnTimeSeriesChangeNotification, onChangeNotification, onError);
         }
 
-        event Action<OperationStatusChange> IChangesConnectionState<OperationStatusChange>.OnChangeNotification
+        void IChangesConnectionState<CounterChange>.RegisterEvents(Action<CounterChange> onChangeNotification, Action<Exception> onError)
         {
-            add => OnOperationStatusChangeNotification += value;
-            remove => OnOperationStatusChangeNotification -= value;
+            RegisterEventsInternal(ref OnCounterChangeNotification, onChangeNotification, onError);
         }
 
-        event Action<IndexChange> IChangesConnectionState<IndexChange>.OnChangeNotification
+        void IChangesConnectionState<CounterChange>.UnregisterEvents(Action<CounterChange> onChangeNotification, Action<Exception> onError)
         {
-            add => OnIndexChangeNotification += value;
-            remove => OnIndexChangeNotification -= value;
+            UnregisterEventsInternal(ref OnCounterChangeNotification, onChangeNotification, onError);
         }
 
-        event Action<DocumentChange> IChangesConnectionState<DocumentChange>.OnChangeNotification
+        void IChangesConnectionState<OperationStatusChange>.RegisterEvents(Action<OperationStatusChange> onChangeNotification, Action<Exception> onError)
         {
-            add => OnDocumentChangeNotification += value;
-            remove => OnDocumentChangeNotification -= value;
+            RegisterEventsInternal(ref OnOperationStatusChangeNotification, onChangeNotification, onError);
         }
 
-        event Action<AggressiveCacheChange> IChangesConnectionState<AggressiveCacheChange>.OnChangeNotification
+        void IChangesConnectionState<OperationStatusChange>.UnregisterEvents(Action<OperationStatusChange> onChangeNotification, Action<Exception> onError)
         {
-            add => OnAggressiveCacheChangeNotification += value;
-            remove => OnAggressiveCacheChangeNotification -= value;
+            UnregisterEventsInternal(ref OnOperationStatusChangeNotification, onChangeNotification, onError);
+        }
+
+        void IChangesConnectionState<IndexChange>.RegisterEvents(Action<IndexChange> onChangeNotification, Action<Exception> onError)
+        {
+            RegisterEventsInternal(ref OnIndexChangeNotification, onChangeNotification, onError);
+        }
+
+        void IChangesConnectionState<IndexChange>.UnregisterEvents(Action<IndexChange> onChangeNotification, Action<Exception> onError)
+        {
+            UnregisterEventsInternal(ref OnIndexChangeNotification, onChangeNotification, onError);
+        }
+
+        void IChangesConnectionState<DocumentChange>.RegisterEvents(Action<DocumentChange> onChangeNotification, Action<Exception> onError)
+        {
+            RegisterEventsInternal(ref OnDocumentChangeNotification, onChangeNotification, onError);
+        }
+
+        void IChangesConnectionState<DocumentChange>.UnregisterEvents(Action<DocumentChange> onChangeNotification, Action<Exception> onError)
+        {
+            UnregisterEventsInternal(ref OnDocumentChangeNotification, onChangeNotification, onError);
+        }
+
+        void IChangesConnectionState<AggressiveCacheChange>.RegisterEvents(Action<AggressiveCacheChange> onChangeNotification, Action<Exception> onError)
+        {
+            RegisterEventsInternal(ref OnAggressiveCacheChangeNotification, onChangeNotification, onError);
+        }
+
+        void IChangesConnectionState<AggressiveCacheChange>.UnregisterEvents(Action<AggressiveCacheChange> onChangeNotification, Action<Exception> onError)
+        {
+            UnregisterEventsInternal(ref OnAggressiveCacheChangeNotification, onChangeNotification, onError);
         }
 
         public override void Dispose()
         {
-            base.Dispose();
+            lock (_eventLock)
+            {
+                base.Dispose();
 
-            OnDocumentChangeNotification = null;
-            OnCounterChangeNotification = null;
-            OnTimeSeriesChangeNotification = null;
-            OnIndexChangeNotification = null;
-            OnAggressiveCacheChangeNotification = null;
-            OnOperationStatusChangeNotification = null;
+                OnDocumentChangeNotification = null;
+                OnCounterChangeNotification = null;
+                OnTimeSeriesChangeNotification = null;
+                OnIndexChangeNotification = null;
+                OnAggressiveCacheChangeNotification = null;
+                OnOperationStatusChangeNotification = null;
+            }
         }
     }
 }

--- a/src/Raven.Client/Documents/Changes/IChangesConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/IChangesConnectionState.cs
@@ -13,7 +13,9 @@ namespace Raven.Client.Documents.Changes
 
         Task EnsureSubscribedNow();
 
-        event Action<T> OnChangeNotification;
+        void RegisterEvents(Action<T> onChangeNotification, Action<Exception> onError);
+
+        void UnregisterEvents(Action<T> onChangeNotification, Action<Exception> onError);
 
         event Action<Exception> OnError;
     }

--- a/src/Raven.Client/Documents/Changes/IChangesConnectionState.cs
+++ b/src/Raven.Client/Documents/Changes/IChangesConnectionState.cs
@@ -5,9 +5,9 @@ namespace Raven.Client.Documents.Changes
 {
     internal interface IChangesConnectionState<out T> : IDisposable
     {
-        void Inc();
+        int Inc();
 
-        void Dec();
+        int Dec();
 
         void Error(Exception e);
 

--- a/src/Raven.Server/Documents/Sharding/Changes/ShardedDatabaseConnectionState.cs
+++ b/src/Raven.Server/Documents/Sharding/Changes/ShardedDatabaseConnectionState.cs
@@ -18,9 +18,23 @@ internal sealed class ShardedDatabaseConnectionState : AbstractDatabaseConnectio
         _onChangeNotification?.Invoke(change);
     }
 
-    event Action<BlittableJsonReaderObject> IChangesConnectionState<BlittableJsonReaderObject>.OnChangeNotification
+    void IChangesConnectionState<BlittableJsonReaderObject>.RegisterEvents(Action<BlittableJsonReaderObject> onChangeNotification, Action<Exception> onError)
     {
-        add => _onChangeNotification += value;
-        remove => _onChangeNotification -= value;
+        RegisterEventsInternal(ref _onChangeNotification, onChangeNotification, onError);
+    }
+
+    void IChangesConnectionState<BlittableJsonReaderObject>.UnregisterEvents(Action<BlittableJsonReaderObject> onChangeNotification, Action<Exception> onError)
+    {
+        UnregisterEventsInternal(ref _onChangeNotification, onChangeNotification, onError);
+    }
+
+    public override void Dispose()
+    {
+        lock (_eventLock)
+        {
+            base.Dispose();
+
+            _onChangeNotification = null;
+        }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-25517.cs
+++ b/test/SlowTests/Issues/RavenDB-25517.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Changes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25517 : RavenTestBase
+{
+
+    public RavenDB_25517(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.ChangesApi)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Subscriber_doesnt_get_disposed_on_other_subscriber_dispose(bool same)
+    {
+        using (var store = GetDocumentStore())
+        {
+            // Create initial document
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestDocument { TimeStamp = DateTime.Now.ToString() }, "Test/1-A");
+                await session.SaveChangesAsync();
+            }
+
+            var messages_v1 = new List<string>();
+            var messages_v2 = new List<string>();
+
+            var changes = store.Changes();
+            await changes.EnsureConnectedNow();
+
+            IChangesObservable<DocumentChange> documentChanges1;
+            IChangesObservable<DocumentChange> documentChanges2;
+            if (same)
+            {
+                documentChanges1 = documentChanges2 = changes.ForDocument("Test/1-A");
+            }
+            else
+            {
+                documentChanges1 = changes.ForDocument("Test/1-A");
+                documentChanges2 = changes.ForDocument("Test/1-A");
+            }
+
+            // Subscribe twice to the same document
+
+            var subscription_v1 = documentChanges1.Subscribe(change =>
+            {
+                if (change.Type == DocumentChangeTypes.Delete)
+                {
+                    messages_v2.Add($"[V1] Change '{change.Type}' detected for document ID: {change.Id}");
+                    return;
+                }
+
+                messages_v1.Add($"[V1] Change '{change.Type}' detected for document ID: {change.Id} at {DateTime.Now}");
+            });
+
+            var subscription_v2 = documentChanges2.Subscribe(change =>
+            {
+                if (change.Type == DocumentChangeTypes.Delete)
+                {
+                    messages_v2.Add($"[V2] Change '{change.Type}' detected for document ID: {change.Id}");
+                    return;
+                }
+
+                messages_v2.Add($"[V2] Change '{change.Type}' detected for document ID: {change.Id} at {DateTime.Now}");
+            });
+
+            await documentChanges1.EnsureSubscribedNow();
+            await documentChanges2.EnsureSubscribedNow();
+
+            // First change - both subscriptions should receive notification
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = new TestDocument { TimeStamp = DateTime.Now.ToString() };
+                await session.StoreAsync(entity, "Test/1-A");
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForValueAsync(() => messages_v1.Any(), true));
+            Assert.True(await WaitForValueAsync(() => messages_v2.Any(), true));
+
+            // Dispose first subscription
+            subscription_v1.Dispose();
+            // Dispose first subscription again
+            subscription_v1.Dispose();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("Test/1-A");
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForValueAsync(() => messages_v2.Count >= 2 && messages_v2.Contains("[V2] Change 'Delete' detected for document ID: Test/1-A"), true));
+
+            Assert.NotEqual(messages_v1.Count, messages_v2.Count);
+
+            Assert.Contains("[V2] Change 'Delete' detected for document ID: Test/1-A", messages_v2);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.ChangesApi)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Each_subscriber_receives_every_notification_twice(bool same)
+    {
+        using (var store = GetDocumentStore())
+        {
+            // Create initial document
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new TestDocument { TimeStamp = DateTime.Now.ToString() }, "Test/1-A");
+                await session.SaveChangesAsync();
+            }
+
+            var messages_v1 = new List<string>();
+            var messages_v2 = new List<string>();
+
+            var changes = store.Changes();
+            await changes.EnsureConnectedNow();
+
+            IChangesObservable<DocumentChange> documentChanges1;
+            IChangesObservable<DocumentChange> documentChanges2;
+            if (same)
+            {
+                documentChanges1 = documentChanges2 = changes.ForDocument("Test/1-A");
+            }
+            else
+            {
+                documentChanges1 = changes.ForDocument("Test/1-A");
+                documentChanges2 = changes.ForDocument("Test/1-A");
+            }
+
+            // Subscribe twice to the same document
+
+            var subscription_v1 = documentChanges1.Subscribe(change =>
+            {
+                messages_v1.Add($"[V1] Change '{change.Type}' detected for document ID: {change.Id} at {DateTime.Now}");
+            });
+
+            var subscription_v2 = documentChanges2.Subscribe(change =>
+            {
+                messages_v2.Add($"[V2] Change '{change.Type}' detected for document ID: {change.Id} at {DateTime.Now}");
+            });
+
+            await documentChanges1.EnsureSubscribedNow();
+            await documentChanges2.EnsureSubscribedNow();
+
+            // First change - both subscriptions should receive notification
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = new TestDocument { TimeStamp = DateTime.Now.ToString() };
+                await session.StoreAsync(entity, "Test/1-A");
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForValueAsync(() => messages_v1.Any(), true));
+            Assert.True(await WaitForValueAsync(() => messages_v2.Any(), true));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("Test/1-A");
+                await session.SaveChangesAsync();
+            }
+
+            Assert.True(await WaitForValueAsync(() => messages_v1.Count >= 2, true));
+            Assert.True(await WaitForValueAsync(() => messages_v2.Count >= 2, true));
+
+            var l = messages_v1.GroupBy(x => x).Select(y => new { Key = y.Key, Count = y.Count() }).ToList();
+            Assert.All(l, x => Assert.Equal(1, x.Count));
+        }
+    }
+
+    private class TestDocument
+    {
+        public string Id { get; set; }
+
+        public string TimeStamp { get; set; }
+    }
+}


### PR DESCRIPTION
- disposing the same subscription twice stops the other subscription
- when subscribing twice to same observable duplicate change are returned

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25517
https://issues.hibernatingrhinos.com/issue/RavenDB-25515

### Additional description

 In changes API fix
- disposing the same subscription twice stops the other subscription
- when subscribing twice to same observable duplicate change are returned

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
