### PR TITLE
RavenDB-25596 - Add support for RemoteAttachmentFlags in index defini…

### DIFF
--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -9,6 +9,7 @@ using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 using Raven.Client.Util;
@@ -647,9 +648,14 @@ namespace Raven.Client.Documents.Indexes
                         }
                         else
                         {
-                            right = _conventions.SaveEnumsAsIntegers
-                                ? Expression.Constant(Convert.ToInt32(constantExpression.Value))
-                                : Expression.Constant(Enum.ToObject(enumType, constantExpression.Value).ToString());
+                            if (_conventions.SaveEnumsAsIntegers)
+                                right = Expression.Constant(Convert.ToInt32(constantExpression.Value));
+                            else
+                            {
+                                right = TypeExistsOnServer(enumType)
+                                    ? Expression.Constant(Enum.ToObject(enumType, constantExpression.Value), enumType)
+                                    : Expression.Constant(Enum.ToObject(enumType, constantExpression.Value).ToString());
+                            }
                         }
                     }
                     else
@@ -1059,6 +1065,9 @@ namespace Raven.Client.Documents.Indexes
                 return true;
 
             if (type.Assembly == typeof(Regex).Assembly) // System.Text.RegularExpressions
+                return true;
+
+            if (type == typeof(RemoteAttachmentFlags)) // Current type is RemoteAttachmentFlags enum
                 return true;
 
             if (type.Assembly.FullName.StartsWith("Lucene.Net") &&

--- a/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
+++ b/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Attachments.Remote;
+using Raven.Client.Documents.Operations.Indexes;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -391,6 +393,86 @@ namespace FastTests.Server.Documents.Attachments
                 })));
                 Assert.Contains($"Destination key 'TEST' is duplicate. Duplicate keys are not allowed in remote attachments configuration", e.Message);
 
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Indexes)]
+        public void RemoteAttachmentIndexWithFlags_ShouldCompile()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var index = new RemoteAttachmentIndexWithFlags
+                {
+                    Conventions = store.Conventions
+                };
+
+                var indexDefinition = index.CreateIndexDefinition();
+
+                Assert.NotNull(indexDefinition);
+                Assert.Equal("RemoteAttachmentIndexWithFlags", indexDefinition.Name);
+                Assert.NotEmpty(indexDefinition.Maps);
+
+                var map = indexDefinition.Maps.First();
+
+                var occurrences1 = map.Split(["this0.att.RemoteFlags.ToString() == Raven.Client.Documents.Attachments.RemoteAttachmentFlags.None.ToString()"], StringSplitOptions.None).Length - 1;
+                Assert.Equal(2, occurrences1);
+
+                var occurrences2 = map.Split(["this1.this0.att.RemoteFlags == Raven.Client.Documents.Attachments.RemoteAttachmentFlags.None"], StringSplitOptions.None).Length - 1;
+                Assert.Equal(2, occurrences2);
+
+                // Verify index can be executed/compiled without errors
+                index.Execute(store);
+
+                // Wait for indexing to ensure it compiles on the server side
+                Indexes.WaitForIndexing(store);
+
+                // Verify no compilation errors
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
+                Assert.Equal(0, indexStats.ErrorsCount);
+            }
+        }
+
+        internal class User
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public string AttName { get; set; }
+        }
+
+        private class RemoteAttachmentIndexWithFlags : AbstractIndexCreationTask<User, RemoteAttachmentIndexWithFlags.Result>
+        {
+            public class Result
+            {
+                public string Id { get; set; }
+                public string Name { get; set; }
+                public RemoteAttachmentFlags Remote { get; set; }
+                public DateTime? RemoteAt { get; set; }
+                public string AttStr { get; set; }
+                public string AttStr2 { get; set; }
+                public string AttEnum { get; set; }
+                public string AttEnum2 { get; set; }
+            }
+
+            public RemoteAttachmentIndexWithFlags()
+            {
+                Map = users => from u in users
+                    let att = LoadAttachment(u, u.AttName)
+                    let isLocalStr = att.RemoteFlags.ToString() == RemoteAttachmentFlags.None.ToString()
+                    let isLocal = att.RemoteFlags == RemoteAttachmentFlags.None
+                    select new Result
+                    {
+                        Name = att.Name,
+                        Remote = att.RemoteFlags,
+                        RemoteAt = att.RemoteAt,
+                        AttStr = isLocalStr ? att.GetContentAsString() : "remote",
+                        AttStr2 = att.RemoteFlags.ToString() == RemoteAttachmentFlags.None.ToString() ? att.GetContentAsString() : "remote",
+                        AttEnum = isLocal ? att.GetContentAsString() : "remote",
+                        AttEnum2 = att.RemoteFlags == RemoteAttachmentFlags.None ? att.GetContentAsString() : "remote",
+
+                    };
+                StoreAllFields(FieldStorage.Yes);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-24489.cs
+++ b/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-24489.cs
@@ -287,7 +287,7 @@ namespace SlowTests.Server.Documents.Attachments.Issues
             }
         }
 
-        public class User
+        internal class User
         { 
             public string Id { get; set; }
 


### PR DESCRIPTION
…tion

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25596/Add-support-for-RemoteAttachmentFlags-in-index-definition

### Additional description

1. Added Raven.Client Assembly to TypeExistsOnServer
2. Build expression with enum type for `TypeExistsOnServer=true`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
