### PR TITLE
RavenDB-25445 : Handle 502 Bad Gateway without triggering JSON parser

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -625,6 +625,14 @@ internal class ChatCompletionClient : IDisposable
             await responseStream.CopyToAsync(ms, token);
             var contentLength = (int)ms.Position;
             ms.Position = 0;
+            if (response.IsSuccessStatusCode == false)
+            {
+                string errorContent = Encoding.UTF8.GetString(ms.GetMemory().Span[..contentLength]);
+                throw UnexpectedResponseException.Create(
+                    message: $"The server returned an error status code: {response.StatusCode}",
+                    response,
+                    errorContent);
+            }
             try
             {
                 return await context.ReadForMemoryAsync(ms, "response/object").ConfigureAwait(false);

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -625,17 +626,17 @@ internal class ChatCompletionClient : IDisposable
             await responseStream.CopyToAsync(ms, token);
             var contentLength = (int)ms.Position;
             ms.Position = 0;
-            if (response.IsSuccessStatusCode == false)
-            {
-                string errorContent = Encoding.UTF8.GetString(ms.GetMemory().Span[..contentLength]);
-                throw UnexpectedResponseException.Create(
-                    message: $"The server returned an error status code: {response.StatusCode}",
-                    response,
-                    errorContent);
-            }
+
             try
             {
                 return await context.ReadForMemoryAsync(ms, "response/object").ConfigureAwait(false);
+            }
+            catch (InvalidDataException ide) when (ide.Message.Contains("Cannot have a '<' in this position at  (1,2) around:")) // likely HTML response
+            {
+                ms.Position = 0;
+                string content = Encoding.UTF8.GetString(ms.GetMemory().Span[..contentLength]);
+
+                throw UnexpectedResponseException.Create(message: "Received an unrecognized response from the server", response, content);
             }
             catch (Exception e)
             {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -277,9 +277,8 @@ public class AiAgentErrors : RavenTestBase
 
         // Raven.Client.Exceptions.RavenException: System.IO.InvalidDataException:  Cannot have a '<' in this position at  (1,2) ...
         var e = await Assert.ThrowsAsync<RavenException>(() => chat.RunAsync<CustomerOutputSchema>(CancellationToken.None));
-        Assert.Contains("Cannot have a '<' in this position at", e.Message);
 
-        Assert.Contains("Cannot have a '<' in this position at", e.Message);
+        RavenTestHelper.AssertContainsRespectingNewLines("Received an unrecognized response from the server.\r\nStatus Code: NotFound\r\nResponse:\r\nStatusCode: 404, ReasonPhrase: 'Not Found'", e.Message);
     }
 
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Settings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25445 : RavenTestBase
+    {
+        public RavenDB_25445(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldHandleBadGateway(Options options, GenAiConfiguration config)
+        {
+            using (var store = GetDocumentStore())
+            {
+                // 1. Simulate the Cloudflare 502 HTML response
+                var response = new HttpResponseMessage(HttpStatusCode.BadGateway)
+                {
+                    Content = new StringContent("<html><body>502 Bad Gateway</body></html>", Encoding.UTF8, "text/html")
+                };
+
+                using (store.GetRequestExecutor().ContextPool.AllocateOperationContext(out var context))
+                {
+                    if (AbstractChatCompletionClientSettings.TryGetParameters(config.Connection, out var settings) == false)
+                        throw new InvalidOperationException("Could not get settings from connection.");
+
+                    var client = new ChatCompletionClient(store.GetRequestExecutor().ContextPool, settings);
+
+                    var ex = await Assert.ThrowsAsync<UnexpectedResponseException>(async () =>
+                    {
+                        await client.GetResponseContentAsync(context, response, CancellationToken.None);
+                    });
+
+                    Assert.Contains("The server returned an error status code: BadGateway", ex.Message);
+
+                    Assert.IsNotType<InvalidDataException>(ex.InnerException);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                         await client.GetResponseContentAsync(context, response, CancellationToken.None);
                     });
 
-                    Assert.Contains("The server returned an error status code: BadGateway", ex.Message);
+                    Assert.Contains("Received an unrecognized response from the server.\r\nStatus Code: BadGateway\r\nResponse:\r\nStatusCode: 502, ReasonPhrase: 'Bad Gateway'", ex.Message);
 
                     Assert.IsNotType<InvalidDataException>(ex.InnerException);
                 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25445.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                         await client.GetResponseContentAsync(context, response, CancellationToken.None);
                     });
 
-                    Assert.Contains("Received an unrecognized response from the server.\r\nStatus Code: BadGateway\r\nResponse:\r\nStatusCode: 502, ReasonPhrase: 'Bad Gateway'", ex.Message);
+                    RavenTestHelper.AssertContainsRespectingNewLines("Received an unrecognized response from the server.\r\nStatus Code: BadGateway\r\nResponse:\r\nStatusCode: 502, ReasonPhrase: 'Bad Gateway'", ex.Message);
 
                     Assert.IsNotType<InvalidDataException>(ex.InnerException);
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25445/SlowTests.Server.Documents.AI.AiAgent.RavenDB24905.ShouldStripQueryToolMetadataToEssentialFieldsoptions-DatabaseMode-Single

### Additional description

This PR addresses an issue where transient infrastructure failures (such as Cloudflare 502 Bad Gateway responses) caused the AI integration to crash with an InvalidDataException.

The Root Cause: During a Cloudflare maintenance window, the AI provider returned an HTML error page. The ChatCompletionClient attempted to parse this HTML as JSON, leading to a parser error: Cannot have a '<' in this position.

The Solution:

Modified ChatCompletionClient.GetResponseContentAsync to explicitly check HttpResponseMessage.IsSuccessStatusCode before attempting to parse the response body.

Added a unit test ShouldHandleBadGateway that mocks a 502 HTML response to verify that the JSON parser is no longer triggered on  that case.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
