### PR TITLE
RavenDB-25635 - Fix connection timeout during slow batch preparation and improve batch interruption logic

### DIFF
--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -19,12 +19,9 @@ using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
-using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server;
-using Sparrow.Server.Utils;
-using Sparrow.Utils;
 using Voron;
 
 namespace Raven.Server.Documents.Replication.Outgoing
@@ -39,6 +36,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         protected readonly AsyncManualResetEvent _waitForChanges;
         internal readonly ReplicationLoader _parent;
         internal DateTime _lastDocumentSentTime;
+        private readonly int _replicationMinimalHeartbeat;
 
         public event Action<DatabaseOutgoingReplicationHandler, Exception> Failed;
 
@@ -53,7 +51,8 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
             _parent = parent;
             _database = database;
-            _waitForChanges = new AsyncManualResetEvent(_database.DatabaseShutdown);
+            _waitForChanges = new AsyncManualResetEvent(database.DatabaseShutdown);
+            _replicationMinimalHeartbeat = (int)database.Configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
             _tcpConnectionOptions = new TcpConnectionOptions
             {
                 DocumentDatabase = database,
@@ -85,7 +84,6 @@ namespace Raven.Server.Documents.Replication.Outgoing
         {
             return Destination.Equals(other.Destination);
         }
-
 
         public LiveReplicationPerformanceCollector.ReplicationPerformanceType GetReplicationPerformanceType()
         {
@@ -239,7 +237,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 OnSuccessfulReplication();
 
                 //if this returns false, this means either timeout or canceled token is activated
-                while (WaitForChanges(_parent.MinimalHeartbeatInterval, _cts.Token) == false)
+                while (WaitForChanges(_replicationMinimalHeartbeat, _cts.Token) == false)
                 {
                     //If we got cancelled we need to break right away
                     if (_cts.IsCancellationRequested)
@@ -348,7 +346,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     // those up with the remove side, so we'll start the replication loop again.
                     // We don't care if they are locally modified or not, because we filter documents that
                     // the other side already have (based on the change vector).
-                    if ((DateTime.UtcNow - _lastDocumentSentTime).TotalMilliseconds > _parent.MinimalHeartbeatInterval)
+                    if ((DateTime.UtcNow - _lastDocumentSentTime).TotalMilliseconds > _replicationMinimalHeartbeat)
                         _waitForChanges.Set();
                 }
             }

--- a/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/DatabaseOutgoingReplicationHandler.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         protected readonly AsyncManualResetEvent _waitForChanges;
         internal readonly ReplicationLoader _parent;
         internal DateTime _lastDocumentSentTime;
-        private readonly int _replicationMinimalHeartbeat;
+        private readonly int _replicationMinimalHeartbeatInMs;
 
         public event Action<DatabaseOutgoingReplicationHandler, Exception> Failed;
 
@@ -52,7 +52,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             _parent = parent;
             _database = database;
             _waitForChanges = new AsyncManualResetEvent(database.DatabaseShutdown);
-            _replicationMinimalHeartbeat = (int)database.Configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
+            _replicationMinimalHeartbeatInMs = (int)database.Configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
             _tcpConnectionOptions = new TcpConnectionOptions
             {
                 DocumentDatabase = database,
@@ -237,7 +237,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 OnSuccessfulReplication();
 
                 //if this returns false, this means either timeout or canceled token is activated
-                while (WaitForChanges(_replicationMinimalHeartbeat, _cts.Token) == false)
+                while (WaitForChanges(_replicationMinimalHeartbeatInMs, _cts.Token) == false)
                 {
                     //If we got cancelled we need to break right away
                     if (_cts.IsCancellationRequested)
@@ -346,7 +346,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     // those up with the remove side, so we'll start the replication loop again.
                     // We don't care if they are locally modified or not, because we filter documents that
                     // the other side already have (based on the change vector).
-                    if ((DateTime.UtcNow - _lastDocumentSentTime).TotalMilliseconds > _replicationMinimalHeartbeat)
+                    if ((DateTime.UtcNow - _lastDocumentSentTime).TotalMilliseconds > _replicationMinimalHeartbeatInMs)
                         _waitForChanges.Set();
                 }
             }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -61,7 +61,6 @@ namespace Raven.Server.Documents.Replication
         public event Action<DatabaseOutgoingReplicationHandler> OutgoingReplicationRemoved;
 
         internal ManualResetEventSlim DebugWaitAndRunReplicationOnce;
-        internal readonly int MinimalHeartbeatInterval;
 
         public DocumentDatabase Database;
         private SingleUseFlag _isInitialized = new SingleUseFlag();
@@ -112,11 +111,8 @@ namespace Raven.Server.Documents.Replication
             _shutdownToken = database.DatabaseShutdown;
             database.TombstoneCleaner.Subscribe(this);
             server.Cluster.Changes.DatabaseChanged += DatabaseValueChanged;
-            var config = database.Configuration.Replication;
-            var reconnectTime = config.RetryReplicateAfter.AsTimeSpan;
-            _reconnectAttemptTimer = new Timer(state => ForceTryReconnectAll(),
-                null, reconnectTime, reconnectTime);
-            MinimalHeartbeatInterval = (int)config.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds;
+            _reconnectAttemptTimer = new Timer(_ => ForceTryReconnectAll(),
+                null, database.Configuration.Replication.RetryReplicateAfter.AsTimeSpan, database.Configuration.Replication.RetryReplicateAfter.AsTimeSpan);
         }
 
         public long GetMinimalEtagForReplication(Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null, string collection = null)

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Exceptions;
+using Raven.Server.Config;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Replication.ReplicationItems;
@@ -37,13 +38,13 @@ namespace Raven.Server.Documents.Replication.Senders
         private readonly byte[] _tempBuffer = new byte[32 * 1024];
         private readonly Stream _stream;
         internal readonly DatabaseOutgoingReplicationHandler _parent;
-        private OutgoingReplicationStatsScope _statsInstance;
-        protected readonly ReplicationStats _stats = new ReplicationStats();
-        public bool MissingAttachmentsInLastBatch { get; private set; }
-        private HashSet<Slice> _deduplicatedAttachmentHashes = new(SliceComparer.Instance);
-        private Queue<Slice> _deduplicatedAttachmentHashesLru = new();
+        private readonly ReplicationStats _stats = new();
+        private readonly HashSet<Slice> _deduplicatedAttachmentHashes = new(SliceComparer.Instance);
+        private readonly Queue<Slice> _deduplicatedAttachmentHashesLru = new();
         private readonly int _numberOfAttachmentsTrackedForDeduplication;
         private readonly ByteStringContext _allocator; // required to clone the hashes 
+        public bool MissingAttachmentsInLastBatch { get; private set; }
+        private OutgoingReplicationStatsScope _statsInstance;
 
         protected ReplicationDocumentSenderBase(Stream stream, DatabaseOutgoingReplicationHandler parent, Logger log)
         {
@@ -99,12 +100,11 @@ namespace Raven.Server.Documents.Replication.Senders
             }
         }
 
-        public bool ExecuteReplicationOnce(TcpConnectionOptions tcpConnectionOptions, OutgoingReplicationStatsScope stats, ref long next)
+        public bool ExecuteReplicationOnce(TcpConnectionOptions tcpConnectionOptions, OutgoingReplicationStatsScope stats, ref long nextReplicateTicks)
         {
             EnsureValidStats(stats);
             var wasInterrupted = false;
-            var delay = GetDelayReplication();
-            var currentNext = next;
+            var currentNextReplicateTicks = nextReplicateTicks;
             using (_parent._database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
             using (documentsContext.OpenReadTransaction())
             {
@@ -132,15 +132,9 @@ namespace Raven.Server.Documents.Replication.Senders
                     var skippedReplicationItemsInfo = new SkippedReplicationItemsInfo();
                     long prevLastEtag = _lastEtag;
 
-                    var state = new ReplicationBatchState(documentsContext, _parent._database.Configuration.Databases.PulseReadTransactionLimit, this, next)
+                    var state = new ReplicationBatchState(documentsContext, _parent._database, parent: this, nextReplicateTicks)
                     {
-                        BatchSize = _parent._database.Configuration.Replication.MaxItemsCount,
-                        MaxSizeToSend = _parent._database.Configuration.Replication.MaxSizeToSend,
-                        CurrentNext = currentNext,
-                        Delay = delay,
-                        LastTransactionMarker = -1,
-                        NumberOfItemsSent = 0,
-                        Size = 0L,
+                        CurrentNextReplicateTicks = currentNextReplicateTicks
                     };
 
                     var replicationSupportedFeatures = new ReplicationSupportedFeatures
@@ -156,7 +150,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
                         while (enumerator.MoveNext())
                         {
-                            next = state.Next;
+                            nextReplicateTicks = state.NextReplicateTicks;
                             if (state.WasInterrupted)
                             {
                                 wasInterrupted = true;
@@ -190,7 +184,7 @@ namespace Raven.Server.Documents.Replication.Senders
                                     attachment.Stream = stream;
                                     var attachmentItem = AttachmentReplicationItem.From(documentsContext, attachment);
                                     AddReplicationItemToBatch(documentsContext, attachmentItem, _stats.Storage, state, skippedReplicationItemsInfo);
-                                    state.Size += attachmentItem.Size;
+                                    state._size += attachmentItem.Size;
                                 }
                             }
 
@@ -205,8 +199,8 @@ namespace Raven.Server.Documents.Replication.Senders
                                 continue;
                             }
 
-                            state.Size += item.Size;
-                            state.NumberOfItemsSent++;
+                            state._size += item.Size;
+                            state._numberOfItemsSent++;
                         }
                     }
 
@@ -227,7 +221,7 @@ namespace Raven.Server.Documents.Replication.Senders
                         {
                             msg += $"encryption buffer overhead size is {new Size(encryptionSize, SizeUnit.Bytes)}, ";
                         }
-                        msg += $"total size: {new Size(state.Size + encryptionSize, SizeUnit.Bytes)}";
+                        msg += $"total size: {new Size(state._size + encryptionSize, SizeUnit.Bytes)}";
 
                         Log.Info(msg);
                     }
@@ -242,6 +236,20 @@ namespace Raven.Server.Documents.Replication.Senders
                         _parent._lastSentDocumentEtag = _lastEtag;
                         _parent._lastDocumentSentTime = DateTime.UtcNow;
                         var changeVector = wasInterrupted ? null : DocumentsStorage.GetDatabaseChangeVector(documentsContext);
+
+                        if (Log.IsInfoEnabled)
+                        {
+                            var reason = wasInterrupted
+                                ? "batch enumeration was interrupted due to limits (time/size)"
+                                : "no items were found to replicate in this batch";
+
+                            var skippedInfo = skippedReplicationItemsInfo.SkippedItems > 0
+                                ? $", Skipped items: '{skippedReplicationItemsInfo.SkippedItems}'"
+                                : string.Empty;
+
+                            Log.Info($"Sending heartbeat (empty batch, {reason}){skippedInfo}. Last scanned etag: '{_lastEtag}'. WasInterrupted: '{wasInterrupted}'.");
+                        }
+
                         _parent.SendHeartbeat(changeVector);
                         return hasModification;
                     }
@@ -258,7 +266,7 @@ namespace Raven.Server.Documents.Replication.Senders
                         {
                             SendDocumentsBatch(documentsContext, _stats.Network);
                             tcpConnectionOptions.LastEtagSent = _lastEtag;
-                            tcpConnectionOptions.RegisterBytesSent(state.Size);
+                            tcpConnectionOptions.RegisterBytesSent(state._size);
                             if (MissingAttachmentsInLastBatch)
                                 return false;
                         }
@@ -688,34 +696,40 @@ namespace Raven.Server.Documents.Replication.Senders
         private sealed class ReplicationBatchState : PulsedEnumerationState<ReplicationBatchItem>
         {
             private readonly ReplicationDocumentSenderBase _parent;
-            public bool WasInterrupted { get; private set; }
+            private readonly RavenConfiguration _config;
+            private readonly DocumentDatabase _database;
+            private readonly TimeSpan _delay;
 
-            private long _next;
-            public long Next
+            private ReplicationBatchItem _item;
+            private long _lastHeartbeatTicks;
+            private short _lastTransactionMarker = -1;
+
+            private long _nextReplicateTicks;
+            internal long NextReplicateTicks
             {
-                get => _next;
-                private set
-                {
-                    _next = value;
-                }
+                get => _nextReplicateTicks;
+                private init => _nextReplicateTicks = value;
             }
 
             public HashSet<Slice> MissingAttachmentBase64Hashes;
-            public TimeSpan Delay;
-            private ReplicationBatchItem _item;
-            public long CurrentNext;
-            public long Size;
-            public int NumberOfItemsSent;
-            public short LastTransactionMarker;
-            public int? BatchSize;
-            public Size? MaxSizeToSend;
+            public long CurrentNextReplicateTicks;
 
-            public ReplicationBatchState(DocumentsOperationContext context, Size pulseLimit, ReplicationDocumentSenderBase parent, long next)
-                : base(context, pulseLimit, parent._parent._parent._server.Configuration.Replication.NumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded)
+            internal long _size;
+            internal int _numberOfItemsSent;
+            internal bool WasInterrupted { get; private set; }
+
+            public ReplicationBatchState(DocumentsOperationContext context, DocumentDatabase database, ReplicationDocumentSenderBase parent, long nextReplicateTicks)
+                : base(context, database.Configuration.Databases.PulseReadTransactionLimit, database.Configuration.Replication.NumberOfEnumeratedDocumentsToCheckIfPulseLimitExceeded)
             {
+                _database = database;
+                _config = database.Configuration;
                 _parent = parent;
+                _delay = parent.GetDelayReplication();
+
                 WasInterrupted = false;
-                Next = next;
+                NextReplicateTicks = nextReplicateTicks;
+
+                _lastHeartbeatTicks = database.Time.GetUtcNow().Ticks;
             }
 
             public override void OnMoveNext(ReplicationBatchItem current)
@@ -725,7 +739,20 @@ namespace Raven.Server.Documents.Replication.Senders
                 _parent._parent.CancellationToken.ThrowIfCancellationRequested();
                 _parent.AssertNoLegacyReplicationViolation(current);
 
-                if (LastTransactionMarker != current.TransactionMarker)
+                if ((ReadCount & 1023) == 0)
+                {
+                    var now = _database.Time.GetUtcNow().Ticks;
+                    if (now - _lastHeartbeatTicks > _config.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.Ticks)
+                    {
+                        if (_parent.Log.IsInfoEnabled)
+                             _parent.Log.Info($"Sending keep-alive heartbeat during active filtering. Current read count: '{ReadCount}'. Last sent etag: '{_parent._lastEtag}'.");
+
+                        _parent._parent.SendHeartbeat(null);
+                        _lastHeartbeatTicks = now;
+                    }
+                }
+
+                if (_lastTransactionMarker != current.TransactionMarker)
                 {
                     _item = current;
                     if (CanContinueBatch() == false)
@@ -733,7 +760,7 @@ namespace Raven.Server.Documents.Replication.Senders
                         WasInterrupted = true;
                         return;
                     }
-                    LastTransactionMarker = current.TransactionMarker;
+                    _lastTransactionMarker = current.TransactionMarker;
                 }
             }
 
@@ -741,28 +768,28 @@ namespace Raven.Server.Documents.Replication.Senders
             {
                 if (_parent.MissingAttachmentsInLastBatch)
                 {
-                    // we do have missing attachments but we haven't gathered yet any of the missing hashes
+                    // we do have missing attachments, but we haven't gathered yet any of the missing hashes
                     if (MissingAttachmentBase64Hashes == null)
                         return true;
 
-                    // we do have missing attachments but we haven't included all of them in the batch yet
+                    // we do have missing attachments, but we haven't included all of them in the batch yet
                     if (MissingAttachmentBase64Hashes.Count > 0)
                         return true;
                 }
 
-                if (Delay.Ticks > 0)
+                if (_delay.Ticks > 0)
                 {
-                    var nextReplication = _item.LastModifiedTicks + Delay.Ticks;
-                    if (_parent._parent._database.Time.GetUtcNow().Ticks < nextReplication)
+                    var nextReplicateTicks = _item.LastModifiedTicks + _delay.Ticks;
+                    if (_database.Time.GetUtcNow().Ticks < nextReplicateTicks)
                     {
-                        if (Interlocked.CompareExchange(ref _next, nextReplication, CurrentNext) == CurrentNext)
+                        if (Interlocked.CompareExchange(ref _nextReplicateTicks, nextReplicateTicks, CurrentNextReplicateTicks) == CurrentNextReplicateTicks)
                         {
                             return false;
                         }
                     }
                 }
 
-                if (NumberOfItemsSent == 0)
+                if (_numberOfItemsSent == 0)
                 {
                     // always send at least one item
                     return true;
@@ -770,22 +797,12 @@ namespace Raven.Server.Documents.Replication.Senders
 
                 // We want to limit batch sizes to reasonable limits.
                 var totalSize =
-                    Size + Context.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes);
+                    _size + Context.Transaction.InnerTransaction.LowLevelTransaction.AdditionalMemoryUsageSize.GetValue(SizeUnit.Bytes);
 
-                if (MaxSizeToSend.HasValue && totalSize >= MaxSizeToSend.Value.GetValue(SizeUnit.Bytes) ||
-                    BatchSize.HasValue && NumberOfItemsSent >= BatchSize.Value)
+                if (_numberOfItemsSent >= _config.Replication.MaxItemsCount ||
+                    _config.Replication.MaxSizeToSend.HasValue && totalSize >= _config.Replication.MaxSizeToSend.Value.GetValue(SizeUnit.Bytes))
                 {
                     return false;
-                }
-
-                var currentCount = _parent._stats.Storage.CurrentStats.InputCount;
-                if (currentCount > 0 && currentCount % 16384 == 0)
-                {
-                    // ReSharper disable once PossibleLossOfFraction
-                    if ((_parent._parent._parent.MinimalHeartbeatInterval / 2) < _parent._stats.Storage.Duration.TotalMilliseconds)
-                    {
-                        return false;
-                    }
                 }
 
                 return true;
@@ -793,7 +810,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
             public override bool ShouldPulseTransaction()
             {
-                if (NumberOfItemsSent == 0) // when we start to collect items to send (NumberOfItemsSent>0), we don't want to pulse transaction to prevent those items from being deleted before we send them in the batch.
+                if (_numberOfItemsSent == 0) // when we start to collect items to send (NumberOfItemsSent>0), we don't want to pulse transaction to prevent those items from being deleted before we send them in the batch.
                 {
                     return base.ShouldPulseTransaction();
                 }

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
@@ -18,6 +19,7 @@ using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server.Config;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
 using Raven.Server.ServerWide;
@@ -2029,6 +2031,136 @@ namespace SlowTests.Issues
                 Assert.False(stats.DatabaseChangeVector.Contains(ChangeVectorParser.SinkTag));
                 Assert.False(stats.DatabaseChangeVector.Contains(hubClusterId));
             }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task ShouldKeepConnectionAlive_WhenFilteringTakesLongTime()
+        {
+            // 1. Configure settings
+            var customSettings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Replication.ReplicationMinimalHeartbeat)] = "1",
+                [RavenConfiguration.GetKey(x => x.Replication.ActiveConnectionTimeout)] = "8"
+            };
+
+            var certificates = Certificates.SetupServerAuthentication(customSettings: customSettings);
+            var dbNameHub = GetDatabaseName();
+            var dbNameSink = GetDatabaseName();
+
+            var adminCert = Certificates.RegisterClientCertificate(
+                certificates.ServerCertificateForCommunication.Value,
+                certificates.ClientCertificate1.Value,
+                new Dictionary<string, DatabaseAccess>(),
+                SecurityClearance.ClusterAdmin);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = _ => dbNameHub
+            });
+
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = _ => dbNameSink
+            });
+
+            // 2. Prepare Data
+            // We replicate enough documents to complete several full 1024-cycles.
+            const int documentsCount = 5000;
+
+            // Using single transactions as requested
+            for (int i = 0; i < documentsCount; i++)
+            {
+                using (var session = hubStore.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new { Type = "Noise" }, $"items/skip/{i}");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            // The marker document
+            using (var session = hubStore.OpenAsyncSession())
+            {
+                await session.StoreAsync(new { Type = "Important" }, "items/include/1");
+                await session.SaveChangesAsync();
+            }
+
+            // 3. Inject dynamic Delay Logic
+            var hubDb = await Databases.GetDocumentDatabaseInstanceFor(hubStore);
+            hubDb.ReplicationLoader.ForTestingPurposesOnly().OnOutgoingReplicationStart = outgoingHandler =>
+            {
+                if (outgoingHandler.Destination.Database != sinkStore.Database)
+                    return;
+
+                int itemsProcessed = 0;
+                var sw = Stopwatch.StartNew();
+
+                outgoingHandler.ForTestingPurposesOnly().OnDocumentSenderFetchNewItem = () =>
+                {
+                    itemsProcessed++;
+
+                    if ((itemsProcessed & 1023) != 0)
+                        return;
+
+                    // We want each batch of 1024 items to take AT LEAST this long.
+                    // 2500ms > 1000ms HeartbeatInterval (triggers heartbeat)
+                    // 2500ms < 8000ms ConnectionTimeout (safe for single batch)
+                    // Total time for 5000 docs approx 10-12s > 8s (fails without heartbeat)
+                    const int targetBatchDurationMs = 2500;
+
+                    var elapsed = sw.ElapsedMilliseconds;
+                    var timeToWait = targetBatchDurationMs - elapsed;
+
+                    if (timeToWait > 0)
+                        Thread.Sleep((int)timeToWait);
+
+                    // Reset for the next batch
+                    sw.Restart();
+                };
+            };
+
+            // 4. Setup Pull Replication
+            var pullCert = certificates.ClientCertificate2.Value;
+            var pullCertBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx));
+            var publicCertBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert));
+
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "slow-hub",
+                Mode = PullReplicationMode.HubToSink,
+                WithFiltering = true
+            }));
+
+            await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("slow-hub",
+                new ReplicationHubAccess
+                {
+                    Name = "SinkUser",
+                    CertificateBase64 = publicCertBase64,
+                    AllowedHubToSinkPaths = ["items/include/*"]
+                }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = "HubConStr",
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                ConnectionStringName = "HubConStr",
+                CertificateWithPrivateKey = pullCertBase64,
+                HubName = "slow-hub",
+                Mode = PullReplicationMode.HubToSink
+            }));
+
+            // 5. Assert
+            // Total simulated time is approx 12 seconds. Connection timeout is 8 seconds.
+            var replicated = WaitForDocument(sinkStore, "items/include/1", timeout: 30_000);
+            Assert.True(replicated, "Document should be replicated. Failure implies connection timeout due to lack of heartbeats.");
         }
     }
 }

--- a/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
@@ -46,7 +46,7 @@ namespace SlowTests.Server.Replication
                 await SetupReplicationAsync(store2, store1);
 
                 Assert.True(WaitForDocumentDeletion(store2, "users/1"));
-                await Task.Delay((int)(documentDatabase.ReplicationLoader.MinimalHeartbeatInterval * 2.5));
+                await Task.Delay((int)(documentDatabase.Configuration.Replication.ReplicationMinimalHeartbeat.AsTimeSpan.TotalMilliseconds * 2.5));
 
                 using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25635

### Additional description

**Issue:**
During replication (specifically Pull Replication with filtering), if the Hub spent too much time iterating or filtering documents without sending data, the Sink would drop the connection due to `ActiveConnectionTimeout`. Additionally, the logic for interrupting a batch relied on a specific modulo check (`CurrentCount % 16384 == 0`), which could be bypassed depending on transaction sizes, preventing the batch from respecting time limits.

**Changes:**
*   **Keep-Alive Heartbeats:** Implemented a check within the document enumeration loop (`OnMoveNext`) to send empty `Heartbeat` messages if the processing time exceeds the `MinimalHeartbeatInterval`. This prevents the connection from being treated as "zombie" during long filtering operations.
*   **Diagnostics:** Added informative logging for scenarios where batches are interrupted or empty due to filtering, including counts of skipped items.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
