### PR TITLE
RavenDB-25574 - Schema Playground: "About this view" section closes when resizing browser window 

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/partials/DocumentSchemaPlayground.tsx
@@ -34,6 +34,22 @@ import DocumentSchemaPlaygroundAboutView from "components/pages/database/setting
 import { ValidationSchemaViewSheetPanel } from "components/pages/database/settings/documentSchema/partials/ValidationSchemaViewSheetPanel";
 
 export default function DocumentSchemaPlayground() {
+    return (
+        <div className="content-margin">
+            <Row className="gy-sm">
+                <Col>
+                    <DocumentSchemaPlaygroundBody />
+                </Col>
+                <Col sm={12} lg={4}>
+                    {/*TODO: remove if about view is finished*/}
+                    {false && <DocumentSchemaPlaygroundAboutView />}
+                </Col>
+            </Row>
+        </div>
+    );
+}
+
+function DocumentSchemaPlaygroundBody() {
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const { appUrl } = useAppUrls();
     const { open } = useViewSheet();
@@ -64,64 +80,50 @@ export default function DocumentSchemaPlayground() {
             component: <ValidationSchemaViewSheetPanel validators={validators} />,
         });
     };
+
     return (
-        <div className="content-margin">
-            <Row className="gy-sm">
-                <Col>
-                    <form onSubmit={handleSubmit(handleOpenSheet)}>
-                        <AboutViewHeading marginBottom={4} title="Document Schema Playground" icon="rocket" />
-                        <span>
-                            Quickly create and test schemas against your documents without affecting your saved data.
-                            The Schema Playground is a temporary workspace designed for safe experimentation.
-                        </span>
+        <form onSubmit={handleSubmit(handleOpenSheet)}>
+            <AboutViewHeading marginBottom={4} title="Document Schema Playground" icon="rocket" />
+            <span>
+                Quickly create and test schemas against your documents without affecting your saved data. The Schema
+                Playground is a temporary workspace designed for safe experimentation.
+            </span>
 
-                        <div className="mt-5 d-flex align-items-center justify-content-between">
-                            <a href={appUrl.forDocumentSchema(databaseName)} className="btn btn-secondary">
-                                <Icon icon="close" />
-                                Cancel
-                            </a>
-                            <Button type="submit" className="rounded-pill">
-                                <Icon icon="rocket" />
-                                Run test
-                            </Button>
-                        </div>
+            <div className="mt-5 d-flex align-items-center justify-content-between">
+                <a href={appUrl.forDocumentSchema(databaseName)} className="btn btn-secondary">
+                    <Icon icon="close" />
+                    Cancel
+                </a>
+                <Button type="submit" className="rounded-pill">
+                    <Icon icon="rocket" />
+                    Run test
+                </Button>
+            </div>
 
-                        <div className="mt-4">
-                            <HrHeader
-                                count={3}
-                                right={
-                                    <Button
-                                        onClick={handleAppendTestField}
-                                        size="xs"
-                                        variant="info"
-                                        className="rounded-pill"
-                                    >
-                                        <Icon icon="plus" />
-                                        Add new
-                                    </Button>
-                                }
-                            >
-                                <Icon icon="documents" />
-                                <span>Collection specific document schemas</span>
-                                <PopoverWithHoverWrapper message="info">
-                                    <Icon icon="info" color="info" margin="ms-1" />
-                                </PopoverWithHoverWrapper>
-                            </HrHeader>
+            <div className="mt-4">
+                <HrHeader
+                    count={3}
+                    right={
+                        <Button onClick={handleAppendTestField} size="xs" variant="info" className="rounded-pill">
+                            <Icon icon="plus" />
+                            Add new
+                        </Button>
+                    }
+                >
+                    <Icon icon="documents" />
+                    <span>Collection specific document schemas</span>
+                    <PopoverWithHoverWrapper message="info">
+                        <Icon icon="info" color="info" margin="ms-1" />
+                    </PopoverWithHoverWrapper>
+                </HrHeader>
 
-                            <FormProvider {...form}>
-                                {fields.map((field, index) => (
-                                    <TestDocumentSchema remove={remove} key={field.id} {...field} index={index} />
-                                ))}
-                            </FormProvider>
-                        </div>
-                    </form>
-                </Col>
-                <Col sm={12} lg={4}>
-                    {/*TODO: remove if about view is finished*/}
-                    {false && <DocumentSchemaPlaygroundAboutView />}
-                </Col>
-            </Row>
-        </div>
+                <FormProvider {...form}>
+                    {fields.map((field, index) => (
+                        <TestDocumentSchema remove={remove} key={field.id} {...field} index={index} />
+                    ))}
+                </FormProvider>
+            </div>
+        </form>
     );
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25574

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
