### PR TITLE
[Release 6.2] RavenDB-25556 Fixed missing keyItem pointer update after ExpandMultiTreeNestedPageSize in MultiTree processing

### DIFF
--- a/src/Voron/Data/BTrees/Tree.MultiTree.cs
+++ b/src/Voron/Data/BTrees/Tree.MultiTree.cs
@@ -169,6 +169,7 @@ namespace Voron.Data.BTrees
                             
                             // We may change the page. Ensure all pointers are valid as well.
                             page = ModifyPage(SearchForPage(key, out _)); 
+                            keyItem = page.GetNode(page.LastSearchPosition);
                             continue;
                         }
                     }

--- a/test/SlowTests/Issues/RavenDB-25556.cs
+++ b/test/SlowTests/Issues/RavenDB-25556.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using FastTests.Voron;
+using SlowTests.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25556(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenTheory(RavenTestCategory.Voron)]
+    [InlineData(45, 733276104)]
+    [InlineData(15, 1886410083)]
+    [InlineData(50, 216822873)]
+    [InlineDataWithRandomSeed(50)]
+    public void ExtendingNestedPageInsideMultiValueTreeHasCorrectOffsetToTheActualUpdatedData(int iterationsToRun, int seed)
+    {
+        const int maxIterations = 1_000;
+        const int bulkSize = 4096;
+        var random = new Random(seed);
+        
+        var collectionNames = Enumerable.Range(0, 11)
+            .Select(_ => RandomString(random, random.Next(10, 18)))
+            .ToList();
+        var mainCollection = collectionNames[random.Next(collectionNames.Count)];
+        collectionNames.Remove(mainCollection);
+        
+        var currentId = 0;
+        var idsOrder = Enumerable.Range(random.Next(0, 20_000_000), maxIterations * bulkSize).ToArray();
+        random.Shuffle(idsOrder); // random insert
+
+        for (int transactionIdx = 0; transactionIdx < iterationsToRun; ++transactionIdx)
+        {
+            using var wTx = Env.WriteTransaction();
+            var mt = wTx.CreateTree("Test");
+            Dictionary<Slice, List<Slice>> bulkInsertContainer = new (SliceComparer.Instance);
+            for (int keyIdx = 0; keyIdx < bulkSize; ++keyIdx)
+            {
+                var collectionsAsSpan = CollectionsMarshal.AsSpan(collectionNames);
+                random.Shuffle(collectionsAsSpan);
+                var valuesToInsert = random.Next(3, collectionNames.Count);
+                var valuesForKey = Enumerable.Range(0, valuesToInsert)
+                    .Select(i => $"{collectionNames[i]}/{random.Next()}").ToArray();
+                
+                var currentKey = $"{mainCollection}/{idsOrder[currentId++]}";
+                List<Slice> valuesAsSlice = new();
+                
+                foreach (var valueToInsert in valuesForKey)
+                {
+                    // We're leaking the memory here. It will be released via transaction release.
+                    Slice.From(wTx.Allocator, valueToInsert, out var slice);
+                    valuesAsSlice.Add(slice);
+                }
+                
+                // We're randomly inserting keys. We're inserting only one value here
+                // since MultiBulkAdd has optimization for a new insertion.
+                mt.MultiAdd(currentKey, valuesAsSlice[^1]);
+                valuesAsSlice.RemoveAt(valuesAsSlice.Count - 1);
+                valuesAsSlice.Sort(SliceComparer.Instance);
+                
+                Slice.From(wTx.Allocator, currentKey, out var currentKeySlice);
+                bulkInsertContainer.Add(currentKeySlice, valuesAsSlice);
+            }
+            
+            // Insert the rest of the values in bulks.
+            foreach (var (key, values) in bulkInsertContainer)
+            {
+                mt.MultiBulkAdd(key, CollectionsMarshal.AsSpan(values));
+            }
+            
+            wTx.Commit();
+        }
+    }
+    
+    private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+    private static string RandomString(Random random, int size)
+    {
+        var buffer = new char[size];
+
+        for (int i = 0; i < size; i++)
+        {
+            buffer[i] = Chars[random.Next(Chars.Length)];
+        }
+
+        return new string(buffer);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25556

### Additional description

This fixes a regression introduced during the optimization in PR #21418.

The `keyItem` pointer was not being updated after calling `ExpandMultiTreeNestedPageSize`. Consequently, the pointer referenced an invalid position within a page that had been modified by operations such as add, remove, or defrag during `MultiBulkAdd`.

This is an edge case scenario that we had to call `ExpandMultiTreeNestedPageSize` at least twice when processing a batch of new items.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
