### PR TITLE
RavenDB-22142 - Initialize the SchemaValidatorCache only when we have enabled validators

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -70,6 +70,7 @@ using Constants = Raven.Client.Constants;
 using MountPointUsage = Raven.Client.ServerWide.Operations.MountPointUsage;
 using Size = Raven.Client.Util.Size;
 using System.Diagnostics.CodeAnalysis;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Server.Documents.AI.Embeddings;
 using Raven.Server.Documents.SchemaValidation;
 using Sparrow.Server.Logging;
@@ -446,7 +447,6 @@ namespace Raven.Server.Documents
 
                 ReplicationLoader = CreateReplicationLoader();
                 PeriodicBackupRunner = new PeriodicBackupRunner(this, _serverStore, wakeup);
-                SchemaValidatorCache = SchemaValidatorCache.Create(DocumentsStorage.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
 
                 _addToInitLog(LogLevel.Debug, "Initializing IndexStore (async)");
                 _indexStoreTask = IndexStore.InitializeAsync(record, index, _addToInitLog);
@@ -1746,8 +1746,8 @@ namespace Raven.Server.Documents
 
             try
             {
+                UpdateSchemaValidation(record.SchemaValidation);
                 PeriodicBackupRunner?.UpdateConfigurations(record.PeriodicBackups);
-                SchemaValidatorCache?.Update(record.SchemaValidation);
                 EmbeddingsGeneratorQueries?.HandleDatabaseRecordChange(record);
                 EmbeddingsGeneratorEtl?.HandleDatabaseRecordChange(record);
                 EtlLoader?.HandleDatabaseRecordChange(record);
@@ -1763,6 +1763,24 @@ namespace Raven.Server.Documents
             OnDatabaseRecordChanged(record);
         }
 
+        private void UpdateSchemaValidation(SchemaValidationConfiguration configuration)
+        {
+            if (configuration != null
+                && configuration.Disabled == false
+                && configuration.ValidatorsPerCollection != null
+                && configuration.ValidatorsPerCollection.Any(x => x.Value.Disabled == false))
+            {
+                SchemaValidatorCache ??= SchemaValidatorCache.Create(DocumentsStorage.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                SchemaValidatorCache.Update(configuration);
+            }
+            else
+            {
+                // we intentionally don't dispose here since it might be used by a transaction,
+                // clearing the resources will be done by the finalizer.
+                SchemaValidatorCache = null;
+            }
+        }
+        
         private void SetUnusedDatabaseIds(DatabaseRecord record)
         {
             if (record.UnusedDatabaseIds == null && DocumentsStorage.UnusedDatabaseIds == null)

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -159,8 +159,15 @@ public class SchemaValidatorCache : IDisposable
 
     public void Dispose()
     {
+        GC.SuppressFinalize(this);
+
         using (_context.Return)
         {
         }
+    }
+
+    ~SchemaValidatorCache()
+    {
+        Dispose();
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22142

### Additional description

Initialize the SchemaValidatorCache only when we have enabled validators.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
