### PR TITLE
RavenDB-25575 Schema Playground: Multiple sample schemas for the same collection behavior

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.stories.tsx
@@ -30,10 +30,11 @@ interface DefaultDocumentSchemaArgs {
 export const DefaultDocumentSchema: StoryObj<DefaultDocumentSchemaArgs> = {
     name: "Document Schema",
     render: (args) => {
-        const { databases, accessManager } = mockStore;
+        const { databases, accessManager, collectionsTracker } = mockStore;
         const { databasesService } = mockServices;
-        const db = databases.withActiveDatabase_NonSharded_SingleNode();
 
+        const db = databases.withActiveDatabase_NonSharded_SingleNode();
+        collectionsTracker.with_Collections();
         databasesService.withSchemaValidations();
         accessManager.with_databaseAccess({
             [db.name]: args.databaseAccess,
@@ -46,9 +47,10 @@ export const DefaultDocumentSchema: StoryObj<DefaultDocumentSchemaArgs> = {
 export const DefaultDocumentSchemaPlayground: StoryObj<DefaultDocumentSchemaArgs> = {
     name: "Document Schema Playground",
     render: () => {
-        const { databases, accessManager } = mockStore;
-        const db = databases.withActiveDatabase_NonSharded_SingleNode();
+        const { databases, accessManager, collectionsTracker } = mockStore;
 
+        const db = databases.withActiveDatabase_NonSharded_SingleNode();
+        collectionsTracker.with_Collections();
         accessManager.with_databaseAccess({
             [db.name]: "DatabaseAdmin",
         });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -20,7 +20,7 @@ import ReactAce from "react-ace/lib/ace";
 import { useAppSelector } from "components/store";
 import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import { useAppUrls } from "hooks/useAppUrls";
-import { FormProvider, useFieldArray, UseFieldArrayRemove, useForm, useFormContext } from "react-hook-form";
+import { FormProvider, useFieldArray, UseFieldArrayRemove, useForm, useFormContext, useWatch } from "react-hook-form";
 import * as yup from "yup";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { FieldArrayWithId } from "react-hook-form/dist/types/fieldArray";
@@ -70,6 +70,19 @@ function DocumentSchemaPlaygroundBody() {
         append({ collection: "", schema: "" });
     };
 
+    const allCollectionNames = useAppSelector(collectionsTrackerSelectors.userCollectionNames);
+
+    const getCollectionOptions = (currentIndex: number): SelectOption[] => {
+        const selectedCollections = fields.filter((_, idx) => idx !== currentIndex).map((schema) => schema.collection);
+
+        return allCollectionNames
+            .filter((collection) => !selectedCollections.includes(collection))
+            .map((x) => ({
+                label: x,
+                value: x,
+            }));
+    };
+
     const handleOpenSheet = (formData: DocumentSchemaFormData) => {
         const validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[] = formData.documentSchemas.map(
             (ds) => ({
@@ -104,7 +117,7 @@ function DocumentSchemaPlaygroundBody() {
 
             <div className="mt-4">
                 <HrHeader
-                    count={3}
+                    count={fields.length}
                     right={
                         <Button onClick={handleAppendTestField} size="xs" variant="info" className="rounded-pill">
                             <Icon icon="plus" />
@@ -121,7 +134,13 @@ function DocumentSchemaPlaygroundBody() {
 
                 <FormProvider {...form}>
                     {fields.map((field, index) => (
-                        <TestDocumentSchema remove={remove} key={field.id} {...field} index={index} />
+                        <TestDocumentSchema
+                            collectionOptions={getCollectionOptions(index)}
+                            remove={remove}
+                            key={field.id}
+                            {...field}
+                            index={index}
+                        />
                     ))}
                 </FormProvider>
             </div>
@@ -129,28 +148,27 @@ function DocumentSchemaPlaygroundBody() {
     );
 }
 
-type ExtendedFieldArrayWithId = FieldArrayWithId<DocumentSchemaFormData["documentSchemas"]> & {
+type TestDocumentSchemaProps = FieldArrayWithId<DocumentSchemaFormData, "documentSchemas", "id"> & {
     index: number;
     remove: UseFieldArrayRemove;
+    collectionOptions: SelectOption[];
 };
 
-function TestDocumentSchema({ index, remove }: ExtendedFieldArrayWithId) {
+function TestDocumentSchema({ index, remove, collectionOptions }: TestDocumentSchemaProps) {
     const { value: isPanelCollapsed, toggle: togglePanelCollapse } = useBoolean(false);
-    const { control, setValue } = useFormContext();
+    const { control, setValue } = useFormContext<DocumentSchemaFormData>();
     const aceRef = useRef<ReactAce>(null);
 
-    const allCollectionNames = useAppSelector(collectionsTrackerSelectors.userCollectionNames);
-
-    const collectionOptions: SelectOption[] = allCollectionNames.map((x) => ({
-        label: x,
-        value: x,
-    }));
+    const field = useWatch({
+        control,
+        name: `documentSchemas.${index}`,
+    });
 
     return (
         <RichPanel>
             <RichPanelHeader>
                 <RichPanelInfo>
-                    <RichPanelName>Document schema {index + 1}</RichPanelName>
+                    <RichPanelName>{field?.collection || `Document schema ${index + 1}`}</RichPanelName>
                 </RichPanelInfo>
                 <RichPanelActions>
                     <Button onClick={() => remove(index)} variant="danger">
@@ -191,7 +209,7 @@ function TestDocumentSchema({ index, remove }: ExtendedFieldArrayWithId) {
                                         component: (
                                             <AceEditor.LoadFileAction
                                                 onLoad={(value) => {
-                                                    setValue("documentSchemas." + index + ".schema", value, {
+                                                    setValue(`documentSchemas.${index}.schema`, value, {
                                                         shouldValidate: true,
                                                     });
                                                 }}


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25575

### Additional description

<img width="1080" height="767" alt="image" src="https://github.com/user-attachments/assets/4df35a76-1994-47ed-a1c0-50d84afe7c07" />
<img width="1155" height="937" alt="image" src="https://github.com/user-attachments/assets/2cd3fbfd-ebda-4565-b17e-938ddf8de2e3" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
