### PR TITLE
RavenDB-24327 Fixing test so x86 tests won't crash

### DIFF
--- a/test/SlowTests/Voron/Issues/RavenDB_24327.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_24327.cs
@@ -273,6 +273,9 @@ public class RavenDB_24327 : StorageTest
         {
             var p = tx.LowLevelTransaction.AllocatePage(10); // this will allocate pages from the sparse region 
             
+            p.Flags |= PageFlags.Overflow;
+            p.OverflowSize = 9 * Constants.Storage.PageSize;
+
             Assert.True(p.PageNumber >= firstFreedPage); // so let's assert that
             
             Memory.Set(p.DataPointer, 13, 10 * Constants.Storage.PageSize - PageHeader.SizeOf);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24327 

### Additional description

Test fix for 32 bits - continuation of https://github.com/ravendb/ravendb/pull/21900

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
