### PR TITLE
RavenDB-25395 Replace `System.IO.Compression` with `SharpZipLib` in snapshot backup code to workaround 'Extra_ERROR Zip64_ERROR'

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,6 +108,7 @@
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.0" />
     <PackageVersion Include="Raven.CodeAnalysis" Version="1.0.13" />
     <PackageVersion Include="Raven.Pal" Version="7.0.850" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="Snappier" Version="1.2.0" />
     <PackageVersion Include="Snowflake.Data" Version="5.1.0" />
     <PackageVersion Include="Spatial4n" Version="0.4.1.1" />

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Zip;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Threading;
@@ -1536,14 +1537,14 @@ namespace Raven.Server.Documents
             }
 
             using (TombstoneCleaner.PreventTombstoneCleaningUpToEtag(lastTombstoneEtag))
-            using (var zipArchive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+            using (var package = new BackupZipArchive(new ZipOutputStream(stream) { IsStreamOwner = false }, compressionAlgorithm, compressionLevel))
             {
                 using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverContext))
                 {
-                    // the smuggler output is already compressed
-                    var zipArchiveEntry = zipArchive.CreateEntry(RestoreSettings.SmugglerValuesFileName);
-                    using (var zipStream = zipArchiveEntry.Open())
-                    using (var outputStream = GetOutputStream(zipStream))
+                    var smugglerValuesEntry = package.CreateEntry(RestoreSettings.SmugglerValuesFileName, noCompression: true); // the smuggler output is already compressed
+                    
+                    using (var smugglerEntryStream = smugglerValuesEntry.Open())
+                    using (var outputStream = GetOutputStream(smugglerEntryStream))
                     {
                         var smugglerSource = new DatabaseSource(this, 0, 0, _logger);
                         using (DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -1572,10 +1573,9 @@ namespace Raven.Server.Documents
 
                     infoNotify?.Invoke(("Backed up Database Record", 1));
 
-                    var package = new BackupZipArchive(zipArchive, compressionAlgorithm, compressionLevel);
                     var settingsEntry = package.CreateEntry(RestoreSettings.SettingsFileName);
-                    using (var zipStream = settingsEntry.Open())
-                    using (var outputStream = GetOutputStream(zipStream))
+                    using (var settingsEntryStream = settingsEntry.Open())
+                    using (var outputStream = GetOutputStream(settingsEntryStream))
                     using (var writer = new BlittableJsonTextWriter(serverContext, outputStream))
                     {
                         writer.WriteStartObject();
@@ -1624,7 +1624,7 @@ namespace Raven.Server.Documents
 
                 infoNotify?.Invoke(("Backed up database values", 1));
 
-                BackupMethods.Full.ToFile(GetAllStoragesForBackup(excludeIndexes), zipArchive, compressionAlgorithm, compressionLevel, maxReadOpsPerSecond, infoNotify, cancellationToken);
+                BackupMethods.Full.ToFile(GetAllStoragesForBackup(excludeIndexes), package, maxReadOpsPerSecond, infoNotify, cancellationToken);
             }
 
             return smugglerResult;

--- a/src/Voron/Impl/Backup/BackupZipArchive.cs
+++ b/src/Voron/Impl/Backup/BackupZipArchive.cs
@@ -1,37 +1,58 @@
 ﻿using System;
 using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Zip;
 using Sparrow.Backups;
 
 namespace Voron.Impl.Backup;
 
-public sealed class BackupZipArchive
+public sealed class BackupZipArchive : IDisposable
 {
-    private readonly ZipArchive _zipArchive;
+    private readonly ZipOutputStream _zipStream;
     private readonly SnapshotBackupCompressionAlgorithm _compressionAlgorithm;
     private readonly CompressionLevel _compressionLevel;
-    private readonly CompressionLevel _compressionLevelForZipEntry;
 
-    public BackupZipArchive(ZipArchive zipArchive, SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
+    public BackupZipArchive(ZipOutputStream zipStream, SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
     {
-        _zipArchive = zipArchive ?? throw new ArgumentNullException(nameof(zipArchive));
+        _zipStream = zipStream ?? throw new ArgumentNullException(nameof(zipStream));
         _compressionAlgorithm = compressionAlgorithm;
         _compressionLevel = compressionLevel;
-        _compressionLevelForZipEntry = GetCompressionLevelForZipEntry(compressionAlgorithm, compressionLevel);
+        
+        var level = GetCompressionLevel(compressionAlgorithm, compressionLevel);
+        _zipStream.SetLevel(level);
     }
 
-    public BackupZipArchiveEntry CreateEntry(string entryName)
+    public BackupZipArchiveEntry CreateEntry(string entryName, bool noCompression = false)
     {
-        var zipEntry = _zipArchive.CreateEntry(entryName, _compressionLevelForZipEntry);
-        return new BackupZipArchiveEntry(zipEntry, _compressionAlgorithm, _compressionLevel);
+        var zipEntry = new ZipEntry(entryName);
+
+        if (noCompression)
+            zipEntry.CompressionMethod = CompressionMethod.Stored;
+        
+        _zipStream.PutNextEntry(zipEntry);
+
+        return new BackupZipArchiveEntry(_zipStream, _compressionAlgorithm, noCompression ? CompressionLevel.NoCompression : _compressionLevel);
     }
 
-    private static CompressionLevel GetCompressionLevelForZipEntry(SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
+    private static int GetCompressionLevel(SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
     {
         return compressionAlgorithm switch
         {
-            SnapshotBackupCompressionAlgorithm.Zstd => CompressionLevel.NoCompression,
-            SnapshotBackupCompressionAlgorithm.Deflate => compressionLevel,
+            SnapshotBackupCompressionAlgorithm.Deflate => compressionLevel switch
+            {
+                CompressionLevel.NoCompression => 0,
+                CompressionLevel.Fastest => 1,
+                CompressionLevel.Optimal => 6,
+                CompressionLevel.SmallestSize => 9,
+                _ => throw new ArgumentOutOfRangeException(nameof(compressionLevel), compressionLevel, null)
+            },
+            SnapshotBackupCompressionAlgorithm.Zstd => 0,
             _ => throw new ArgumentOutOfRangeException(nameof(compressionAlgorithm), compressionAlgorithm, null)
         };
+    }
+
+    public void Dispose()
+    {
+        _zipStream.Finish();
+        _zipStream.Dispose();
     }
 }

--- a/src/Voron/Impl/Backup/BackupZipArchiveEntry.cs
+++ b/src/Voron/Impl/Backup/BackupZipArchiveEntry.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Zip;
 using Sparrow.Backups;
 using Sparrow.Utils;
 
@@ -8,32 +9,63 @@ namespace Voron.Impl.Backup;
 
 public sealed class BackupZipArchiveEntry
 {
-    private readonly ZipArchiveEntry _zipEntry;
+    private readonly ZipOutputStream _zipStream;
     private readonly SnapshotBackupCompressionAlgorithm _compressionAlgorithm;
     private readonly CompressionLevel _compressionLevel;
 
-    public BackupZipArchiveEntry(ZipArchiveEntry zipEntry, SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
+    public BackupZipArchiveEntry(ZipOutputStream zipStream, SnapshotBackupCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
     {
-        _zipEntry = zipEntry;
+        _zipStream = zipStream ?? throw new ArgumentNullException(nameof(zipStream));
         _compressionAlgorithm = compressionAlgorithm;
         _compressionLevel = compressionLevel;
     }
 
     public Stream Open()
     {
-        var stream = _zipEntry.Open();
+        var stream = new ZipEntryOutputStream(_zipStream);
 
         switch (_compressionAlgorithm)
         {
             case SnapshotBackupCompressionAlgorithm.Zstd:
                 if (_compressionLevel == CompressionLevel.NoCompression)
                     return stream;
-
                 return ZstdStream.Compress(stream, _compressionLevel);
             case SnapshotBackupCompressionAlgorithm.Deflate:
                 return stream;
             default:
                 throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    private sealed class ZipEntryOutputStream(ZipOutputStream zipStream) : Stream
+    {
+        private bool _disposed;
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush() => zipStream.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        
+        public override void Write(byte[] buffer, int offset, int count) => zipStream.Write(buffer, offset, count);
+        public override void Write(ReadOnlySpan<byte> buffer) => zipStream.Write(buffer);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+            
+            _disposed = true;
+            
+            if (disposing) 
+                zipStream.CloseEntry();
+            
+            base.Dispose(disposing);
         }
     }
 }

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Zip;
 using System.Linq;
 using System.Threading;
 using Sparrow;
@@ -44,16 +45,15 @@ namespace Voron.Impl.Backup
 
             using (var file = SafeFileStream.Create(backupPath.FullPath, FileMode.Create))
             {
-                using (var package = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: true))
+                using (var package = new BackupZipArchive(new ZipOutputStream(file) { IsStreamOwner = false }, compressionAlgorithm, compressionLevel))
                 {
                     infoNotify(("Voron backup started", 0));
                     var dataPager = env.DataPager;
                     var copier = new DataCopier(Constants.Storage.PageSize * 16);
-                    Backup(env, compressionAlgorithm, compressionLevel, dataPager, package, string.Empty, copier, infoNotify);
-
-                    file.Flush(true); // make sure that we fully flushed to disk
-
+                    Backup(env, dataPager, package, string.Empty, copier, infoNotify);
                 }
+                
+                file.Flush(true); // make sure that we fully flushed to disk
             }
 
             infoNotify(("Voron backup db finished", 0));
@@ -63,9 +63,7 @@ namespace Voron.Impl.Backup
         /// Do a full backup of a set of environments. Note that the order of the environments matter!
         /// </summary>
         public void ToFile(IEnumerable<StorageEnvironmentInformation> envs,
-            ZipArchive archive,
-            SnapshotBackupCompressionAlgorithm compressionAlgorithm,
-            CompressionLevel compressionLevel,
+            BackupZipArchive archive,
             int? maxReadOpsPerSecond = null,
             Action<(string Message, int FilesCount)> infoNotify = null,
             CancellationToken cancellationToken = default)
@@ -85,7 +83,7 @@ namespace Voron.Impl.Backup
                 if (ForTestingPurposes?.OnBeforeRateGateWaitToProceed != null)
                     copier.ForTestingPurposesOnly().OnBeforeRateGateWaitToProceed = ForTestingPurposes?.OnBeforeRateGateWaitToProceed;
 
-                Backup(env, compressionAlgorithm, compressionLevel, env.DataPager, archive, basePath, copier, infoNotify, cancellationToken);
+                Backup(env, env.DataPager, archive, basePath, copier, infoNotify, cancellationToken);
             }
 
             infoNotify(("Voron backup db finished", 0));
@@ -93,10 +91,8 @@ namespace Voron.Impl.Backup
 
         private static void Backup(
             StorageEnvironment env,
-            SnapshotBackupCompressionAlgorithm compressionAlgorithm,
-            CompressionLevel compressionLevel,
             Pager dataPager,
-            ZipArchive zipArchive,
+            BackupZipArchive package,
             string basePath,
             DataCopier copier,
             Action<(string Message, int FilesCount)> infoNotify,
@@ -107,9 +103,7 @@ namespace Voron.Impl.Backup
             long lastWrittenLogFile = -1;
             LowLevelTransaction txr = null;
             var backupSuccess = false;
-
-            var package = new BackupZipArchive(zipArchive, compressionAlgorithm, compressionLevel);
-
+            
             try
             {
                 long allocatedPages;
@@ -294,7 +288,7 @@ namespace Voron.Impl.Backup
             int? maxReadOpsPerSecond = null,
             CancellationToken cancellationToken = default)
         {
-            using (var zip = ZipFile.Open(backupPath.FullPath, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
+            using (var zip = System.IO.Compression.ZipFile.Open(backupPath.FullPath, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
                 Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, cancellationToken);
         }
 

--- a/src/Voron/Impl/Backup/IncrementalBackup.cs
+++ b/src/Voron/Impl/Backup/IncrementalBackup.cs
@@ -5,17 +5,17 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using ICSharpCode.SharpZipLib.Zip;
+using Sparrow.Backups;
 using System.Linq;
 using Sparrow.Server;
 using Sparrow.Server.Platform;
 using Sparrow.Threading;
 using Sparrow.Utils;
 using Voron.Data.BTrees;
-using Voron.Exceptions;
 using Voron.Impl.Journal;
 using Voron.Global;
 using Voron.Impl.FileHeaders;
-using Voron.Impl.Paging;
 using Voron.Util;
 using Voron.Util.Settings;
 
@@ -48,11 +48,11 @@ namespace Voron.Impl.Backup
             using (var file = SafeFileStream.Create(backupPath, FileMode.Create))
             {
                 long numberOfBackedUpPages;
-                using (var package = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: true))
+                using (var package = new BackupZipArchive(new ZipOutputStream(file) { IsStreamOwner = false }, SnapshotBackupCompressionAlgorithm.Deflate, compression))
                 {
-                    numberOfBackedUpPages = Incremental_Backup(env, compression, infoNotify,
-                        backupStarted, package, string.Empty, copier);
+                    numberOfBackedUpPages = Incremental_Backup(env, compression, infoNotify, backupStarted, package, string.Empty, copier);
                 }
+                
                 file.Flush(true); // make sure that this is actually persisted fully to disk
                 return numberOfBackedUpPages;
             }
@@ -70,7 +70,7 @@ namespace Voron.Impl.Backup
             long totalNumberOfBackedUpPages = 0;
             using (var file = SafeFileStream.Create(backupPath, FileMode.Create))
             {
-                using (var package = new ZipArchive(file, ZipArchiveMode.Create, leaveOpen: true))
+                using (var package = new BackupZipArchive(new ZipOutputStream(file) { IsStreamOwner = false }, SnapshotBackupCompressionAlgorithm.Deflate, compression))
                 {
                     foreach (var e in envs)
                     {
@@ -92,7 +92,7 @@ namespace Voron.Impl.Backup
         }
 
         private static long Incremental_Backup(StorageEnvironment env, CompressionLevel compression, Action<string> infoNotify,
-            Action backupStarted, ZipArchive package, string basePath, DataCopier copier)
+            Action backupStarted, BackupZipArchive package, string basePath, DataCopier copier)
         {
             long numberOfBackedUpPages = 0;
             long lastWrittenLogFile = -1;
@@ -157,10 +157,8 @@ namespace Voron.Impl.Backup
                         if (startBackupAt >= journalFile.JournalWriter.NumberOfAllocated4Kb) // nothing to do here
                             continue;
 
-                        var part =
-                            package.CreateEntry(
-                                Path.Combine(basePath, StorageEnvironmentOptions.JournalName(journalNum))
-                                , compression);
+                        var part = package.CreateEntry(
+                                Path.Combine(basePath, StorageEnvironmentOptions.JournalName(journalNum)));
                         Debug.Assert(part != null);
 
                         if (journalFile.Number == lastWrittenLogFile)
@@ -279,7 +277,7 @@ namespace Voron.Impl.Backup
                 var transactionPersistentContext = new TransactionPersistentContext(true);
                 using (var txw = env.NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite))
                 {
-                    using (var package = ZipFile.Open(singleBackupFile, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
+                    using (var package = System.IO.Compression.ZipFile.Open(singleBackupFile, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
                     {
                         if (package.Entries.Count == 0)
                             return;

--- a/src/Voron/Voron.csproj
+++ b/src/Voron/Voron.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\Sparrow.Server\Sparrow.Server.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="SharpZipLib" />
     <PackageReference Include="System.Numerics.Tensors" />
   </ItemGroup>
 


### PR DESCRIPTION
… in the main Raven.voron entry header when using Shared Journals feature

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25395

### Additional description

This workarounds https://github.com/dotnet/runtime/issues/122489 that we started to experience in version 8.0 when using Shared Journals feature.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
