### PR TITLE
RavenDB-25687 - Skip schema validation for internal RavenDB operations

### DIFF
--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -214,6 +214,8 @@ namespace Raven.Client.ServerWide
 
         public void AddIndex(IndexDefinition definition, string source, DateTime createdAt, long raftIndex, int revisionsToKeep, IndexDeploymentMode globalDeploymentMode)
         {
+            ValidateSchemaCollections(definition);
+
             var lockMode = IndexLockMode.Unlock;
 
             IndexDefinitionCompareDifferences? differences = null;
@@ -283,6 +285,30 @@ namespace Raven.Client.ServerWide
             }
 
             definition.ClusterState.LastIndex = raftIndex;
+        }
+
+        private void ValidateSchemaCollections(IndexDefinition definition)
+        {
+            if (SchemaValidation == null || SchemaValidation.HasEnabledConfiguration() == false)
+                return;
+
+            if (definition.Reduce == null || definition.OutputReduceToCollection == null)
+                return;
+
+            if (SchemaValidation.ValidatorsPerCollection.TryGetValue(definition.OutputReduceToCollection, out var schemaDefinition) &&
+                schemaDefinition.Disabled == false)
+            {
+                throw new InvalidOperationException($"Cannot create index '{definition.Name}' which outputs to collection " +
+                                                    $"'{definition.OutputReduceToCollection}' that has a schema validation configured.");
+            }
+
+            if (definition.PatternReferencesCollectionName != null &&
+                SchemaValidation.ValidatorsPerCollection.TryGetValue(definition.PatternReferencesCollectionName, out schemaDefinition) &&
+                schemaDefinition.Disabled == false)
+            {
+                throw new InvalidOperationException($"Cannot create index '{definition.Name}' which outputs the pattern to collection " +
+                                                    $"'{definition.PatternReferencesCollectionName}' that has a schema validation configured.");
+            }
         }
 
         internal void AddIndexHistory(IndexDefinition definition, string source, int revisionsToKeep, DateTime createdAt, Dictionary<string, RollingIndexDeployment> rollingIndexDeployment = null, bool isFromCommand = false, bool isRolling = false)

--- a/src/Raven.Client/ServerWide/DatabaseRecord.cs
+++ b/src/Raven.Client/ServerWide/DatabaseRecord.cs
@@ -289,22 +289,17 @@ namespace Raven.Client.ServerWide
 
         private void ValidateSchemaCollections(IndexDefinition definition)
         {
-            if (SchemaValidation == null || SchemaValidation.HasEnabledConfiguration() == false)
+            if (SchemaValidation == null || definition.Reduce == null || definition.OutputReduceToCollection == null)
                 return;
 
-            if (definition.Reduce == null || definition.OutputReduceToCollection == null)
-                return;
-
-            if (SchemaValidation.ValidatorsPerCollection.TryGetValue(definition.OutputReduceToCollection, out var schemaDefinition) &&
-                schemaDefinition.Disabled == false)
+            if (SchemaValidation.ValidatorsPerCollection.TryGetValue(definition.OutputReduceToCollection, out _))
             {
                 throw new InvalidOperationException($"Cannot create index '{definition.Name}' which outputs to collection " +
                                                     $"'{definition.OutputReduceToCollection}' that has a schema validation configured.");
             }
 
             if (definition.PatternReferencesCollectionName != null &&
-                SchemaValidation.ValidatorsPerCollection.TryGetValue(definition.PatternReferencesCollectionName, out schemaDefinition) &&
-                schemaDefinition.Disabled == false)
+                SchemaValidation.ValidatorsPerCollection.TryGetValue(definition.PatternReferencesCollectionName, out _))
             {
                 throw new InvalidOperationException($"Cannot create index '{definition.Name}' which outputs the pattern to collection " +
                                                     $"'{definition.PatternReferencesCollectionName}' that has a schema validation configured.");

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -561,7 +561,7 @@ namespace Raven.Server.Documents
                 using (data = context.ReadObject(data, documentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 {
                     collectionName = extractCollectionName ? _documentsStorage.ExtractCollectionName(context, data) : default;
-                    var nonPersistentDocumentFlags = NonPersistentDocumentFlags.ByAttachmentUpdate | NonPersistentDocumentFlags.SkipSchemaValidation;
+                    const NonPersistentDocumentFlags nonPersistentDocumentFlags = NonPersistentDocumentFlags.ByAttachmentUpdate | NonPersistentDocumentFlags.SkipSchemaValidation;
                     return _documentsStorage.Put(context, documentId, null, data, null, null, null, flags, nonPersistentDocumentFlags).ChangeVector;
                 }
             }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -561,7 +561,8 @@ namespace Raven.Server.Documents
                 using (data = context.ReadObject(data, documentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
                 {
                     collectionName = extractCollectionName ? _documentsStorage.ExtractCollectionName(context, data) : default;
-                    return _documentsStorage.Put(context, documentId, null, data, null, null, null, flags, NonPersistentDocumentFlags.ByAttachmentUpdate).ChangeVector;
+                    var nonPersistentDocumentFlags = NonPersistentDocumentFlags.ByAttachmentUpdate | NonPersistentDocumentFlags.SkipSchemaValidation;
+                    return _documentsStorage.Put(context, documentId, null, data, null, null, null, flags, nonPersistentDocumentFlags).ChangeVector;
                 }
             }
             finally

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -2194,7 +2194,7 @@ namespace Raven.Server.Documents
             if (newData == null)
                 return null;
 
-            var putResult = _documentDatabase.DocumentsStorage.Put(context, docId, expectedChangeVector: null, newData, flags: flags, nonPersistentFlags: nonPersistentDocumentFlags);
+            var putResult = _documentDatabase.DocumentsStorage.Put(context, docId, expectedChangeVector: null, newData, flags: flags, nonPersistentFlags: nonPersistentDocumentFlags | NonPersistentDocumentFlags.SkipSchemaValidation);
             return putResult.ChangeVector;
         }
 

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -2113,7 +2113,7 @@ namespace Raven.Server.Documents
                         using (document.Data = document.Data.Clone(context))
                         {
                             _documentDatabase.DocumentsStorage.Put(context, docId, expectedChangeVector: null, document.Data, flags: document.Flags,
-                                nonPersistentFlags: document.NonPersistentFlags);
+                                nonPersistentFlags: document.NonPersistentFlags | NonPersistentDocumentFlags.SkipSchemaValidation);
                         }
                     }
                     catch (InvalidOperationException e)

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -54,7 +54,7 @@ namespace Raven.Server.Documents
 
             using (doc.Data)
             {
-                PutDocument(context, docId, expectedChangeVector: null, document: doc.Data, nonPersistentFlags: type.ResolveConflictFlag);
+                PutDocument(context, docId, expectedChangeVector: null, document: doc.Data, nonPersistentFlags: type.ResolveConflictFlag | NonPersistentDocumentFlags.SkipSchemaValidation);
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PutConversationCommand.cs
@@ -42,13 +42,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     var historyId = _database.DocumentsStorage.DocumentPut.BuildDocumentId($"{AiAgentConversationHistoryIdPrefix}{_database.IdentityPartsSeparator}", _database.DocumentsStorage.GenerateNextEtag(), out _);
                     historyId = $"{historyId}${_id}";
 
-                    var putHistoryResult = _database.DocumentsStorage.Put(context, historyId, null, historyDoc);
+                    var putHistoryResult = _database.DocumentsStorage.Put(context, historyId, null, historyDoc, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
                     _conversation.LinkedConversations.Add(putHistoryResult.Id);
                 }
             }
 
             _conversationDoc = _conversation.ToBlittable(context);
-            PutResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _conversationDoc);
+            PutResult = _database.DocumentsStorage.Put(context, _id, _expectedChangeVector, _conversationDoc, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
 
             return 1;
         }

--- a/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForGetNextHiLo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForGetNextHiLo.cs
@@ -126,7 +126,7 @@ internal sealed class HiLoHandlerProcessorForGetNextHiLo : AbstractHiLoHandlerPr
                     };
 
                     using (var freshHilo = context.ReadObject(newDoc, hiLoDocumentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                        Database.DocumentsStorage.Put(context, hiLoDocumentId, null, freshHilo);
+                        Database.DocumentsStorage.Put(context, hiLoDocumentId, null, freshHilo, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
                 }
                 else
                 {
@@ -139,7 +139,7 @@ internal sealed class HiLoHandlerProcessorForGetNextHiLo : AbstractHiLoHandlerPr
                     };
 
                     using (var freshHilo = context.ReadObject(hiloDocReader, hiLoDocumentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
-                        Database.DocumentsStorage.Put(context, hiLoDocumentId, null, freshHilo);
+                        Database.DocumentsStorage.Put(context, hiLoDocumentId, null, freshHilo, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
                 }
 
                 Prefix = prefix;

--- a/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForReturnHiLo.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/HiLo/HiLoHandlerProcessorForReturnHiLo.cs
@@ -58,7 +58,7 @@ internal sealed class HiLoHandlerProcessorForReturnHiLo : AbstractHiLoHandlerPro
 
             using (var hiloReader = context.ReadObject(document.Data, hiLoDocumentId, BlittableJsonDocumentBuilder.UsageMode.ToDisk))
             {
-                Database.DocumentsStorage.Put(context, hiLoDocumentId, null, hiloReader);
+                Database.DocumentsStorage.Put(context, hiLoDocumentId, null, hiloReader, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
             }
 
             return 1;

--- a/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/OutputToCollection/OutputReduceToCollectionCommand.cs
@@ -217,7 +217,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.OutputToCollection
 
         public void ArtificialPut(DocumentsOperationContext context, string key, BlittableJsonReaderObject document)
         {
-            _database.DocumentsStorage.Put(context, key, null, document, flags: DocumentFlags.Artificial | DocumentFlags.FromIndex);
+            _database.DocumentsStorage.Put(context, key, null, document, flags: DocumentFlags.Artificial | DocumentFlags.FromIndex, nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
         }
     }
 

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -215,7 +215,6 @@ namespace Raven.Server.Documents.Patch
                         {
                             originalDocument.Flags &= ~DocumentFlags.Archived;
                             nonPersistentFlags |= NonPersistentDocumentFlags.Unarchive;
-                            nonPersistentFlags |= NonPersistentDocumentFlags.SkipSchemaValidation;
                         }
                         
                         if (_isTest == false || run.PutOrDeleteCalled)

--- a/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDocumentCommand.cs
@@ -215,6 +215,7 @@ namespace Raven.Server.Documents.Patch
                         {
                             originalDocument.Flags &= ~DocumentFlags.Archived;
                             nonPersistentFlags |= NonPersistentDocumentFlags.Unarchive;
+                            nonPersistentFlags |= NonPersistentDocumentFlags.SkipSchemaValidation;
                         }
                         
                         if (_isTest == false || run.PutOrDeleteCalled)

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -62,7 +62,7 @@ public class SchemaValidatorCache : IDisposable
             SchemaValidator schemaValidator;
             try
             {
-                if (collection.StartsWith("@") && collection != Constants.Documents.Collections.EmptyCollection)
+                if (collection.StartsWith('@') && collection != Constants.Documents.Collections.EmptyCollection)
                     throw new InvalidOperationException($"Schema validation cannot be defined for system collections other than '{Constants.Documents.Collections.EmptyCollection}'. Invalid collection name: '{collection}'.");
 
                 var blittable = _context.Sync.ReadForMemory(validator.Schema, "schema-validation");

--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
+using Raven.Client;
 using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.Exceptions.SchemaValidation;
 using Raven.Server.Documents.SchemaValidation.ErrorMessage;
@@ -61,6 +62,9 @@ public class SchemaValidatorCache : IDisposable
             SchemaValidator schemaValidator;
             try
             {
+                if (collection.StartsWith("@") && collection != Constants.Documents.Collections.EmptyCollection)
+                    throw new InvalidOperationException($"Schema validation cannot be defined for system collections other than '{Constants.Documents.Collections.EmptyCollection}'. Invalid collection name: '{collection}'.");
+
                 var blittable = _context.Sync.ReadForMemory(validator.Schema, "schema-validation");
                 schemaValidator = SchemaValidationHelper.InitValidatorForDocument(_context, blittable, validator.Schema, _configuration, validator.Disabled);
             }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2311,10 +2311,13 @@ namespace Raven.Server.Documents.TimeSeries
             var flags = doc.Flags.Strip(DocumentFlags.FromClusterTransaction | DocumentFlags.Resolved);
             flags |= DocumentFlags.HasTimeSeries;
 
+            nonPersistentFlags |= NonPersistentDocumentFlags.ByTimeSeriesUpdate;
+            nonPersistentFlags |= NonPersistentDocumentFlags.SkipSchemaValidation;
+
             using (data)
             {
                 var newDocumentData = ctx.ReadObject(doc.Data, docId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                _documentDatabase.DocumentsStorage.Put(ctx, doc.Id, null, newDocumentData, flags: flags, nonPersistentFlags: nonPersistentFlags |= NonPersistentDocumentFlags.ByTimeSeriesUpdate);
+                _documentDatabase.DocumentsStorage.Put(ctx, doc.Id, null, newDocumentData, flags: flags, nonPersistentFlags: nonPersistentFlags);
             }
         }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -548,7 +548,7 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 var newDocumentData = ctx.ReadObject(doc.Data, doc.Id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
                 storage.Put(ctx, doc.Id, null, newDocumentData, flags: flags,
-                    nonPersistentFlags: NonPersistentDocumentFlags.ByTimeSeriesUpdate);
+                    nonPersistentFlags: NonPersistentDocumentFlags.ByTimeSeriesUpdate | NonPersistentDocumentFlags.SkipSchemaValidation);
             }
         }
 
@@ -2240,7 +2240,7 @@ namespace Raven.Server.Documents.TimeSeries
             using (data)
             {
                 var newDocumentData = ctx.ReadObject(doc.Data, docId, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
-                _documentDatabase.DocumentsStorage.Put(ctx, doc.Id, null, newDocumentData, flags: flags, nonPersistentFlags: NonPersistentDocumentFlags.ByTimeSeriesUpdate);
+                _documentDatabase.DocumentsStorage.Put(ctx, doc.Id, null, newDocumentData, flags: flags, nonPersistentFlags: NonPersistentDocumentFlags.ByTimeSeriesUpdate | NonPersistentDocumentFlags.SkipSchemaValidation);
             }
         }
 

--- a/src/Raven.Server/ServerWide/Commands/EditSchemaValidationConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditSchemaValidationConfigurationCommand.cs
@@ -1,6 +1,6 @@
 ﻿using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.ServerWide;
-using Raven.Server.Utils;
+using Raven.Server.Rachis;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide.Commands;
@@ -27,6 +27,28 @@ public class EditSchemaValidationConfigurationCommand : UpdateDatabaseCommand
     public override void UpdateDatabaseRecord(DatabaseRecord record, long etag)
     {
         record.SchemaValidation = Configuration;
+
+        if (Configuration == null || Configuration.HasEnabledConfiguration() == false || record.Indexes == null)
+            return;
+
+        foreach (var index in record.Indexes.Values)
+        {
+            if (index.Reduce == null || index.OutputReduceToCollection == null)
+                continue;
+
+            if (Configuration.ValidatorsPerCollection.TryGetValue(index.OutputReduceToCollection, out var schemaDefinition) &&
+                schemaDefinition.Disabled == false)
+            {
+                throw new RachisApplyException($"Cannot have an index that outputs to collection '{index.OutputReduceToCollection}' which has an active schema validation defined.");
+            }
+
+            if (index.PatternReferencesCollectionName != null &&
+                Configuration.ValidatorsPerCollection.TryGetValue(index.PatternReferencesCollectionName, out schemaDefinition) &&
+                schemaDefinition.Disabled == false)
+            {
+                throw new RachisApplyException($"Cannot have an index that uses the pattern for outputs the pattern to collection '{index.PatternReferencesCollectionName}' which has an active schema validation defined.");
+            }
+        }
     }
 
     public override void FillJson(DynamicJsonValue json)

--- a/src/Raven.Server/ServerWide/Commands/EditSchemaValidationConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditSchemaValidationConfigurationCommand.cs
@@ -29,15 +29,12 @@ public class EditSchemaValidationConfigurationCommand : UpdateDatabaseCommand
     {
         record.SchemaValidation = Configuration;
 
-        if (Configuration == null || Configuration.HasEnabledConfiguration() == false)
+        if (Configuration == null || Configuration.ValidatorsPerCollection == null)
             return;
 
         foreach (var keyValue in Configuration.ValidatorsPerCollection)
         {
-            if (keyValue.Value.Disabled)
-                continue;
-
-            if (keyValue.Key.StartsWith("@") && keyValue.Key != Constants.Documents.Collections.EmptyCollection)
+            if (keyValue.Key.StartsWith('@') && keyValue.Key != Constants.Documents.Collections.EmptyCollection)
             {
                 throw new RachisApplyException($"Schema validation cannot be defined for system collections other than '{Constants.Documents.Collections.EmptyCollection}'. Invalid collection name: '{keyValue.Key}'.");
             }
@@ -51,15 +48,13 @@ public class EditSchemaValidationConfigurationCommand : UpdateDatabaseCommand
             if (index.Reduce == null || index.OutputReduceToCollection == null)
                 continue;
 
-            if (Configuration.ValidatorsPerCollection.TryGetValue(index.OutputReduceToCollection, out var schemaDefinition) &&
-                schemaDefinition.Disabled == false)
+            if (Configuration.ValidatorsPerCollection.TryGetValue(index.OutputReduceToCollection, out _))
             {
                 throw new RachisApplyException($"Cannot have an index that outputs to collection '{index.OutputReduceToCollection}' which has an active schema validation defined.");
             }
 
             if (index.PatternReferencesCollectionName != null &&
-                Configuration.ValidatorsPerCollection.TryGetValue(index.PatternReferencesCollectionName, out schemaDefinition) &&
-                schemaDefinition.Disabled == false)
+                Configuration.ValidatorsPerCollection.TryGetValue(index.PatternReferencesCollectionName, out _))
             {
                 throw new RachisApplyException($"Cannot have an index that uses the pattern for outputs the pattern to collection '{index.PatternReferencesCollectionName}' which has an active schema validation defined.");
             }

--- a/src/Raven.Server/ServerWide/Commands/EditSchemaValidationConfigurationCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/EditSchemaValidationConfigurationCommand.cs
@@ -1,4 +1,5 @@
-﻿using Raven.Client.Documents.Operations.SchemaValidation;
+﻿using Raven.Client;
+using Raven.Client.Documents.Operations.SchemaValidation;
 using Raven.Client.ServerWide;
 using Raven.Server.Rachis;
 using Sparrow.Json.Parsing;
@@ -28,7 +29,21 @@ public class EditSchemaValidationConfigurationCommand : UpdateDatabaseCommand
     {
         record.SchemaValidation = Configuration;
 
-        if (Configuration == null || Configuration.HasEnabledConfiguration() == false || record.Indexes == null)
+        if (Configuration == null || Configuration.HasEnabledConfiguration() == false)
+            return;
+
+        foreach (var keyValue in Configuration.ValidatorsPerCollection)
+        {
+            if (keyValue.Value.Disabled)
+                continue;
+
+            if (keyValue.Key.StartsWith("@") && keyValue.Key != Constants.Documents.Collections.EmptyCollection)
+            {
+                throw new RachisApplyException($"Schema validation cannot be defined for system collections other than '{Constants.Documents.Collections.EmptyCollection}'. Invalid collection name: '{keyValue.Key}'.");
+            }
+        }
+
+        if (record.Indexes == null)
             return;
 
         foreach (var index in record.Indexes.Values)

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -8,6 +8,7 @@ using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Client.Documents.Operations.ETL;
@@ -163,10 +164,11 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
                 [Constants.Documents.Metadata.ArchiveAt] = expiry.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite)
             };
 
+            const string docId = "users/1-A";
             using (var session = store.OpenAsyncSession())
             {
                 var user = new User { Name = "Grisha" };
-                await session.StoreAsync(user);
+                await session.StoreAsync(user, docId);
                 var metadataFromDoc = session.Advanced.GetMetadataFor(user);
                 metadataFromDoc[Constants.Documents.Metadata.ArchiveAt] = metadata[Constants.Documents.Metadata.ArchiveAt];
                 await session.SaveChangesAsync();
@@ -188,12 +190,30 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             var documentsArchiver = database.DataArchivist;
             await documentsArchiver.ArchiveDocs();
 
-            await Indexes.WaitForIndexingAsync(store);
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>(docId);
+                var metadataFromDoc = session.Advanced.GetMetadataFor(user);
+                Assert.True(metadataFromDoc.ContainsKey(Constants.Documents.Metadata.Archived));
+                Assert.Equal(true, metadataFromDoc[Constants.Documents.Metadata.Archived]);
+            }
+
+            string patchByQuery = @"
+  from Users
+  update 
+  {
+      archived.unarchive(this)
+  }";
+
+            var patchByQueryOp = new PatchByQueryOperation(patchByQuery);
+            var operation = await store.Operations.SendAsync(patchByQueryOp);
+            await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromSeconds(30));
 
             using (var session = store.OpenAsyncSession())
             {
-                var count = await session.Query<User>().Where(x => x.Name == "Grisha").CountAsync();
-                Assert.Equal(0, count);
+                var user = await session.LoadAsync<User>(docId);
+                var metadataFromDoc = session.Advanced.GetMetadataFor(user);
+                Assert.False(metadataFromDoc.ContainsKey(Constants.Documents.Metadata.Archived));
             }
         }
     }

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -206,14 +206,37 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
 
             var patchByQueryOp = new PatchByQueryOperation(patchByQuery);
             var operation = await store.Operations.SendAsync(patchByQueryOp);
-            await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromSeconds(30));
+            var error = await Assert.ThrowsAsync<SchemaValidationException>(async () => await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromSeconds(30)));
+            Assert.Contains("The length of the value 'Grisha' at 'Name' should not exceed 1, but its actual length is 6.", error.Message);
 
             using (var session = store.OpenAsyncSession())
             {
                 var user = await session.LoadAsync<User>(docId);
                 var metadataFromDoc = session.Advanced.GetMetadataFor(user);
-                Assert.False(metadataFromDoc.ContainsKey(Constants.Documents.Metadata.Archived));
+                Assert.True(metadataFromDoc.ContainsKey(Constants.Documents.Metadata.Archived));
             }
+
+
+            patchByQuery = @"
+  from Users
+  update 
+  {
+      this.Name = ""Grisha Kotler"";
+      archived.unarchive(this)
+  }";
+
+            patchByQueryOp = new PatchByQueryOperation(patchByQuery);
+            operation = await store.Operations.SendAsync(patchByQueryOp);
+            error = await Assert.ThrowsAsync<SchemaValidationException>(async () => await operation.WaitForCompletionAsync<BulkOperationResult>(TimeSpan.FromSeconds(30)));
+            Assert.Contains("The length of the value 'Grisha Kotler' at 'Name' should not exceed 1, but its actual length is 13.", error.Message);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>(docId);
+                var metadataFromDoc = session.Advanced.GetMetadataFor(user);
+                Assert.True(metadataFromDoc.ContainsKey(Constants.Documents.Metadata.Archived));
+            }
+
         }
     }
 

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -481,7 +481,7 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             };
 
             var error = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
-            Assert.Contains("Invalid collection name: '@hilo'", error.Message);
+            Assert.Contains($"Invalid collection name: '{CollectionName.HiLoCollection}'", error.Message);
 
             configuration.ValidatorsPerCollection.Remove(CollectionName.HiLoCollection);
             configuration.ValidatorsPerCollection["@companies"] = new SchemaDefinition
@@ -490,8 +490,16 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             };
             error = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
             Assert.Contains("Invalid collection name: '@companies'", error.Message);
-
+            
             configuration.ValidatorsPerCollection.Remove("@companies");
+            configuration.ValidatorsPerCollection[Constants.Documents.Collections.AiAgentConversationCollection] = new SchemaDefinition
+            {
+                Schema = schemaDefinition
+            };
+            error = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains($"Invalid collection name: '{Constants.Documents.Collections.AiAgentConversationCollection}'", error.Message);
+
+            configuration.ValidatorsPerCollection.Remove(Constants.Documents.Collections.AiAgentConversationCollection);
             configuration.ValidatorsPerCollection["@empty"] = new SchemaDefinition
             {
                 Schema = schemaDefinition

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -505,6 +506,84 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
                 Schema = schemaDefinition
             };
             await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Counters | RavenTestCategory.TimeSeries)]
+    public async Task AddingAttachmentsCountersTimeSeriesShouldWork()
+    {
+        using (var store = GetDocumentStore())
+        {
+            const string documentId = "users/1-A";
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = new User { Name = "Grisha" };
+                await session.StoreAsync(user, documentId);
+                await session.SaveChangesAsync();
+            }
+
+            string schemaDefinition;
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                schemaDefinition =
+                    context.ReadObject(
+                        new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Name"] = new DynamicJsonValue { [SVC.MaxLength] = 1 } } },
+                        "schema-validation-configuration").ToString();
+            }
+
+            var configuration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+                {
+                    {
+                        "Users", new SchemaDefinition
+                        {
+                            Schema = schemaDefinition
+                        }
+                    }
+                }
+            };
+
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>(documentId);
+                user.Name += "Kotler";
+                await Assert.ThrowsAsync<SchemaValidationException>(async () => await session.SaveChangesAsync());
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var rnd = new Random();
+                var b = new byte[8];
+                rnd.NextBytes(b);
+
+                const string attachmentName = "test";
+                using (var stream = new MemoryStream(b))
+                {
+                    session.Advanced.Attachments.Store(documentId, attachmentName, stream, "application/zip");
+                    await session.SaveChangesAsync();
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var counters = session.CountersFor(documentId);
+                counters.Increment("likes");
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var baseline = DateTime.Now;
+                var tsf = session.TimeSeriesFor(documentId, "heartbeat");
+
+                tsf.Append(baseline, new List<double> { 10 }, "herz");
+                tsf.Append(baseline.AddMinutes(10), new List<double> { 20 }, "herz");
+
+                await session.SaveChangesAsync();
+            }
         }
     }
 

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -18,6 +18,7 @@ using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.SchemaValidation;
 using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Documents;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow;
 using Sparrow.Json;
@@ -449,6 +450,53 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             schemaError = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
             Assert.Contains("names1", schemaError.Message);
             Assert.DoesNotContain("companies1", error.Message);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ExpirationRefresh)]
+    public async Task CollectionsThatStartWithReservedCollectionName()
+    {
+        using (var store = GetDocumentStore())
+        {
+            string schemaDefinition;
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                schemaDefinition =
+                    context.ReadObject(
+                        new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Name"] = new DynamicJsonValue { [SVC.MaxLength] = 1 } } },
+                        "schema-validation-configuration").ToString();
+            }
+
+            var configuration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+                {
+                    {
+                        CollectionName.HiLoCollection, new SchemaDefinition
+                        {
+                            Schema = schemaDefinition
+                        }
+                    }
+                }
+            };
+
+            var error = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains("Invalid collection name: '@hilo'", error.Message);
+
+            configuration.ValidatorsPerCollection.Remove(CollectionName.HiLoCollection);
+            configuration.ValidatorsPerCollection["@companies"] = new SchemaDefinition
+            {
+                Schema = schemaDefinition
+            };
+            error = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains("Invalid collection name: '@companies'", error.Message);
+
+            configuration.ValidatorsPerCollection.Remove("@companies");
+            configuration.ValidatorsPerCollection["@empty"] = new SchemaDefinition
+            {
+                Schema = schemaDefinition
+            };
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
         }
     }
 

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -108,7 +108,6 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
         }
     }
 
-
     [RavenFact(RavenTestCategory.ExpirationRefresh)]
     public async Task RefreshShouldSkipSchemaValidation()
     {
@@ -462,8 +461,10 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             Assert.Contains("companies1", schemaError.Message);
 
             configuration.ValidatorsPerCollection["companies1"].Disabled = true;
-            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+            schemaError = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains("companies1", schemaError.Message);
 
+            configuration.ValidatorsPerCollection.Remove("companies1");
             configuration.ValidatorsPerCollection["names1"] = new SchemaDefinition
             {
                 Schema = schemaDefinition
@@ -471,6 +472,11 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             schemaError = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
             Assert.Contains("names1", schemaError.Message);
             Assert.DoesNotContain("companies1", error.Message);
+
+            configuration.ValidatorsPerCollection["names1"].Disabled = true;
+            configuration.Disabled = true;
+            schemaError = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains("names1", schemaError.Message);
         }
     }
 

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -510,7 +510,7 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
     }
 
     [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Counters | RavenTestCategory.TimeSeries)]
-    public async Task AddingAttachmentsCountersTimeSeriesShouldWork()
+    public async Task UpdatingAttachmentsCountersTimeSeriesShouldWork()
     {
         using (var store = GetDocumentStore())
         {
@@ -565,12 +565,19 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
                     session.Advanced.Attachments.Store(documentId, attachmentName, stream, "application/zip");
                     await session.SaveChangesAsync();
                 }
+
+                session.Advanced.Attachments.Delete(documentId, attachmentName);
+                await session.SaveChangesAsync();
             }
 
             using (var session = store.OpenAsyncSession())
             {
                 var counters = session.CountersFor(documentId);
-                counters.Increment("likes");
+                const string counterName = "likes";
+                counters.Increment(counterName);
+                await session.SaveChangesAsync();
+
+                counters.Delete(counterName);
                 await session.SaveChangesAsync();
             }
 
@@ -581,7 +588,9 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
 
                 tsf.Append(baseline, new List<double> { 10 }, "herz");
                 tsf.Append(baseline.AddMinutes(10), new List<double> { 20 }, "herz");
-
+                await session.SaveChangesAsync();
+                
+                tsf.Delete();
                 await session.SaveChangesAsync();
             }
         }

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -6,12 +6,15 @@ using System.Threading.Tasks;
 using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.DataArchival;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Refresh;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.SchemaValidation;
 using Raven.Client.Util;
 using Raven.Server.Config;
@@ -191,35 +194,6 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
                 Assert.Equal(0, count);
             }
         }
-    }
-
-    private static async Task SetupSchemaValidation(DocumentStore store)
-    {
-        string schemaDefinition;
-        using (var context = JsonOperationContext.ShortTermSingleUse())
-        {
-            schemaDefinition =
-                context.ReadObject(
-                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Name"] = new DynamicJsonValue { [SVC.MaxLength] = 1 } } },
-                    "schema-validation-configuration").ToString();
-        }
-
-        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(new SchemaValidationConfiguration
-        {
-            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
-            {
-                {"Users", new SchemaDefinition
-                {
-                    Schema = schemaDefinition
-                }}
-            }
-        }));
-    }
-
-    private class TestObj
-    {
-        public string Id { get; set; }
-        public string Prop { get; set; }
     }
 
     [RavenFact(RavenTestCategory.Replication)]
@@ -416,7 +390,96 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
         }
     }
 
+    [RavenFact(RavenTestCategory.ExpirationRefresh)]
+    public async Task MapReduceWithOutputReduceToCollection()
+    {
+        using (var store = GetDocumentStore())
+        {
+            string schemaDefinition;
+            using (var context = JsonOperationContext.ShortTermSingleUse())
+            {
+                schemaDefinition =
+                    context.ReadObject(
+                        new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Name"] = new DynamicJsonValue { [SVC.MaxLength] = 1 } } },
+                        "schema-validation-configuration").ToString();
+            }
 
+            var configuration = new SchemaValidationConfiguration
+            {
+                ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+                {
+                    {
+                        "companies", new SchemaDefinition
+                        {
+                            Schema = schemaDefinition
+                        }
+                    },
+                    {
+                        "Names", new SchemaDefinition
+                        {
+                            Schema = schemaDefinition
+                        }
+                    }
+                }
+            };
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            var error = await Assert.ThrowsAsync<IndexCreationException>(async () => await new Index("companies", "names").ExecuteAsync(store));
+            Assert.Contains("companies", error.Message);
+            error = await Assert.ThrowsAsync<IndexCreationException>(async () => await new Index("companies1", "names").ExecuteAsync(store));
+            Assert.Contains("names", error.Message);
+            Assert.DoesNotContain("companies", error.Message);
+
+            await new Index("companies1", "names1").ExecuteAsync(store);
+
+            configuration.ValidatorsPerCollection["companies1"] = new SchemaDefinition
+            {
+                Schema = schemaDefinition
+            };
+            var schemaError = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains("companies1", schemaError.Message);
+
+            configuration.ValidatorsPerCollection["companies1"].Disabled = true;
+            await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+
+            configuration.ValidatorsPerCollection["names1"] = new SchemaDefinition
+            {
+                Schema = schemaDefinition
+            };
+            schemaError = await Assert.ThrowsAsync<RavenException>(async () => await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration)));
+            Assert.Contains("names1", schemaError.Message);
+            Assert.DoesNotContain("companies1", error.Message);
+        }
+    }
+
+    private static async Task SetupSchemaValidation(DocumentStore store)
+    {
+        string schemaDefinition;
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            schemaDefinition =
+                context.ReadObject(
+                    new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Name"] = new DynamicJsonValue { [SVC.MaxLength] = 1 } } },
+                    "schema-validation-configuration").ToString();
+        }
+
+        await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(new SchemaValidationConfiguration
+        {
+            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
+            {
+                {"Users", new SchemaDefinition
+                {
+                    Schema = schemaDefinition
+                }}
+            }
+        }));
+    }
+
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public string Prop { get; set; }
+    }
 
     private class Category
     {
@@ -478,5 +541,33 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
         }
     }
 
+    private class Index : AbstractIndexCreationTask<User>
+    {
+        public Index(string outputCollection, string outputCollectionForPattern)
+        {
+            Map = users => from user in users
+                select new
+                {
+                    user.Name,
+                    Count = 1
+                };
 
+            Reduce = results => from result in results
+                group result by result.Name
+                into g
+                select new
+                {
+                    Name = g.Key,
+                    Count = g.Sum(x => x.Count)
+                };
+
+            OutputReduceToCollection = outputCollection;
+
+            if (outputCollectionForPattern != null)
+            {
+                PatternForOutputReduceToCollectionReferences = x => $"patterns/{x.Name}";
+                PatternReferencesCollectionName = outputCollectionForPattern;
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25687/RavenDB-features-integration-with-Schema-Validation

### Additional description

- Prevent creating schema validators for collections that are part of output reduce to collection.
- Prevent creating a map reduce with output reduce to collections that are have a validator.
- Skip schema validation when creating/deleting an attachment, counter or time series.
- Skip schema validation when unarching a document.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
