### PR TITLE
RavenDB-25576 - Schema Playground: Allow selecting which collections to test

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
@@ -49,12 +49,12 @@ import { LoadingView } from "components/common/LoadingView";
 import genUtils from "common/generalUtils";
 import Dropdown from "react-bootstrap/Dropdown";
 import Spinner from "react-bootstrap/Spinner";
-import Code from "components/common/Code";
 import DocumentSchemaFilter from "components/pages/database/settings/documentSchema/DocumentSchemaFilter";
 import Ajv from "ajv";
 import { useViewSheet } from "components/common/splitView/ViewSheet";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
+import { ScriptSyntaxHelp } from "components/pages/database/settings/documentSchema/partials/ScriptSyntaxHelp";
 
 const ajv = new Ajv({
     allErrors: true,
@@ -444,69 +444,6 @@ const RichPanelDetailsViewSchema = ({ schema }: RichPanelDetailsProps) => {
         </RichPanelDetails>
     );
 };
-
-function ScriptSyntaxHelp() {
-    const employeeSchema = `
-{
-    "title": "Employee",
-    "type": "object",
-    "properties": {
-        "FirstName": { "type": "string" },
-        "LastName": { "type": "string" },
-        "Title": { "type": "string" },
-        "Address": {
-            "type": "object",
-            "properties": {
-                "City": { "type": "string" },
-                "Country": { "type": "string" },
-                "Line1": { "type": "string" },
-                "Line2": { "type": ["string", "null"] },
-                "Location": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "Latitude": { "type": "number" },
-                        "Longitude": { "type": "number" }
-                    }
-                },
-                "PostalCode": { "type": "string" },
-                "Region": { "type": ["string", "null"] }
-            },
-            "required": ["City", "Country", "Line1", "PostalCode", "Region"]
-        },
-        "Birthday": { "type": "string", "format": "date-time" },
-        "HiredAt": { "type": "string", "format": "date-time" },
-        "ReportsTo": {
-            "type": ["string", "null"],
-            "pattern": "^employees/\\\\d+-[A-Z]$"
-        },
-        "HomePhone": {
-            "type": ["string", "null"],
-            "pattern": "^\\\\(\\\\d{1,3}\\\\)\\\\s?\\\\d{3}-\\\\d{4}$",
-            "description": "Phone number in the format (206) 555-1189 or (71) 555-4848."
-        },
-        "Notes": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "minLength": 10,
-                "maxLength": 1000
-            },
-            "maxItems": 10
-        }
-    },
-    "required": ["FirstName", "LastName", "Title", "Address", "HomePhone"],
-    "additionalProperties": true
-}`;
-
-    return (
-        <div>
-            <div>
-                Sample schema for a document in the <code>Employees</code> collection:
-            </div>
-            <Code code={employeeSchema} language="json" />
-        </div>
-    );
-}
 
 interface RichPanelDetailsEditSchemaProps extends RichPanelDetailsProps {
     collectionName: string;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -61,7 +61,8 @@ export default function DocumentSchemaPlayground() {
             })
         );
         open({
-            component: <ValidationSchemaViewSheetPanel validators={validators} />,
+            component: <ValidationSchemaViewSheetPanel isPlayground validators={validators} />,
+            initialWidth: "40%",
         });
     };
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -32,6 +32,7 @@ import { SelectOption } from "components/common/select/Select";
 import { DocumentSchemaValidatorConfig } from "components/pages/database/settings/documentSchema/store/documentSchemaSlice";
 import DocumentSchemaPlaygroundAboutView from "components/pages/database/settings/documentSchema/partials/DocumentSchemaPlaygroundAboutView";
 import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
+import { ScriptSyntaxHelp } from "components/pages/database/settings/documentSchema/partials/ScriptSyntaxHelp";
 
 export default function DocumentSchemaPlayground() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
@@ -194,6 +195,10 @@ function TestDocumentSchema({ index, remove }: ExtendedFieldArrayWithId) {
                                                 }}
                                             />
                                         ),
+                                    },
+                                    {
+                                        component: <AceEditor.HelpAction message={<ScriptSyntaxHelp />} />,
+                                        position: "bottom",
                                     },
                                 ]}
                                 mode="json"

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ScriptSyntaxHelp.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ScriptSyntaxHelp.tsx
@@ -1,0 +1,65 @@
+import Code from "components/common/Code";
+import React from "react";
+
+export function ScriptSyntaxHelp() {
+    const employeeSchema = `
+{
+    "title": "Employee",
+    "type": "object",
+    "properties": {
+        "FirstName": { "type": "string" },
+        "LastName": { "type": "string" },
+        "Title": { "type": "string" },
+        "Address": {
+            "type": "object",
+            "properties": {
+                "City": { "type": "string" },
+                "Country": { "type": "string" },
+                "Line1": { "type": "string" },
+                "Line2": { "type": ["string", "null"] },
+                "Location": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "Latitude": { "type": "number" },
+                        "Longitude": { "type": "number" }
+                    }
+                },
+                "PostalCode": { "type": "string" },
+                "Region": { "type": ["string", "null"] }
+            },
+            "required": ["City", "Country", "Line1", "PostalCode", "Region"]
+        },
+        "Birthday": { "type": "string", "format": "date-time" },
+        "HiredAt": { "type": "string", "format": "date-time" },
+        "ReportsTo": {
+            "type": ["string", "null"],
+            "pattern": "^employees/\\\\d+-[A-Z]$"
+        },
+        "HomePhone": {
+            "type": ["string", "null"],
+            "pattern": "^\\\\(\\\\d{1,3}\\\\)\\\\s?\\\\d{3}-\\\\d{4}$",
+            "description": "Phone number in the format (206) 555-1189 or (71) 555-4848."
+        },
+        "Notes": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 10,
+                "maxLength": 1000
+            },
+            "maxItems": 10
+        }
+    },
+    "required": ["FirstName", "LastName", "Title", "Address", "HomePhone"],
+    "additionalProperties": true
+}`;
+
+    return (
+        <div>
+            <div>
+                Sample schema for a document in the <code>Employees</code> collection:
+            </div>
+            <Code code={employeeSchema} language="json" />
+        </div>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -217,7 +217,7 @@ export function ValidationSchemaViewSheetPanel({ validators, isPlayground }: Val
                                     maxDocumentsToValidate={formValues.maxDocumentsToValidate}
                                     selected={getIsCollectionSelected(validator.Name, selectedCollections)}
                                     toggleSelection={() => handleSelectCollections(validator)}
-                                    hideSelection={isPlayground}
+                                    showSelection={isPlayground}
                                 />
                             ))}
                         </Accordion>
@@ -537,7 +537,7 @@ interface ValidationCollectionAccordionItemProps {
     maxDocumentsToValidate: number | null;
     selected: boolean;
     toggleSelection: (x: ChangeEvent<HTMLInputElement>) => void;
-    hideSelection?: boolean;
+    showSelection?: boolean;
 }
 
 function ValidationCollectionAccordionItem({
@@ -548,7 +548,7 @@ function ValidationCollectionAccordionItem({
     maxDocumentsToValidate,
     selected,
     toggleSelection,
-    hideSelection,
+    showSelection,
 }: ValidationCollectionAccordionItemProps) {
     const errorCount = monitorOperationProgress?.ErrorCount ?? 0;
     const isCompleted = monitorOperationProgress?.status === "complete";
@@ -575,7 +575,7 @@ function ValidationCollectionAccordionItem({
                 })}
             >
                 <div className="hstack gap-2">
-                    {hideSelection && (
+                    {showSelection && (
                         <Checkbox
                             color="primary"
                             className="mb-0"
@@ -659,9 +659,8 @@ function ValidationCollectionAccordionItem({
 }
 
 function getIsCollectionSelected(name: string, selectedCollections: Record<string, boolean>): boolean {
-    const explicit = selectedCollections[name];
-    if (typeof explicit === "boolean") {
-        return explicit;
+    if (selectedCollections[name] != null) {
+        return selectedCollections[name];
     }
 
     return true;

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -52,7 +52,13 @@ export function ValidationSchemaViewSheetPanel({ validators, isPlayground }: Val
     const [monitorOperationProgress, setMonitorOperationProgress] = React.useState<
         Record<string, ValidationOperationProgress>
     >({});
-    const [selectedCollections, setSelectedCollections] = React.useState<Record<string, boolean>>({});
+    const [selectedCollections, setSelectedCollections] = React.useState<Record<string, boolean>>(() => {
+        const initialState: Record<string, boolean> = {};
+        validators.forEach((validator) => {
+            initialState[validator.Name] = true;
+        });
+        return initialState;
+    });
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
     const collections = useAppSelector(collectionsTrackerSelectors.collections);
@@ -61,9 +67,12 @@ export function ValidationSchemaViewSheetPanel({ validators, isPlayground }: Val
         resolver: yupResolver(schema),
     });
 
-    const asyncGetOperationIds = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
-        const activeValidators = isPlayground ? getSelectedValidators(validators, selectedCollections) : validators;
+    const activeValidators = useMemo(
+        () => (isPlayground ? getSelectedValidators(validators, selectedCollections) : validators),
+        [isPlayground, validators, selectedCollections]
+    );
 
+    const asyncGetOperationIds = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
         const dtos: ValidateSchemaRequestDto[] = activeValidators.map((validator) =>
             documentSchemaUtils.mapToValidateSchemaRequestDto(validator, formData)
         );
@@ -74,8 +83,6 @@ export function ValidationSchemaViewSheetPanel({ validators, isPlayground }: Val
     });
 
     const asyncTestSchema = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
-        const activeValidators = isPlayground ? getSelectedValidators(validators, selectedCollections) : validators;
-
         if (activeValidators.length === 0) {
             return;
         }
@@ -167,8 +174,6 @@ export function ValidationSchemaViewSheetPanel({ validators, isPlayground }: Val
     const isValidating = validators.some((validator) => monitorOperationProgress[validator.Name]?.status === "loading");
 
     const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || isValidating;
-
-    const activeValidators = isPlayground ? getSelectedValidators(validators, selectedCollections) : validators;
 
     const isDisabledRunTest = isPlayground && isEmpty(activeValidators);
 
@@ -658,12 +663,8 @@ function ValidationCollectionAccordionItem({
     );
 }
 
-function getIsCollectionSelected(name: string, selectedCollections: Record<string, boolean>): boolean {
-    if (selectedCollections[name] != null) {
-        return selectedCollections[name];
-    }
-
-    return true;
+function getIsCollectionSelected(name: string, selectedCollections: Record<string, boolean>) {
+    return selectedCollections[name];
 }
 
 function getSelectedValidators(

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel.tsx
@@ -1,6 +1,6 @@
 import { ViewSheet } from "components/common/splitView/ViewSheet";
 import { Icon } from "components/common/Icon";
-import React, { useMemo } from "react";
+import React, { ChangeEvent, useMemo } from "react";
 import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
 import {
     ColumnDef,
@@ -34,9 +34,11 @@ import { CellWithCopyWrapper } from "components/common/virtualTable/cells/CellWi
 import CellDocumentValue from "components/common/virtualTable/cells/CellDocumentValue";
 import Code from "components/common/Code";
 import { virtualTableConstants } from "components/common/virtualTable/utils/virtualTableConstants";
+import { Checkbox } from "components/common/Checkbox";
 
 interface ValidationSchemaViewSheetPanelProps {
     validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[];
+    isPlayground?: boolean;
 }
 
 interface ValidationOperationProgress extends ValidateSchemaResult {
@@ -44,12 +46,13 @@ interface ValidationOperationProgress extends ValidateSchemaResult {
     error?: unknown;
 }
 
-export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaViewSheetPanelProps) {
+export function ValidationSchemaViewSheetPanel({ validators, isPlayground }: ValidationSchemaViewSheetPanelProps) {
     // TODO: At the moment, when i close viewSheet, the entire state is deleted. I need to add the ability to persist this state if, for example, someone runs a test.
     // In Phase 2 i will rewrite monitorOperationProgress logic into redux.
     const [monitorOperationProgress, setMonitorOperationProgress] = React.useState<
         Record<string, ValidationOperationProgress>
     >({});
+    const [selectedCollections, setSelectedCollections] = React.useState<Record<string, boolean>>({});
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { databasesService } = useServices();
     const collections = useAppSelector(collectionsTrackerSelectors.collections);
@@ -59,7 +62,9 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
     });
 
     const asyncGetOperationIds = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
-        const dtos: ValidateSchemaRequestDto[] = validators.map((validator) =>
+        const activeValidators = isPlayground ? getSelectedValidators(validators, selectedCollections) : validators;
+
+        const dtos: ValidateSchemaRequestDto[] = activeValidators.map((validator) =>
             documentSchemaUtils.mapToValidateSchemaRequestDto(validator, formData)
         );
 
@@ -69,9 +74,15 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
     });
 
     const asyncTestSchema = useAsyncCallback(async (formData: ValidateSchemaFormData) => {
+        const activeValidators = isPlayground ? getSelectedValidators(validators, selectedCollections) : validators;
+
+        if (activeValidators.length === 0) {
+            return;
+        }
+
         setMonitorOperationProgress({});
 
-        const dtos: ValidateSchemaRequestDto[] = validators.map((validator) =>
+        const dtos: ValidateSchemaRequestDto[] = activeValidators.map((validator) =>
             documentSchemaUtils.mapToValidateSchemaRequestDto(validator, formData)
         );
 
@@ -157,6 +168,17 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
 
     const isTestSettingsDisabled = !formValues.isTestSettingsEnabled || isValidating;
 
+    const activeValidators = isPlayground ? getSelectedValidators(validators, selectedCollections) : validators;
+
+    const isDisabledRunTest = isPlayground && isEmpty(activeValidators);
+
+    const handleSelectCollections = (validator: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">) => {
+        setSelectedCollections((prev) => ({
+            ...prev,
+            [validator.Name]: !getIsCollectionSelected(validator.Name, prev),
+        }));
+    };
+
     return (
         <FormProvider {...form}>
             <form className="h-100" onSubmit={handleSubmit(asyncTestSchema.execute)}>
@@ -171,7 +193,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                         <h4 className="w-100 text-center">
                             {isValidating ? (
                                 <ValidationProgressSummary
-                                    validators={validators}
+                                    validators={activeValidators}
                                     monitorOperationProgress={monitorOperationProgress}
                                     collections={collections}
                                     isTestSettingsEnabled={formValues.isTestSettingsEnabled}
@@ -193,6 +215,9 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                                     collections={collections}
                                     isTestSettingsEnabled={formValues.isTestSettingsEnabled}
                                     maxDocumentsToValidate={formValues.maxDocumentsToValidate}
+                                    selected={getIsCollectionSelected(validator.Name, selectedCollections)}
+                                    toggleSelection={() => handleSelectCollections(validator)}
+                                    hideSelection={isPlayground}
                                 />
                             ))}
                         </Accordion>
@@ -252,6 +277,7 @@ export function ValidationSchemaViewSheetPanel({ validators }: ValidationSchemaV
                                 icon="start"
                                 variant="primary"
                                 type="submit"
+                                disabled={isDisabledRunTest}
                                 className="rounded-pill"
                             >
                                 Run test
@@ -509,6 +535,9 @@ interface ValidationCollectionAccordionItemProps {
     collections: { name: string; documentCount: number }[];
     isTestSettingsEnabled: boolean;
     maxDocumentsToValidate: number | null;
+    selected: boolean;
+    toggleSelection: (x: ChangeEvent<HTMLInputElement>) => void;
+    hideSelection?: boolean;
 }
 
 function ValidationCollectionAccordionItem({
@@ -517,6 +546,9 @@ function ValidationCollectionAccordionItem({
     collections,
     isTestSettingsEnabled,
     maxDocumentsToValidate,
+    selected,
+    toggleSelection,
+    hideSelection,
 }: ValidationCollectionAccordionItemProps) {
     const errorCount = monitorOperationProgress?.ErrorCount ?? 0;
     const isCompleted = monitorOperationProgress?.status === "complete";
@@ -530,6 +562,10 @@ function ValidationCollectionAccordionItem({
         ? ((monitorOperationProgress.error as any)?.Error ?? JSON.stringify(monitorOperationProgress.error, null, 2))
         : null;
 
+    const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>) => {
+        toggleSelection(e);
+    };
+
     return (
         <Accordion.Item eventKey={validator.Name}>
             <Accordion.Header
@@ -538,7 +574,19 @@ function ValidationCollectionAccordionItem({
                     "hide-accordion-dropdown": !isCompleted || (isCompleted && errorCount === 0 && !isErrored),
                 })}
             >
-                <span>{validator.Name}</span>{" "}
+                <div className="hstack gap-2">
+                    {hideSelection && (
+                        <Checkbox
+                            color="primary"
+                            className="mb-0"
+                            selected={selected}
+                            toggleSelection={handleCheckboxChange}
+                            disabled={isLoading}
+                            onClick={(e) => e.stopPropagation()} // Prevent checkbox click from propagating to accordion header
+                        />
+                    )}
+                    <span>{validator.Name}</span>{" "}
+                </div>
                 <small className="ms-3 text-muted text-truncate flex-grow-1">
                     {isErrored && (
                         <b className="text-danger">
@@ -608,4 +656,20 @@ function ValidationCollectionAccordionItem({
             )}
         </Accordion.Item>
     );
+}
+
+function getIsCollectionSelected(name: string, selectedCollections: Record<string, boolean>): boolean {
+    const explicit = selectedCollections[name];
+    if (typeof explicit === "boolean") {
+        return explicit;
+    }
+
+    return true;
+}
+
+function getSelectedValidators(
+    validators: Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[],
+    selectedCollections: Record<string, boolean>
+): Pick<DocumentSchemaValidatorConfig, "Name" | "Schema">[] {
+    return validators.filter((v) => getIsCollectionSelected(v.Name, selectedCollections));
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25576

### Additional description

<img width="1159" height="1202" alt="image" src="https://github.com/user-attachments/assets/50d66092-df1b-40cf-b201-10d2af9f3983" />

<img width="1178" height="1212" alt="image" src="https://github.com/user-attachments/assets/2a0a0877-9c51-4d67-bdcf-f176f6476d94" />

<img width="1228" height="1222" alt="image" src="https://github.com/user-attachments/assets/0de4e78d-d58e-4897-8e25-77a169c64dae" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
