### PR TITLE
RavenDB-25605 - fix schema update exception on rare voron optimizations

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.Sharding.cs
@@ -110,12 +110,6 @@ namespace Raven.Server.Documents
 
         internal static void UpdateBucketStatsForAttachments(Transaction tx, Slice key, ref TableValueReader oldValue, ref TableValueReader newValue)
         {
-            if (tx.Owner is not DocumentsOperationContext { DocumentDatabase: ShardedDocumentDatabase documentDatabase })
-            {
-                Debug.Assert(false, $"tx.Owner is not DocumentsOperationContext");
-                return;
-            }
-
             var streamSize = 0L;
             var tree = tx.CreateTree(AttachmentsSlice);
 
@@ -131,12 +125,11 @@ namespace Raven.Server.Documents
             key.AsReadOnlySpan().Slice(0, sizeof(int)).CopyTo(bufferAsSpan);
             old.CopyTo(bufferAsSpan.Slice(sizeof(int)));
 
-            var schema = documentDatabase.ShardedDocumentsStorage.AttachmentsStorage.AttachmentsSchema;
-            var table = tx.OpenTable(schema, AttachmentsMetadataSlice);
+            var table = tx.OpenTable(ShardingAttachmentsSchemaBase, AttachmentsMetadataSlice);
             using (Slice.External(tx.Allocator, buffer, sizeof(int) + oldHashSize, ByteStringType.Immutable, out var slice))
             using (Slice.External(tx.Allocator, oldHashPtr, oldHashSize, ByteStringType.Immutable, out var hashSlice))
             {
-                var refCount = table.GetCountOfMatchesFor(schema.DynamicKeyIndexes[AttachmentsBucketAndHashSlice], slice);
+                var refCount = table.GetCountOfMatchesFor(ShardingAttachmentsSchemaBase.DynamicKeyIndexes[AttachmentsBucketAndHashSlice], slice);
                 switch (refCount)
                 {
                     case 1:

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Sharding;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Binary;
@@ -41,6 +42,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             using var o = Slice.From(ctx.Allocator, AttachmentsHash, out var attachmentsHashSlice);
             using var r = Slice.From(ctx.Allocator, AttachmentsFlagAndHash, out var attachmentsFlagAndHashSlice);
 
+            var isSharded = step.DocumentsStorage is ShardedDocumentsStorage;
             step.WriteTx.CreateTree(attachmentsFlagAndHashSlice, isIndexTree: true);
 
             TableSchema attachmentsSchemaBase = new TableSchema();
@@ -72,13 +74,32 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
             attachmentsSchemaBase.DefineIndex(dynamicIndex);
 
-            UpdateSchemaInternal(step, attachmentsSchemaBase, dynamicIndex, PopulateAttachmentsFlagAndHashDynamicIndex);
-            UpdateSchemaInternal(step, attachmentsSchemaBase, dynamicIndex, AttachmentsTableSchemaUpdate);
+            if (isSharded)
+            {
+                attachmentsSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = AttachmentsStorage.GenerateBucketAndHashForAttachments,
+                    IsGlobal = true,
+                    Name = Raven.Server.Documents.Schemas.Attachments.AttachmentsBucketAndHashSlice,
+                    SupportDuplicateKeys = true
+                });
+
+                attachmentsSchemaBase.DefineIndex(new TableSchema.DynamicKeyIndexDef
+                {
+                    GenerateKey = AttachmentsStorage.GenerateBucketAndEtagIndexKeyForAttachments,
+                    OnEntryChanged = AttachmentsStorage.UpdateBucketStatsForAttachments,
+                    IsGlobal = true,
+                    Name = Raven.Server.Documents.Schemas.Attachments.AttachmentsBucketAndEtagSlice
+                });
+            }
+
+            UpdateSchemaInternal(step, attachmentsSchemaBase, dynamicIndex, isSharded, PopulateAttachmentsFlagAndHashDynamicIndex);
+            UpdateSchemaInternal(step, attachmentsSchemaBase, dynamicIndex, isSharded, AttachmentsTableSchemaUpdate);
 
             return true;
         }
 
-        private void UpdateSchemaInternal(UpdateStep step, TableSchema attachmentsSchemaBase, TableSchema.DynamicKeyIndexDef dynamicIndex,
+        private void UpdateSchemaInternal(UpdateStep step, TableSchema attachmentsSchemaBase, TableSchema.DynamicKeyIndexDef dynamicIndex, bool isSharded,
             Func<TableSchema.DynamicKeyIndexDef, Table, Slice, TableValueBuilder, bool> update)
         {
             var skip = 0L;
@@ -89,6 +110,13 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             {
                 using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 {
+                    if (isSharded)
+                    {
+                        step.WriteTx.Owner = context;
+                        step.WriteTx.OnBeforeCommit += ((ShardedDocumentsStorage)step.DocumentsStorage).OnBeforeCommit;
+                        step.WriteTx.LowLevelTransaction.OnRollBack += ((ShardedDocumentsStorage)step.DocumentsStorage).OnFailure;
+                    }
+
                     context.TransactionMarkerOffset = (short)step.WriteTx.LowLevelTransaction.Id;
                     var commit = false;
                     var readTable = step.ReadTx.OpenTable(attachmentsSchemaBase, AttachmentsMetadata);
@@ -128,6 +156,16 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                         }
 
                         done = true;
+                    }
+
+                    if (isSharded)
+                    {
+                        // for sharded we need to manually commit here, since it is using the context in the tx.OnBeforeCommit event
+                        step.Commit(context);
+                        step.RenewTransactions();
+                        step.WriteTx.Owner = null;
+                        step.WriteTx.OnBeforeCommit -= ((ShardedDocumentsStorage)step.DocumentsStorage).OnBeforeCommit;
+                        step.WriteTx.LowLevelTransaction.OnRollBack -= ((ShardedDocumentsStorage)step.DocumentsStorage).OnFailure;
                     }
                 }
             }

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Raven.Server.Documents;
 using Raven.Server.Json;
@@ -71,6 +70,17 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                 SupportDuplicateKeys = true
             };
 
+            attachmentsSchemaBase.DefineIndex(dynamicIndex);
+
+            UpdateSchemaInternal(step, attachmentsSchemaBase, dynamicIndex, PopulateAttachmentsFlagAndHashDynamicIndex);
+            UpdateSchemaInternal(step, attachmentsSchemaBase, dynamicIndex, AttachmentsTableSchemaUpdate);
+
+            return true;
+        }
+
+        private void UpdateSchemaInternal(UpdateStep step, TableSchema attachmentsSchemaBase, TableSchema.DynamicKeyIndexDef dynamicIndex,
+            Func<TableSchema.DynamicKeyIndexDef, Table, Slice, TableValueBuilder, bool> update)
+        {
             var skip = 0L;
             var processed = 0L;
             var done = false;
@@ -97,15 +107,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                                 using (scope)
                                 using (AttachmentOldToTableValue(context, writeTable, attachmentOld, out var tvb, out var pkSlice))
                                 {
-                                    writeTable.DeleteByKey(pkSlice);
-
-                                    var id = writeTable.Insert(tvb);
-
-                                    using (dynamicIndex.GetValue(writeTable._tx, tvb, out Slice newVal))
-                                    {
-                                        var indexTree = writeTable.GetTree(dynamicIndex);
-                                        writeTable.AddValueToDynamicIndex(id, dynamicIndex, indexTree, newVal, TreeNodeFlags.Data);
-                                    }
+                                    update.Invoke(dynamicIndex, writeTable, pkSlice, tvb);
                                 }
                             }
 
@@ -129,7 +131,26 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     }
                 }
             }
+        }
 
+        private static bool PopulateAttachmentsFlagAndHashDynamicIndex(TableSchema.DynamicKeyIndexDef dynamicIndex, Table writeTable, Slice pkSlice, TableValueBuilder tvb)
+        {
+            if (writeTable.TryFindIdFromPrimaryKey(pkSlice, out var id))
+            {
+                // populate value into the new dynamic index
+                using (dynamicIndex.GetValue(writeTable._tx, tvb, out Slice newVal))
+                {
+                    var indexTree = writeTable.GetTree(dynamicIndex);
+                    writeTable.AddValueToDynamicIndex(id, dynamicIndex, indexTree, newVal, TreeNodeFlags.Data);
+                }
+            }
+
+            return true;
+        }
+
+        private bool AttachmentsTableSchemaUpdate(TableSchema.DynamicKeyIndexDef dynamicIndex, Table writeTable, Slice pkSlice, TableValueBuilder tvb)
+        {
+            writeTable.Set(tvb, forceUpdate: true);
             return true;
         }
 
@@ -198,8 +219,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
         {
             var hashPtr = tvr.Read((int)AttachmentsTable.Hash, out var hashSize);
 
-            var flags = *(int*)tvr.Read((int)AttachmentsTable.Flags, out var size);
-            Debug.Assert(size == sizeof(int));
+            int flags = tvr.Count == 7 ? 0 : *(int*)tvr.Read((int)AttachmentsTable.Flags, out var size);
             var scope = tx.Allocator.Allocate(sizeof(int) + 1 + hashSize, out var buffer); // flag + record separator + hash
 
             var span = new Span<byte>(buffer.Ptr, buffer.Length);

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Raven.Client.Documents.Attachments;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Json;
@@ -28,6 +29,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
         private static readonly string AttachmentsEtag = "AttachmentsEtag";
         private static readonly string AttachmentsHash = "AttachmentsHash";
         private static readonly string AttachmentsFlagAndHash = "AttachmentsFlagAndHash";
+        private static readonly int _oldSchemaSize = 7;
 
         internal static int NumberOfAttachmentsToMigrateInSingleTransaction = PlatformDetails.Is32Bits ? 2048 : 32768;
 
@@ -257,7 +259,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
         {
             var hashPtr = tvr.Read((int)AttachmentsTable.Hash, out var hashSize);
 
-            int flags = tvr.Count == 7 ? 0 : *(int*)tvr.Read((int)AttachmentsTable.Flags, out var size);
+            int flags = tvr.Count == _oldSchemaSize ? (int)RemoteAttachmentFlags.None : *(int*)tvr.Read((int)AttachmentsTable.Flags, out var size);
             var scope = tx.Allocator.Allocate(sizeof(int) + 1 + hashSize, out var buffer); // flag + record separator + hash
 
             var span = new Span<byte>(buffer.Ptr, buffer.Length);

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -208,7 +208,7 @@ namespace Voron.Data.Tables
             return pkTree.TryRead(key, out _);
         }
 
-        private bool TryFindIdFromPrimaryKey(Slice key, out long id)
+        internal bool TryFindIdFromPrimaryKey(Slice key, out long id)
         {
             id = -1;
             var pkTree = GetTree(_schema.Key);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25605

### Additional description

Fixed an issue when attachment schema update was trying to defrag pages that not yet were processed, which lead to missing entry in a dynamic voron index. Now we first populate the new dynamic index, and then update the attachments table schema.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
