### PR TITLE
RavenDB-25508 Ignore the score function of VectorSearch when the method is not evaluated.

### DIFF
--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -123,7 +123,13 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
     public void Score(Span<long> matches, Span<float> scores, float _)
     {
-        Debug.Assert(_persisted, "Score() should be called after Fill() or AndWith()");
+        if (_persisted == false)
+        {
+            // BinaryMatch may skip the method call if the other node of the AND clause 
+            // is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.
+            return;
+        }
+        
         if (_singleVectorSearchDoNotSortByIds == false)
         {
             for (int i = 0; i < matches.Length; ++i)

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -216,6 +216,13 @@ public struct VectorSearchMatch : IQueryMatch
 
     public void Score(Span<long> matches, Span<float> scores, float boostFactor)
     {
+        if (_resultsNotPersisted)
+        {
+            // BinaryMatch may skip the method call if the other node of the AND clause 
+            // is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.
+            return;
+        }
+        
         if (_isEmpty)
             return;
 

--- a/test/SlowTests.Issues/Issues/RavenDB-25508.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25508.cs
@@ -1,0 +1,61 @@
+﻿using FastTests;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25508(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public void CanSortByScoreWhenMultiVectorSearchIsSkippedInBinaryMatch()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+        session.Store(new Dto("Yes", "Yes"));
+        session.SaveChanges();
+
+        var result = session.Advanced.DocumentQuery<Dto>()
+            .OpenSubclause()
+                .WhereIn(x => x.Name, ["Yes"])
+                    .AndAlso()
+                .VectorSearch(f => f.WithText(p => p.Vector), v => v.ByTexts(["Yes", "Something"]))
+            .CloseSubclause()
+            .OrElse()
+            .OpenSubclause()
+                .WhereLessThan(x => x.Name, "Yes")
+                    .AndAlso()
+                .VectorSearch(f => f.WithText(p => p.Vector), v => v.ByTexts(["Yes", "Something"]))
+            .CloseSubclause()
+            .OrderByScore()
+            .ToList();
+        Assert.NotEmpty(result);
+    }
+    
+    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    public void CanSortByScoreWhenVectorSearchIsSkippedInBinaryMatch()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenSession();
+        session.Store(new Dto("Yes", "Yes"));
+        session.SaveChanges();
+
+        var result = session.Advanced.DocumentQuery<Dto>()
+            .OpenSubclause()
+                .WhereIn(x => x.Name, ["Yes"])
+                    .AndAlso()
+                .VectorSearch(f => f.WithText(p => p.Vector), v => v.ByText("Yes"))
+            .CloseSubclause()
+            .OrElse()
+            .OpenSubclause()
+                .WhereLessThan(x => x.Name, "Yes")
+                    .AndAlso()
+                    .VectorSearch(f => f.WithText(p => p.Vector), v => v.ByText("Yes"))
+            .CloseSubclause()
+            .OrderByScore()
+            .ToList();
+        Assert.NotEmpty(result);
+    }
+
+    private record Dto(string Name, string Vector);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25508

### Additional description

BinaryMatch may skip the method call if the other node of the AND clause is empty, the evaluation of this primitive is pointless. In these cases, the call is ignored.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
