### PR TITLE
RavenDB-25530 - Cannot add document when schema validation is disabled

### DIFF
--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
@@ -223,9 +223,13 @@ public static class SchemaValidationHelper
         return true;
     }
 
-    public static SchemaValidator InitValidatorForDocument(JsonOperationContext context, BlittableJsonReaderObject definition, string strDefinition)
+    public static SchemaValidator InitValidatorForDocument(JsonOperationContext context, BlittableJsonReaderObject definition, string strDefinition, bool disabled = false)
     {
-        var validator = new SchemaValidator { SchemaDefinition = strDefinition };
+        var validator = new SchemaValidator
+        {
+            SchemaDefinition = strDefinition,
+            Disabled = disabled
+        };
         ValidateSchemaDefinitionForDocument(definition);
         ExcludeMetadata(context, ref definition);
         validator.Init(definition);

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
@@ -10,16 +10,12 @@ namespace Raven.Server.Documents.SchemaValidation;
 [DebuggerDisplay("{SchemaDefinition}")]
 public class SchemaValidator
 {
-    public readonly bool Disabled;
-
     private ElementSchemaRuleValidator _root;
+
     public string SchemaDefinition { get; set; }
 
-    public SchemaValidator(bool disabled = false)
-    {
-        Disabled = disabled;
-    }
-    
+    public bool Disabled { get; set; }
+
     // The caller (holder) is responsible for keeping the underlying Blittable / context alive (and disposing it) for as long as this SchemaValidator is used.
     public void Init(BlittableJsonReaderObject schemaDefinition)
     {

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -57,13 +57,16 @@ public class SchemaValidatorCache : IDisposable
         {
             if (_schemaValidatorsPerCollection.TryGetValue(collection, out var existingValidator)
                 && validator.Schema.Equals(existingValidator.SchemaDefinition))
+            {
+                existingValidator.Disabled = validator.Disabled;
                 continue;
+            }
 
             SchemaValidator schemaValidator;
             try
             {
                 var blittable = _context.Value.Sync.ReadForMemory(validator.Schema, "schema-validation");
-                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context.Value, blittable, validator.Schema);
+                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context.Value, blittable, validator.Schema, validator.Disabled);
             }
             catch (Exception e)
             {

--- a/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
@@ -58,6 +58,105 @@ public class SchemaValidationBasicTests : RavenTestBase
         }
     }
 
+    [RavenFact(RavenTestCategory.ClientApi, LicenseRequired = true)]
+    public async Task DisableSchemaAfterCreation()
+    {
+        var schema = JsonSchema.FromType<User>();
+        var schemaData = schema.ToJson();
+
+        using (var store = GetDocumentStore())
+        {
+            var configuration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+                {
+                    {
+                        "Users", new SchemaDefinition
+                        {
+                            Schema = schemaData
+                        }
+                    },
+                    {
+                        "Orders", new SchemaDefinition
+                        {
+                            Schema = schemaData
+                        }
+                    }
+                }
+            };
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Age = 17 }, "users/1");
+                var error = await Assert.ThrowsAsync<SchemaValidationException>(async () => await session.SaveChangesAsync());
+                Assert.Contains("The value '17' at 'Age' should be greater than or equal to 21.0.", error.Message);
+            }
+
+            configuration.ValidatorsPerCollection["Users"].Disabled = true;
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Age = 80 }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Age = 39 }, "users/1");
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi, LicenseRequired = true)]
+    public async Task CanStartWithDisabledSchema()
+    {
+        var schema = JsonSchema.FromType<User>();
+        var schemaData = schema.ToJson();
+
+        using (var store = GetDocumentStore())
+        {
+            var configuration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+                {
+                    {
+                        "Users", new SchemaDefinition
+                        {
+                            Disabled = true,
+                            Schema = schemaData
+                        }
+                    },
+                    {
+                        "Orders", new SchemaDefinition
+                        {
+                            Schema = schemaData
+                        }
+                    }
+                }
+            };
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Age = 17 }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            configuration.ValidatorsPerCollection["Users"].Disabled = false;
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Age = 80 }, "users/1");
+                var error = await Assert.ThrowsAsync<SchemaValidationException>(async () => await session.SaveChangesAsync());
+                Assert.Contains("The value '80' at 'Age' should be less than or equal to 67.0.", error.Message);
+            }
+        }
+    }
+
     private class User
     {
         [Range(21, 67)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25530/Cannot-add-document-when-schema-validation-is-disabled

### Additional description

Update the schema validation status when the schema definition is unchanged.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
