### PR TITLE
RavenDB-25618 Add debug flag to FreePage to skip TrackOverflowPageRemoval() for overflow page shrink tracking

### DIFF
--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -917,7 +917,11 @@ namespace Voron.Impl
 
             for (int i = lowerNumberOfPages; i < prevNumberOfPages; i++)
             {
-                FreePage(page.PageNumber + i);
+                FreePage(page.PageNumber + i
+#if DEBUG
+                    , isOverflowShrink: true
+#endif
+                );
             }
 
             // need to set the proper number of pages in the scratch page
@@ -1053,14 +1057,21 @@ namespace Voron.Impl
             UntrackDirtyPage(pageNumber);
         }
 
-        public void FreePage(long pageNumber)
+        public void FreePage(long pageNumber
+#if DEBUG
+            , bool isOverflowShrink = false
+#endif
+        )
         {
             if (_txState != TxState.None)
                 ThrowObjectDisposed();
 
             try
             {
-                TrackOverflowPageRemoval(pageNumber);
+#if DEBUG
+                if (isOverflowShrink == false)
+                    TrackOverflowPageRemoval(pageNumber);
+#endif
                 UntrackPage(pageNumber);
                 Debug.Assert(pageNumber >= 0);
 


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25618

### Additional description

It is expected that we might get garbage data in that scenario.

It's related to ShrinkOverflowPage / TrackOverflowPageRemoval

```
Unexpected exception occurred: System.IO.InvalidDataException: When reading page 1081, we read a page with header of page 72347200115913024. Page flags: Overflow, VariableSizeTreePage, FixedSizeTreePage, Stream, RawData. Overflow size: 1879507968. 
   at Voron.StorageEnvironment.ThrowInvalidPageNumber(Int64 pageNumber, PageHeader* current)
   at Voron.StorageEnvironment.UnlikelyValidatePage(Int64 pageNumber, PageHeader* current, Int64 index, Int64 old, Int64 bitToSet)
   at Voron.Impl.LowLevelTransaction.GetPageInternal(Int64 pageNumber)
   at Voron.Impl.LowLevelTransaction.TrackOverflowPageRemoval(Int64 pageId) <---- debug only check
   at Voron.Impl.LowLevelTransaction.FreePage(Int64 pageNumber)
   at Voron.Impl.LowLevelTransaction.ShrinkOverflowPage(Int64 pageNumber, Int32 newSize, TreeMutableState treeState) <-- very specific FreePage on _remaining_ pages of an overflow
   at Voron.Data.BTrees.Tree.StreamToPageWriter.Write(Stream stream)
   ```


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
