### PR TITLE
RavenDB-24992 AI Assistant improvements 

### DIFF
--- a/src/Raven.Server/Config/Categories/AiConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/AiConfiguration.cs
@@ -59,4 +59,9 @@ public sealed class AiConfiguration : ConfigurationCategory
     [DefaultValue(false)]
     [ConfigurationEntry("Ai.Assistant.Disable", ConfigurationEntryScope.ServerWideOnly)]
     public bool DisableAiAssistant { get; set; }
+
+    [Description("Prevents sending any user data, such as documents or query results, to the AI assistant.")]
+    [DefaultValue(false)]
+    [ConfigurationEntry("Ai.Assistant.DisableDataSubmission", ConfigurationEntryScope.ServerWideOnly)]
+    public bool DisableDataSubmission { get; set; }
 }

--- a/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
+++ b/src/Raven.Server/Documents/AI/SseStreamingJsonParser.cs
@@ -53,11 +53,11 @@ public unsafe class SseStreamingJsonParser : IDisposable
     {
         token?.ThrowIfCancellationRequested();
 
-        _totalSize += dataChunk.Length;
+        _totalSize += dataChunk.Size;
         if (_totalSize > _maxSize)
             throw new ArgumentException($"The maximum size allowed ({_maxSize}) has been exceeded, aborting");
 
-        _parser.SetBuffer(dataChunk.Buffer, dataChunk.Length);
+        _parser.SetBuffer(dataChunk.Buffer, dataChunk.Size);
         if (_builder.Read())
         {
             _builder.FinalizeDocument();

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -797,7 +797,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document> GetDocumentsInReverseEtagOrder(DocumentsOperationContext context, long start, long take)
+        public IEnumerable<Document> GetDocumentsInReverseEtagOrder(DocumentsOperationContext context, long start, long take, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -806,11 +806,11 @@ namespace Raven.Server.Documents
             {
                 if (take-- <= 0)
                     yield break;
-                yield return TableValueToDocument(context, ref result.Reader);
+                yield return TableValueToDocument(context, ref result.Reader, fields);
             }
         }
 
-        public IEnumerable<Document> GetDocumentsInReverseEtagOrderFrom(DocumentsOperationContext context, long etag, long take, long skip)
+        public IEnumerable<Document> GetDocumentsInReverseEtagOrderFrom(DocumentsOperationContext context, long etag, long take, long skip, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -819,11 +819,11 @@ namespace Raven.Server.Documents
             {
                 if (take-- <= 0)
                     yield break;
-                yield return TableValueToDocument(context, ref result.Reader);
+                yield return TableValueToDocument(context, ref result.Reader, fields);
             }
         }
 
-        public IEnumerable<Document> GetDocumentsInReverseEtagOrder(DocumentsOperationContext context, string collection, long start, long take)
+        public IEnumerable<Document> GetDocumentsInReverseEtagOrder(DocumentsOperationContext context, string collection, long start, long take, DocumentFields fields = DocumentFields.All)
         {
             var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -840,7 +840,7 @@ namespace Raven.Server.Documents
             {
                 if (take-- <= 0)
                     yield break;
-                yield return TableValueToDocument(context, ref result.Reader);
+                yield return TableValueToDocument(context, ref result.Reader, fields);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/CollectionsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CollectionsHandler.cs
@@ -27,6 +27,13 @@ namespace Raven.Server.Documents.Handlers
                 await processor.ExecuteAsync();
         }
 
+        [RavenAction("/databases/*/collections/docs/ids", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+        public async Task GetCollectionDocumentsIds()
+        {
+            using (var processor = new CollectionHandlerProcessorForGetDocumentIds(this))
+                await processor.ExecuteAsync();
+        }
+
         [RavenAction("/databases/*/collections/last-change-vector", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task GetLastDocumentChangeVectorForCollection()
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Collections/AbstractCollectionHandlerProcessorForGetDocumentIds.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Collections/AbstractCollectionHandlerProcessorForGetDocumentIds.cs
@@ -1,0 +1,154 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Raven.Client.Http;
+using Raven.Server.Documents.Sharding.Executors;
+using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.Documents.Sharding.Handlers.ContinuationTokens;
+using Raven.Server.Documents.Sharding.Operations;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.Processors.Collections
+{
+    internal abstract class AbstractCollectionHandlerProcessorForGetDocumentIds<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+        where TOperationContext : JsonOperationContext
+        where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+    {
+        protected AbstractCollectionHandlerProcessorForGetDocumentIds([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected abstract Task<string[]> GetCollectionIdsAsync(string name, int start, int pageSize, CancellationToken token);
+
+        public override async ValueTask ExecuteAsync()
+        {
+            var pageSize = RequestHandler.GetPageSize();
+            var start = RequestHandler.GetStart();
+            var name = RequestHandler.GetStringQueryString("name");
+
+            using (var token = RequestHandler.CreateHttpRequestBoundOperationToken())
+            {
+                var ids = await GetCollectionIdsAsync(name, start, pageSize, token.Token);
+                using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
+                {
+                    var results = context.ReadObject(new DynamicJsonValue
+                    {
+                        ["Results"] = ids
+                    },"get-ids");
+
+                    await context.WriteAsync(RequestHandler.ResponseBodyStream(), results, token.Token);
+                }
+            }
+        }
+    }
+
+    internal class CollectionHandlerProcessorForGetDocumentIds : AbstractCollectionHandlerProcessorForGetDocumentIds<DatabaseRequestHandler, DocumentsOperationContext>
+    {
+        public CollectionHandlerProcessorForGetDocumentIds(DatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override Task<string[]> GetCollectionIdsAsync(string name, int start, int pageSize, CancellationToken token)
+        {
+            var isAllDocsCollection = string.IsNullOrEmpty(name);
+            using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var documents = isAllDocsCollection
+                    ? RequestHandler.Database.DocumentsStorage
+                        .GetDocumentsInReverseEtagOrder(context, start, pageSize, fields: DocumentFields.Id)
+                    : RequestHandler.Database.DocumentsStorage
+                        .GetDocumentsInReverseEtagOrder(context, name, start, pageSize, fields: DocumentFields.Id);
+
+                return Task.FromResult(documents.Select(d => d.Id.ToString()).ToArray());
+            }
+        }
+    }
+
+    internal class ShardedCollectionHandlerProcessorForGetDocumentIds : AbstractCollectionHandlerProcessorForGetDocumentIds<ShardedDatabaseRequestHandler, TransactionOperationContext>
+    {
+        public ShardedCollectionHandlerProcessorForGetDocumentIds(ShardedDatabaseRequestHandler requestHandler) : base(requestHandler)
+        {
+        }
+
+        protected override async Task<string[]> GetCollectionIdsAsync(string name, int start, int pageSize, CancellationToken token)
+        {
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
+            {
+                var continuationToken = RequestHandler.ContinuationTokens.GetOrCreateContinuationToken(context, start, pageSize);
+
+                var op = new ShardedStreamDocumentsCollectionOperation(RequestHandler.HttpContext, name, continuationToken);
+                var results = await RequestHandler.ShardExecutor.ExecuteParallelForAllAsync(op, token);
+                return results.Result.Results;
+            }
+        }
+
+        public class DocumentIdsResult
+        {
+            public string[] Results;
+        }
+
+        public readonly struct ShardedStreamDocumentsCollectionOperation : IShardedReadOperation<DocumentIdsResult>
+        {
+            private readonly HttpContext _httpContext;
+            private readonly string _collectionName;
+            private readonly ShardedPagingContinuation _token;
+
+            public ShardedStreamDocumentsCollectionOperation(HttpContext httpContext, string collectionName, ShardedPagingContinuation token)
+            {
+                _httpContext = httpContext;
+                _collectionName = collectionName;
+                _token = token;
+            }
+
+            public HttpRequest HttpRequest => _httpContext.Request;
+            public RavenCommand<DocumentIdsResult> CreateCommandForShard(int shardNumber) => 
+                new GetIdsCommand(_collectionName, _token.Pages[shardNumber].Start, _token.PageSize);
+
+            public string ExpectedEtag { get; } = null;
+            public DocumentIdsResult CombineResults(Dictionary<int, ShardExecutionResult<DocumentIdsResult>> results)
+            {
+                var ids = new List<string>();
+                foreach (var shard in results)
+                {
+                    ids.AddRange(shard.Value.Result.Results);
+                }
+
+                return new DocumentIdsResult
+                {
+                    Results = ids.ToArray()
+                };
+            }
+        }
+
+        public class GetIdsCommand : RavenCommand<DocumentIdsResult>
+        {
+            private readonly string _collection;
+            private readonly int _start;
+            private readonly int _pageSize;
+
+            public GetIdsCommand(string collection, int start, int pageSize)
+            {
+                _collection = collection;
+                _start = start;
+                _pageSize = pageSize;
+            }
+            public override bool IsReadRequest => false;
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/collections/ids?name={_collection}&start={_start}&pageSize={_pageSize}";
+
+                return new HttpRequestMessage
+                {
+                    Method = HttpMethod.Get,
+                };
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedCollectionHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedCollectionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.Processors.Collections;
 using Raven.Server.Documents.Sharding.Handlers.Processors.Collections;
 using Raven.Server.Routing;
 
@@ -24,6 +25,13 @@ namespace Raven.Server.Documents.Sharding.Handlers
         public async Task GetCollectionDocuments()
         {
             using (var processor = new ShardedCollectionsHandlerProcessorForGetCollectionDocuments(this))
+                await processor.ExecuteAsync();
+        }
+
+        [RavenShardedAction("/databases/*/collections/docs/ids", "GET")]
+        public async Task GetCollectionDocumentsIds()
+        {
+            using (var processor = new ShardedCollectionHandlerProcessorForGetDocumentIds(this))
                 await processor.ExecuteAsync();
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24992

### Additional description

* new endpoint to efficiently fetch only document IDs from collections
* Added new configuration property `DisableDataSubmission` to `AiConfiguration` to prevent sending user data to the AI assistant.
* Fixed a bug in `SseStreamingJsonParser` by using `dataChunk.Size` instead of `dataChunk.Length` for buffer management.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed