### PR TITLE
RavenDB-22142 Prevent resource exhaustion and log

### DIFF
--- a/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
+++ b/src/Raven.Server/Config/Categories/ConfigurationCategoryType.cs
@@ -43,6 +43,8 @@ namespace Raven.Server.Config.Categories
         [Description("Export & Import")]
         ExportImport,
         Debug,
-        Ai
+        Ai,
+        [Description("Schema Validation")]
+        SchemaValidation
     }
 }

--- a/src/Raven.Server/Config/Categories/SchemaValidationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SchemaValidationConfiguration.cs
@@ -20,13 +20,13 @@ namespace Raven.Server.Config.Categories
         public TimeSetting ValidationTimeout { get; set; }
 
         [Description("The maximum depth allowed for document schema validation")]
-        [DefaultValue(8)]
+        [DefaultValue(16)]
         [MinValue(1)]
         [ConfigurationEntry("SchemaValidation.MaxDepth", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxDepth { get; set; }
 
         [Description("The maximum time allowed for regular expression matching during schema validation (in milliseconds)")]
-        [DefaultValue(100)]
+        [DefaultValue(200)]
         [MinValue(10)]
         [TimeUnit(TimeUnit.Milliseconds)]
         [ConfigurationEntry("SchemaValidation.RegexTimeoutInMs", ConfigurationEntryScope.ServerWideOrPerDatabase)]

--- a/src/Raven.Server/Config/Categories/SchemaValidationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SchemaValidationConfiguration.cs
@@ -12,21 +12,14 @@ namespace Raven.Server.Config.Categories
         {
         }
 
-        [Description("The maximum time allowed for a single document schema validation (in milliseconds)")]
-        [DefaultValue(500)]
-        [MinValue(10)]
-        [TimeUnit(TimeUnit.Milliseconds)]
-        [ConfigurationEntry("SchemaValidation.DocumentValidationTimeoutInMs", ConfigurationEntryScope.ServerWideOrPerDatabase)]
-        public TimeSetting ValidationTimeout { get; set; }
-
         [Description("The maximum depth allowed for document schema validation")]
-        [DefaultValue(16)]
+        [DefaultValue(64)]
         [MinValue(1)]
         [ConfigurationEntry("SchemaValidation.MaxDepth", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxDepth { get; set; }
 
         [Description("The maximum time allowed for regular expression matching during schema validation (in milliseconds)")]
-        [DefaultValue(200)]
+        [DefaultValue(1000)]
         [MinValue(10)]
         [TimeUnit(TimeUnit.Milliseconds)]
         [ConfigurationEntry("SchemaValidation.RegexTimeoutInMs", ConfigurationEntryScope.ServerWideOrPerDatabase)]

--- a/src/Raven.Server/Config/Categories/SchemaValidationConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/SchemaValidationConfiguration.cs
@@ -1,0 +1,35 @@
+using System;
+using System.ComponentModel;
+using Raven.Server.Config.Attributes;
+using Raven.Server.Config.Settings;
+
+namespace Raven.Server.Config.Categories
+{
+    [ConfigurationCategory(ConfigurationCategoryType.SchemaValidation)]
+    public sealed class SchemaValidationConfiguration : ConfigurationCategory
+    {
+        public SchemaValidationConfiguration()
+        {
+        }
+
+        [Description("The maximum time allowed for a single document schema validation (in milliseconds)")]
+        [DefaultValue(500)]
+        [MinValue(10)]
+        [TimeUnit(TimeUnit.Milliseconds)]
+        [ConfigurationEntry("SchemaValidation.DocumentValidationTimeoutInMs", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting ValidationTimeout { get; set; }
+
+        [Description("The maximum depth allowed for document schema validation")]
+        [DefaultValue(8)]
+        [MinValue(1)]
+        [ConfigurationEntry("SchemaValidation.MaxDepth", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public int MaxDepth { get; set; }
+
+        [Description("The maximum time allowed for regular expression matching during schema validation (in milliseconds)")]
+        [DefaultValue(100)]
+        [MinValue(10)]
+        [TimeUnit(TimeUnit.Milliseconds)]
+        [ConfigurationEntry("SchemaValidation.RegexTimeoutInMs", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting RegexTimeout { get; set; }
+    }
+}

--- a/src/Raven.Server/Config/RavenConfiguration.cs
+++ b/src/Raven.Server/Config/RavenConfiguration.cs
@@ -113,6 +113,8 @@ namespace Raven.Server.Config
         public ExportImportConfiguration ExportImport { get; }
 
         public ShardingConfiguration Sharding { get; set; }
+        
+        public SchemaValidationConfiguration SchemaValidation { get; set; }
 
         internal string ConfigPath => _customConfigPath
                        ?? Path.Combine(AppContext.BaseDirectory, "settings.json");
@@ -180,6 +182,7 @@ namespace Raven.Server.Config
             ExportImport = new ExportImportConfiguration();
             QueueSink = new QueueSinkConfiguration();
             Sharding = new ShardingConfiguration();
+            SchemaValidation = new SchemaValidationConfiguration();
         }
 
         private void AddJsonConfigurationVariables(string customConfigPath = null)
@@ -246,6 +249,7 @@ namespace Raven.Server.Config
             ExportImport.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             QueueSink.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
             Sharding.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
+            SchemaValidation.Initialize(Settings, settingsNames, ServerWideSettings, serverWideSettingsNames, ResourceType, ResourceName);
 
             PostInit();
 

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1775,7 +1775,7 @@ namespace Raven.Server.Documents
                 }
                 else
                 {
-                    var cache = new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                    var cache = new SchemaValidatorCache(NotificationCenter, Configuration.SchemaValidation, Loggers.GetLogger<SchemaValidatorCache>());
                     cache.Update(configuration);
                     SchemaValidatorCache = cache;
                 }

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForPost.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForPost.cs
@@ -3,6 +3,7 @@ using JetBrains.Annotations;
 using Raven.Server.Documents.Handlers.Processors.Databases;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.SchemaValidation;
 
@@ -17,6 +18,10 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForPost<TRequest
     protected override void OnBeforeUpdateConfiguration(ref BlittableJsonReaderObject configuration, JsonOperationContext context)
     {
         RequestHandler.ServerStore.LicenseManager.AssertCanAddSchemaValidation();
+        
+        if(RavenLogManager.Instance.IsAuditEnabled)
+            RequestHandler.LogAuditForDatabase("PUT", "Update schema validation configuration.");
+        
         base.OnBeforeUpdateConfiguration(ref configuration, context);
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForPost.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForPost.cs
@@ -18,10 +18,10 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForPost<TRequest
     protected override void OnBeforeUpdateConfiguration(ref BlittableJsonReaderObject configuration, JsonOperationContext context)
     {
         RequestHandler.ServerStore.LicenseManager.AssertCanAddSchemaValidation();
-        
-        if(RavenLogManager.Instance.IsAuditEnabled)
+
+        if (RavenLogManager.Instance.IsAuditEnabled)
             RequestHandler.LogAuditForDatabase("PUT", "Update schema validation configuration.");
-        
+
         base.OnBeforeUpdateConfiguration(ref configuration, context);
     }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -30,9 +30,9 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
             Parameters = JsonDeserializationServer.Parameters.ValidateSchemaOperationParameters(json);
             ValidateParameters();
 
-            if(RavenLogManager.Instance.IsAuditEnabled)
+            if (RavenLogManager.Instance.IsAuditEnabled)
                 RequestHandler.LogAuditForDatabase("VALIDATE", $"Start schema validation operation for collection '{Parameters.Collection}'");
-            
+
             var token = RequestHandler.CreateBackgroundOperationToken();
 
             StartValidationOperation(operationId, token);

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/AbstractSchemaValidationHandlerProcessorForValidate.cs
@@ -6,6 +6,7 @@ using Raven.Client.Exceptions;
 using Raven.Server.Json;
 using Raven.Server.ServerWide;
 using Sparrow.Json;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.SchemaValidation;
 
@@ -27,9 +28,11 @@ internal abstract class AbstractSchemaValidationHandlerProcessorForValidate<TReq
 
             var json = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "SchemaValidation/Validate");
             Parameters = JsonDeserializationServer.Parameters.ValidateSchemaOperationParameters(json);
-
             ValidateParameters();
 
+            if(RavenLogManager.Instance.IsAuditEnabled)
+                RequestHandler.LogAuditForDatabase("VALIDATE", $"Start schema validation operation for collection '{Parameters.Collection}'");
+            
             var token = RequestHandler.CreateBackgroundOperationToken();
 
             StartValidationOperation(operationId, token);

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForGet.cs
@@ -13,9 +13,6 @@ internal sealed class SchemaValidationHandlerProcessorForGet : AbstractSchemaVal
 
     protected override SchemaValidationConfiguration GetSchemaValidationConfiguration()
     {
-        if(RavenLogManager.Instance.IsAuditEnabled)
-            RequestHandler.LogAuditForDatabase("GET", "Get schema validation configuration.");
-        
         using (RequestHandler.Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         using (context.OpenReadTransaction())
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForGet.cs
@@ -1,6 +1,7 @@
 ﻿using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Logging;
 
 namespace Raven.Server.Documents.Handlers.Processors.SchemaValidation;
 
@@ -12,6 +13,9 @@ internal sealed class SchemaValidationHandlerProcessorForGet : AbstractSchemaVal
 
     protected override SchemaValidationConfiguration GetSchemaValidationConfiguration()
     {
+        if(RavenLogManager.Instance.IsAuditEnabled)
+            RequestHandler.LogAuditForDatabase("GET", "Get schema validation configuration.");
+        
         using (RequestHandler.Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
         using (context.OpenReadTransaction())
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -27,11 +27,35 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
             OperationType.ValidateSchema,
             $"Schema validation for collection '{Parameters.Collection}' '{RequestHandler.Database.Name}'",
             detailedDescription: null,
-            StartValidation,
+            onProgress => StartValidation(operationId, onProgress),
             token: token).ContinueWith(_ => token.Dispose());
     }
 
-    private Task<IOperationResult> StartValidation(Action<IOperationProgress> onProgress)
+    private async Task<IOperationResult> StartValidation(long operationId, Action<IOperationProgress> onProgress)
+    {
+        try
+        {
+            if(Logger.IsDebugEnabled)
+                Logger.Debug($"Starting schema validation for collection '{Parameters.Collection}' in database '{RequestHandler.Database.Name}'. Operation ID: {operationId}");
+            
+            var result = await ValidateDocuments(onProgress);
+            var schemaResult = (ValidateSchemaResult)result;
+            
+            if(Logger.IsDebugEnabled)
+                Logger.Debug($"Finished schema validation for collection '{Parameters.Collection}' in database '{RequestHandler.Database.Name}'. Operation ID: {operationId}. Validated: {schemaResult.ValidatedCount}, Errors: {schemaResult.ErrorCount}");
+            
+            return result;
+        }
+        catch (Exception e)
+        {
+            if(Logger.IsErrorEnabled)
+                Logger.Error($"Failed to validate schema for collection '{Parameters.Collection}' in database '{RequestHandler.Database.Name}'. Operation ID: {operationId}", e);
+            throw;
+        }
+    }
+    
+
+    private Task<IOperationResult> ValidateDocuments(Action<IOperationProgress> onProgress)
     {
         var maxErrorsMsg = Parameters.MaxErrorMessages ?? 1024;
         var maxToValidate = Parameters.MaxDocumentsToValidate ?? long.MaxValue;
@@ -52,7 +76,8 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
             var totalValidated = 0L;
             
             using var blittable = context.Sync.ReadForMemory(Parameters.SchemaDefinition, "schema-validation");
-            var schemaValidator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Parameters.SchemaDefinition);
+            var configuration = RequestHandler.Configuration.SchemaValidation;
+            var schemaValidator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, Parameters.SchemaDefinition, configuration);
 
             using var errorBuilder = new ErrorBuilder(context);
             

--- a/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/SchemaValidation/SchemaValidationHandlerProcessorForValidate.cs
@@ -35,25 +35,25 @@ internal sealed class SchemaValidationHandlerProcessorForValidate : AbstractSche
     {
         try
         {
-            if(Logger.IsDebugEnabled)
+            if (Logger.IsDebugEnabled)
                 Logger.Debug($"Starting schema validation for collection '{Parameters.Collection}' in database '{RequestHandler.Database.Name}'. Operation ID: {operationId}");
-            
+
             var result = await ValidateDocuments(onProgress);
             var schemaResult = (ValidateSchemaResult)result;
-            
-            if(Logger.IsDebugEnabled)
+
+            if (Logger.IsDebugEnabled)
                 Logger.Debug($"Finished schema validation for collection '{Parameters.Collection}' in database '{RequestHandler.Database.Name}'. Operation ID: {operationId}. Validated: {schemaResult.ValidatedCount}, Errors: {schemaResult.ErrorCount}");
-            
+
             return result;
         }
         catch (Exception e)
         {
-            if(Logger.IsErrorEnabled)
+            if (Logger.IsErrorEnabled)
                 Logger.Error($"Failed to validate schema for collection '{Parameters.Collection}' in database '{RequestHandler.Database.Name}'. Operation ID: {operationId}", e);
             throw;
         }
     }
-    
+
 
     private Task<IOperationResult> ValidateDocuments(Action<IOperationProgress> onProgress)
     {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -875,7 +875,7 @@ namespace Raven.Server.Documents.Indexes
                 DocumentDatabase.Changes.OnIndexChange += HandleIndexChange;
 
                 if (Definition.SchemaValidation != null)
-                    _schemaValidators = IndexSchemaValidatorsByCollection.Create(_contextPool, Definition.SchemaValidation);
+                    _schemaValidators = IndexSchemaValidatorsByCollection.Create(_contextPool, Definition.SchemaValidation, DocumentDatabase.Configuration.SchemaValidation);
                 
                 OnInitialization();
 

--- a/src/Raven.Server/Documents/Indexes/SchemaValidation/IndexSchemaValidatorsByCollection.cs
+++ b/src/Raven.Server/Documents/Indexes/SchemaValidation/IndexSchemaValidatorsByCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Config.Categories;
 using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Sync;
@@ -19,7 +20,7 @@ public sealed class IndexSchemaValidatorsByCollection : IDisposable
         _validators = validators;
     }
 
-    public static IndexSchemaValidatorsByCollection Create(TransactionContextPool ctxPool, IndexSchemaDefinitions definitions)
+    public static IndexSchemaValidatorsByCollection Create(TransactionContextPool ctxPool, IndexSchemaDefinitions definitions, SchemaValidationConfiguration config)
     {
         var returnContext = ctxPool.AllocateOperationContext(out TransactionOperationContext context);
         var validators = new Dictionary<string, SchemaValidator>(StringComparer.OrdinalIgnoreCase);
@@ -28,7 +29,7 @@ public sealed class IndexSchemaValidatorsByCollection : IDisposable
             foreach (var (collection, definition) in definitions)
             {
                 var blittable = context.Sync.ReadForMemory(definition, "schema-validation");
-                var validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, definition);
+                var validator = SchemaValidationHelper.InitValidatorForDocument(context, blittable, definition, config);
                 validators[collection] = validator;
             }
 

--- a/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/CurrentIndexingScope.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents.ETL.Providers.AI.Embeddings;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static.Spatial;
 using Raven.Server.Documents.Patch;
+using Raven.Server.Documents.SchemaValidation;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -305,9 +306,11 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 return schemaValidatorCache.Validate(collection, doc, errorBuilder);
             }
+
+            if (validators.TryGet(collection, out var validator) == false)
+                return true;
             
-            return validators.TryGet(collection, out var validator) == false
-                   || validator.Validate(doc, errorBuilder);
+            return validator.Validate(doc, errorBuilder);
         }
 
         private Slice GetIdSlice(LazyStringValue id)

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
@@ -42,7 +42,7 @@ public class ErrorBuilder : IDisposable
     }
 
     public ReadOnlySpan<char> GetError() => _errorBuffer.AsSpan();
-    
+
     public IEnumerable<string> GetErrors()
     {
         var span = _errorBuffer.AsSpan();
@@ -50,7 +50,7 @@ public class ErrorBuilder : IDisposable
             yield break;
 
         var startIndex = 0;
-        for(var i = 0; i < _errorOffsets.Length; i++)
+        for (var i = 0; i < _errorOffsets.Length; i++)
         {
             var offset = _errorOffsets[i];
             Debug.Assert(offset < _errorBuffer.Length);
@@ -58,8 +58,8 @@ public class ErrorBuilder : IDisposable
             yield return _errorBuffer.AsSpan().Slice(startIndex, offset - startIndex).ToString();
             startIndex = offset + NewErrorDelimiter.Length;
         }
-        
-        if(startIndex < _errorBuffer.Length)
+
+        if (startIndex < _errorBuffer.Length)
             yield return _errorBuffer.AsSpan()[startIndex..].ToString();
     }
 

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/ErrorBuilder.cs
@@ -13,14 +13,14 @@ public class ErrorBuilder : IDisposable
     private static readonly string NewErrorDelimiter = Environment.NewLine;
     
     private readonly AbstractBuffer<int> _errorOffsets;
-    public readonly IErrorBuffer ErrorBuffer;
+    private readonly IErrorBuffer _errorBuffer;
         
     public ValidationPath Path { get; }
 
     public ErrorBuilder()
     {
         var innerBuffer = new RentedBuffer<char>();
-        ErrorBuffer = new ErrorBuffer(innerBuffer);
+        _errorBuffer = new ErrorBuffer(innerBuffer);
         _errorOffsets = new RentedBuffer<int>();
         Path = new ValidationPath();
     }
@@ -28,7 +28,7 @@ public class ErrorBuilder : IDisposable
     public ErrorBuilder(ByteStringContext allocator)
     {
         var innerBuffer = new ByteStringContextBuffer<char>(allocator);
-        ErrorBuffer = new ErrorBuffer(innerBuffer);
+        _errorBuffer = new ErrorBuffer(innerBuffer);
         _errorOffsets = new ByteStringContextBuffer<int>(allocator);
         Path = new ValidationPath(allocator);
     }
@@ -36,16 +36,16 @@ public class ErrorBuilder : IDisposable
     public ErrorBuilder(JsonOperationContext context)
     {
         var innerBuffer = new JsonOperationContextBuffer<char>(context);
-        ErrorBuffer = new ErrorBuffer(innerBuffer);
+        _errorBuffer = new ErrorBuffer(innerBuffer);
         _errorOffsets = new JsonOperationContextBuffer<int>(context);
         Path = new ValidationPath(context);
     }
 
-    public ReadOnlySpan<char> GetError() => ErrorBuffer.AsSpan();
+    public ReadOnlySpan<char> GetError() => _errorBuffer.AsSpan();
     
     public IEnumerable<string> GetErrors()
     {
-        var span = ErrorBuffer.AsSpan();
+        var span = _errorBuffer.AsSpan();
         if (span.IsEmpty)
             yield break;
 
@@ -53,55 +53,55 @@ public class ErrorBuilder : IDisposable
         for(var i = 0; i < _errorOffsets.Length; i++)
         {
             var offset = _errorOffsets[i];
-            Debug.Assert(offset < ErrorBuffer.Length);
+            Debug.Assert(offset < _errorBuffer.Length);
 
-            yield return ErrorBuffer.AsSpan().Slice(startIndex, offset - startIndex).ToString();
+            yield return _errorBuffer.AsSpan().Slice(startIndex, offset - startIndex).ToString();
             startIndex = offset + NewErrorDelimiter.Length;
         }
         
-        if(startIndex < ErrorBuffer.Length)
-            yield return ErrorBuffer.AsSpan()[startIndex..].ToString();
+        if(startIndex < _errorBuffer.Length)
+            yield return _errorBuffer.AsSpan()[startIndex..].ToString();
     }
 
     public void FinishErrorMessage()
     {
-        _errorOffsets.Append(ErrorBuffer.Length);
+        _errorOffsets.Append(_errorBuffer.Length);
         Append(NewErrorDelimiter);
     }
 
     public ErrorBuilder Append(string value)
     {
-        ErrorBuffer.Append(value);
+        _errorBuffer.Append(value);
         return this;
     }
     public ErrorBuilder Append(BlittableJsonReaderObject value)
     {
-        ErrorBuffer.Append(value);
+        _errorBuffer.Append(value);
         return this;
     }
     public ErrorBuilder Append(LazyStringValue value)
     {
-        ErrorBuffer.AppendUtf8(value.AsSpan());
+        _errorBuffer.AppendUtf8(value.AsSpan());
         return this;
     }
     public ErrorBuilder Append(ValidationPath value)
     {
-        ErrorBuffer.Append(value.AsSpan());
+        _errorBuffer.Append(value.AsSpan());
         return this;
     }
     public ErrorBuilder Append(Regex value)
     {
-        ErrorBuffer.Append(value.ToString());
+        _errorBuffer.Append(value.ToString());
         return this;
     }
     public ErrorBuilder Append(bool value)
     {
-        ErrorBuffer.Append(value.ToString());
+        _errorBuffer.Append(value.ToString());
         return this;
     }
     public ErrorBuilder Append(ISpanFormattable value)
     {
-        ErrorBuffer.Append(value);
+        _errorBuffer.Append(value);
         return this;
     }
     public ErrorBuilder Append(IEnumerable<string> value, string format)
@@ -110,9 +110,9 @@ public class ErrorBuilder : IDisposable
         foreach (var v in value)
         {
             if (first == false)
-                ErrorBuffer.Append(format);
+                _errorBuffer.Append(format);
             first = false;
-            ErrorBuffer.Append(v);
+            _errorBuffer.Append(v);
         }
         return this;
     } 
@@ -122,7 +122,7 @@ public class ErrorBuilder : IDisposable
         foreach (var v in value)
         {
             if (first == false)
-                ErrorBuffer.Append(format);
+                _errorBuffer.Append(format);
             first = false;
             switch (v)
             {
@@ -163,10 +163,10 @@ public class ErrorBuilder : IDisposable
                 break;
             case string:
             case null:
-                ErrorBuffer.Append((string)value);
+                _errorBuffer.Append((string)value);
                 break;
             default:
-                ErrorBuffer.Append(value);
+                _errorBuffer.Append(value);
                 break;
         }
 
@@ -175,14 +175,14 @@ public class ErrorBuilder : IDisposable
 
     public void Reset()
     {
-        ErrorBuffer.Reset();
+        _errorBuffer.Reset();
         _errorOffsets.Reset();
         Path.Reset();
     }
 
     public LazyStringValue ToLazyStringValue(JsonOperationContext context) => context.GetLazyString(GetError(), null, false);
     
-    public override string ToString() => ErrorBuffer?.ToString();
+    public override string ToString() => _errorBuffer?.ToString();
     
     [InterpolatedStringHandler]
     public readonly ref struct ErrorInterpolatedStringHandler
@@ -209,7 +209,7 @@ public class ErrorBuilder : IDisposable
 
     public void Dispose()
     {
-        ErrorBuffer?.Dispose();
+        _errorBuffer?.Dispose();
         _errorOffsets.Dispose();
         Path.Dispose();
     }

--- a/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/JsonOperationContextBuffer.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ErrorMessage/JsonOperationContextBuffer.cs
@@ -40,10 +40,10 @@ public class JsonOperationContextBuffer<T> : AbstractBuffer<T>
         _context.ReturnMemory(_buffer);
         _buffer = newBuffer;
     }
-    
+
     public override void Dispose()
     {
-        if(_buffer != null)
+        if (_buffer != null)
             _context.ReturnMemory(_buffer);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/ISchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/ISchemaRuleValidator.cs
@@ -4,16 +4,16 @@ namespace Raven.Server.Documents.SchemaValidation;
 
 public interface ISchemaRuleValidator
 {
-    bool Validate(object value, ErrorBuilder errorBuilder);
+    bool Validate(SchemaValidationContext context, object value);
 }
 
 public abstract class SchemaRuleValidator<T> : ISchemaRuleValidator
 {
-    public abstract bool Validate(T value, ErrorBuilder errorBuilder);
+    public abstract bool Validate(SchemaValidationContext context, T value);
     
-    bool ISchemaRuleValidator.Validate(object value, ErrorBuilder errorBuilder)
+    bool ISchemaRuleValidator.Validate(SchemaValidationContext context, object value)
     {
-        return CheckTypeAndGetValue(value, out T tValue) == false || Validate(tValue, errorBuilder);
+        return CheckTypeAndGetValue(value, out T tValue) == false || Validate(context, tValue);
     }
 
     protected virtual bool CheckTypeAndGetValue(object value, out T tValue)

--- a/src/Raven.Server/Documents/SchemaValidation/RefSchemas.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/RefSchemas.cs
@@ -38,17 +38,17 @@ public class RefSchemas
 
     private void ReadAllDefinitions(BlittableJsonReaderObject schema, SchemaPath schemaPath)
     {
-        if(schema == null)
+        if (schema == null)
             return;
-        
+
         var property = default(BlittableJsonReaderObject.PropertyDetails);
         for (int i = 0; i < schema.Count; i++)
         {
             schema.GetPropertyByIndex(i, ref property);
-            var propertyPath =  schemaPath + property.Name;
+            var propertyPath = schemaPath + property.Name;
             if (property.Name.Equals(SchemaValidatorConstants.Defs))
                 ReadDefs(property, propertyPath);
-            
+
             if (schema.TryGetWithoutThrowingOnError(property.Name, out BlittableJsonReaderObject propSchema))
                 ReadAllDefinitions(propSchema, propertyPath);
         }
@@ -80,8 +80,8 @@ public class RefSchemas
                 if (refStack.Contains(@ref))
                     throw new InvalidSchemaValidationDefinitionException(
                         $"A circular reference was detected at '{propPath.FullPath}'.");
-                        
-                if(_data.TryGetValue(@ref, out var refSchema) == false)
+
+                if (_data.TryGetValue(@ref, out var refSchema) == false)
                     throw new InvalidSchemaValidationDefinitionException(
                         $"The reference '{@ref}' does not match any defined subschema.");
 
@@ -90,7 +90,7 @@ public class RefSchemas
                 refStack.Pop();
                 continue;
             }
-                    
+
             if (schema.TryGetWithoutThrowingOnError(property.Name, out BlittableJsonReaderObject propSchema) == false || propSchema == null)
                 continue;
 

--- a/src/Raven.Server/Documents/SchemaValidation/RefSchemas.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/RefSchemas.cs
@@ -23,7 +23,7 @@ public class RefSchemas
         return false;
     }
     
-    public void Init(BlittableJsonReaderObject schemaDefinition)
+    public void Init(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition)
     {
         var root = new SchemaPath();
         ReadAllDefinitions(schemaDefinition, root);
@@ -31,7 +31,7 @@ public class RefSchemas
 
         foreach (var (fullPath, refSchema) in _data)
         {
-            var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(refSchema.Raw, root + fullPath, this);
+            var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, refSchema.Raw, root + fullPath);
             refSchema.Validator = validator;
         }
     }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaBuilderContext.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaBuilderContext.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Raven.Server.Documents.SchemaValidation;
+
+public class SchemaBuilderContext
+{
+    public RefSchemas RefSchemas { init; get; }
+    
+    public SchemaValidatorSettings Configuration { get; set; }
+}
+

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaRuleValidatorFactory.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaRuleValidatorFactory.cs
@@ -6,13 +6,13 @@ namespace Raven.Server.Documents.SchemaValidation;
 
 public interface ISchemaRuleValidatorFactory
 {
-    ISchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas);
+    ISchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath);
 }
 
 public abstract class SchemaRuleValidatorFactory<T> : ISchemaRuleValidatorFactory where T : ISchemaRuleValidator
 {
     protected readonly string Rule;
     protected SchemaRuleValidatorFactory() => Rule = GetType().GetCustomAttribute<SchemaRuleAttribute>()?.Rule;
-    ISchemaRuleValidator ISchemaRuleValidatorFactory.Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas) => Create(schemaDefinition, schemaPath, refSchemas);
-    public abstract T Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas);
+    ISchemaRuleValidator ISchemaRuleValidatorFactory.Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath) => Create(context, schemaDefinition, schemaPath);
+    public abstract T Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath);
 }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaRuleValidatorFactoryHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaRuleValidatorFactoryHelper.cs
@@ -39,25 +39,25 @@ public abstract class SchemaRuleValidatorFactoryHelper
             .ToFrozenDictionary(x => x.Rule, x => x!.FactoryInstance);
     }
 
-    public static bool TryCreateValidator(string rule, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas,
+    public static bool TryCreateValidator(SchemaBuilderContext context, string rule, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
         out ISchemaRuleValidator validator)
     {
         if (SchemaRuleValidatorFactories.TryGetValue(rule, out ISchemaRuleValidatorFactory factory))
         {
-            validator = factory.Create(schemaDefinition, schemaPath, refSchemas);
+            validator = factory.Create(context, schemaDefinition, schemaPath);
             return validator != null;
         }
         validator = null;
         return false;
     }
 
-    public static ObjectSchemaRuleValidator CreateObjectValidator(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public static ObjectSchemaRuleValidator CreateObjectValidator(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        return ObjectSchemaRuleValidatorFactory.Create(schemaDefinition, schemaPath, refSchemas);
+        return ObjectSchemaRuleValidatorFactory.Create(context, schemaDefinition, schemaPath);
     }
-    public static ArraySchemaRuleValidator CreateArrayValidator(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public static ArraySchemaRuleValidator CreateArrayValidator(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        return ArraySchemaRuleValidatorFactory.Create(schemaDefinition, schemaPath, refSchemas);
+        return ArraySchemaRuleValidatorFactory.Create(context, schemaDefinition, schemaPath);
     }
 
     internal static class TestingStuff

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationContext.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationContext.cs
@@ -51,13 +51,13 @@ public class SchemaValidationContext
         ErrorBuilder?.Path.StepOut();
         --_currentDepth;
     }
-    
+
     private void CheckMaxDepthAndThrow()
     {
-        if(_currentDepth >= _maxDepth)
+        if (_currentDepth >= _maxDepth)
             throw new SchemaValidationException($"Maximum validation path depth of {_maxDepth} exceeded.");
     }
-    
+
     public void CheckTimeoutAndThrow()
     {
         if (Stopwatch.GetTimestamp() > _timeoutAt)

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationContext.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationContext.cs
@@ -8,8 +8,6 @@ namespace Raven.Server.Documents.SchemaValidation;
 
 public class SchemaValidationContext
 {
-    private readonly long _timeoutAt;
-    private readonly TimeSpan _timeout;
     private int _currentDepth;
     private readonly int _maxDepth;
 
@@ -25,8 +23,6 @@ public class SchemaValidationContext
     public SchemaValidationContext(SchemaValidatorSettings configuration)
     {
         _maxDepth = configuration.MaxDepth;
-        _timeout = configuration.ValidationTimeout;
-        _timeoutAt = Stopwatch.GetTimestamp() + (long)(_timeout.TotalMilliseconds * (Stopwatch.Frequency / 1000.0));
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -58,12 +54,6 @@ public class SchemaValidationContext
             throw new SchemaValidationException($"Maximum validation path depth of {_maxDepth} exceeded.");
     }
 
-    public void CheckTimeoutAndThrow()
-    {
-        if (Stopwatch.GetTimestamp() > _timeoutAt)
-            throw new SchemaValidationException($"Schema validation timed out after {_timeout.TotalMilliseconds}ms.");
-    }
-    
     public WithoutErrorScope WithoutCollectingErrors()
     {
         return new WithoutErrorScope(this);

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationContext.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationContext.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Raven.Client.Exceptions.SchemaValidation;
+using Raven.Server.Documents.SchemaValidation.ErrorMessage;
+
+namespace Raven.Server.Documents.SchemaValidation;
+
+public class SchemaValidationContext
+{
+    private readonly long _timeoutAt;
+    private readonly TimeSpan _timeout;
+    private int _currentDepth;
+    private readonly int _maxDepth;
+
+    public ErrorBuilder ErrorBuilder
+    {
+        init;
+        get => _withError ? field : null;
+    }
+
+    private bool _withError = true;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public SchemaValidationContext(SchemaValidatorSettings configuration)
+    {
+        _maxDepth = configuration.MaxDepth;
+        _timeout = configuration.ValidationTimeout;
+        _timeoutAt = Stopwatch.GetTimestamp() + (long)(_timeout.TotalMilliseconds * (Stopwatch.Frequency / 1000.0));
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void StepIn(string property)
+    {
+        ErrorBuilder?.Path.StepIn(property);
+        ++_currentDepth;
+        CheckMaxDepthAndThrow();
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void StepIn(int index)
+    {
+        ErrorBuilder?.Path.StepIn(index);
+        ++_currentDepth;
+        CheckMaxDepthAndThrow();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void StepOut()
+    {
+        ErrorBuilder?.Path.StepOut();
+        --_currentDepth;
+    }
+    
+    private void CheckMaxDepthAndThrow()
+    {
+        if(_currentDepth >= _maxDepth)
+            throw new SchemaValidationException($"Maximum validation path depth of {_maxDepth} exceeded.");
+    }
+    
+    public void CheckTimeoutAndThrow()
+    {
+        if (Stopwatch.GetTimestamp() > _timeoutAt)
+            throw new SchemaValidationException($"Schema validation timed out after {_timeout.TotalMilliseconds}ms.");
+    }
+    
+    public WithoutErrorScope WithoutCollectingErrors()
+    {
+        return new WithoutErrorScope(this);
+    }
+    
+    public struct WithoutErrorScope : IDisposable
+    {
+        private SchemaValidationContext _context;
+        private readonly bool _previousWithError;
+
+        public WithoutErrorScope(SchemaValidationContext context)
+        {
+            _context = context;
+            _previousWithError = context._withError;
+            _context._withError = false;
+        }
+
+        public void Dispose()
+        {
+            _context._withError = _previousWithError;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Raven.Client;
+using Raven.Server.Config.Categories;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
+using Raven.Server.Documents.SchemaValidation.Validators.String;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -223,7 +226,7 @@ public static class SchemaValidationHelper
         return true;
     }
 
-    public static SchemaValidator InitValidatorForDocument(JsonOperationContext context, BlittableJsonReaderObject definition, string strDefinition, bool disabled = false)
+    public static SchemaValidator InitValidatorForDocument(JsonOperationContext context, BlittableJsonReaderObject definition, string strDefinition, SchemaValidationConfiguration config, bool disabled = false)
     {
         var validator = new SchemaValidator
         {
@@ -232,8 +235,27 @@ public static class SchemaValidationHelper
         };
         ValidateSchemaDefinitionForDocument(definition);
         ExcludeMetadata(context, ref definition);
-        validator.Init(definition);
+        var validatorConfig = SchemaValidationConfigurationToSchemaValidatorSettings(config);
+        validator.Init(definition, validatorConfig);
         return validator;
+    }
+
+    private static SchemaValidatorSettings SchemaValidationConfigurationToSchemaValidatorSettings(SchemaValidationConfiguration config)
+    {
+        var regexTimeout = config.RegexTimeout.AsTimeSpan;
+        // We have to respect the Regex limit. We can't allow the schema building to fail due to configuration.
+        if (regexTimeout <= TimeSpan.Zero)
+            regexTimeout = TimeSpan.FromSeconds(1);
+
+        if (regexTimeout.TotalMilliseconds > PatternSchemaRuleValidator.MaxTimeoutInMilliseconds)
+            regexTimeout = Regex.InfiniteMatchTimeout;
+        
+        return new SchemaValidatorSettings
+        {
+            RegexTimeout = regexTimeout, 
+            ValidationTimeout = config.ValidationTimeout.AsTimeSpan, 
+            MaxDepth = config.MaxDepth
+        };
     }
     
     private static void ExcludeMetadata(JsonOperationContext context, ref BlittableJsonReaderObject blittable)

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidationHelper.cs
@@ -253,7 +253,6 @@ public static class SchemaValidationHelper
         return new SchemaValidatorSettings
         {
             RegexTimeout = regexTimeout, 
-            ValidationTimeout = config.ValidationTimeout.AsTimeSpan, 
             MaxDepth = config.MaxDepth
         };
     }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Raven.Server.Documents.SchemaValidation.Validators;
+using Raven.Server.Documents.SchemaValidation.Validators.String;
 using Sparrow.Json;
-using Sparrow.Threading;
 
 namespace Raven.Server.Documents.SchemaValidation;
 
@@ -12,21 +13,47 @@ public class SchemaValidator
 {
     private ElementSchemaRuleValidator _root;
 
-    public string SchemaDefinition { get; set; }
+    private SchemaValidatorSettings _configuration;
+
+    public string SchemaDefinition { get; init; }
 
     public bool Disabled { get; set; }
 
-    // The caller (holder) is responsible for keeping the underlying Blittable / context alive (and disposing it) for as long as this SchemaValidator is used.
-    public void Init(BlittableJsonReaderObject schemaDefinition)
+    public static void ValidateInit(BlittableJsonReaderObject schemaDefinition)
     {
-        var refSchemas = new RefSchemas();
-        refSchemas.Init(schemaDefinition);
-
-        _root = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(schemaDefinition, new SchemaPath(), refSchemas);
+        //To make sure the schema is valid, we run Init on an instance of SchemaValidator, but it is not used
+        new SchemaValidator().Init(schemaDefinition, new SchemaValidatorSettings{RegexTimeout = Regex.InfiniteMatchTimeout});
     }
 
+    // The caller (holder) is responsible for keeping the underlying Blittable / context alive (and disposing it) for as long as this SchemaValidator is used.
+    public void Init(BlittableJsonReaderObject schemaDefinition, SchemaValidatorSettings configuration)
+    {
+        _configuration = configuration;
+        var context = new SchemaBuilderContext
+        {
+            RefSchemas = new RefSchemas(),
+            Configuration = _configuration
+        };
+        
+        context.RefSchemas.Init(context, schemaDefinition);
+
+        _root = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, schemaDefinition, new SchemaPath());
+    }
+    
     public bool Validate(BlittableJsonReaderObject obj, ErrorBuilder errorBuilder)
     {
-        return _root.Validate(obj, errorBuilder);
+        var context = new SchemaValidationContext(_configuration)
+        {
+            ErrorBuilder = errorBuilder,
+        };
+        
+        return _root.Validate(context, obj);
     }
+}
+
+public class SchemaValidatorSettings
+{
+    public TimeSpan RegexTimeout { get; init; }
+    public TimeSpan ValidationTimeout { get; init; }
+    public int MaxDepth { get; init; }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidator.cs
@@ -54,6 +54,5 @@ public class SchemaValidator
 public class SchemaValidatorSettings
 {
     public TimeSpan RegexTimeout { get; init; }
-    public TimeSpan ValidationTimeout { get; init; }
     public int MaxDepth { get; init; }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -11,6 +11,7 @@ using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
 using Sparrow.Server.Logging;
+using SchemaValidationSettings = Raven.Server.Config.Categories.SchemaValidationConfiguration;
 
 namespace Raven.Server.Documents.SchemaValidation;
 
@@ -19,15 +20,17 @@ public class SchemaValidatorCache : IDisposable
     private static readonly FrozenDictionary<string, SchemaValidator> EmptyCache = Array.Empty<KeyValuePair<string, SchemaValidator>>().ToFrozenDictionary();
 
     private readonly AbstractDatabaseNotificationCenter _notificationCenter;
+    private readonly SchemaValidationSettings _configuration;
     private readonly RavenLogger _logger;
     private readonly JsonOperationContext _context;
     private FrozenDictionary<string, SchemaValidator> _schemaValidatorsPerCollection = EmptyCache;
     public bool Disabled { get; private set; } = true;
 
-    public SchemaValidatorCache(AbstractDatabaseNotificationCenter notificationCenter, RavenLogger logger)
+    public SchemaValidatorCache(AbstractDatabaseNotificationCenter notificationCenter, SchemaValidationSettings configuration, RavenLogger logger)
     {
         _context = JsonOperationContext.ShortTermSingleUse();
         _notificationCenter = notificationCenter;
+        _configuration = configuration;
         _logger = logger;
     }
 
@@ -59,7 +62,7 @@ public class SchemaValidatorCache : IDisposable
             try
             {
                 var blittable = _context.Sync.ReadForMemory(validator.Schema, "schema-validation");
-                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context, blittable, validator.Schema, validator.Disabled);
+                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context, blittable, validator.Schema, _configuration, validator.Disabled);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ArraySchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ArraySchemaRuleValidator.cs
@@ -77,12 +77,12 @@ public class ArraySchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ArrayS
         var itemsValidators = ReadItemsSchema(context, schemaDefinition, schemaPath);
         return new ArraySchemaRuleValidator(prefixValidators, itemsValidators, schemaPath);
     }
-    
+
     private static ElementSchemaRuleValidator[] ReadPrefixItemsSchema(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        const string rule =  SchemaValidatorConstants.PrefixItems;
+        const string rule = SchemaValidatorConstants.PrefixItems;
         schemaPath += rule;
-        if(SchemaValidationHelper.TryGetArray(schemaDefinition, rule, schemaPath, out var prefixItemsSchema) == false)
+        if (SchemaValidationHelper.TryGetArray(schemaDefinition, rule, schemaPath, out var prefixItemsSchema) == false)
             return null;
 
         List<ElementSchemaRuleValidator> validators = null;
@@ -92,16 +92,15 @@ public class ArraySchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ArrayS
             if (item is not BlittableJsonReaderObject blittableItem)
             {
                 SchemaValidationHelper.ThrowRuleTypeError(item, typeof(BlittableJsonReaderObject), schemaPath);
-                return null;// Required to satisfy compiler flow analysis; method above always throws
+                return null; // Required to satisfy compiler flow analysis; method above always throws
             }
-                    
+
             var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, blittableItem, schemaPath + i);
             (validators ??= []).Add(validator);
         }
         return validators?.ToArray();
     }
-    
-    
+
     private static (bool Allowed, ElementSchemaRuleValidator Validator) ReadItemsSchema(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         const string rule = SchemaValidatorConstants.Items;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ArraySchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ArraySchemaRuleValidator.cs
@@ -22,7 +22,7 @@ public class ArraySchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
         _schemaPath = schemaPath;
     }
     
-    public override bool Validate(BlittableJsonReaderArray value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderArray value)
     {
         var isValid = true;
         int i = 0;
@@ -34,11 +34,11 @@ public class ArraySchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
             {
                 for (; i < length; i++)
                 {
-                    errorBuilder?.Path.StepIn(i);
-                    isValid &= _prefixValidators[i].Validate(value[i], errorBuilder);
-                    errorBuilder?.Path.StepOut();
+                    context.StepIn(i);
+                    isValid &= _prefixValidators[i].Validate(context, value[i]);
+                    context.StepOut();
 
-                    if (errorBuilder == null && isValid == false)
+                    if (context.ErrorBuilder == null && isValid == false)
                         return false;
                 }
             }
@@ -46,9 +46,9 @@ public class ArraySchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
         
         if (value.Length > i && _itemsValidator.Allowed == false)
         {
-            errorBuilder?.AddError($"The array at '{errorBuilder.Path}' contains additional items, which are not allowed.");
+            context.ErrorBuilder?.AddError($"The array at '{context.ErrorBuilder.Path}' contains additional items, which are not allowed.");
             isValid = false;
-            if (errorBuilder == null)
+            if (context.ErrorBuilder == null)
                 return false;
         }
         
@@ -56,11 +56,11 @@ public class ArraySchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
         {
             for (; i < value.Length; i++)
             {
-                errorBuilder?.Path.StepIn(i);
-                isValid &=_itemsValidator.validator.Validate(value[i], errorBuilder);
-                errorBuilder?.Path.StepOut();
+                context.StepIn(i);
+                isValid &=_itemsValidator.validator.Validate(context, value[i]);
+                context.StepOut();
                 
-                if (errorBuilder == null && isValid == false)
+                if (context.ErrorBuilder == null && isValid == false)
                     return false;
             }
         }
@@ -71,14 +71,14 @@ public class ArraySchemaRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
 
 public class ArraySchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ArraySchemaRuleValidator>
 {
-    public override ArraySchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override ArraySchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        var prefixValidators = ReadPrefixItemsSchema(schemaDefinition, schemaPath, refSchemas);
-        var itemsValidators = ReadItemsSchema(schemaDefinition, schemaPath, refSchemas);
+        var prefixValidators = ReadPrefixItemsSchema(context, schemaDefinition, schemaPath);
+        var itemsValidators = ReadItemsSchema(context, schemaDefinition, schemaPath);
         return new ArraySchemaRuleValidator(prefixValidators, itemsValidators, schemaPath);
     }
     
-    private static ElementSchemaRuleValidator[] ReadPrefixItemsSchema(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    private static ElementSchemaRuleValidator[] ReadPrefixItemsSchema(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         const string rule =  SchemaValidatorConstants.PrefixItems;
         schemaPath += rule;
@@ -95,15 +95,14 @@ public class ArraySchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ArrayS
                 return null;// Required to satisfy compiler flow analysis; method above always throws
             }
                     
-            var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(blittableItem, schemaPath + i, refSchemas);
+            var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, blittableItem, schemaPath + i);
             (validators ??= []).Add(validator);
         }
         return validators?.ToArray();
     }
     
     
-    private static (bool Allowed, ElementSchemaRuleValidator Validator) ReadItemsSchema(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
-        RefSchemas refSchemas)
+    private static (bool Allowed, ElementSchemaRuleValidator Validator) ReadItemsSchema(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         const string rule = SchemaValidatorConstants.Items;
         schemaPath += rule;
@@ -115,7 +114,7 @@ public class ArraySchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ArrayS
             case bool isAdditionalPropertiesAllowed:
                 return (isAdditionalPropertiesAllowed, null);
             case BlittableJsonReaderObject additionalPropertiesSchema:
-                var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(additionalPropertiesSchema, schemaPath + rule, refSchemas);
+                var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, additionalPropertiesSchema, schemaPath + rule);
                 return (true, validator);
             default:
                 var expectedTypes = new HashSet<Type> { typeof(bool), typeof(BlittableJsonReaderObject) };

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ContainsRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ContainsRuleValidator.cs
@@ -17,13 +17,16 @@ public class ContainsRuleValidator : SchemaRuleValidator<BlittableJsonReaderArra
         _maxContains = maxContains;
     }
 
-    public override bool Validate(BlittableJsonReaderArray value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderArray value)
     {
         var count = 0;
         for (var i = 0; i < value.Length; i++)
         {
-            if (_containsValidator.Validate(value[i], null) == false) 
-                continue;
+            using (context.WithoutCollectingErrors())
+            {
+                if (_containsValidator.Validate(context, value[i]) == false) 
+                    continue;
+            }
             
             if (++count >= _minContains && _maxContains > (value.Length - i + count))
                 return true;
@@ -32,14 +35,14 @@ public class ContainsRuleValidator : SchemaRuleValidator<BlittableJsonReaderArra
         var isValid = true;
         if (count > _maxContains)
         {
-            errorBuilder?.AddError(
-                $"The array at '{errorBuilder.Path}' must not contain more than {_maxContains} items matching the required schema, but {count} matching items were found. schema : {_containsValidator.SchemaDefinition}");
+            context.ErrorBuilder?.AddError(
+                $"The array at '{context.ErrorBuilder.Path}' must not contain more than {_maxContains} items matching the required schema, but {count} matching items were found. schema : {_containsValidator.SchemaDefinition}");
             isValid = false;
         }
         if (count < _minContains)
         {
-            errorBuilder?.AddError(
-                $"The array at '{errorBuilder.Path}' must contain at least {_minContains} items matching the required schema, but {(count==0?"no items where": $"only {count} matching item{(count>1?"s":"")} were")} found. Schema : {_containsValidator.SchemaDefinition}");
+            context.ErrorBuilder?.AddError(
+                $"The array at '{context.ErrorBuilder.Path}' must contain at least {_minContains} items matching the required schema, but {(count==0?"no items where": $"only {count} matching item{(count>1?"s":"")} were")} found. Schema : {_containsValidator.SchemaDefinition}");
             isValid = false;
         }
 
@@ -51,7 +54,7 @@ public class ContainsRuleValidator : SchemaRuleValidator<BlittableJsonReaderArra
 // ReSharper disable once UnusedType.Global
 public class ContainsRuleValidatorRuleValidatorFactory : SchemaRuleValidatorFactory<ContainsRuleValidator>
 {
-    public override ContainsRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override ContainsRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if(SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var containsSchema) == false)
@@ -63,7 +66,7 @@ public class ContainsRuleValidatorRuleValidatorFactory : SchemaRuleValidatorFact
         if (SchemaValidationHelper.TryGetInteger(schemaDefinition, SchemaValidatorConstants.MaxContains, schemaPath, out var maxContains) == false)
             maxContains = long.MaxValue;
         
-        var containsValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(containsSchema, schemaPath + Rule, refSchemas);
+        var containsValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, containsSchema, schemaPath + Rule);
         return new ContainsRuleValidator(containsValidator, minContains, maxContains);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ContainsRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Array/ContainsRuleValidator.cs
@@ -57,15 +57,15 @@ public class ContainsRuleValidatorRuleValidatorFactory : SchemaRuleValidatorFact
     public override ContainsRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
-        if(SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var containsSchema) == false)
+        if (SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var containsSchema) == false)
             return null;
 
         if (SchemaValidationHelper.TryGetInteger(schemaDefinition, SchemaValidatorConstants.MinContains, schemaPath, out var minContains) == false)
             minContains = 1L;
-        
+
         if (SchemaValidationHelper.TryGetInteger(schemaDefinition, SchemaValidatorConstants.MaxContains, schemaPath, out var maxContains) == false)
             maxContains = long.MaxValue;
-        
+
         var containsValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, containsSchema, schemaPath + Rule);
         return new ContainsRuleValidator(containsValidator, minContains, maxContains);
     }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Array/UniqueItemsRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Array/UniqueItemsRuleValidator.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Array;
 public class UniqueItemsRuleValidator : SchemaRuleValidator<BlittableJsonReaderArray>
 {
     // ReSharper disable once ConvertToPrimaryConstructor
-    public override bool Validate(BlittableJsonReaderArray value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderArray value)
     {
         HashSet<object> duplicates = null;
         var hashSet = new HashSet<object>();
@@ -20,7 +20,7 @@ public class UniqueItemsRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
         if (duplicates == null)
             return true;
         
-        errorBuilder?.AddError($"The array at '{errorBuilder.Path}' contains duplicate value{(duplicates.Count == 1?"":"s")}: '{duplicates: \"', '\"}'. Each item must be unique.");
+        context.ErrorBuilder?.AddError($"The array at '{context.ErrorBuilder.Path}' contains duplicate value{(duplicates.Count == 1?"":"s")}: '{duplicates: \"', '\"}'. Each item must be unique.");
         return false;
     }
 }
@@ -29,7 +29,7 @@ public class UniqueItemsRuleValidator : SchemaRuleValidator<BlittableJsonReaderA
 // ReSharper disable once UnusedType.Global
 public class UniqueItemsRuleValidatorFactory : SchemaRuleValidatorFactory<UniqueItemsRuleValidator>
 {
-    public override UniqueItemsRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override UniqueItemsRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         if (SchemaValidationHelper.TryGetBoolean(schemaDefinition, Rule, schemaPath + Rule, out bool uniqueItems) == false) 
             return null;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidator.cs
@@ -33,8 +33,6 @@ public class ElementSchemaRuleValidator
     
     public bool Validate(SchemaValidationContext context, object value)
     {
-        context.CheckTimeoutAndThrow();
-
         if (IsOfRequiredType(value) == false)
         {
             context.ErrorBuilder?.AddError($"'{context.ErrorBuilder.Path}' should be of type '{_publicTypesRestriction:' or '}' but actual type is '{SchemaValidationHelper.GetPublicType(value?.GetType())}'.");

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidator.cs
@@ -31,18 +31,20 @@ public class ElementSchemaRuleValidator
         SchemaPath = schemaPath;
     }
     
-    public bool Validate(object value, ErrorBuilder errorBuilder)
+    public bool Validate(SchemaValidationContext context, object value)
     {
+        context.CheckTimeoutAndThrow();
+
         if (IsOfRequiredType(value) == false)
         {
-            errorBuilder?.AddError($"'{errorBuilder.Path}' should be of type '{_publicTypesRestriction:' or '}' but actual type is '{SchemaValidationHelper.GetPublicType(value?.GetType())}'.");
+            context.ErrorBuilder?.AddError($"'{context.ErrorBuilder.Path}' should be of type '{_publicTypesRestriction:' or '}' but actual type is '{SchemaValidationHelper.GetPublicType(value?.GetType())}'.");
             return false;
         }
         
-        return CheckAllValidators(value, errorBuilder);
+        return CheckAllValidators(context, value);
     }
 
-    private bool CheckAllValidators(object value, ErrorBuilder errorBuilder)
+    private bool CheckAllValidators(SchemaValidationContext context, object value)
     {
         if (_ruleValidators == null)
             return true;
@@ -50,8 +52,8 @@ public class ElementSchemaRuleValidator
         var isValid = true;
         foreach (var ruleValidator in _ruleValidators)
         {
-            isValid &= ruleValidator.Validate(value, errorBuilder);
-            if (errorBuilder == null && isValid == false)
+            isValid &= ruleValidator.Validate(context, value);
+            if (context.ErrorBuilder == null && isValid == false)
                 return false;
         }
         return isValid;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidatorFactory.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidatorFactory.cs
@@ -50,11 +50,11 @@ public static class ElementSchemaRuleValidatorFactory
 
         return allowedTypes.ToArray();
     }
-    
+
     private static Type[] ConvertToTypes(object type, SchemaPath schemaPath)
     {
         var stringType = GetLazyString(type, schemaPath);
-        if(SchemaValidationHelper.TryGetTypesForPublicType(stringType, out Type[] tokens) == false)
+        if (SchemaValidationHelper.TryGetTypesForPublicType(stringType, out Type[] tokens) == false)
         {
             throw new InvalidSchemaValidationDefinitionException(
                 $"The '{SchemaValidatorConstants.Type}' restriction must be one of the allowed types ('{string.Join("', '", SchemaValidationHelper.PublicTypes)}'), but found '{type}'. " +
@@ -62,7 +62,7 @@ public static class ElementSchemaRuleValidatorFactory
         }
         return tokens;
     }
-    
+
     private static LazyStringValue GetLazyString(object type, SchemaPath schemaPath)
     {
         return type switch

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidatorFactory.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidatorFactory.cs
@@ -7,16 +7,14 @@ namespace Raven.Server.Documents.SchemaValidation.Validators;
 
 public static class ElementSchemaRuleValidatorFactory
 {
-    public static ElementSchemaRuleValidator CreateElementSchemaRuleValidator(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
-        RefSchemas refSchemas)
+    public static ElementSchemaRuleValidator CreateElementSchemaRuleValidator(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        return TryReadSchema(schemaDefinition, schemaPath, refSchemas, out Type[] typesRestriction, out ISchemaRuleValidator[] ruleValidators)
+        return TryReadSchema(context, schemaDefinition, schemaPath, out Type[] typesRestriction, out ISchemaRuleValidator[] ruleValidators)
             ? new ElementSchemaRuleValidator(typesRestriction, ruleValidators, schemaPath) {SchemaDefinition = schemaDefinition} : 
             null;
     }
     
-    private static bool TryReadSchema(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
-        RefSchemas refSchemas,
+    private static bool TryReadSchema(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
         out Type[] typesRestriction, out ISchemaRuleValidator[] ruleValidators)
     {
         if (schemaDefinition == null)
@@ -26,7 +24,7 @@ public static class ElementSchemaRuleValidatorFactory
             return false;
         }
         typesRestriction = ReadTypeRestrictionsRule(schemaDefinition, schemaPath);
-        ruleValidators = ReadValueSchemaRuleValidators(schemaDefinition, schemaPath, refSchemas);
+        ruleValidators = ReadValueSchemaRuleValidators(context, schemaDefinition, schemaPath);
 
         return true;
     }
@@ -75,8 +73,7 @@ public static class ElementSchemaRuleValidatorFactory
         };
     }
     
-    private static ISchemaRuleValidator[] ReadValueSchemaRuleValidators(BlittableJsonReaderObject propertySchemaDefinition, SchemaPath schemaPath,
-        RefSchemas refSchemas)
+    private static ISchemaRuleValidator[] ReadValueSchemaRuleValidators(SchemaBuilderContext context, BlittableJsonReaderObject propertySchemaDefinition, SchemaPath schemaPath)
     {
         List<ISchemaRuleValidator> ruleValidators = null;
         var alreadyHasObjectRestrictions = false;
@@ -93,7 +90,7 @@ public static class ElementSchemaRuleValidatorFactory
                 {
                     if (alreadyHasObjectRestrictions)
                         continue;
-                    validator = SchemaRuleValidatorFactoryHelper.CreateObjectValidator(propertySchemaDefinition, schemaPath, refSchemas);
+                    validator = SchemaRuleValidatorFactoryHelper.CreateObjectValidator(context, propertySchemaDefinition, schemaPath);
                     alreadyHasObjectRestrictions = true;
                     break;
                 }
@@ -101,13 +98,13 @@ public static class ElementSchemaRuleValidatorFactory
                 {
                     if (alreadyHasArrayRestrictions)
                         continue;
-                    validator = SchemaRuleValidatorFactoryHelper.CreateArrayValidator(propertySchemaDefinition, schemaPath, refSchemas);
+                    validator = SchemaRuleValidatorFactoryHelper.CreateArrayValidator(context, propertySchemaDefinition, schemaPath);
                     alreadyHasArrayRestrictions = true;
                     break;
                 }
                 default:
                 {
-                    if (SchemaRuleValidatorFactoryHelper.TryCreateValidator(rule, propertySchemaDefinition, schemaPath, refSchemas, out validator) == false)
+                    if (SchemaRuleValidatorFactoryHelper.TryCreateValidator(context, rule, propertySchemaDefinition, schemaPath, out validator) == false)
                         continue;
                     break;
                 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MaximumSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MaximumSchemaRuleValidator.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Number;
 public class MaximumSchemaRuleValidator : NumberSchemaRuleValidator
 {
     private readonly decimal _maximum;
-    private readonly Func<decimal, ErrorBuilder, bool> _validatePredicate;
+    private readonly Func<SchemaValidationContext, decimal, bool> _validatePredicate;
 
     // ReSharper disable once IntroduceOptionalParameters.Global
     public MaximumSchemaRuleValidator(decimal maximum, bool exclusiveMinimum)
@@ -16,26 +16,26 @@ public class MaximumSchemaRuleValidator : NumberSchemaRuleValidator
         _validatePredicate = exclusiveMinimum ? ExclusiveValidate : NonExclusiveValidate;
     }
 
-    public override bool Validate(decimal value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, decimal value)
     {
-        return _validatePredicate(value, errorBuilder);
+        return _validatePredicate(context, value);
     }
 
-    private bool NonExclusiveValidate(decimal value, ErrorBuilder errorBuilder)
+    private bool NonExclusiveValidate(SchemaValidationContext context, decimal value)
     {
         if (value.CompareTo(_maximum) <= 0) 
             return true;
         
-        errorBuilder?.AddError($"The value '{value}' at '{errorBuilder.Path}' should be less than or equal to {_maximum}.");
+        context.ErrorBuilder?.AddError($"The value '{value}' at '{context.ErrorBuilder.Path}' should be less than or equal to {_maximum}.");
         return false;
     }
 
-    private bool ExclusiveValidate(decimal value, ErrorBuilder errorBuilder)
+    private bool ExclusiveValidate(SchemaValidationContext context, decimal value)
     {
         if (value.CompareTo(_maximum) < 0) 
             return true;
         
-        errorBuilder?.AddError($"The value '{value}' at '{errorBuilder.Path}' should be less than {_maximum}.");
+        context.ErrorBuilder?.AddError($"The value '{value}' at '{context.ErrorBuilder.Path}' should be less than {_maximum}.");
         return false;
     }
 }
@@ -44,7 +44,7 @@ public class MaximumSchemaRuleValidator : NumberSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class MaximumSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MaximumSchemaRuleValidator>
 {
-    public override MaximumSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MaximumSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if(SchemaValidationHelper.TryGetNumber(schemaDefinition, Rule, schemaPath, out var maximum) == false)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MaximumSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MaximumSchemaRuleValidator.cs
@@ -47,11 +47,11 @@ public class MaximumSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Maxi
     public override MaximumSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
-        if(SchemaValidationHelper.TryGetNumber(schemaDefinition, Rule, schemaPath, out var maximum) == false)
+        if (SchemaValidationHelper.TryGetNumber(schemaDefinition, Rule, schemaPath, out var maximum) == false)
             return null;
 
         SchemaValidationHelper.TryGetBoolean(schemaDefinition, SchemaValidatorConstants.ExclusiveMaximum, schemaPath, out bool exclusiveMaximum);
-        
+
         return new MaximumSchemaRuleValidator(maximum, exclusiveMaximum);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MinimumSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MinimumSchemaRuleValidator.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Number;
 public class MinimumSchemaRuleValidator : NumberSchemaRuleValidator
 {
     private readonly decimal _minimum;
-    private readonly Func<decimal, ErrorBuilder, bool> _validatePredicate;
+    private readonly Func<SchemaValidationContext, decimal, bool> _validatePredicate;
 
     // ReSharper disable once IntroduceOptionalParameters.Global
     public MinimumSchemaRuleValidator(decimal minimum, bool exclusiveMinimum)
@@ -16,23 +16,23 @@ public class MinimumSchemaRuleValidator : NumberSchemaRuleValidator
         _validatePredicate = exclusiveMinimum ? ExclusiveValidate : NonExclusiveValidate;
     }
 
-    public override bool Validate(decimal value, ErrorBuilder errorBuilder) => _validatePredicate(value, errorBuilder);
+    public override bool Validate(SchemaValidationContext context, decimal value) => _validatePredicate(context, value);
 
-    private bool NonExclusiveValidate(decimal value, ErrorBuilder errorBuilder)
+    private bool NonExclusiveValidate(SchemaValidationContext context, decimal value)
     {
         if (value.CompareTo(_minimum) >= 0) 
             return true;
         
-        errorBuilder?.AddError($"The value '{value}' at '{errorBuilder.Path}' should be greater than or equal to {_minimum}.");
+        context.ErrorBuilder?.AddError($"The value '{value}' at '{context.ErrorBuilder.Path}' should be greater than or equal to {_minimum}.");
         return false;
     }
 
-    private bool ExclusiveValidate(decimal value, ErrorBuilder errorBuilder)
+    private bool ExclusiveValidate(SchemaValidationContext context, decimal value)
     {
         if (value.CompareTo(_minimum) > 0) 
             return true;
         
-        errorBuilder?.AddError($"The value '{value}' at '{errorBuilder.Path}' should be greater than {_minimum}.");
+        context.ErrorBuilder?.AddError($"The value '{value}' at '{context.ErrorBuilder.Path}' should be greater than {_minimum}.");
         return false;
     }
 }
@@ -41,7 +41,7 @@ public class MinimumSchemaRuleValidator : NumberSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class MinimumSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MinimumSchemaRuleValidator>
 {
-    public override MinimumSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MinimumSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetNumber(schemaDefinition, Rule, schemaPath, out var minimum) == false)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MultipleOfSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Number/MultipleOfSchemaRuleValidator.cs
@@ -13,12 +13,12 @@ public class MultipleOfSchemaRuleValidator : NumberSchemaRuleValidator
         _multipleOf = multipleOf;
     }
 
-    public override bool Validate(decimal value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, decimal value)
     {
         if (value % _multipleOf == 0) 
             return true;
         
-        errorBuilder?.AddError($"The value '{value}' at '{errorBuilder.Path}' should be a multiple of {_multipleOf}.");
+        context.ErrorBuilder?.AddError($"The value '{value}' at '{context.ErrorBuilder.Path}' should be a multiple of {_multipleOf}.");
         return false;
     }
 }
@@ -27,7 +27,7 @@ public class MultipleOfSchemaRuleValidator : NumberSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class MultipleOfSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MultipleOfSchemaRuleValidator>
 {
-    public override MultipleOfSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MultipleOfSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetNumber(schemaDefinition, Rule, schemaPath + Rule, out var multipleOf)
             ? new MultipleOfSchemaRuleValidator(multipleOf) 

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependedRequiredSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependedRequiredSchemaRuleValidator.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Object;
 // ReSharper disable once UnusedType.Global
 public class DependentRequiredSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<GroupedIfThenElseSchemaRuleValidator>
 {
-    public override GroupedIfThenElseSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override GroupedIfThenElseSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var dependentRequiredSchema) == false)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependedRequiredSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependedRequiredSchemaRuleValidator.cs
@@ -24,13 +24,13 @@ public class DependentRequiredSchemaRuleValidatorFactory : SchemaRuleValidatorFa
             dependentRequiredSchema.GetPropertyByIndex(i, ref prop);
             var requiredSchema = SchemaValidationHelper.CheckTypeAndThrow<BlittableJsonReaderArray>(prop.Value, schemaPath);
             var requiredProperties = SchemaValidationHelper.CheckBlittableArrayElementTypesAndThrow<LazyStringValue>(requiredSchema, schemaPath);
-            if(requiredProperties == null)
+            if (requiredProperties == null)
                 continue;
-                    
-            var propertySchemaPath = schemaPath + prop.Name; 
+
+            var propertySchemaPath = schemaPath + prop.Name;
             var ifRequiredValidator = new RequiredSchemaRuleValidator(prop.Name);
             var ifValidator = new ElementSchemaRuleValidator([ifRequiredValidator], propertySchemaPath);
-            
+
             var thenRequiredValidator = new RequiredSchemaRuleValidator(requiredProperties);
             var thenValidator = new ElementSchemaRuleValidator([thenRequiredValidator], propertySchemaPath);
 
@@ -39,7 +39,7 @@ public class DependentRequiredSchemaRuleValidatorFactory : SchemaRuleValidatorFa
 
         if (dependentRequires == null)
             return null;
-        
+
         return new GroupedIfThenElseSchemaRuleValidator(dependentRequires.ToArray());
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependentSchemasSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependentSchemasSchemaRuleValidator.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.Object;
 // ReSharper disable once UnusedType.Global
 public class DependentSchemasSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<GroupedIfThenElseSchemaRuleValidator>
 {
-    public override GroupedIfThenElseSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override GroupedIfThenElseSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var dependentRequiredSchema) == false)
@@ -33,7 +33,7 @@ public class DependentSchemasSchemaRuleValidatorFactory : SchemaRuleValidatorFac
             var ifRequiredValidator = new RequiredSchemaRuleValidator(prop.Name);
             var ifValidator = new ElementSchemaRuleValidator([ifRequiredValidator], propertySchemaPath);
             
-            var thenValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(dependentSchemas, propertySchemaPath, refSchemas);
+            var thenValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, dependentSchemas, propertySchemaPath);
 
             (dependentRequires ??= []).Add(new IfThenElseSchemaRuleValidator(ifValidator, thenValidator));
         }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependentSchemasSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/DependentSchemasSchemaRuleValidator.cs
@@ -24,15 +24,15 @@ public class DependentSchemasSchemaRuleValidatorFactory : SchemaRuleValidatorFac
         {
             dependentRequiredSchema.GetPropertyByIndex(i, ref prop);
             var dependentSchemas = SchemaValidationHelper.CheckTypeAndThrow<BlittableJsonReaderObject>(prop.Value, schemaPath);
-            
+
             var propertySchemaPath = schemaPath + prop.Name;
-            
-            if(dependentSchemas.Count == 0)
+
+            if (dependentSchemas.Count == 0)
                 continue;
-                    
+
             var ifRequiredValidator = new RequiredSchemaRuleValidator(prop.Name);
             var ifValidator = new ElementSchemaRuleValidator([ifRequiredValidator], propertySchemaPath);
-            
+
             var thenValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, dependentSchemas, propertySchemaPath);
 
             (dependentRequires ??= []).Add(new IfThenElseSchemaRuleValidator(ifValidator, thenValidator));
@@ -40,6 +40,7 @@ public class DependentSchemasSchemaRuleValidatorFactory : SchemaRuleValidatorFac
 
         if (dependentRequires == null)
             return null;
-        
+
         return new GroupedIfThenElseSchemaRuleValidator(dependentRequires.ToArray());
-    }}
+    }
+}

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MaxPropertiesSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MaxPropertiesSchemaRuleValidator.cs
@@ -12,11 +12,11 @@ public class MaxPropertiesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
     {
         _maxProperties = maxProperties;
     }
-    public override bool Validate(BlittableJsonReaderObject value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
         if(value.Count <= _maxProperties)
             return true;
-        errorBuilder?.AddError($"The object at '{errorBuilder.Path}' must have no more than {_maxProperties} properties, but it has {value.Count}.");
+        context.ErrorBuilder?.AddError($"The object at '{context.ErrorBuilder.Path}' must have no more than {_maxProperties} properties, but it has {value.Count}.");
         return false;
     }
 }
@@ -25,7 +25,7 @@ public class MaxPropertiesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
 // ReSharper disable once UnusedType.Global
 public class MaxPropertiesSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MaxPropertiesSchemaRuleValidator>
 {
-    public override MaxPropertiesSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MaxPropertiesSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetInteger(schemaDefinition, Rule, schemaPath + Rule, out var maxProperties) 
             ? new MaxPropertiesSchemaRuleValidator(maxProperties)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MaxPropertiesSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MaxPropertiesSchemaRuleValidator.cs
@@ -14,7 +14,7 @@ public class MaxPropertiesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
     }
     public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
-        if(value.Count <= _maxProperties)
+        if (value.Count <= _maxProperties)
             return true;
         context.ErrorBuilder?.AddError($"The object at '{context.ErrorBuilder.Path}' must have no more than {_maxProperties} properties, but it has {value.Count}.");
         return false;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MinPropertiesSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MinPropertiesSchemaRuleValidator.cs
@@ -14,9 +14,9 @@ public class MinPropertiesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
     }
     public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
-        if(value.Count >= _minProperties)
+        if (value.Count >= _minProperties)
             return true;
-        context.ErrorBuilder?.AddError($"The object at '{context.ErrorBuilder.Path}' must have at least {_minProperties} {(_minProperties == 1 ? "property": "properties")}, but it has only {value.Count}.");
+        context.ErrorBuilder?.AddError($"The object at '{context.ErrorBuilder.Path}' must have at least {_minProperties} {(_minProperties == 1 ? "property" : "properties")}, but it has only {value.Count}.");
         return false;
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MinPropertiesSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/MinPropertiesSchemaRuleValidator.cs
@@ -12,11 +12,11 @@ public class MinPropertiesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
     {
         _minProperties = minProperties;
     }
-    public override bool Validate(BlittableJsonReaderObject value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
         if(value.Count >= _minProperties)
             return true;
-        errorBuilder?.AddError($"The object at '{errorBuilder.Path}' must have at least {_minProperties} {(_minProperties == 1 ? "property": "properties")}, but it has only {value.Count}.");
+        context.ErrorBuilder?.AddError($"The object at '{context.ErrorBuilder.Path}' must have at least {_minProperties} {(_minProperties == 1 ? "property": "properties")}, but it has only {value.Count}.");
         return false;
     }
 }
@@ -25,7 +25,7 @@ public class MinPropertiesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
 // ReSharper disable once UnusedType.Global
 public class MinPropertiesSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MinPropertiesSchemaRuleValidator>
 {
-    public override MinPropertiesSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MinPropertiesSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetInteger(schemaDefinition, Rule, schemaPath + Rule, out var minProperties) 
             ? new MinPropertiesSchemaRuleValidator(minProperties)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
@@ -36,15 +36,15 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
         }
     }
 
-    public override bool Validate(BlittableJsonReaderObject value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
         var isValid = true;
         if (_namedPropertyValidators != null)
         {
             foreach (var (prop, validator) in _namedPropertyValidators)
             {
-                isValid &= ValidateProperty(validator, value, prop, errorBuilder);
-                if (errorBuilder == null && isValid == false)
+                isValid &= ValidateProperty(context, validator, value, prop);
+                if (context.ErrorBuilder == null && isValid == false)
                     return false;
             }
         }
@@ -75,8 +75,8 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
                         hasValidator = true;
                         var prop = default(BlittableJsonReaderObject.PropertyDetails);
                         value.GetPropertyByIndex(i, ref prop);
-                        isValid &= ValidateProperty(validator, propName, prop.Value, errorBuilder);
-                        if (errorBuilder == null && isValid == false)
+                        isValid &= ValidateProperty(context, validator, propName, prop.Value);
+                        if (context.ErrorBuilder == null && isValid == false)
                             return false;
                     }
                 }
@@ -87,15 +87,15 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
                 var (allowed, additionalPropertiesValidator) = _additionalPropertiesValidator;
                 if (allowed == false)
                 {
-                    errorBuilder?.AddError($"The property '{propName}' at '{errorBuilder.Path}' is not defined and additional properties are not allowed.");
+                    context.ErrorBuilder?.AddError($"The property '{propName}' at '{context.ErrorBuilder.Path}' is not defined and additional properties are not allowed.");
                     isValid = false;
                 }
                 else if (additionalPropertiesValidator != null)
                 {
                     var prop = default(BlittableJsonReaderObject.PropertyDetails);
                     value.GetPropertyByIndex(i, ref prop);
-                    isValid &= ValidateProperty(additionalPropertiesValidator, propName, prop.Value, errorBuilder);
-                    if (errorBuilder == null && isValid == false)
+                    isValid &= ValidateProperty(context, additionalPropertiesValidator, propName, prop.Value);
+                    if (context.ErrorBuilder == null && isValid == false)
                         return false;
                 }
             }
@@ -108,31 +108,30 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
         return isValid;
     }
 
-    private static bool ValidateProperty(ElementSchemaRuleValidator validator, BlittableJsonReaderObject value, LazyStringValue prop,
-        ErrorBuilder errorBuilder)
+    private static bool ValidateProperty(SchemaValidationContext context, ElementSchemaRuleValidator validator, BlittableJsonReaderObject value, LazyStringValue prop)
     {
-        return value.TryGetMember((string)prop, out object propValue) == false || ValidateProperty(validator, prop, propValue, errorBuilder);
+        return value.TryGetMember((string)prop, out object propValue) == false || ValidateProperty(context, validator, prop, propValue);
     }
 
-    private static bool ValidateProperty(ElementSchemaRuleValidator validator, LazyStringValue prop, object propValue, ErrorBuilder errorBuilder)
+    private static bool ValidateProperty(SchemaValidationContext context, ElementSchemaRuleValidator validator, LazyStringValue prop, object propValue)
     {
-        errorBuilder?.Path.StepIn(prop);
-        var isValid = validator.Validate(propValue, errorBuilder);
-        errorBuilder?.Path.StepOut();
+        context.StepIn(prop);
+        var isValid = validator.Validate(context, propValue);
+        context.StepOut();
         return isValid;
     }
 }
 
 public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ObjectSchemaRuleValidator>
 {
-    public override ObjectSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override ObjectSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        var named = ReadPropertyValidators(schemaDefinition, schemaPath + SchemaValidatorConstants.Properties, refSchemas)?
+        var named = ReadPropertyValidators(context, schemaDefinition, schemaPath + SchemaValidatorConstants.Properties)?
             .ToDictionary(x => x.property, x => x.validator);
-        var pattern = ReadPropertyValidators(schemaDefinition, schemaPath + SchemaValidatorConstants.PatternProperties, refSchemas)?
+        var pattern = ReadPropertyValidators(context, schemaDefinition, schemaPath + SchemaValidatorConstants.PatternProperties)?
             .Select(x => (new Regex(x.property), x.validator)).ToArray();
 
-        var additional = ReadAdditionalProperties(schemaDefinition, schemaPath, refSchemas);
+        var additional = ReadAdditionalProperties(context, schemaDefinition, schemaPath);
 
         if (named == null && pattern == null && additional is { IsAllowed: true, Validator: null })
             return null;
@@ -142,8 +141,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
         return new ObjectSchemaRuleValidator(named, pattern, additional, schemaPath, exclude);
     }
     
-    private static (bool IsAllowed, ElementSchemaRuleValidator Validator) ReadAdditionalProperties(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
-        RefSchemas refSchemas)
+    private static (bool IsAllowed, ElementSchemaRuleValidator Validator) ReadAdditionalProperties(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         const string rule = SchemaValidatorConstants.AdditionalProperties;
         if (schemaDefinition.TryGet(rule, out object additionalProperties) == false)
@@ -158,7 +156,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
                 return (isAdditionalPropertiesAllowed, null);
             case BlittableJsonReaderObject additionalPropertiesSchema:
             {
-                var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(additionalPropertiesSchema, schemaPath, refSchemas);
+                var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, additionalPropertiesSchema, schemaPath);
                 return (true, validator);
             }
             default:
@@ -191,8 +189,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
         return excluded;
     }
 
-    private static List<(LazyStringValue property, ElementSchemaRuleValidator validator)> ReadPropertyValidators(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath,
-        RefSchemas refSchemas)
+    private static List<(LazyStringValue property, ElementSchemaRuleValidator validator)> ReadPropertyValidators(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         if(SchemaValidationHelper.TryGetObject(schemaDefinition, schemaPath.Property, schemaPath, out var propertySchema) == false)
             return null;
@@ -206,7 +203,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
 
             var propertySchemaDefinition = SchemaValidationHelper.CheckTypeAndThrow<BlittableJsonReaderObject>(prop.Value, schemaPath);
 
-            var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(propertySchemaDefinition, propertySchemaPath, refSchemas);
+            var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, propertySchemaDefinition, propertySchemaPath);
             if(validator != null)
                 (validators ??= []).Add((prop.Name, validator));
         }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
@@ -55,9 +55,9 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
             for (int i = 0; i < value.Count; i++)
             {
                 var propName = value.GetPropertyNameByIndex(i);
-                if (_exclude?.Contains(propName) == true) 
+                if (_exclude?.Contains(propName) == true)
                     continue;
-                
+
                 var hasValidator = _namedPropertyValidators != null && _namedPropertyValidators.ContainsKey(propName);
                 if (_patternPropertiesValidators != null)
                 {
@@ -69,9 +69,9 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
                             buffer = ArrayPool<char>.Shared.Rent(propName.Length);
                         }
                         propName.TryCopyTo(buffer);
-                        if(regex.IsMatch(buffer.AsSpan(0, propName.Length)) == false)
+                        if (regex.IsMatch(buffer.AsSpan(0, propName.Length)) == false)
                             continue;
-                
+
                         hasValidator = true;
                         var prop = default(BlittableJsonReaderObject.PropertyDetails);
                         value.GetPropertyByIndex(i, ref prop);
@@ -81,9 +81,9 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
                     }
                 }
 
-                if (hasValidator) 
+                if (hasValidator)
                     continue;
-            
+
                 var (allowed, additionalPropertiesValidator) = _additionalPropertiesValidator;
                 if (allowed == false)
                 {
@@ -165,12 +165,12 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
                 return (false, null);
         }
     }
-    
+
     private static LazyStringValue[] ReadExcludeProperties(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         const string rule = SchemaValidatorConstants.ExcludedProperties;
         schemaPath += rule;
-        if(SchemaValidationHelper.TryGetArray(schemaDefinition, rule, schemaPath, out var excludeProperties) == false)
+        if (SchemaValidationHelper.TryGetArray(schemaDefinition, rule, schemaPath, out var excludeProperties) == false)
             return null;
 
         var excluded = new LazyStringValue[excludeProperties.Length];
@@ -182,7 +182,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
                 SchemaValidationHelper.ThrowRuleTypeError(item, typeof(LazyStringValue), schemaPath + $"[{i}]");
                 return null; // never hit
             }
-            
+
             excluded[i] = str;
         }
 
@@ -191,7 +191,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
 
     private static List<(LazyStringValue property, ElementSchemaRuleValidator validator)> ReadPropertyValidators(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        if(SchemaValidationHelper.TryGetObject(schemaDefinition, schemaPath.Property, schemaPath, out var propertySchema) == false)
+        if (SchemaValidationHelper.TryGetObject(schemaDefinition, schemaPath.Property, schemaPath, out var propertySchema) == false)
             return null;
 
         List<(LazyStringValue property, ElementSchemaRuleValidator validator)> validators = null;
@@ -204,7 +204,7 @@ public class ObjectSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Objec
             var propertySchemaDefinition = SchemaValidationHelper.CheckTypeAndThrow<BlittableJsonReaderObject>(prop.Value, schemaPath);
 
             var validator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, propertySchemaDefinition, propertySchemaPath);
-            if(validator != null)
+            if (validator != null)
                 (validators ??= []).Add((prop.Name, validator));
         }
 

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/PropertyNamesSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/PropertyNamesSchemaRuleValidator.cs
@@ -43,14 +43,14 @@ public class PropertyNamesSchemaRuleValidatorFactory : SchemaRuleValidatorFactor
     public override PropertyNamesSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
-        if(SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var propertyNames) == false)
+        if (SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var propertyNames) == false)
             return null;
-        
+
         List<SchemaRuleValidator<LazyStringValue>> propertyNameValidators = null;
         for (int i = 0; i < propertyNames.Count; i++)
         {
             var propName = propertyNames.GetPropertyNameByIndex(i);
-            if(SchemaRuleValidatorFactoryHelper.TryCreateValidator(context, propName, propertyNames, schemaPath, out var ruleValidator) == false)
+            if (SchemaRuleValidatorFactoryHelper.TryCreateValidator(context, propName, propertyNames, schemaPath, out var ruleValidator) == false)
                 continue;
             var ruleSchemaPath = schemaPath + propName;
             if (ruleValidator is not StringSchemaRuleValidator stringValidator)
@@ -63,7 +63,7 @@ public class PropertyNamesSchemaRuleValidatorFactory : SchemaRuleValidatorFactor
 
         if (propertyNameValidators == null)
             return null;
-        
+
         return new PropertyNamesSchemaRuleValidator(propertyNameValidators.ToArray());
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/PropertyNamesSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/PropertyNamesSchemaRuleValidator.cs
@@ -15,7 +15,7 @@ public class PropertyNamesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
         _propertyNameValidators = propertyNameValidators;
     }
 
-    public override bool Validate(BlittableJsonReaderObject value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
         if (_propertyNameValidators == null)
             return true;
@@ -26,8 +26,8 @@ public class PropertyNamesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
             var propName = value.GetPropertyNameByIndex(i);
             foreach (var validator in _propertyNameValidators)
             {
-                isValid &= validator.Validate(propName, errorBuilder);
-                if (errorBuilder == null && isValid == false)
+                isValid &= validator.Validate(context, propName);
+                if (context.ErrorBuilder == null && isValid == false)
                     return false;
             }
         }
@@ -40,7 +40,7 @@ public class PropertyNamesSchemaRuleValidator : SchemaRuleValidator<BlittableJso
 // ReSharper disable once UnusedType.Global
 public class PropertyNamesSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<PropertyNamesSchemaRuleValidator>
 {
-    public override PropertyNamesSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override PropertyNamesSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if(SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var propertyNames) == false)
@@ -50,7 +50,7 @@ public class PropertyNamesSchemaRuleValidatorFactory : SchemaRuleValidatorFactor
         for (int i = 0; i < propertyNames.Count; i++)
         {
             var propName = propertyNames.GetPropertyNameByIndex(i);
-            if(SchemaRuleValidatorFactoryHelper.TryCreateValidator(propName, propertyNames, schemaPath, refSchemas, out var ruleValidator) == false)
+            if(SchemaRuleValidatorFactoryHelper.TryCreateValidator(context, propName, propertyNames, schemaPath, out var ruleValidator) == false)
                 continue;
             var ruleSchemaPath = schemaPath + propName;
             if (ruleValidator is not StringSchemaRuleValidator stringValidator)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/RequiredSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/RequiredSchemaRuleValidator.cs
@@ -17,14 +17,14 @@ public class RequiredSchemaRuleValidator : SchemaRuleValidator<BlittableJsonRead
         _requiredProperties = [required];
     }
     
-    public override bool Validate(BlittableJsonReaderObject value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
         var isValid = true;
         foreach (var required in _requiredProperties)
         {
             if(value.Contains(required))
                 continue;
-            errorBuilder?.AddError($"The required property '{required}' is missing at '{errorBuilder.Path}'.");
+            context.ErrorBuilder?.AddError($"The required property '{required}' is missing at '{context.ErrorBuilder.Path}'.");
             isValid = false;
         }
         return isValid;
@@ -35,7 +35,7 @@ public class RequiredSchemaRuleValidator : SchemaRuleValidator<BlittableJsonRead
 // ReSharper disable once UnusedType.Global
 public class RequiredSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<RequiredSchemaRuleValidator>
 {
-    public override RequiredSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override RequiredSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         if (SchemaValidationHelper.TryGetArray(schemaDefinition, Rule, schemaPath + Rule, out var blittableRequired) == false)
             return null;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/RequiredSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/RequiredSchemaRuleValidator.cs
@@ -11,18 +11,18 @@ public class RequiredSchemaRuleValidator : SchemaRuleValidator<BlittableJsonRead
     {
         _requiredProperties = required;
     }
-    
+
     public RequiredSchemaRuleValidator(LazyStringValue required)
     {
         _requiredProperties = [required];
     }
-    
+
     public override bool Validate(SchemaValidationContext context, BlittableJsonReaderObject value)
     {
         var isValid = true;
         foreach (var required in _requiredProperties)
         {
-            if(value.Contains(required))
+            if (value.Contains(required))
                 continue;
             context.ErrorBuilder?.AddError($"The required property '{required}' is missing at '{context.ErrorBuilder.Path}'.");
             isValid = false;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/String/MaximumLengthSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/String/MaximumLengthSchemaRuleValidator.cs
@@ -13,12 +13,12 @@ public class MaximumLengthSchemaRuleValidator : StringSchemaRuleValidator
         _maxLength = maxLength;
     }
 
-    public override bool Validate(LazyStringValue value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, LazyStringValue value)
     {
         if (value.Length <= _maxLength) 
             return true;
         
-        errorBuilder?.AddError($"The length of the {Target} '{value}' at '{errorBuilder.Path}' should not exceed {_maxLength}, but its actual length is {value.Length}.");
+        context.ErrorBuilder?.AddError($"The length of the {Target} '{value}' at '{context.ErrorBuilder.Path}' should not exceed {_maxLength}, but its actual length is {value.Length}.");
         return false;
     }
 }
@@ -27,7 +27,7 @@ public class MaximumLengthSchemaRuleValidator : StringSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class MaximumLengthSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MaximumLengthSchemaRuleValidator>
 {
-    public override MaximumLengthSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MaximumLengthSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetInteger(schemaDefinition, Rule, schemaPath + Rule, out var maximumLength) 
             ? new MaximumLengthSchemaRuleValidator(maximumLength)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/String/MinimumLengthSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/String/MinimumLengthSchemaRuleValidator.cs
@@ -13,12 +13,12 @@ public class MinimumLengthSchemaRuleValidator : StringSchemaRuleValidator
         _minLength = minLength;
     }
 
-    public override bool Validate(LazyStringValue value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, LazyStringValue value)
     {
         if (value.Length >= _minLength) 
             return true;
         
-        errorBuilder?.AddError($"The length of the {Target} '{value}' at '{errorBuilder.Path}' should be at least {_minLength}, but its actual length is {value.Length}.");
+        context.ErrorBuilder?.AddError($"The length of the {Target} '{value}' at '{context.ErrorBuilder.Path}' should be at least {_minLength}, but its actual length is {value.Length}.");
         return false;
     }
 }
@@ -27,7 +27,7 @@ public class MinimumLengthSchemaRuleValidator : StringSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class MinimumLengthSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<MinimumLengthSchemaRuleValidator>
 {
-    public override MinimumLengthSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override MinimumLengthSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetInteger(schemaDefinition, Rule, schemaPath + Rule, out var minimumLength) 
             ? new MinimumLengthSchemaRuleValidator(minimumLength)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/String/PatternSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/String/PatternSchemaRuleValidator.cs
@@ -8,24 +8,39 @@ namespace Raven.Server.Documents.SchemaValidation.Validators.String;
 
 public class PatternSchemaRuleValidator : StringSchemaRuleValidator
 {
-    private readonly Regex _pattern;
+    public const int MaxTimeoutInMilliseconds = 2147483646;
+
+    private readonly Regex _regex;
 
     // ReSharper disable once ConvertToPrimaryConstructor
-    public PatternSchemaRuleValidator(string pattern) 
+    public PatternSchemaRuleValidator(string pattern, TimeSpan timeout)
     {
-        _pattern = new Regex(pattern, RegexOptions.Compiled);
+        try
+        {
+            _regex = new Regex(pattern, RegexOptions.Compiled, timeout);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
     }
 
-    public override bool Validate(LazyStringValue value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, LazyStringValue value)
     {
         var buffer = ArrayPool<char>.Shared.Rent(value.Length);
         try
         {
             value.TryCopyTo(buffer);
-            if (_pattern.IsMatch(buffer.AsSpan(0, value.Length))) 
+            if (_regex.IsMatch(buffer.AsSpan(0, value.Length)))
                 return true;
         
-            errorBuilder?.AddError($"The pattern of the {Target} '{value}' at '{errorBuilder.Path}' does not match the required pattern '{_pattern}'.");
+            context.ErrorBuilder?.AddError($"The pattern of the {Target} '{value}' at '{context.ErrorBuilder.Path}' does not match the required pattern '{_regex}'.");
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            context.ErrorBuilder?.AddError($"The pattern matching of the {Target} '{value}' at '{context.ErrorBuilder.Path}' timed out for pattern '{_regex}'.");
             return false;
         }
         finally
@@ -39,10 +54,10 @@ public class PatternSchemaRuleValidator : StringSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class PatternSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<PatternSchemaRuleValidator>
 {
-    public override PatternSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override PatternSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetString(schemaDefinition, Rule, schemaPath + Rule, out var pattern) 
-            ? new PatternSchemaRuleValidator(pattern)
+            ? new PatternSchemaRuleValidator(pattern, context.Configuration.RegexTimeout)
             : null;
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/String/PatternSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/String/PatternSchemaRuleValidator.cs
@@ -15,15 +15,7 @@ public class PatternSchemaRuleValidator : StringSchemaRuleValidator
     // ReSharper disable once ConvertToPrimaryConstructor
     public PatternSchemaRuleValidator(string pattern, TimeSpan timeout)
     {
-        try
-        {
-            _regex = new Regex(pattern, RegexOptions.Compiled, timeout);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-            throw;
-        }
+        _regex = new Regex(pattern, RegexOptions.Compiled, timeout);
     }
 
     public override bool Validate(SchemaValidationContext context, LazyStringValue value)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/AllOfSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/AllOfSchemaRuleValidator.cs
@@ -12,13 +12,13 @@ public class AllOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
     {
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
         var validate = true;
         foreach (var validator in Validators)
         {
-            validate &= validator.Validate(value, errorBuilder);
-            if(errorBuilder == null && validate == false)
+            validate &= validator.Validate(context, value);
+            if(context.ErrorBuilder == null && validate == false)
                return false;
         }
         return validate;
@@ -29,9 +29,9 @@ public class AllOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
 // ReSharper disable once UnusedType.Global
 public class AllOfSchemaRuleValidatorFactory : MultiSubschemaAggregatorValidatorFactory<AllOfSchemaRuleValidator>
 {
-    public override AllOfSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override AllOfSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        var validators = Read(schemaDefinition, schemaPath, refSchemas);
+        var validators = Read(context, schemaDefinition, schemaPath);
         return new AllOfSchemaRuleValidator(validators);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/AllOfSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/AllOfSchemaRuleValidator.cs
@@ -8,7 +8,7 @@ public class AllOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
 {
     // ReSharper disable once ConvertToPrimaryConstructor
     public AllOfSchemaRuleValidator([NotNull] ElementSchemaRuleValidator[] validators)
-        :base(validators)
+        : base(validators)
     {
     }
 
@@ -18,8 +18,8 @@ public class AllOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
         foreach (var validator in Validators)
         {
             validate &= validator.Validate(context, value);
-            if(context.ErrorBuilder == null && validate == false)
-               return false;
+            if (context.ErrorBuilder == null && validate == false)
+                return false;
         }
         return validate;
     }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/AnyOfSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/AnyOfSchemaRuleValidator.cs
@@ -12,14 +12,18 @@ public class AnyOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
     {
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
         foreach (var validator in Validators)
         {
-            if (validator.Validate(value, null))
-                return true;
+            using (context.WithoutCollectingErrors())
+            {
+                if (validator.Validate(context, value))
+                    return true;
+            }
         }
-        errorBuilder?.AddError($"The value at '{errorBuilder.Path}' does not match any of the schema restrictions.");
+            
+        context.ErrorBuilder?.AddError($"The value at '{context.ErrorBuilder.Path}' does not match any of the schema restrictions.");
         return false;
     }
 }
@@ -28,9 +32,9 @@ public class AnyOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
 // ReSharper disable once UnusedType.Global
 public class AnyOfSchemaRuleValidatorFactory : MultiSubschemaAggregatorValidatorFactory<AnyOfSchemaRuleValidator>
 {
-    public override AnyOfSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override AnyOfSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        var validators = Read(schemaDefinition, schemaPath, refSchemas);
+        var validators = Read(context, schemaDefinition, schemaPath);
         return new AnyOfSchemaRuleValidator(validators);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ConstantSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ConstantSchemaRuleValidator.cs
@@ -15,14 +15,14 @@ public class ConstantSchemaRuleValidator : FixedValueSchemaRuleValidator
         _constantValueForError = IsString(_constantValue) ? $"\"{_constantValue}\"" : _constantValue;
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
         //The order here is extremely important since when comparing between blittable objects the function uses the first object context and _constantValue is used concurrently 
         if (Equals(ConvertTypeForComparison(value), _constantValue)) 
             return true;
 
         var quoteIfString = IsString(value) ? "\"" : "";
-        errorBuilder?.AddError($"The value at '{errorBuilder.Path}' must be '{_constantValueForError}', but it is '{quoteIfString}{value}{quoteIfString}'.");
+        context.ErrorBuilder?.AddError($"The value at '{context.ErrorBuilder.Path}' must be '{_constantValueForError}', but it is '{quoteIfString}{value}{quoteIfString}'.");
         return false;
     }
 
@@ -37,7 +37,7 @@ public class ConstantSchemaRuleValidator : FixedValueSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class ConstantSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ConstantSchemaRuleValidator>
 {
-    public override ConstantSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override ConstantSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return schemaDefinition.TryGet(Rule, out object multipleOf)
             ? new ConstantSchemaRuleValidator(multipleOf) 

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/EnumSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/EnumSchemaRuleValidator.cs
@@ -15,14 +15,14 @@ public class EnumSchemaRuleValidator : FixedValueSchemaRuleValidator
         _enums = enums.Select(ConvertTypeForComparison).ToArray();
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
         //The order here is extremely important since when comparing between blittable objects the function uses the first object context and _constantValue is used concurrently 
         if (_enums.Any(x => Equals(value, x))) 
             return true;
         
         var quoteIfString = IsString(value) ? "\"" : "";
-        errorBuilder?.AddError($"The value '{quoteIfString}{value}{quoteIfString}' at '{errorBuilder.Path}' is not an allowed value. Expected one of: '{_enums:', '}'.");
+        context.ErrorBuilder?.AddError($"The value '{quoteIfString}{value}{quoteIfString}' at '{context.ErrorBuilder.Path}' is not an allowed value. Expected one of: '{_enums:', '}'.");
         return false;
     }
     
@@ -37,7 +37,7 @@ public class EnumSchemaRuleValidator : FixedValueSchemaRuleValidator
 // ReSharper disable once UnusedType.Global
 public class EnumSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<EnumSchemaRuleValidator>
 {
-    public override EnumSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override EnumSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return SchemaValidationHelper.TryGetArray(schemaDefinition, Rule, schemaPath + Rule, out var enums) 
             ? new EnumSchemaRuleValidator(enums)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/GroupedIfThenElseSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/GroupedIfThenElseSchemaRuleValidator.cs
@@ -12,13 +12,13 @@ public class GroupedIfThenElseSchemaRuleValidator : SchemaRuleValidator<object>
         _ifThenElseSchemaRuleValidators = ifThenElseSchemaRuleValidators;
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
         var isValid = true;
         foreach (var dependentRequire in _ifThenElseSchemaRuleValidators)
         {
-            isValid = dependentRequire.Validate(value, errorBuilder);
-            if (isValid == false && errorBuilder == null)
+            isValid = dependentRequire.Validate(context, value);
+            if (isValid == false && context.ErrorBuilder == null)
                 return false;
         }
 

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/IfThenElseSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/IfThenElseSchemaRuleValidator.cs
@@ -18,11 +18,15 @@ public class IfThenElseSchemaRuleValidator : SchemaRuleValidator<object>
         _elseValidator = elseValidator;
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
-        return _ifValidator.Validate(value, null) 
-            ? _thenValidator.Validate(value, errorBuilder) 
-            : _elseValidator == null || _elseValidator.Validate(value, errorBuilder);
+        bool validate;
+        using (context.WithoutCollectingErrors())
+            validate = _ifValidator.Validate(context, value);
+         
+        return validate 
+            ? _thenValidator.Validate(context, value) 
+            : _elseValidator == null || _elseValidator.Validate(context, value);
     }
 }
 
@@ -30,22 +34,22 @@ public class IfThenElseSchemaRuleValidator : SchemaRuleValidator<object>
 // ReSharper disable once UnusedType.Global
 public class IfThenElseSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<IfThenElseSchemaRuleValidator>
 {
-    public override IfThenElseSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override IfThenElseSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         var ifPath = schemaPath + Rule;
         if (SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, ifPath, out var ifSchema) == false)
             return null;
         
-        var ifSchemaValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(ifSchema, ifPath, refSchemas);
+        var ifSchemaValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, ifSchema, ifPath);
 
         var thenPath = schemaPath + SchemaValidatorConstants.Then;
         var thenValidator = SchemaValidationHelper.TryGetObject(schemaDefinition, SchemaValidatorConstants.Then, thenPath, out var thenSchema)
-            ? ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(thenSchema, thenPath, refSchemas)
+            ? ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, thenSchema, thenPath)
             : null;
 
         var elsePath = schemaPath + SchemaValidatorConstants.Else;
         var elseValidator = SchemaValidationHelper.TryGetObject(schemaDefinition, SchemaValidatorConstants.Else, elsePath, out var elseSchema)
-            ? ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(elseSchema, elsePath, refSchemas)
+            ? ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, elseSchema, elsePath)
             : null;
 
         if (thenValidator == null && elseValidator == null)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/MultiSubschemaAggregatorValidatorFactory.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/MultiSubschemaAggregatorValidatorFactory.cs
@@ -19,7 +19,7 @@ public abstract class MultiSubschemaAggregatorValidator : SchemaRuleValidator<ob
 
 public abstract class MultiSubschemaAggregatorValidatorFactory<T> : SchemaRuleValidatorFactory<T> where T : MultiSubschemaAggregatorValidator
 {
-    public ElementSchemaRuleValidator[] Read(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public ElementSchemaRuleValidator[] Read(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetArray(schemaDefinition, Rule, schemaPath, out var validatorsSchema) == false)
@@ -30,7 +30,7 @@ public abstract class MultiSubschemaAggregatorValidatorFactory<T> : SchemaRuleVa
         {
             var itemPath = schemaPath + i;
             var itemSchema = SchemaValidationHelper.CheckTypeAndThrow<BlittableJsonReaderObject>(validatorsSchema[i], itemPath);
-            (validators ??= []).Add(ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(itemSchema, itemPath, refSchemas));
+            (validators ??= []).Add(ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, itemSchema, itemPath));
         }
         if(validators == null)
             return null;

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/MultiSubschemaAggregatorValidatorFactory.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/MultiSubschemaAggregatorValidatorFactory.cs
@@ -32,7 +32,7 @@ public abstract class MultiSubschemaAggregatorValidatorFactory<T> : SchemaRuleVa
             var itemSchema = SchemaValidationHelper.CheckTypeAndThrow<BlittableJsonReaderObject>(validatorsSchema[i], itemPath);
             (validators ??= []).Add(ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, itemSchema, itemPath));
         }
-        if(validators == null)
+        if (validators == null)
             return null;
 
         return validators.ToArray();

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/NotSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/NotSchemaRuleValidator.cs
@@ -14,12 +14,15 @@ public class NotSchemaRuleValidator : SchemaRuleValidator<object>
         _not = not;
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
-        if (_not.Validate(value, null) == false)
-            return true;
+        using (context.WithoutCollectingErrors())
+        {
+            if (_not.Validate(context, value) == false)
+                return true;
+        }
         
-        errorBuilder?.AddError($"The value at '{errorBuilder.Path}' is invalid because it matches a `not` schema.");
+        context.ErrorBuilder?.AddError($"The value at '{context.ErrorBuilder.Path}' is invalid because it matches a `not` schema.");
         return false;
     }
 }
@@ -28,13 +31,13 @@ public class NotSchemaRuleValidator : SchemaRuleValidator<object>
 // ReSharper disable once UnusedType.Global
 public class NotSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<NotSchemaRuleValidator>
 {
-    public override NotSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override NotSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetObject(schemaDefinition, Rule, schemaPath, out var not) == false)
             return null;
         
-        var notSchemaValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(not, schemaPath, refSchemas);
+        var notSchemaValidator = ElementSchemaRuleValidatorFactory.CreateElementSchemaRuleValidator(context, not, schemaPath);
 
         return new NotSchemaRuleValidator(notSchemaValidator);
     }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/OneOfSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/OneOfSchemaRuleValidator.cs
@@ -12,17 +12,20 @@ public class OneOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
     {
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder)
+    public override bool Validate(SchemaValidationContext context, object value)
     {
         var alreadyHasOneValid = false;
         foreach (var validator in Validators)
         {
-            if(validator.Validate(value, null) == false)
-                continue;
+            using (context.WithoutCollectingErrors())
+            {
+                if(validator.Validate(context, value) == false)
+                    continue;
+            }
             
             if(alreadyHasOneValid)
             {                
-                errorBuilder?.AddError($"The value at '{errorBuilder.Path}' matches more than one schema, but it must match exactly one.");
+                context.ErrorBuilder?.AddError($"The value at '{context.ErrorBuilder.Path}' matches more than one schema, but it must match exactly one.");
                 return false;
             }
 
@@ -31,7 +34,7 @@ public class OneOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
 
         if (alreadyHasOneValid == false)
         {
-            errorBuilder?.AddError($"The value at '{errorBuilder.Path}' does not match any of the schema restrictions, and it must match exactly one.");
+            context.ErrorBuilder?.AddError($"The value at '{context.ErrorBuilder.Path}' does not match any of the schema restrictions, and it must match exactly one.");
             return false;
         }
 
@@ -43,9 +46,9 @@ public class OneOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
 // ReSharper disable once UnusedType.Global
 public class OneOfSchemaRuleValidatorFactory : MultiSubschemaAggregatorValidatorFactory<OneOfSchemaRuleValidator>
 {
-    public override OneOfSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override OneOfSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
-        var validators = Read(schemaDefinition, schemaPath, refSchemas);
+        var validators = Read(context, schemaDefinition, schemaPath);
         return new OneOfSchemaRuleValidator(validators);
     }
 }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/OneOfSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/OneOfSchemaRuleValidator.cs
@@ -19,12 +19,12 @@ public class OneOfSchemaRuleValidator : MultiSubschemaAggregatorValidator
         {
             using (context.WithoutCollectingErrors())
             {
-                if(validator.Validate(context, value) == false)
+                if (validator.Validate(context, value) == false)
                     continue;
             }
-            
-            if(alreadyHasOneValid)
-            {                
+
+            if (alreadyHasOneValid)
+            {
                 context.ErrorBuilder?.AddError($"The value at '{context.ErrorBuilder.Path}' matches more than one schema, but it must match exactly one.");
                 return false;
             }

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ReferenceSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ReferenceSchemaRuleValidator.cs
@@ -14,20 +14,20 @@ public class ReferenceSchemaRuleValidator : SchemaRuleValidator<object>
         _reference = reference;
     }
 
-    public override bool Validate(object value, ErrorBuilder errorBuilder) => _reference.Validate(value, errorBuilder);
+    public override bool Validate(SchemaValidationContext context, object value) => _reference.Validate(context, value);
 }
 
 [SchemaRule(SchemaValidatorConstants.Ref)]
 // ReSharper disable once UnusedType.Global
 public class ReferenceSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<ReferenceSchemaRuleValidator>
 {
-    public override ReferenceSchemaRuleValidator Create(BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath, RefSchemas refSchemas)
+    public override ReferenceSchemaRuleValidator Create(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetString(schemaDefinition, Rule, schemaPath, out var reference) == false)
             return null;
         
-        if(refSchemas.TryGet(reference, out var validator) == false)
+        if(context.RefSchemas.TryGet(reference, out var validator) == false)
             throw new InvalidSchemaValidationDefinitionException(
                 $"The reference '{reference}' at '{schemaPath.FullPath}' does not match any defined subschema.");
                 

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ReferenceSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ReferenceSchemaRuleValidator.cs
@@ -26,11 +26,11 @@ public class ReferenceSchemaRuleValidatorFactory : SchemaRuleValidatorFactory<Re
         schemaPath += Rule;
         if (SchemaValidationHelper.TryGetString(schemaDefinition, Rule, schemaPath, out var reference) == false)
             return null;
-        
-        if(context.RefSchemas.TryGet(reference, out var validator) == false)
+
+        if (context.RefSchemas.TryGet(reference, out var validator) == false)
             throw new InvalidSchemaValidationDefinitionException(
                 $"The reference '{reference}' at '{schemaPath.FullPath}' does not match any defined subschema.");
-                
+
         return new ReferenceSchemaRuleValidator(validator);
     }
 }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -116,7 +116,7 @@ namespace Raven.Server.Documents.Sharding
                 }
                 else
                 {
-                    var cache = new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                    var cache = new SchemaValidatorCache(NotificationCenter, Configuration.SchemaValidation, Loggers.GetLogger<SchemaValidatorCache>());
                     cache.Update(configuration);
                     SchemaValidatorCache = cache;
                 }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -45,6 +45,7 @@ using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Commercial;
 using Raven.Server.Config;
+using Raven.Server.Config.Categories;
 using Raven.Server.Config.Settings;
 using Raven.Server.Dashboard;
 using Raven.Server.Documents;
@@ -105,6 +106,7 @@ using DeleteSubscriptionCommand = Raven.Server.ServerWide.Commands.Subscriptions
 using MemoryCache = Raven.Server.Utils.Imports.Memory.MemoryCache;
 using MemoryCacheOptions = Raven.Server.Utils.Imports.Memory.MemoryCacheOptions;
 using NodeInfo = Raven.Client.ServerWide.Commands.NodeInfo;
+using SchemaValidationConfiguration = Raven.Client.Documents.Operations.SchemaValidation.SchemaValidationConfiguration;
 using Size = Sparrow.Size;
 
 namespace Raven.Server.ServerWide
@@ -2091,17 +2093,15 @@ namespace Raven.Server.ServerWide
             return SendToLeaderAsync(editSchemaValidation);
         }
 
-        private static void ValidateSchemaConfiguration(JsonOperationContext context, SchemaValidationConfiguration configurationJson)
+        private void ValidateSchemaConfiguration(JsonOperationContext context, SchemaValidationConfiguration definitions)
         {
-            if (configurationJson.ValidatorsPerCollection == null)
+            if (definitions.ValidatorsPerCollection == null)
                 throw new InvalidOperationException($"'{nameof(SchemaValidationConfiguration.ValidatorsPerCollection)}' cannot be null");
 
-            foreach (var item in configurationJson.ValidatorsPerCollection)
+            foreach (var item in definitions.ValidatorsPerCollection)
             {
                 using var schema = context.Sync.ReadForMemory(item.Value.Schema, "schema-validation");
-                //To make sure the schema is valid, we run Init on an instance of SchemaValidator, but it is not used
-                var validator = new SchemaValidator();
-                validator.Init(schema);
+                SchemaValidator.ValidateInit(schema);
                 SchemaValidationHelper.ValidateSchemaDefinitionForDocument(schema);
             }
         }

--- a/test/FastTests/SchemaValidation/AdditionalPropertiesRulesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/AdditionalPropertiesRulesSchemaValidationTests.cs
@@ -33,7 +33,7 @@ public class AdditionalPropertiesRulesSchemaValidationTests : SchemaValidationTe
         }
 
         using var _ = ReadObjectOnNewCtx(jsonSchemaValidator, out var schemaDefinition);
-        schemaValidator.Init(schemaDefinition);
+        schemaValidator.Init(schemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -75,7 +75,7 @@ public class AdditionalPropertiesRulesSchemaValidationTests : SchemaValidationTe
         }
 
         using var _ = ReadObjectOnNewCtx(jsonSchemaValidator, out var schemaDefinition);
-        schemaValidator.Init(schemaDefinition);
+        schemaValidator.Init(schemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/AdditionalPropertiesRulesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/AdditionalPropertiesRulesSchemaValidationTests.cs
@@ -79,9 +79,9 @@ public class AdditionalPropertiesRulesSchemaValidationTests : SchemaValidationTe
 
         await AssertMultipleParallel(() =>
             {
-                if(withDefinedProp == false)
+                if (withDefinedProp == false)
                     return;
-                
+
                 using var ctx = ReadObjectOnNewCtx(new DynamicJsonValue { ["definedProp"] = 1 }, out var obj);
 
                 Assert.True(schemaValidator.Validate(obj, out var errors), errors);

--- a/test/FastTests/SchemaValidation/AdvancedSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/AdvancedSchemaValidationTests.cs
@@ -39,7 +39,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -92,7 +92,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -135,7 +135,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -171,7 +171,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -205,7 +205,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -243,7 +243,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -281,7 +281,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -323,7 +323,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -363,7 +363,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(
             () =>
@@ -415,7 +415,7 @@ public class ComplexSchemaValidationTests : SchemaValidationTestsBase
 
         var schemaValidator = new SchemaValidator();
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         await AssertMultipleParallel(
             () =>

--- a/test/FastTests/SchemaValidation/ArraySchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/ArraySchemaValidationTests.cs
@@ -21,7 +21,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue { [SchemaValidatorConstants.Properties] = new DynamicJsonValue { ["prop1"] = new DynamicJsonValue { [SchemaValidatorConstants.UniqueItems] = true } } };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -64,7 +64,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -127,7 +127,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -155,7 +155,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
             [SchemaValidatorConstants.Properties] = new DynamicJsonValue { [prop] = new DynamicJsonValue { [SchemaValidatorConstants.Items] = new DynamicJsonValue { [SchemaValidatorConstants.Type] = "string" } } }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -183,7 +183,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
             [SchemaValidatorConstants.Properties] = new DynamicJsonValue { [prop] = new DynamicJsonValue { [SchemaValidatorConstants.Contains] = new DynamicJsonValue { [SchemaValidatorConstants.Type] = "string" } } }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -216,7 +216,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -259,7 +259,7 @@ public class ArraySchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/ConditionalSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/ConditionalSchemaValidationTests.cs
@@ -41,7 +41,7 @@ public class ConditionalSchemaValidationTests : SchemaValidationTestsBase
         };
 
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -130,7 +130,7 @@ public class ConditionalSchemaValidationTests : SchemaValidationTestsBase
         };
 
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -159,7 +159,7 @@ public class ConditionalSchemaValidationTests : SchemaValidationTestsBase
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue { [SVC.DependentRequired] = new DynamicJsonValue { ["prop1"] = new[] { "prop2", "prop3" } } };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -211,7 +211,7 @@ public class ConditionalSchemaValidationTests : SchemaValidationTestsBase
         };
         
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -250,7 +250,7 @@ public class ConditionalSchemaValidationTests : SchemaValidationTestsBase
         };
         
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -292,7 +292,7 @@ public class ConditionalSchemaValidationTests : SchemaValidationTestsBase
         };
         
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/ConstantSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/ConstantSchemaValidationTests.cs
@@ -30,7 +30,7 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -62,7 +62,7 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -100,7 +100,7 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -132,7 +132,7 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/GeneralSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/GeneralSchemaValidationTests.cs
@@ -31,7 +31,7 @@ public class GeneralSchemaValidationTests : SchemaValidationTestsBase
         }
 
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -62,7 +62,7 @@ public class GeneralSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -85,7 +85,7 @@ public class GeneralSchemaValidationTests : SchemaValidationTestsBase
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue { [SVC.MinProperties] = 2 };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -114,7 +114,7 @@ public class GeneralSchemaValidationTests : SchemaValidationTestsBase
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue { [SVC.MaxProperties] = 3 };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/InvalidSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/InvalidSchemaValidationTests.cs
@@ -89,7 +89,7 @@ public class InvalidSchemaValidationTests : SchemaValidationTestsBase
 
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
         {
-            var exception = Assert.Throws<InvalidSchemaValidationDefinitionException>(() => schemaValidator.Init(blitSchemaDefinition));
+            var exception = Assert.Throws<InvalidSchemaValidationDefinitionException>(() => schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings));
             AssertError(error, exception.Message);
         }
     }

--- a/test/FastTests/SchemaValidation/NumberRulesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/NumberRulesSchemaValidationTests.cs
@@ -39,7 +39,7 @@ public class NumberRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         await AssertMultipleParallel(() =>
         {
@@ -127,7 +127,7 @@ public class NumberRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
         {
@@ -195,7 +195,7 @@ public class NumberRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
         {
@@ -282,7 +282,7 @@ public class NumberRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         
         await AssertMultipleParallel(() =>
@@ -368,7 +368,7 @@ public class NumberRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         
         await AssertMultipleParallel(() =>

--- a/test/FastTests/SchemaValidation/PatternPropertiesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/PatternPropertiesSchemaValidationTests.cs
@@ -29,7 +29,7 @@ public class PatternPropertiesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         using var ctx = ReadObjectOnNewCtx(new DynamicJsonValue
         {
@@ -55,7 +55,7 @@ public class PatternPropertiesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         using var ctx = ReadObjectOnNewCtx(new DynamicJsonValue
         {
@@ -82,7 +82,7 @@ public class PatternPropertiesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         using var ctx = ReadObjectOnNewCtx(new DynamicJsonValue
         {

--- a/test/FastTests/SchemaValidation/PropertyNamesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/PropertyNamesSchemaValidationTests.cs
@@ -27,7 +27,7 @@ public class PropertyNamesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -62,7 +62,7 @@ public class PropertyNamesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -106,7 +106,7 @@ public class PropertyNamesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/RefDefSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/RefDefSchemaValidationTests.cs
@@ -41,7 +41,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -101,7 +101,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -152,7 +152,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -203,7 +203,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -250,7 +250,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -298,7 +298,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -353,7 +353,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
         {
-            var exception = Assert.ThrowsAny<InvalidSchemaValidationDefinitionException>(() => schemaValidator.Init(blitSchemaDefinition));
+            var exception = Assert.ThrowsAny<InvalidSchemaValidationDefinitionException>(() => schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings));
             AssertError("A circular reference was detected at '#/$defs/firstSchema/properties/prop1/$ref/properties/prop1/$ref/properties/prop1/$ref'.", exception.Message);
         }
     }
@@ -394,7 +394,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -453,7 +453,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -529,7 +529,7 @@ public class RefDefSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {

--- a/test/FastTests/SchemaValidation/SchemaValidationTestsBase.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationTestsBase.cs
@@ -20,7 +20,7 @@ public abstract class SchemaValidationTestsBase : ParallelTestBase
     {
     }
 
-    protected static SchemaValidatorSettings SchemaValidatorSettings { get;  } = new SchemaValidatorSettings{ValidationTimeout = TimeSpan.FromSeconds(1), RegexTimeout = TimeSpan.FromSeconds(1), MaxDepth = 10};
+    protected static SchemaValidatorSettings SchemaValidatorSettings { get;  } = new SchemaValidatorSettings{RegexTimeout = TimeSpan.FromSeconds(1), MaxDepth = 64};
     
     protected static void AssertError(string expected, string actual)
     {

--- a/test/FastTests/SchemaValidation/SchemaValidationTestsBase.cs
+++ b/test/FastTests/SchemaValidation/SchemaValidationTestsBase.cs
@@ -20,7 +20,8 @@ public abstract class SchemaValidationTestsBase : ParallelTestBase
     {
     }
 
-
+    protected static SchemaValidatorSettings SchemaValidatorSettings { get;  } = new SchemaValidatorSettings{ValidationTimeout = TimeSpan.FromSeconds(1), RegexTimeout = TimeSpan.FromSeconds(1), MaxDepth = 10};
+    
     protected static void AssertError(string expected, string actual)
     {
         Assert.True(actual.StartsWith(expected), $"expected: '{expected}', \nactual: '{actual}'.");
@@ -59,7 +60,7 @@ public static class SchemaValidationTestsHelper
                 return true;
             }
 
-            errors = new string(errorBuilder.ToString());
+            errors = errorBuilder.ToString();
             return false;
         }
     }

--- a/test/FastTests/SchemaValidation/StringRulesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/StringRulesSchemaValidationTests.cs
@@ -32,7 +32,7 @@ public class StringRulesSchemaValidationTests : SchemaValidationTestsBase
         };
 
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         await AssertMultipleParallel(() =>
         {
@@ -71,7 +71,7 @@ public class StringRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
         {
@@ -109,7 +109,7 @@ public class StringRulesSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         await AssertMultipleParallel(() =>
         {

--- a/test/FastTests/SchemaValidation/TypeSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/TypeSchemaValidationTests.cs
@@ -27,7 +27,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             [SVC.Type] = "object",
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         using var obj = context.ReadObject(new DynamicJsonValue(), "test object");
         Assert.True(schemaValidator.Validate(obj, out var errors), errors);
     }
@@ -50,7 +50,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         using var obj = context.ReadObject(new DynamicJsonValue
         {
@@ -78,7 +78,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         
         using var testObj = context.ReadObject(new DynamicJsonValue
         {
@@ -107,7 +107,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         using var testObj = context.ReadObject(new DynamicJsonValue
         {
             ["prop"] = "some string"
@@ -134,7 +134,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         using var obj = context.ReadObject(new DynamicJsonValue
         {
             ["prop"] = new DynamicJsonValue()
@@ -162,7 +162,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         using var obj = context.ReadObject(new DynamicJsonValue
         {
             ["prop"] = 1
@@ -189,7 +189,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         var obj = context.ReadObject(new DynamicJsonValue
         {
             ["prop"] = new DynamicJsonValue()
@@ -217,7 +217,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var blitSchemaDefinition = context.ReadObject(schemaDefinition, "schema Definition");
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
         using var testObj = context.ReadObject(new DynamicJsonValue
         {
             ["prop"] = 3.14
@@ -242,7 +242,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -280,7 +280,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -312,7 +312,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -348,7 +348,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -384,7 +384,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -407,7 +407,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
             }
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
-        schemaValidator.Init(blitSchemaDefinition);
+        schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings);
 
         await AssertMultipleParallel(() =>
             {
@@ -467,7 +467,7 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
         };
         using var _ = ReadObjectOnNewCtx(schemaDefinition, out var blitSchemaDefinition);
         {
-            var e = Assert.Throws<InvalidSchemaValidationDefinitionException>(() => schemaValidator.Init(blitSchemaDefinition));
+            var e = Assert.Throws<InvalidSchemaValidationDefinitionException>(() => schemaValidator.Init(blitSchemaDefinition, SchemaValidatorSettings));
             AssertError(error, e.Message);
         }
     }

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -67,7 +67,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
     public async Task SchemaValidation_WhenDefineCollectionTwice_ShouldThrow()
     {
         using var context = JsonOperationContext.ShortTermSingleUse();
-        Assert.ThrowsAny<ArgumentException>(() => _ = new SchemaValidationConfiguration
+        Assert.ThrowsAny<ArgumentException>(() => _ = new SchemaValidationConfiguration()
         {
             Disabled = false,
             ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
@@ -599,52 +599,6 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         var e = await Assert.ThrowsAnyAsync<RavenException>(async () =>
         {
             using var session = mentee.OpenAsyncSession();
-            var load = await session.LoadAsync<TestObj>(id);
-            load.Prop2 = "something";
-            await session.SaveChangesAsync();
-        });
-        Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
-    }
-    
-    [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenExternalReplicateInvalidData_ShouldNotThrow()
-    {
-        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
-
-        using var context = JsonOperationContext.ShortTermSingleUse();
-        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
-        using var source = GetDocumentStore();
-
-        const string id = "random-id";
-        using (var session = source.OpenAsyncSession())
-        {
-            await session.StoreAsync(new TestObj { Prop = "1234" }, id);
-            await session.SaveChangesAsync();
-        }
-
-        using var destination = GetDocumentStore();
-        var configuration = new SchemaValidationConfiguration
-        {
-            Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
-            {
-                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
-            }
-        };
-        await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
-
-        await SetupReplicationAsync(source, destination);
-
-        await AssertWaitForTrueAsync(async () =>
-        {
-            using var session = destination.OpenAsyncSession();
-            var load = await session.LoadAsync<TestObj>(id);
-            return load != null;
-        });
-        
-        var e = await Assert.ThrowsAnyAsync<RavenException>(async () =>
-        {
-            using var session = destination.OpenAsyncSession();
             var load = await session.LoadAsync<TestObj>(id);
             load.Prop2 = "something";
             await session.SaveChangesAsync();

--- a/test/SlowTests/SchemaValidation/SchemaValidationConfigurationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationConfigurationTests.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Server.Config;
+using Raven.Server.Documents.SchemaValidation;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.SchemaValidation;
+
+public class SchemaValidationConfigurationTests : ReplicationTestBase
+{
+    public SchemaValidationConfigurationTests(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenExceedMaxDepth_ShouldThrow()
+    {
+        var settings = new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.SchemaValidation.MaxDepth)] = "2"
+        };
+        var server = GetNewServer(new ServerCreationOptions{CustomSettings = settings});
+        
+        var schemaDefinitionObj = new DynamicJsonValue
+        {
+            [SchemaValidatorConstants.Properties] = new DynamicJsonValue
+            {
+                ["Nested"] = new DynamicJsonValue
+                {
+                    [SchemaValidatorConstants.Properties] = new DynamicJsonValue
+                    {
+                        ["Nested"] = new DynamicJsonValue
+                        {
+                            [SchemaValidatorConstants.Properties] = new DynamicJsonValue
+                            {
+                                ["Prop"] = new DynamicJsonValue
+                                {
+                                    [SchemaValidatorConstants.Const] = "123"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore(new Options{Server = server});
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Nested = new TestObj { Nested = new TestObj { Prop = "123" }} });
+            var e = await Assert.ThrowsAnyAsync<Exception>(async () => await session.SaveChangesAsync());
+            Assert.Contains("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: Maximum validation path depth of 2 exceeded.", e.Message);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenExceedRegexTimeout_ShouldThrow()
+    {
+        const string propValue = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!";
+        const string pattern = "^([a-z]+)+$";
+        
+        var settings = new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.SchemaValidation.RegexTimeout)] = "1"
+        };
+        var server = GetNewServer(new ServerCreationOptions{CustomSettings = settings});
+        
+        var schemaDefinitionObj = new DynamicJsonValue
+        {
+            [SchemaValidatorConstants.Properties] = new DynamicJsonValue
+            {
+                ["Prop"] = new DynamicJsonValue
+                {
+                    [SchemaValidatorConstants.Pattern] = pattern
+                }
+            }
+        };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore(new Options{Server = server});
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = propValue });
+            var e = await Assert.ThrowsAnyAsync<Exception>(async () => await session.SaveChangesAsync());
+            Assert.Contains("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The pattern matching of the value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!' at 'Prop' timed out for pattern '^([a-z]+)+$'.", e.Message);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.JavaScript)]
+    public async Task SchemaValidation_WhenExceedValidationTimeout_ShouldThrow()
+    {
+        const string propValue = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!";
+        const string pattern = "^([a-z]+)+$";
+        
+        var settings = new Dictionary<string, string>
+        {
+            [RavenConfiguration.GetKey(x => x.SchemaValidation.ValidationTimeout)] = "1",
+            [RavenConfiguration.GetKey(x => x.SchemaValidation.RegexTimeout)] = int.MaxValue.ToString()
+        };
+        var server = GetNewServer(new ServerCreationOptions{CustomSettings = settings});
+        
+        var schemaDefinitionObj = new DynamicJsonValue
+        {
+            [SchemaValidatorConstants.Properties] = new DynamicJsonValue
+            {
+                ["Prop"] = new DynamicJsonValue
+                {
+                    [SchemaValidatorConstants.Pattern] = pattern
+                },
+                ["Prop2"] = new DynamicJsonValue
+                {
+                    [SchemaValidatorConstants.Pattern] = pattern
+                }
+            }
+        };
+
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
+        using var store = GetDocumentStore(new Options{Server = server});
+        var configuration = new SchemaValidationConfiguration
+        {
+            Disabled = false,
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
+            }
+        };
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = propValue, Prop2 = propValue });
+            var e = await Assert.ThrowsAnyAsync<Exception>(async () => await session.SaveChangesAsync());
+            Assert.Contains("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: Schema validation timed out after 10ms.", e.Message);
+        }
+    }
+}
+
+public class TestObj
+{
+    public string Prop { get; set; }
+    public TestObj Nested { get; set; }
+    public string Prop2 { get; set; }
+}

--- a/test/SlowTests/SchemaValidation/SchemaValidationConfigurationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationConfigurationTests.cs
@@ -114,55 +114,6 @@ public class SchemaValidationConfigurationTests : ReplicationTestBase
             Assert.Contains("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The pattern matching of the value 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!' at 'Prop' timed out for pattern '^([a-z]+)+$'.", e.Message);
         }
     }
-
-    [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenExceedValidationTimeout_ShouldThrow()
-    {
-        const string propValue = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!";
-        const string pattern = "^([a-z]+)+$";
-        
-        var settings = new Dictionary<string, string>
-        {
-            [RavenConfiguration.GetKey(x => x.SchemaValidation.ValidationTimeout)] = "1",
-            [RavenConfiguration.GetKey(x => x.SchemaValidation.RegexTimeout)] = int.MaxValue.ToString()
-        };
-        var server = GetNewServer(new ServerCreationOptions{CustomSettings = settings});
-        
-        var schemaDefinitionObj = new DynamicJsonValue
-        {
-            [SchemaValidatorConstants.Properties] = new DynamicJsonValue
-            {
-                ["Prop"] = new DynamicJsonValue
-                {
-                    [SchemaValidatorConstants.Pattern] = pattern
-                },
-                ["Prop2"] = new DynamicJsonValue
-                {
-                    [SchemaValidatorConstants.Pattern] = pattern
-                }
-            }
-        };
-
-        using var context = JsonOperationContext.ShortTermSingleUse();
-        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
-        using var store = GetDocumentStore(new Options{Server = server});
-        var configuration = new SchemaValidationConfiguration
-        {
-            Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
-            {
-                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
-            }
-        };
-        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
-
-        using (var session = store.OpenAsyncSession())
-        {
-            await session.StoreAsync(new TestObj { Prop = propValue, Prop2 = propValue });
-            var e = await Assert.ThrowsAnyAsync<Exception>(async () => await session.SaveChangesAsync());
-            Assert.Contains("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: Schema validation timed out after 10ms.", e.Message);
-        }
-    }
 }
 
 public class TestObj

--- a/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationOperationTests.cs
@@ -19,7 +19,7 @@ public class SchemaValidationOperationTests : RavenTestBase
     {
     }
 
-    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenTheory(RavenTestCategory.JavaScript)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task ValidateSchema_WhenDone_ShouldAbleToFetchResult(Options options)
     {
@@ -57,7 +57,7 @@ public class SchemaValidationOperationTests : RavenTestBase
         Assert.Contains("The length of the value '0123456789a' at 'Prop' should not exceed 10, but its actual length is 11.", error);
     }
     
-    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenTheory(RavenTestCategory.JavaScript)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task ValidateSchema_WhenLimitErrors_ShouldGetOnlyTheRequiredLimit(Options options)
     {
@@ -110,7 +110,7 @@ public class SchemaValidationOperationTests : RavenTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenFact(RavenTestCategory.JavaScript)]
     public async Task ValidateSchemaOperation_WhenSettingEtagOnNonSharded_ShouldStartFromTheEtag()
     {
         const string id1 = "user/1";
@@ -158,7 +158,7 @@ public class SchemaValidationOperationTests : RavenTestBase
         Assert.StartsWith("The length of the value '0123456789ab' at 'Prop' should not exceed 10, but its actual length is 12.", result2.Errors.First().Value);
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenFact(RavenTestCategory.JavaScript)]
     public async Task ValidateSchemaOperation_WhenSettingEtagOnSharded_ShouldFail()
     {
         const int maxLength = 10;

--- a/test/SlowTests/SlowTests.csproj
+++ b/test/SlowTests/SlowTests.csproj
@@ -161,7 +161,6 @@
   <ItemGroup>
     <Folder Include="Core\AdminConsole" />
     <Folder Include="SchemaUpgrade\Issues\VoronCurrentVersion\" />
-    <Folder Include="SchemaValidation\" />
     <Folder Include="Server\Basic" />
     <Folder Include="Server\Documents\AI\Embeddings\QueryEmbeddingsBatchTest\" />
     <Folder Include="Server\Documents\Notifications" />


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22142

### Additional description
This PR addresses:
https://github.com/ravendb/ravendb/pull/21925#pullrequestreview-3574450450
https://issues.hibernatingrhinos.com/issue/RavenDB-22142/Schema-Validation#focus=Comments-67-1071728.0-0

The main additions here are the configuration settings.
I added 3 new settings:
* SchemaValidation.Timeout
* SchemaValidation.MaxDepth
* SchemaValidation.RegexTimeout

To make the configuration available during schema build and validation, I added a build/validate context.
Also, I needed to add another kind of schema configuration, and to make it more readable, I renamed the previous SchemaValidationConfiguration to DatabaseSchemaValidationConfiguration.
These two refactorings (adding context and changing names) make up most of the changes in this PR.
I will add comments in the important places.

"SchemaValidation.Timeout" - Timeout for one document validation.
I considered what the exception should be, and I decided to keep the SchemaValidationException to make it easier for the client to handle.
I wonder if I should add a "warn" timeout so it will notify/log and increase the value of this "fail" timeout.

"SchemaValidation.MaxDepth" - Max nesting during validation.
Regardless of this configuration, we prevent defining recursion in the schema validation.
With this limitation, we can actually validate the depth at build time.
But since the configuration can change between server restarts, I do not think it is good to rely on the configuration when validating the schema.

"SchemaValidation.RegexTimeout" - Timeout for the regex validation.
Initially, I wanted the time to be dynamic according to the time left for SchemaValidation.Timeout, but the C# API doesn't support that.

This PR also contains audit logs for schema validation:
GetSchemaValidationConfig
ConfigSchemaValidation
ValidateSchema

Simple logs were added to ValidateSchema:
Start, End, Failed

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
