### PR TITLE
RavenDB-25578 ForceUsing32BitsPager does not affect PulseReadTransactionLimit and MaxTxSize configurations

### DIFF
--- a/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/DatabaseConfiguration.cs
@@ -1,6 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
+using Raven.Server.ServerWide;
 using Sparrow;
 using Sparrow.Platform;
 using Sparrow.Server.LowMemory;
@@ -10,13 +15,22 @@ namespace Raven.Server.Config.Categories
     [ConfigurationCategory(ConfigurationCategoryType.Database)]
     public sealed class DatabaseConfiguration : ConfigurationCategory
     {
-        public DatabaseConfiguration(bool forceUsing32BitsPager)
+        private readonly StorageConfiguration _storageConfiguration;
+
+        public DatabaseConfiguration([NotNull] StorageConfiguration storageConfiguration)
         {
+            _storageConfiguration = storageConfiguration ?? throw new ArgumentNullException(nameof(storageConfiguration));
+        }
+
+        public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
+        {
+            base.Initialize(settings, settingsNames, serverWideSettings, serverWideSettingsNames, type, resourceName);
+            
             var totalMem = MemoryInformation.TotalPhysicalMemory;
 
             Size defaultPulseReadTransactionLimit;
 
-            if (PlatformDetails.Is32Bits || forceUsing32BitsPager || totalMem <= new Size(1, SizeUnit.Gigabytes))
+            if (PlatformDetails.Is32Bits || _storageConfiguration.ForceUsing32BitsPager || totalMem <= new Size(1, SizeUnit.Gigabytes))
                 defaultPulseReadTransactionLimit = new Size(16, SizeUnit.Megabytes);
             else if (totalMem <= new Size(4, SizeUnit.Gigabytes))
                 defaultPulseReadTransactionLimit = new Size(32, SizeUnit.Megabytes);
@@ -29,7 +43,6 @@ namespace Raven.Server.Config.Categories
 
             PulseReadTransactionLimit = defaultPulseReadTransactionLimit;
         }
-
 
         /// <summary>
         /// The time in seconds to wait before canceling query

--- a/src/Raven.Server/Config/Categories/TransactionMergerConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/TransactionMergerConfiguration.cs
@@ -1,6 +1,11 @@
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Configuration;
 using Raven.Server.Config.Attributes;
 using Raven.Server.Config.Settings;
+using Raven.Server.ServerWide;
 using Sparrow;
 using Sparrow.Platform;
 using Sparrow.Server.LowMemory;
@@ -10,9 +15,18 @@ namespace Raven.Server.Config.Categories
     [ConfigurationCategory(ConfigurationCategoryType.TransactionMerger)]
     public sealed class TransactionMergerConfiguration : ConfigurationCategory
     {
-        public TransactionMergerConfiguration(bool forceUsing32BitsPager)
+        private readonly StorageConfiguration _storageConfiguration;
+
+        public TransactionMergerConfiguration([NotNull] StorageConfiguration storageConfiguration)
         {
-            if (PlatformDetails.Is32Bits || forceUsing32BitsPager)
+            _storageConfiguration = storageConfiguration ?? throw new ArgumentNullException(nameof(storageConfiguration));
+        }
+
+        public override void Initialize(IConfigurationRoot settings, HashSet<string> settingsNames, IConfigurationRoot serverWideSettings, HashSet<string> serverWideSettingsNames, ResourceType type, string resourceName)
+        {
+            base.Initialize(settings, settingsNames, serverWideSettings, serverWideSettingsNames, type, resourceName);
+            
+            if (PlatformDetails.Is32Bits || _storageConfiguration.ForceUsing32BitsPager)
             {
                 MaxTxSize = new Size(4, SizeUnit.Megabytes);
                 return;

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -147,13 +147,13 @@ namespace Raven.Server.Config
             Logs = new LogsConfiguration();
             Server = new ServerConfiguration();
             Embedded = new EmbeddedConfiguration();
-            Databases = new DatabaseConfiguration(Storage.ForceUsing32BitsPager);
+            Databases = new DatabaseConfiguration(Storage);
             Memory = new MemoryConfiguration();
             Studio = new StudioConfiguration();
             Licensing = new LicenseConfiguration();
             Tombstones = new TombstoneConfiguration();
             Subscriptions = new SubscriptionsConfiguration();
-            TransactionMergerConfiguration = new TransactionMergerConfiguration(Storage.ForceUsing32BitsPager);
+            TransactionMergerConfiguration = new TransactionMergerConfiguration(Storage);
             Notifications = new NotificationsConfiguration();
             Updates = new UpdatesConfiguration();
             Migration = new MigrationConfiguration();

--- a/test/FastTests/Issues/RavenDB_25578.cs
+++ b/test/FastTests/Issues/RavenDB_25578.cs
@@ -1,0 +1,71 @@
+﻿using Raven.Server.Config;
+using Raven.Server.ServerWide;
+using Sparrow;
+using Sparrow.Platform;
+using Sparrow.Server.LowMemory;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_25578 : NoDisposalNeeded
+{
+    public RavenDB_25578(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Core, RavenArchitecture.AllX64)]
+    public void ForceUsing32BitsPager_should_flow_into_DatabaseConfiguration_and_TransactionMergerConfiguration_defaults()
+    {
+        var server = RavenConfiguration.CreateForTesting("server", ResourceType.Server);
+
+        server.SetSetting(RavenConfiguration.GetKey(x => x.Storage.ForceUsing32BitsPager), "true");
+
+        server.Initialize();
+
+        Assert.True(server.Storage.ForceUsing32BitsPager);
+
+        // DatabaseConfiguration(forceUsing32BitsPager) should pick the 32-bit defaults
+        Assert.Equal(new Size(16, SizeUnit.Megabytes), server.Databases.PulseReadTransactionLimit);
+
+        // TransactionMergerConfiguration(forceUsing32BitsPager) should pick the 32-bit defaults
+        Assert.Equal(new Size(4, SizeUnit.Megabytes), server.TransactionMergerConfiguration.MaxTxSize);
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Core, RavenArchitecture.AllX64)]
+    public void ForceUsing32BitsPager_false_should_use_64bit_dependent_defaults()
+    {
+        Assert.False(PlatformDetails.Is32Bits);
+
+        var server = RavenConfiguration.CreateForTesting("server", ResourceType.Server);
+
+        server.SetSetting(RavenConfiguration.GetKey(x => x.Storage.ForceUsing32BitsPager), "false");
+
+        server.Initialize();
+
+        Assert.False(server.Storage.ForceUsing32BitsPager);
+
+        var totalMem = MemoryInformation.TotalPhysicalMemory;
+
+        Size expectedPulseReadTransactionLimit;
+        if (totalMem <= new Size(1, SizeUnit.Gigabytes))
+            expectedPulseReadTransactionLimit = new Size(16, SizeUnit.Megabytes);
+        else if (totalMem <= new Size(4, SizeUnit.Gigabytes))
+            expectedPulseReadTransactionLimit = new Size(32, SizeUnit.Megabytes);
+        else if (totalMem <= new Size(16, SizeUnit.Gigabytes))
+            expectedPulseReadTransactionLimit = new Size(64, SizeUnit.Megabytes);
+        else if (totalMem <= new Size(64, SizeUnit.Gigabytes))
+            expectedPulseReadTransactionLimit = new Size(128, SizeUnit.Megabytes);
+        else
+            expectedPulseReadTransactionLimit = new Size(256, SizeUnit.Megabytes);
+
+        var expectedMaxTxSize = Size.Min(
+            new Size(512, SizeUnit.Megabytes),
+            totalMem / 10);
+
+        Assert.Equal(expectedPulseReadTransactionLimit, server.Databases.PulseReadTransactionLimit);
+        Assert.Equal(expectedMaxTxSize, server.TransactionMergerConfiguration.MaxTxSize);
+        Assert.NotEqual(new Size(4, SizeUnit.Megabytes), server.TransactionMergerConfiguration.MaxTxSize);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25578

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
