### PR TITLE
RavenDB-25594 - Expose SchemaDefinitions property of indexes in Studio

### DIFF
--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -814,6 +814,14 @@ class genUtils {
 
         return Number(tokens).toLocaleString();
     }
+
+    static prettifyContent(content: string, spacing: number = 2) {
+        try {
+            return JSON.stringify(JSON.parse(content), null, spacing);
+        } catch (e) {
+            return content;
+        }
+    }
 } 
 
 export = genUtils;

--- a/src/Raven.Studio/typescript/common/generalUtils.ts
+++ b/src/Raven.Studio/typescript/common/generalUtils.ts
@@ -815,10 +815,10 @@ class genUtils {
         return Number(tokens).toLocaleString();
     }
 
-    static prettifyContent(content: string, spacing: number = 2) {
+    static prettifyJson(content: string, spacing: number = 2) {
         try {
             return JSON.stringify(JSON.parse(content), null, spacing);
-        } catch (e) {
+        } catch {
             return content;
         }
     }

--- a/src/Raven.Studio/typescript/models/database/index/documentSchema.ts
+++ b/src/Raven.Studio/typescript/models/database/index/documentSchema.ts
@@ -1,0 +1,16 @@
+/// <reference path="../../../../typings/tsd.d.ts"/>
+
+class documentSchema {
+    collectionName = ko.observable<string>();
+    schema = ko.observable<string>();
+
+    static create(collectionName: string, schema: string) {
+        const item = new documentSchema();
+        item.collectionName(collectionName);
+        item.schema(schema);
+        return item;
+    }
+}
+
+export = documentSchema;
+

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -48,7 +48,7 @@ class indexDefinition {
     additionalSources = ko.observableArray<additionalSource>();
     additionalAssemblies = ko.observableArray<additionalAssembly>();
     
-    schemaDefinitions = ko.observableArray<schemaDefinitionModel>();
+    schemaDefinitions = ko.observableArray<schemaDefinitionModel>([]);
 
     defaultFieldOptions = ko.observable<indexFieldOptions>(null);
     isAutoIndex = ko.observable<boolean>(false);
@@ -138,11 +138,9 @@ class indexDefinition {
         if (dto.SchemaDefinitions) {
             this.schemaDefinitions(
                 Object.entries(dto.SchemaDefinitions).map(([collectionName, schemaText]) =>
-                    new schemaDefinitionModel(collectionName, generalUtils.prettifyContent(schemaText))
+                    new schemaDefinitionModel(collectionName, generalUtils.prettifyJson(schemaText))
                 )
             );
-        } else {
-            this.schemaDefinitions([]);
         }
 
         this.hasDuplicateFieldsNames = ko.pureComputed(() => {

--- a/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
+++ b/src/Raven.Studio/typescript/models/database/index/indexDefinition.ts
@@ -2,6 +2,7 @@
 import indexFieldOptions = require("models/database/index/indexFieldOptions");
 import additionalSource = require("models/database/index/additionalSource");
 import additionalAssembly = require("models/database/index/additionalAssemblyModel");
+import schemaDefinitionModel = require("models/database/index/schemaDefinitionModel");
 import configurationItem = require("models/database/index/configurationItem");
 import validateNameCommand = require("commands/resources/validateNameCommand");
 import generalUtils = require("common/generalUtils");
@@ -47,6 +48,8 @@ class indexDefinition {
     additionalSources = ko.observableArray<additionalSource>();
     additionalAssemblies = ko.observableArray<additionalAssembly>();
     
+    schemaDefinitions = ko.observableArray<schemaDefinitionModel>();
+
     defaultFieldOptions = ko.observable<indexFieldOptions>(null);
     isAutoIndex = ko.observable<boolean>(false);
 
@@ -132,6 +135,16 @@ class indexDefinition {
             this.additionalAssemblies(dto.AdditionalAssemblies.map(assembly => new additionalAssembly(assembly)));
         }
         
+        if (dto.SchemaDefinitions) {
+            this.schemaDefinitions(
+                Object.entries(dto.SchemaDefinitions).map(([collectionName, schemaText]) =>
+                    new schemaDefinitionModel(collectionName, generalUtils.prettifyContent(schemaText))
+                )
+            );
+        } else {
+            this.schemaDefinitions([]);
+        }
+
         this.hasDuplicateFieldsNames = ko.pureComputed(() => {
             const nonEmptyFields = this.fields().filter(x => x.name());
             return new Set(nonEmptyFields.map(x => x.name())).size !== nonEmptyFields.length;
@@ -296,9 +309,23 @@ class indexDefinition {
         return result;
     }
 
+    private schemaDefinitionsToDto(): Record<string, string> {
+        if (!this.schemaDefinitions().length) {
+            return null;
+        }
+        const result = {} as Record<string, string>;
+        this.schemaDefinitions().forEach(schema => {
+            const collectionName = schema.collectionName();
+            if (collectionName) {
+                result[collectionName] = schema.schemaText();
+            }
+        });
+        return result;
+    }
+
     toDto(): Raven.Client.Documents.Indexes.IndexDefinition {
         return {
-            SchemaDefinitions: null,
+            SchemaDefinitions: this.schemaDefinitionsToDto(),
             Name: this.name(),
             Maps: this.maps().map(m => m.map()),
             Reduce: this.reduce(),
@@ -368,6 +395,15 @@ class indexDefinition {
 
     removeConfigurationOption(item: configurationItem) {
         this.configuration.remove(item);
+    }
+
+    addSchemaDefinition() {
+        const schema = schemaDefinitionModel.empty();
+        this.schemaDefinitions.push(schema);
+    }
+
+    removeSchemaDefinition(item: schemaDefinitionModel) {
+        this.schemaDefinitions.remove(item);
     }
 
     removeDefaultFieldOptions() {

--- a/src/Raven.Studio/typescript/models/database/index/schemaDefinitionModel.ts
+++ b/src/Raven.Studio/typescript/models/database/index/schemaDefinitionModel.ts
@@ -1,0 +1,51 @@
+/// <reference path="../../../../typings/tsd.d.ts"/>
+import jsonUtil = require("common/jsonUtil");
+
+class schemaDefinitionModel {
+
+    collectionName = ko.observable<string>();
+    schemaText = ko.observable<string>("");
+
+    dirtyFlag: () => DirtyFlag;
+    validationGroup: KnockoutObservable<any>;
+
+    constructor(collectionName: string = "", schemaText: string = "") {
+        this.collectionName(collectionName);
+        this.schemaText(schemaText);
+
+        this.initObservables();
+        this.initValidation();
+    }
+
+    private initObservables() {
+        this.dirtyFlag = new ko.DirtyFlag([
+            this.collectionName,
+            this.schemaText
+        ], false, jsonUtil.newLineNormalizingHashFunction);
+    }
+
+    private initValidation() {
+        // TODO Maksym: add unique collection validation
+        this.collectionName.extend({
+            required: true
+        });
+
+        this.validationGroup = ko.validatedObservable({
+            collectionName: this.collectionName
+        });
+    }
+
+    static empty(): schemaDefinitionModel {
+        return new schemaDefinitionModel();
+    }
+
+    toDto(): { collectionName: string; schemaText: string } {
+        return {
+            collectionName: this.collectionName(),
+            schemaText: this.schemaText()
+        };
+    }
+}
+
+export = schemaDefinitionModel;
+

--- a/src/Raven.Studio/typescript/models/database/index/schemaDefinitionModel.ts
+++ b/src/Raven.Studio/typescript/models/database/index/schemaDefinitionModel.ts
@@ -38,13 +38,6 @@ class schemaDefinitionModel {
     static empty(): schemaDefinitionModel {
         return new schemaDefinitionModel();
     }
-
-    toDto(): { collectionName: string; schemaText: string } {
-        return {
-            collectionName: this.collectionName(),
-            schemaText: this.schemaText()
-        };
-    }
 }
 
 export = schemaDefinitionModel;

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -1281,11 +1281,7 @@ class editIndex extends shardViewModelBase {
     }
 
     formatSchemaDefinition(schemaItem: schemaDefinitionModel) {
-        try {
-            schemaItem.schemaText(generalUtils.prettifyContent(schemaItem.schemaText()));
-        } catch (e) {
-            console.error("Failed to format schema definition", e);
-        }
+        schemaItem.schemaText(generalUtils.prettifyJson(schemaItem.schemaText()));
     }
 
     private setFormattedText(textToFormat: KnockoutObservable<string>) {

--- a/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/indexes/editIndex.ts
@@ -23,6 +23,7 @@ import showDataDialog = require("viewmodels/common/showDataDialog");
 import formatIndexCommand = require("commands/database/index/formatIndexCommand");
 import additionalSource = require("models/database/index/additionalSource");
 import additionalAssembly = require("models/database/index/additionalAssemblyModel");
+import schemaDefinitionModel = require("models/database/index/schemaDefinitionModel");
 import viewHelpers = require("common/helpers/view/viewHelpers");
 import mapIndexSyntax = require("viewmodels/database/indexes/mapIndexSyntax");
 import fileDownloader = require("common/fileDownloader");
@@ -65,6 +66,7 @@ import indexingDatabaseSettingsTypes = require("models/database/index/types")
 import genUtils = require("common/generalUtils");
 import storeCompat = require("components/storeCompat");
 import chatbotSlice = require("components/shell/chatbot/store/chatbotSlice");
+import collectionsTracker = require("common/helpers/database/collectionsTracker");
 
 class editIndex extends shardViewModelBase {
     
@@ -104,6 +106,8 @@ class editIndex extends shardViewModelBase {
     selectedSourcePreview = ko.observable<additionalSource>();
     additionalSourcePreviewHtml: KnockoutComputed<string>;
     
+    collections = ko.pureComputed(() => collectionsTracker.default.collections().filter(x => x.name !== "@hilo" && !x.isAllDocuments && x.name !== "@empty"))
+
     indexHistory = ko.observableArray<Raven.Client.ServerWide.IndexHistoryEntry>([]);
     showIndexHistory = ko.observable<boolean>(false);
     loadedIndexHistory = ko.observable<boolean>(false);
@@ -172,7 +176,10 @@ class editIndex extends shardViewModelBase {
             "loadFullIndexDefinitionFromHistory",
             "loadOnlyMapAndReduceFromHistory",
             "useIndexRevisionItem",
-            "previewIndex");
+            "previewIndex",
+            "addSchemaDefinition",
+            "removeSchemaDefinition",
+            "formatSchemaDefinition");
 
         aceEditorBindingHandler.install();
         autoCompleteBindingHandler.install();
@@ -822,6 +829,7 @@ class editIndex extends shardViewModelBase {
             indexDef.collectionNameForReferenceDocuments,
             indexDef.additionalSources,
             indexDef.additionalAssemblies,
+            indexDef.schemaDefinitions,
             indexDef.archivedDataProcessingBehavior,
             hasAnyDirtyField,
             hasAnyDirtyCompoundField,
@@ -1260,6 +1268,24 @@ class editIndex extends shardViewModelBase {
         const reduceToFormat = index.reduce;
 
         this.setFormattedText(reduceToFormat);
+    }
+
+    addSchemaDefinition() {
+        eventsCollector.default.reportEvent("index", "add-schema-definition");
+        this.editedIndex().addSchemaDefinition();
+    }
+
+    removeSchemaDefinition(item: schemaDefinitionModel) {
+        eventsCollector.default.reportEvent("index", "remove-schema-definition");
+        this.editedIndex().removeSchemaDefinition(item);
+    }
+
+    formatSchemaDefinition(schemaItem: schemaDefinitionModel) {
+        try {
+            schemaItem.schemaText(generalUtils.prettifyContent(schemaItem.schemaText()));
+        } catch (e) {
+            console.error("Failed to format schema definition", e);
+        }
     }
 
     private setFormattedText(textToFormat: KnockoutObservable<string>) {

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/editIndex.html
@@ -274,6 +274,14 @@
                                   data-bind="text: editedIndex().additionalSources().length || undefined"></span>
                         </a>
                     </li>
+                    <li role="presentation" id="schemaDefinitionsTab">
+                        <a href="#schemaDefinitions" aria-controls="schemaDefinitions" role="tab" data-toggle="tab">
+                            <i class="icon-additional-sources"></i>
+                            <span>Schema Definitions</span>
+                            <span class="label label-primary margin-left margin-left-sm"
+                                  data-bind="text: editedIndex().schemaDefinitions().length || undefined"></span>
+                        </a>
+                    </li>
                 </ul>
                 <div class="tab-content">
                     <div role="tabpanel" class="tab-pane fade in active" id="fields">
@@ -596,6 +604,54 @@
                             </ul>
                             <div class="flex-grow margin-left" data-bind="html: $root.additionalSourcePreviewHtml">
                             </div>
+                        </div>
+                    </div>
+                    <div role="tabpanel" class="tab-pane fade" id="schemaDefinitions">
+                        <div class="margin-bottom-sm">
+                            <button type="button" data-bind="click: addSchemaDefinition, requiredAccess: 'DatabaseReadWrite'" class="btn btn-default">
+                                <i class="icon-plus"></i> <span>Add new schema definition</span>
+                            </button>
+                        </div>
+                        <div data-bind="foreach: editedIndex().schemaDefinitions">
+                            <hr data-bind="visible: $index() > 0" />
+                            <div class="row">
+                                <div class="col-sm-3">
+                                    <div>
+                                        Select collection for schema definition
+                                    </div>
+                                    <div class="form-group" data-bind="validationElement: collectionName">
+                                        <div class="btn-group">
+                                            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" title="Select collection">
+                                                <span data-bind="text: collectionName() || 'Select collection'"></span>&nbsp;&nbsp;<span class="caret"></span>
+                                            </button>
+                                            <ul class="dropdown-menu" role="menu" data-bind="foreach: $root.collections">
+                <li data-bind="click: () => $parent.collectionName($data.name)"><a href="#" data-bind="text: $data.name"></a></li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-sm-9">
+                                    <div class="clearfix">
+                                        <div class="btn-group-sm pull-right" role="group" aria-label="...">
+                                            <button type="button" class="btn btn-default btn-sm" data-bind="click: _.partial($root.formatSchemaDefinition, $data)" title="Format JSON">
+                                                <i class="icon-indent"></i><span>Format</span>
+                                            </button>
+                                            <button type="button" class="btn btn-danger btn-sm" data-bind="click: _.partial($root.removeSchemaDefinition, $data), requiredAccess: 'DatabaseReadWrite'" title="Delete this schema definition">
+                                                <i class="icon-trash"></i> <span>Delete</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div class="margin-bottom">
+                                        <pre class="form-control"
+                                             data-bind="aceEditor: { code: schemaText, minHeight: 300, maxHeight: 300, allowResize: true, getFocus: false, lang: 'ace/mode/json_newline_friendly', readOnly: $root.isReadOnlyAccess() }"
+                                            ></pre>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="text-center text-muted" data-bind="visible: !editedIndex().schemaDefinitions().length">
+                            <i class="icon-lg icon-empty-set"></i>
+                            <h2 class="margin-top margin-top-sm">No schema definitions added</h2>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25594

### Additional description

I added validation for a unique collection name to TODO, and then I will add validation for correct JSON to aceEditor.

<img width="2279" height="1089" alt="image" src="https://github.com/user-attachments/assets/9dd409c8-cb95-48e6-ae49-9de39557a852" />

<img width="1491" height="275" alt="image" src="https://github.com/user-attachments/assets/725f5acd-d414-4715-b0e1-4d6029f23c46" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
