### PR TITLE
RavenDB-24992 move AI Exception to the client and inherit from RavenException

### DIFF
--- a/src/Raven.Client/Exceptions/AiExceptions.cs
+++ b/src/Raven.Client/Exceptions/AiExceptions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Net;
+
+namespace Raven.Client.Exceptions
+{
+    public class AiException : RavenException
+    {
+        public AiException(string message) : base(message)
+        {
+        }
+
+        public AiException(string message, Exception e) : base(message, e)
+        {
+        }
+
+        public string RequestId { get; set; }
+    }
+
+    public sealed class RefusedToAnswerException(string message) : AiException(message)
+    {
+        public string Refusal;
+        public string FinishReason;
+
+        public static void Throw(string refusal, string responseContent, string finishReason, string requestId)
+        {
+            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}', response content: {responseContent}")
+            {
+                Refusal = refusal,
+                FinishReason = finishReason,
+                RequestId = requestId
+            };
+        }
+    }
+
+    public class UnsuccessfulAiRequestException : AiException
+    {
+        public HttpStatusCode StatusCode { get; internal set; }
+
+        public UnsuccessfulAiRequestException(string message, HttpStatusCode statusCode) : base(message)
+        {
+            StatusCode = statusCode;
+        }
+
+        public static void Throw(string message, HttpStatusCode statusCode, string requestId)
+        {
+            throw new UnsuccessfulAiRequestException($"Status Code: {statusCode}, Message: {message}", statusCode)
+            {
+                RequestId = requestId
+            };
+        }
+    }
+
+    public class TooManyRequestsException : UnsuccessfulAiRequestException
+    {
+        public TooManyRequestsException(string message) : base(message, (HttpStatusCode)429)
+        {
+        }
+    }
+
+    public sealed class RateLimitException(string message) : TooManyRequestsException(message)
+    {
+        public TimeSpan RetryAfter { get; set; }
+    }
+
+    public class InsufficientQuotaException(string message) : TooManyRequestsException(message)
+    {
+    }
+
+    public sealed class TooManyTokensException(string message) : TooManyRequestsException(message)
+    {
+    }
+}

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -130,6 +130,21 @@ namespace Raven.Client.Exceptions
         {
             switch (exception)
             {
+                case RateLimitException rateLimitException:
+                    rateLimitException.StatusCode = (HttpStatusCode)429;
+                    json.TryGet(nameof(RateLimitException.RetryAfter), out string retryAfter);
+                    if (TimeSpan.TryParse(retryAfter, out var timeSpan))
+                        rateLimitException.RetryAfter = timeSpan;
+                    break;
+                case UnsuccessfulAiRequestException unsuccessfulAiRequestException:
+                    json.TryGet(nameof(UnsuccessfulAiRequestException.StatusCode), out string code);
+                    if (Enum.TryParse<HttpStatusCode>(code, out var status))
+                        unsuccessfulAiRequestException.StatusCode = status;
+                    break;
+                case RefusedToAnswerException refusedToAnswerException:
+                    json.TryGet(nameof(RefusedToAnswerException.Refusal), out refusedToAnswerException.Refusal);
+                    json.TryGet(nameof(RefusedToAnswerException.FinishReason), out refusedToAnswerException.FinishReason);
+                    break;
                 case IndexCompilationException indexCompilationException:
                     json.TryGet(nameof(IndexCompilationException.IndexDefinitionProperty), out indexCompilationException.IndexDefinitionProperty);
                     json.TryGet(nameof(IndexCompilationException.ProblematicText), out indexCompilationException.ProblematicText);

--- a/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
+++ b/src/Raven.Client/Exceptions/ExceptionDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -133,7 +134,7 @@ namespace Raven.Client.Exceptions
                 case RateLimitException rateLimitException:
                     rateLimitException.StatusCode = (HttpStatusCode)429;
                     json.TryGet(nameof(RateLimitException.RetryAfter), out string retryAfter);
-                    if (TimeSpan.TryParse(retryAfter, out var timeSpan))
+                    if (TimeSpan.TryParse(retryAfter, formatProvider: CultureInfo.InvariantCulture, out var timeSpan))
                         rateLimitException.RetryAfter = timeSpan;
                     break;
                 case UnsuccessfulAiRequestException unsuccessfulAiRequestException:

--- a/src/Raven.Server/Documents/AI/AiExceptions.cs
+++ b/src/Raven.Server/Documents/AI/AiExceptions.cs
@@ -3,41 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using Raven.Client.Exceptions;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.AI
 {
-    /// <summary>Base for all Gen‑AI service errors.</summary>
-    public class AiException : Exception
-    {
-        public AiException(string message) : base(message)
-        {
-        }
-
-        public AiException(string message, Exception e) : base(message, e)
-        {
-        }
-
-        public required string RequestId { get; set; }
-    }
-
-    public sealed class RefusedToAnswerException(string message) : AiException(message)
-    {
-        public string Refusal;
-        public string FinishReason;
-
-        [DoesNotReturn]
-        public static void Throw(string refusal, string responseContent, string finishReason, string requestId)
-        {
-            throw new RefusedToAnswerException($"The request was refused by the model: '{refusal}', response content: {responseContent}")
-            {
-                Refusal = refusal,
-                FinishReason = finishReason,
-                RequestId = requestId
-            };
-        }
-    }
-
     public sealed class UnexpectedResponseException : AiException
     {
         public UnexpectedResponseException(string message) : base(message)
@@ -63,46 +33,5 @@ namespace Raven.Server.Documents.AI
                 RequestId = ChatCompletionClient.GetRequestId(response.Headers)
             };
         }
-    }
-
-    public class UnsuccessfulRequestException : AiException
-    {
-        public HttpStatusCode StatusCode { get; }
-
-        public UnsuccessfulRequestException(string message, HttpStatusCode statusCode) : base(message)
-        {
-            StatusCode = statusCode;
-        }
-
-        [DoesNotReturn]
-        public static void Throw(string message, HttpStatusCode statusCode, string requestId)
-        {
-            throw new UnsuccessfulRequestException($"Status Code: {statusCode}, Message: {message}", statusCode)
-            {
-                RequestId = requestId
-            };
-        }
-    }
-
-    public class TooManyRequestsException : UnsuccessfulRequestException
-    {
-
-        public TooManyRequestsException(string message) : base(message, HttpStatusCode.TooManyRequests)
-        {
-        }
-    }
-
-    public sealed class RateLimitException(string message) : TooManyRequestsException(message)
-    {
-        public TimeSpan RetryAfter { get; set; }
-    }
-
-
-    public class InsufficientQuotaException(string message) : TooManyRequestsException(message)
-    {
-    }
-
-    public sealed class TooManyTokensException(string message) : TooManyRequestsException(message)
-    {
     }
 }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Server.Documents.AI.Settings;
@@ -695,7 +696,7 @@ internal class ChatCompletionClient : IDisposable
                 RefusedToAnswerException.Throw(message, content.ToString(), null, reqId);
                 break;
             default:
-                UnsuccessfulRequestException.Throw(content.ToString(), response.StatusCode, reqId);
+                UnsuccessfulAiRequestException.Throw(content.ToString(), response.StatusCode, reqId);
                 break;
         }
     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.ETL.Metrics;

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -347,42 +347,45 @@ namespace Raven.Server
 
         private static void MaybeAddAdditionalExceptionData(DynamicJsonValue djv, Exception exception)
         {
-            if (exception is IndexCompilationException indexCompilationException)
+            switch (exception)
             {
-                djv[nameof(IndexCompilationException.IndexDefinitionProperty)] = indexCompilationException.IndexDefinitionProperty;
-                djv[nameof(IndexCompilationException.ProblematicText)] = indexCompilationException.ProblematicText;
-                return;
-            }
-
-            if (exception is DocumentConflictException documentConflictException)
-            {
-                djv[nameof(DocumentConflictException.DocId)] = documentConflictException.DocId;
-                djv[nameof(DocumentConflictException.LargestEtag)] = documentConflictException.LargestEtag;
-            }
-
-            if (exception is ConcurrencyException concurrencyException)
-            {
-                djv[nameof(ConcurrencyException.Id)] = concurrencyException.Id;
-                djv[nameof(ConcurrencyException.ExpectedChangeVector)] = concurrencyException.ExpectedChangeVector;
-                djv[nameof(ConcurrencyException.ActualChangeVector)] = concurrencyException.ActualChangeVector;
-            }
-
-            if (exception is RavenTimeoutException timeoutException)
-            {
-                djv[nameof(RavenTimeoutException.FailImmediately)] = timeoutException.FailImmediately;
-            }
-
-            if (exception is ClusterTransactionConcurrencyException { ConcurrencyViolations: { } } ctxConcurrencyException)
-                djv[nameof(ClusterTransactionConcurrencyException.ConcurrencyViolations)] = new DynamicJsonArray(ctxConcurrencyException.ConcurrencyViolations.Select(c => c.ToJson()));
-
-            if (exception is BackupAlreadyRunningException backupAlreadyRunningException)
-            {
-                djv[nameof(BackupAlreadyRunningException.OperationId)] = backupAlreadyRunningException.OperationId;
-                djv[nameof(BackupAlreadyRunningException.NodeTag)] = backupAlreadyRunningException.NodeTag;
-            }
-            if (exception is LicenseLimitException licenseLimitException)
-            {
-                djv[nameof(LicenseLimitException.LimitType)] = licenseLimitException.LimitType;
+                case RateLimitException rateLimitException:
+                    rateLimitException.StatusCode = (HttpStatusCode)429;
+                    djv[nameof(RateLimitException.RetryAfter)] = rateLimitException.RetryAfter;
+                    djv[nameof(RateLimitException.StatusCode)] = HttpStatusCode.TooManyRequests;
+                    break;
+                case UnsuccessfulAiRequestException unsuccessfulAiRequestException:
+                    djv[nameof(RateLimitException.StatusCode)] = unsuccessfulAiRequestException.StatusCode;
+                    break;
+                case RefusedToAnswerException refusedToAnswerException:
+                    djv[nameof(RefusedToAnswerException.Refusal)] = refusedToAnswerException.Refusal;
+                    djv[nameof(RefusedToAnswerException.FinishReason)] = refusedToAnswerException.FinishReason;
+                    break;
+                case IndexCompilationException indexCompilationException:
+                    djv[nameof(IndexCompilationException.IndexDefinitionProperty)] = indexCompilationException.IndexDefinitionProperty;
+                    djv[nameof(IndexCompilationException.ProblematicText)] = indexCompilationException.ProblematicText;
+                    return;
+                case DocumentConflictException documentConflictException:
+                    djv[nameof(DocumentConflictException.DocId)] = documentConflictException.DocId;
+                    djv[nameof(DocumentConflictException.LargestEtag)] = documentConflictException.LargestEtag;
+                    break;
+                case ConcurrencyException concurrencyException:
+                    djv[nameof(ConcurrencyException.Id)] = concurrencyException.Id;
+                    djv[nameof(ConcurrencyException.ExpectedChangeVector)] = concurrencyException.ExpectedChangeVector;
+                    djv[nameof(ConcurrencyException.ActualChangeVector)] = concurrencyException.ActualChangeVector;
+                    if (concurrencyException is ClusterTransactionConcurrencyException { ConcurrencyViolations: { } } ctxConcurrencyException)
+                        djv[nameof(ClusterTransactionConcurrencyException.ConcurrencyViolations)] = new DynamicJsonArray(ctxConcurrencyException.ConcurrencyViolations.Select(c => c.ToJson()));
+                    break;
+                case RavenTimeoutException timeoutException:
+                    djv[nameof(RavenTimeoutException.FailImmediately)] = timeoutException.FailImmediately;
+                    break;
+                case BackupAlreadyRunningException backupAlreadyRunningException:
+                    djv[nameof(BackupAlreadyRunningException.OperationId)] = backupAlreadyRunningException.OperationId;
+                    djv[nameof(BackupAlreadyRunningException.NodeTag)] = backupAlreadyRunningException.NodeTag;
+                    break;
+                case LicenseLimitException licenseLimitException:
+                    djv[nameof(LicenseLimitException.LimitType)] = licenseLimitException.LimitType;
+                    break;
             }
         }
 

--- a/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Exceptions;
 using Raven.Server.Documents.AI;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
@@ -92,7 +93,7 @@ public class ChatCompletionClientTests : RavenTestBase
             configuration.Connection.OpenAiSettings.ApiKey += "xyz"; // wrong api key
             using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
             {
-                var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.TestCompleteAsync(prompt, context, defaultJsonSchema, default));
+                var ex = await Assert.ThrowsAsync<UnsuccessfulAiRequestException>(() => client.TestCompleteAsync(prompt, context, defaultJsonSchema, default));
                 Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
             }
             configuration.Connection.OpenAiSettings.ApiKey = 
@@ -118,14 +119,14 @@ public class ChatCompletionClientTests : RavenTestBase
                 writer.WriteEndObject();
             };
 
-            var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.TestCompleteAsync(prompt, context, defaultJsonSchema, default));
+            var ex = await Assert.ThrowsAsync<UnsuccessfulAiRequestException>(() => client.TestCompleteAsync(prompt, context, defaultJsonSchema, default));
             Assert.Equal(HttpStatusCode.BadRequest, ex.StatusCode);
         }
 
         SetModel("gpt-4kabcdefg", out var originalModel); // wrong model name
         using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))
         {
-            var ex = await Assert.ThrowsAsync<UnsuccessfulRequestException>(() => client.TestCompleteAsync(prompt, context, defaultJsonSchema, default));
+            var ex = await Assert.ThrowsAsync<UnsuccessfulAiRequestException>(() => client.TestCompleteAsync(prompt, context, defaultJsonSchema, default));
             Assert.Equal(HttpStatusCode.NotFound, ex.StatusCode);
         }
         SetModel(originalModel, out _); // back to the original model name

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiErrorHandling.cs
@@ -10,6 +10,7 @@ using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;
@@ -445,7 +446,7 @@ this.Comments[idx].IsSpam = $output.Blocked;";
             if (ctx.Contains("alex"))
             {
                 if (Interlocked.CompareExchange(ref enteredOnce, 1, 0) == 0)
-                    throw new UnsuccessfulRequestException("Unauthorized", HttpStatusCode.Unauthorized) { RequestId = "fake-request-id" };
+                    throw new UnsuccessfulAiRequestException("Unauthorized", HttpStatusCode.Unauthorized) { RequestId = "fake-request-id" };
 
                 return blockEtlMre.WaitAsync(TimeSpan.FromSeconds(60));
             }

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiStats.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiStats.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.AI.GenAi;

--- a/test/StressTests/GenAi/ChatCompletionClientStressTests.cs
+++ b/test/StressTests/GenAi/ChatCompletionClientStressTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Exceptions;
 using Raven.Server.Documents.AI;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24992

### Additional description

Allow the client to catch exceptions like `RateLimitException` and do an error handling 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
Previously we were throwing a generic RavenException, now we throw a specific Exception
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
