### PR TITLE
RavenDB-25577 Schema Playground: Total count of documents is not updated

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -5,6 +5,8 @@ import getCollectionsStatsCommand = require("commands/database/documents/getColl
 import collectionsStats = require("models/database/documents/collectionsStats");
 import generalUtils = require("common/generalUtils");
 import getRevisionsPreviewCommand = require("commands/database/documents/getRevisionsPreviewCommand");
+import storeCompat = require("components/storeCompat");
+import collectionsTrackerSlice = require("components/common/shell/collectionsTrackerSlice");
 
 class collectionsTracker {
 
@@ -60,6 +62,7 @@ class collectionsTracker {
         this.collections([allDocsCollection].concat(collections));
 
         this.conflictsCount(collectionsStats.numberOfConflicts);
+        storeCompat.globalDispatch(collectionsTrackerSlice.collectionsTrackerActions.collectionsLoaded(this.collections().map((x) => x.toCollectionState())));
     }
 
     getCollectionCount(collectionName: string) {
@@ -109,6 +112,7 @@ class collectionsTracker {
         });
         
         this.conflictsCount(notification.CountOfConflicts);
+        storeCompat.globalDispatch(collectionsTrackerSlice.collectionsTrackerActions.collectionsLoaded(this.collections().map((x) => x.toCollectionState())));
     }
 
     getCollectionNames() {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25577

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
