### PR TITLE
RavenDB-25685 - fix size calculation for remote attachment in ETL

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.TimeSeries;
+using Raven.Client.Extensions;
 using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.TimeSeries;
 using Sparrow.Json;
@@ -149,7 +150,11 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             }
 
             attachments.Add((name ?? attachment.Name, attachment));
-            _stats.IncrementBatchSize(attachment.Stream.Length);
+
+            if (attachment.RemoteParameters.IsLocalStorageAttachment())
+            {
+                _stats.IncrementBatchSize(attachment.Stream.Length);
+            }
         }
 
         public void DeleteAttachment(string documentId, string name)

--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseDocumentTransformerBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseDocumentTransformerBase.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Jint.Native;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Extensions;
 using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Patch;
 using Raven.Server.Documents.TimeSeries;
@@ -82,7 +83,10 @@ where TRelationalEtlConfiguration: EtlConfiguration<TRelationalConnectionString>
                 relationalColumn.Type = 0;
                 relationalColumn.Value = attachment.Stream;
 
-                _stats.IncrementBatchSize(attachment.Stream.Length);
+                if (attachment.RemoteParameters.IsLocalStorageAttachment())
+                {
+                    _stats.IncrementBatchSize(attachment.Stream.Length);
+                }
             }
 
             columns.Add(relationalColumn);

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -1669,11 +1669,11 @@ namespace SlowTests.Server.Documents.Attachments
 var meta = this['@metadata'];
 if (!meta || !meta['@attachments'])
     return;
-
+var doc = loadToOrders(this);
 for (var i = 0; i < meta['@attachments'].length; i++) {
     var att = meta['@attachments'][i];
-	
-	loadToOrders(this).addAttachment(att.Name, loadAttachment(att.Name));
+    
+    doc.addAttachment(att.Name, loadAttachment(att.Name));
 }
 
 " } }

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -1645,6 +1645,73 @@ namespace SlowTests.Server.Documents.Attachments
         }
 
         [AmazonS3RetryTheory]
+        [InlineData(1, 3)]
+        [InlineData(32, 3)]
+        public async Task CanEtlRemoteAttachmentsToDestination2(int attachmentsCount, int size)
+        {
+            await using (var holder = CreateCloudSettings())
+            {
+                int docsCount = RemoteAttachmentsHolderBase.GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                var ids = new List<(string Id, string Collection)>();
+                using (var store = GetDocumentStore())
+                using (var replica = GetDocumentStore())
+                {
+                    var identifier = await CanUploadRemoteAttachmentToCloudAndGetInternal(attachmentsCount, size, store, docsCount, ids, attachmentsPerDoc);
+                    var taskName = "etl-test";
+                    var csName = "cs-test";
+
+                    var configuration = new RavenEtlConfiguration
+                    {
+                        ConnectionStringName = csName,
+                        Name = taskName,
+                        Transforms = { new Transformation { Name = "S1", Collections = { "Orders" }, Script = @"
+
+var meta = this['@metadata'];
+if (!meta || !meta['@attachments'])
+    return;
+
+for (var i = 0; i < meta['@attachments'].length; i++) {
+    var att = meta['@attachments'][i];
+	
+	loadToOrders(this).addAttachment(att.Name, loadAttachment(att.Name));
+}
+
+" } }
+                    };
+
+                    var connectionString = new RavenConnectionString { Name = csName, TopologyDiscoveryUrls = replica.Urls, Database = replica.Database, };
+
+                    var etlDone = Etl.WaitForEtlToComplete(store);
+                    Etl.AddEtl(store, configuration, connectionString);
+                    await etlDone.WaitAsync(TimeSpan.FromSeconds(15));
+
+                    var replicaDb = await Databases.GetDocumentDatabaseInstanceFor(replica);
+                    var val3 = WaitForValue(() =>
+                    {
+                        using (replicaDb.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                        using (context.OpenReadTransaction())
+                        {
+                            var c = replicaDb.DocumentsStorage.AttachmentsStorage.GetAllAttachments(context).Count();
+
+                            return c;
+                        }
+                    }, attachmentsCount, 30_000);
+                    Assert.Equal(attachmentsCount, val3);
+
+                    foreach (var remote in Attachments)
+                    {
+                        var e = await Assert.ThrowsAsync<RavenException>(async () =>
+                            await replica.Operations.SendAsync(new GetAttachmentOperation(remote.DocumentId, remote.Name, AttachmentType.Document, null)));
+                        Assert.Contains($"Cannot perform 'GetAttachmentOperation' for remote attachment '{remote.Name}' on document '{remote.DocumentId}' because the database does not have a RemoteAttachmentsConfiguration configured.", e.Message);
+                    }
+
+                    var identifier2 = await PutRemoteAttachmentsConfiguration(replica, Settings);
+                    await AssertGetRemoteAttachmentsInBulk(replica, size, identifier2, RemoteAttachmentFlags.Remote);
+                }
+            }
+        }
+
+        [AmazonS3RetryTheory]
         [InlineData(1, 3, true)]
         [InlineData(1, 3, false)]
         [InlineData(64, 3, true)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25685

### Additional description

We were using `Stream.Length` for batch stats calculation, for remote attachments there is no `Stream`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
