### PR TITLE
RavenDB-25634 fix aggregation on the boundary

### DIFF
--- a/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/TimeSeries/TimeSeriesRetriever.cs
@@ -228,7 +228,7 @@ namespace Raven.Server.Documents.Queries.Results.TimeSeries
                         // if the range it cover needs to be broken up to multiple ranges.
                         // For example, if the segment covers 3 days, but we have group by 1 hour,
                         // we still have to deal with the individual values
-                        if (it.Segment.End > rangeSpec.End || _individualValuesOnly || IsLastDuplicate(it.Segment.Summary, aggregationHolder))
+                        if (it.Segment.End >= rangeSpec.End || _individualValuesOnly || IsLastDuplicate(it.Segment.Summary, aggregationHolder))
                         {
                             foreach (var value in AggregateIndividualItems(it.Segment.Values))
                             {

--- a/test/SlowTests/Client/TimeSeries/Issues/RavenDB_25101.cs
+++ b/test/SlowTests/Client/TimeSeries/Issues/RavenDB_25101.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Documents.Queries;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Tests.Infrastructure;
@@ -73,6 +75,76 @@ namespace SlowTests.Client.TimeSeries.Issues
 
                     Assert.Equal(ts1Seconds, tsSeconds);
                     Assert.Equal(ts2Seconds, tsSeconds);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+        public async Task CanQueryTimeSeriesAggregationOnSegmentBoundary()
+        {
+            var today = DateTime.Today.AddDays(-1);
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User
+                    {
+                        Name = "U1",
+                        Age = 30,
+                    }, "users/1");
+
+                    await session.StoreAsync(new User
+                    {
+                        Name = "U2",
+                        Age = 30,
+                    }, "users/2");
+
+                    var tsf1 = session.TimeSeriesFor("users/1", "HeartRate");
+                    var tsf2 = session.TimeSeriesFor("users/2", "HeartRate");
+
+                    for (int i = 0; i < 25; i++)
+                    {
+                        tsf1.Append(today.AddHours(i), [60 + i]);
+                        tsf2.Append(today.AddHours(i), [60 + i]);
+                    }
+
+                    tsf2.Append(today.AddHours(25), [60 + 25]);
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var offset = TimeZoneInfo.Local.GetUtcOffset(today);
+                    var query = session.Query<User>()
+                        .Select(p => RavenQuery.TimeSeries(p, "HeartRate")
+                            .GroupBy(g => g.Days(1)).Offset(offset)
+                            .Select(ts => new
+                            {
+                                Sum = ts.Sum(),
+                                Count = ts.Count()
+                            })
+                            .ToList());
+
+                    var agg = await query.ToListAsync();
+                    Assert.Equal(agg.Count, 2);
+                    var r1 = agg[0];
+                    Assert.Equal(r1.Results.Length, 2);
+                    Assert.Equal(r1.Results[0].Count[0], 24);
+                    Assert.Equal(r1.Results[0].From, today.Add(offset).ToUniversalTime());
+                    Assert.Equal(r1.Results[0].To, today.AddDays(1).Add(offset).ToUniversalTime());
+                    Assert.Equal(r1.Results[1].Count[0], 1);
+                    Assert.Equal(r1.Results[1].From, today.AddDays(1).Add(offset).ToUniversalTime());
+                    Assert.Equal(r1.Results[1].To, today.AddDays(2).Add(offset).ToUniversalTime());
+
+                    var r2 = agg[1];
+                    Assert.Equal(r2.Results.Length, 2);
+                    Assert.Equal(r2.Results[0].Count[0], 24);
+                    Assert.Equal(r2.Results[0].From, today.Add(offset).ToUniversalTime());
+                    Assert.Equal(r2.Results[0].To, today.AddDays(1).Add(offset).ToUniversalTime());
+                    Assert.Equal(r2.Results[1].Count[0], 2);
+                    Assert.Equal(r2.Results[1].From, today.AddDays(1).Add(offset).ToUniversalTime());
+                    Assert.Equal(r2.Results[1].To, today.AddDays(2).Add(offset).ToUniversalTime());
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25634

### Additional description

There was an edge case that we missed an aggregation entry, if the end of the segment was exactly at the time of the aggregation end.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
