### PR TITLE
RavenDB-25564 - Validate the schema before saving the cluster-wide transactions

### DIFF
--- a/src/Raven.Client/Documents/Operations/SchemaValidation/GetSchemaValidationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/GetSchemaValidationConfiguration.cs
@@ -6,14 +6,14 @@ using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.SchemaValidation;
 
-public sealed class GetSchemaValidationConfiguration : IMaintenanceOperation<GetSchemaValidationConfigurationResult>
+public sealed class GetSchemaValidationConfiguration : IMaintenanceOperation<SchemaValidationConfiguration>
 {
-    public RavenCommand<GetSchemaValidationConfigurationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    public RavenCommand<SchemaValidationConfiguration> GetCommand(DocumentConventions conventions, JsonOperationContext context)
     {
         return new GetSchemaValidationCommand();
     }
 
-    internal sealed class GetSchemaValidationCommand : RavenCommand<GetSchemaValidationConfigurationResult>
+    internal sealed class GetSchemaValidationCommand : RavenCommand<SchemaValidationConfiguration>
     {
         public override bool IsReadRequest => true;
 
@@ -34,7 +34,7 @@ public sealed class GetSchemaValidationConfiguration : IMaintenanceOperation<Get
             if (response == null)
                 return;
 
-            Result = JsonDeserializationClient.GetSchemaValidationConfiguration(response);
+            Result = JsonDeserializationClient.SchemaValidationConfiguration(response);
         }
     }
 }

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/GetSchemaValidationConfigurationResult.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/GetSchemaValidationConfigurationResult.cs
@@ -1,6 +1,0 @@
-﻿namespace Raven.Client.Documents.Operations.SchemaValidation;
-
-public sealed class GetSchemaValidationConfigurationResult
-{
-    public SchemaValidationConfiguration Configuration { get; set; }
-}

--- a/src/Raven.Client/Documents/Operations/SchemaValidation/SchemaValidationConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/SchemaValidation/SchemaValidationConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.SchemaValidation;
@@ -14,6 +15,17 @@ public sealed class SchemaValidationConfiguration
     {
         get => _validatorsPerCollection;
         set => _validatorsPerCollection = new Dictionary<string, SchemaDefinition>(value, StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal bool HasEnabledConfiguration()
+    {
+        if (Disabled)
+            return false;
+
+        if (ValidatorsPerCollection == null || ValidatorsPerCollection.Count == 0)
+            return false;
+
+        return ValidatorsPerCollection.Any(x => x.Value.Disabled == false);
     }
 
     public DynamicJsonValue ToJson()

--- a/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
+++ b/src/Raven.Client/Json/Serialization/JsonDeserializationClient.cs
@@ -310,7 +310,7 @@ namespace Raven.Client.Json.Serialization
 
         internal static readonly Func<BlittableJsonReaderObject, DatabaseSettings> DatabaseSettings = GenerateJsonDeserializationRoutine<DatabaseSettings>();
 
-        internal static readonly Func<BlittableJsonReaderObject, GetSchemaValidationConfigurationResult> GetSchemaValidationConfiguration = GenerateJsonDeserializationRoutine<GetSchemaValidationConfigurationResult>();
+        internal static readonly Func<BlittableJsonReaderObject, SchemaValidationConfiguration> SchemaValidationConfiguration = GenerateJsonDeserializationRoutine<SchemaValidationConfiguration>();
 
         public static readonly Func<BlittableJsonReaderObject, PutTrafficWatchConfigurationOperation.Parameters> GetTrafficWatchConfigurationResult = GenerateJsonDeserializationRoutine<PutTrafficWatchConfigurationOperation.Parameters>();
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1767,10 +1767,7 @@ namespace Raven.Server.Documents
 
         private void UpdateSchemaValidation(SchemaValidationConfiguration configuration)
         {
-            if (configuration != null
-                && configuration.Disabled == false
-                && configuration.ValidatorsPerCollection != null
-                && configuration.ValidatorsPerCollection.Any(x => x.Value.Disabled == false))
+            if (configuration != null && configuration.HasEnabledConfiguration())
             {
                 SchemaValidatorCache ??= SchemaValidatorCache.Create(DocumentsStorage.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
                 SchemaValidatorCache.Update(configuration);

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/ClusterTransactionMergedCommand.cs
@@ -75,7 +75,7 @@ public sealed class ClusterTransactionMergedCommand : TransactionMergedCommand
                                 }
 
                                 var putResult = Database.DocumentsStorage.Put(context, cmd.Id, null, cmd.Document, changeVector: changeVector,
-                                    flags: DocumentFlags.FromClusterTransaction);
+                                    flags: DocumentFlags.FromClusterTransaction, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
                                 context.DocumentDatabase.HugeDocuments.AddIfDocIsHuge(cmd.Id, cmd.Document.Size);
                                 AddPutResult(putResult);
                             }

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/AbstractClusterTransactionRequestProcessor.cs
@@ -11,6 +11,7 @@ using Raven.Client.Exceptions;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Handlers.Batches;
 using Raven.Server.Documents.Handlers.Batches.Commands;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.Extensions;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
@@ -39,6 +40,8 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
 
     protected abstract ClusterConfiguration GetClusterConfiguration();
 
+    protected abstract SchemaValidatorCache SchemaValidatorCache { get; }
+
     public async ValueTask<(long Index, DynamicJsonArray Results)> ProcessAsync(JsonOperationContext context, TBatchCommand command, CancellationToken token)
     {
         ArraySegment<BatchRequestParser.CommandData> parsedCommands = GetParsedCommands(command);
@@ -52,6 +55,8 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
         CheckBackwardCompatibility(ref disableAtomicDocumentWrites);
 
         ValidateCommands(parsedCommands, disableAtomicDocumentWrites);
+
+        ValidateSchema(parsedCommands);
 
         var raftRequestId = RequestHandler.GetRaftRequestIdFromQuery();
 
@@ -84,6 +89,37 @@ public abstract class AbstractClusterTransactionRequestProcessor<TRequestHandler
             }
 
             return (index, array);
+        }
+    }
+
+    private void ValidateSchema(ArraySegment<BatchRequestParser.CommandData> parsedCommands)
+    {
+        var schemaValidatorCache = SchemaValidatorCache;
+        if (schemaValidatorCache == null)
+            return;
+
+        JsonOperationContext context = null;
+        IDisposable disposable = null;
+
+        try
+        {
+            foreach (var command in parsedCommands)
+            {
+                if (command.Type != CommandType.PUT)
+                    continue;
+
+                if (context == null)
+                {
+                    disposable = RequestHandler.ServerStore.ContextPool.AllocateOperationContext(out context);
+                }
+
+                var collectionName = CollectionName.GetCollectionName(command.Document);
+                schemaValidatorCache.Validate(collectionName, command.Document, NonPersistentDocumentFlags.None, context);
+            }
+        }
+        finally
+        {
+            disposable?.Dispose();
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Batches/ClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Batches/ClusterTransactionRequestProcessor.cs
@@ -8,6 +8,7 @@ using Raven.Client.ServerWide;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Handlers.Batches;
 using Raven.Server.Documents.Handlers.Batches.Commands;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.ServerWide.Commands;
 using Raven.Server.ServerWide.Context;
 using static Raven.Server.ServerWide.Commands.ClusterTransactionCommand;
@@ -27,6 +28,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Batches
         protected override ArraySegment<BatchRequestParser.CommandData> GetParsedCommands(MergedBatchCommand command) => command.ParsedCommands;
 
         protected override ClusterConfiguration GetClusterConfiguration() => RequestHandler.Database.Configuration.Cluster;
+
+        protected override SchemaValidatorCache SchemaValidatorCache => RequestHandler.Database.SchemaValidatorCache;
 
         public override async Task WaitForDatabaseCompletion(Task<HashSet<string>> onDatabaseCompletionTask, long index, ClusterTransactionOptions options, CancellationToken token)
         {

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -300,6 +300,9 @@ namespace Raven.Server.Documents.Indexes.Static
             if (validators == null)
             {
                 var schemaValidatorCache = QueryContext.Documents.DocumentDatabase.SchemaValidatorCache;
+                if (schemaValidatorCache == null)
+                    return true;
+
                 return schemaValidatorCache.Validate(collection, doc, errorBuilder);
             }
             

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -18,20 +18,20 @@ public class SchemaValidatorCache : IDisposable
 {
     private static readonly FrozenDictionary<string, SchemaValidator> EmptyCache = Array.Empty<KeyValuePair<string, SchemaValidator>>().ToFrozenDictionary();
 
-    private readonly DatabaseNotificationCenter _notificationCenter;
+    private readonly AbstractDatabaseNotificationCenter _notificationCenter;
     private readonly RavenLogger _logger;
     private readonly (IDisposable Return, JsonOperationContext Value) _context;
     private FrozenDictionary<string, SchemaValidator> _schemaValidatorsPerCollection = EmptyCache;
     public bool Disabled { get; private set; } = true;
 
-    public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, DatabaseNotificationCenter notificationCenter, RavenLogger logger)
+    public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, AbstractDatabaseNotificationCenter notificationCenter, RavenLogger logger)
         where T : JsonOperationContext
     {
         var returnContext = contextPool.AllocateOperationContext(out JsonOperationContext context);
         return new SchemaValidatorCache(returnContext, context, notificationCenter, logger);
     }
     
-    private SchemaValidatorCache(IDisposable returnCtx, JsonOperationContext ctx, DatabaseNotificationCenter notificationCenter, RavenLogger logger)
+    private SchemaValidatorCache(IDisposable returnCtx, JsonOperationContext ctx, AbstractDatabaseNotificationCenter notificationCenter, RavenLogger logger)
     {
         _context.Return = returnCtx;
         _context.Value = ctx;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Batches/ShardedClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Batches/ShardedClusterTransactionRequestProcessor.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Raven.Server.Config.Categories;
 using Raven.Server.Documents.Handlers.Batches;
 using Raven.Server.Documents.Handlers.Processors.Batches;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.Documents.Sharding.Handlers.Batches;
 using Raven.Server.ServerWide.Commands;
 using static Raven.Server.ServerWide.Commands.ClusterTransactionCommand;
@@ -21,6 +22,8 @@ public sealed class ShardedClusterTransactionRequestProcessor : AbstractClusterT
     protected override ArraySegment<BatchRequestParser.CommandData> GetParsedCommands(ShardedBatchCommand command) => command.ParsedCommands;
 
     protected override ClusterConfiguration GetClusterConfiguration() => RequestHandler.DatabaseContext.Configuration.Cluster;
+
+    protected override SchemaValidatorCache SchemaValidatorCache => RequestHandler.DatabaseContext.SchemaValidationCache;
 
     public override Task WaitForDatabaseCompletion(Task<HashSet<string>> onDatabaseCompletionTask, long index, ClusterTransactionOptions options, CancellationToken token)
     {

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -5,22 +5,22 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.Changes;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Http;
 using Raven.Client.ServerWide;
 using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.Documents.Sharding.Executors;
 using Raven.Server.Documents.Sharding.NotificationCenter;
 using Raven.Server.Documents.Sharding.Queries;
 using Raven.Server.Documents.TcpHandlers;
-using Raven.Server.Logging;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Collections;
 using Sparrow.Json;
-using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Logging;
 using Sparrow.Utils;
@@ -58,6 +58,8 @@ namespace Raven.Server.Documents.Sharding
         private readonly DatabasesLandlord.StateChange _orchestratorStateChange;
         private readonly DatabasesLandlord.StateChange _urlUpdateStateChange;
 
+        public SchemaValidatorCache SchemaValidationCache { get; private set; }
+
         public ShardedDatabaseContext(ServerStore serverStore, DatabaseRecord record)
         {
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "RavenDB-19086 reduce the record to the needed fields");
@@ -77,6 +79,7 @@ namespace Raven.Server.Documents.Sharding
 
             UpdateConfiguration(record.Settings);
 
+            UpdateSchemaValidationCache(record.SchemaValidation);
             Indexes = new ShardedIndexesContext(this, serverStore);
 
             ShardExecutor = new ShardExecutor(ServerStore, _record, _record.DatabaseName);
@@ -101,6 +104,21 @@ namespace Raven.Server.Documents.Sharding
 
             CompareExchangeStorage = new ShardedCompareExchangeStorage(this);
             CompareExchangeStorage.Initialize(DatabaseName);
+        }
+
+        private void UpdateSchemaValidationCache(SchemaValidationConfiguration configuration)
+        {
+            if (configuration != null && configuration.HasEnabledConfiguration())
+            {
+                SchemaValidationCache ??= SchemaValidatorCache.Create(ServerStore.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                SchemaValidationCache.Update(configuration);
+            }
+            else
+            {
+                // we intentionally don't dispose here since it might be currently being used for validation,
+                // clearing the resources will be done by the finalizer.
+                SchemaValidationCache = null;
+            }
         }
 
         public IDisposable AllocateOperationContext(out JsonOperationContext context) => ServerStore.ContextPool.AllocateOperationContext(out context);
@@ -152,6 +170,8 @@ namespace Raven.Server.Documents.Sharding
                 AllOrchestratorNodesExecutor.ForgetAbout();
                 AllOrchestratorNodesExecutor = new AllOrchestratorNodesExecutor(ServerStore, record);
             }
+
+            UpdateSchemaValidationCache(record.SchemaValidation);
 
             Indexes.Update(record, index);
 

--- a/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationBasicTests.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using NJsonSchema;
 using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions.SchemaValidation;
 using Tests.Infrastructure;
 using Xunit;
@@ -53,6 +54,62 @@ public class SchemaValidationBasicTests : RavenTestBase
             using (var session = store.OpenAsyncSession())
             {
                 await session.StoreAsync(new User { Age = 39 }, "users/1");
+                await session.SaveChangesAsync();
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.ClientApi, LicenseRequired = true)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task StoreClusterTransaction(Options options)
+    {
+        var schema = JsonSchema.FromType<User>();
+        var schemaData = schema.ToJson();
+
+        using (var store = GetDocumentStore(options))
+        {
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>()
+                {
+                    {"Users", new SchemaDefinition
+                    {
+                        Schema = schemaData
+                    }}
+                }
+            }));
+
+            using (var session = store.OpenAsyncSession(new SessionOptions{ TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Age = 17 }, "users/1");
+                var error = await Assert.ThrowsAsync<SchemaValidationException>(async () => await session.SaveChangesAsync());
+                Assert.Contains("The value '17' at 'Age' should be greater than or equal to 21.0.", error.Message);
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Age = 80 }, "users/1");
+                var error = await Assert.ThrowsAsync<SchemaValidationException>(async () => await session.SaveChangesAsync());
+                Assert.Contains("The value '80' at 'Age' should be less than or equal to 67.0.", error.Message);
+            }
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Age = 39 }, "users/1");
+                await session.SaveChangesAsync();
+            }
+
+            var configuration = await store.Maintenance.SendAsync(new GetSchemaValidationConfiguration());
+            configuration.ValidatorsPerCollection["Companies"] = new SchemaDefinition
+            {
+                Schema = schemaData
+            };
+            configuration.ValidatorsPerCollection["Users"].Disabled = true;
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            using (var session = store.OpenAsyncSession(new SessionOptions { TransactionMode = TransactionMode.ClusterWide }))
+            {
+                await session.StoreAsync(new User { Age = 20 }, "users/2");
                 await session.SaveChangesAsync();
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25564/Schema-validation-during-cluster-wide-transactions.

### Additional description

Validate the schema before saving the cluster-wide transactions.
- For non sharded we are going to use the schema cache of the `DocumentDatabase`.
- For sharded database, we'll a cache that is going to be saved in the `ShardedDatabaseContext`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
