### PR TITLE
RavenDB-25627 - Fix double disposal of a context

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1769,8 +1769,16 @@ namespace Raven.Server.Documents
         {
             if (configuration != null && configuration.HasEnabledConfiguration())
             {
-                SchemaValidatorCache ??= new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
-                SchemaValidatorCache.Update(configuration);
+                if (SchemaValidatorCache != null)
+                {
+                    SchemaValidatorCache.Update(configuration);
+                }
+                else
+                {
+                    var cache = new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                    cache.Update(configuration);
+                    SchemaValidatorCache = cache;
+                }
             }
             else
             {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1769,7 +1769,7 @@ namespace Raven.Server.Documents
         {
             if (configuration != null && configuration.HasEnabledConfiguration())
             {
-                SchemaValidatorCache ??= SchemaValidatorCache.Create(DocumentsStorage.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                SchemaValidatorCache ??= new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
                 SchemaValidatorCache.Update(configuration);
             }
             else

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -20,21 +20,13 @@ public class SchemaValidatorCache : IDisposable
 
     private readonly AbstractDatabaseNotificationCenter _notificationCenter;
     private readonly RavenLogger _logger;
-    private readonly (IDisposable Return, JsonOperationContext Value) _context;
+    private readonly JsonOperationContext _context;
     private FrozenDictionary<string, SchemaValidator> _schemaValidatorsPerCollection = EmptyCache;
     public bool Disabled { get; private set; } = true;
 
-    public static SchemaValidatorCache Create<T>(JsonContextPoolBase<T> contextPool, AbstractDatabaseNotificationCenter notificationCenter, RavenLogger logger)
-        where T : JsonOperationContext
+    public SchemaValidatorCache(AbstractDatabaseNotificationCenter notificationCenter, RavenLogger logger)
     {
-        var returnContext = contextPool.AllocateOperationContext(out JsonOperationContext context);
-        return new SchemaValidatorCache(returnContext, context, notificationCenter, logger);
-    }
-    
-    private SchemaValidatorCache(IDisposable returnCtx, JsonOperationContext ctx, AbstractDatabaseNotificationCenter notificationCenter, RavenLogger logger)
-    {
-        _context.Return = returnCtx;
-        _context.Value = ctx;
+        _context = JsonOperationContext.ShortTermSingleUse();
         _notificationCenter = notificationCenter;
         _logger = logger;
     }
@@ -66,8 +58,8 @@ public class SchemaValidatorCache : IDisposable
             SchemaValidator schemaValidator;
             try
             {
-                var blittable = _context.Value.Sync.ReadForMemory(validator.Schema, "schema-validation");
-                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context.Value, blittable, validator.Schema, validator.Disabled);
+                var blittable = _context.Sync.ReadForMemory(validator.Schema, "schema-validation");
+                schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context, blittable, validator.Schema, validator.Disabled);
             }
             catch (Exception e)
             {
@@ -170,7 +162,7 @@ public class SchemaValidatorCache : IDisposable
     {
         GC.SuppressFinalize(this);
 
-        using (_context.Return)
+        using (_context)
         {
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Batches/ShardedClusterTransactionRequestProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Batches/ShardedClusterTransactionRequestProcessor.cs
@@ -23,7 +23,7 @@ public sealed class ShardedClusterTransactionRequestProcessor : AbstractClusterT
 
     protected override ClusterConfiguration GetClusterConfiguration() => RequestHandler.DatabaseContext.Configuration.Cluster;
 
-    protected override SchemaValidatorCache SchemaValidatorCache => RequestHandler.DatabaseContext.SchemaValidationCache;
+    protected override SchemaValidatorCache SchemaValidatorCache => RequestHandler.DatabaseContext.SchemaValidatorCache;
 
     public override Task WaitForDatabaseCompletion(Task<HashSet<string>> onDatabaseCompletionTask, long index, ClusterTransactionOptions options, CancellationToken token)
     {

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Sharding
         private readonly DatabasesLandlord.StateChange _orchestratorStateChange;
         private readonly DatabasesLandlord.StateChange _urlUpdateStateChange;
 
-        public SchemaValidatorCache SchemaValidationCache { get; private set; }
+        public SchemaValidatorCache SchemaValidatorCache { get; private set; }
 
         public ShardedDatabaseContext(ServerStore serverStore, DatabaseRecord record)
         {
@@ -110,14 +110,22 @@ namespace Raven.Server.Documents.Sharding
         {
             if (configuration != null && configuration.HasEnabledConfiguration())
             {
-                SchemaValidationCache ??= new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
-                SchemaValidationCache.Update(configuration);
+                if (SchemaValidatorCache != null)
+                {
+                    SchemaValidatorCache.Update(configuration);
+                }
+                else
+                {
+                    var cache = new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                    cache.Update(configuration);
+                    SchemaValidatorCache = cache;
+                }
             }
             else
             {
                 // we intentionally don't dispose here since it might be currently being used for validation,
                 // clearing the resources will be done by the finalizer.
-                SchemaValidationCache = null;
+                SchemaValidatorCache = null;
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -110,7 +110,7 @@ namespace Raven.Server.Documents.Sharding
         {
             if (configuration != null && configuration.HasEnabledConfiguration())
             {
-                SchemaValidationCache ??= SchemaValidatorCache.Create(ServerStore.ContextPool, NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
+                SchemaValidationCache ??= new SchemaValidatorCache(NotificationCenter, Loggers.GetLogger<SchemaValidatorCache>());
                 SchemaValidationCache.Update(configuration);
             }
             else


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25627/SchemaValidation-test-process-crashed

### Additional description

The disposal of the `SchemaValidatorCache` was **after** of the documents storage context pool which caused double disposal of the memory (error: `Test host process crashed : double free or corruption (out)`).
We have a finalizer in the `SchemaValidatorCache` so we cannot use another context pool since the context pool might be disposed first.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
