### PR TITLE
RavenDB-25557 Skip schema validation for documents during import

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/Data/ISmugglerDestination.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Smuggler.Documents.Data
 
         IDatabaseRecordActions DatabaseRecord();
 
-        IDocumentActions Documents(bool throwOnCollectionMismatchError = true);
+        IDocumentActions Documents(bool throwOnCollectionMismatchError = true, BackupKind? backupKind = null);
 
         IDocumentActions RevisionDocuments();
 

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -82,9 +82,9 @@ namespace Raven.Server.Smuggler.Documents
             return new DatabaseRecordActions(_database, log: _log);
         }
 
-        public IDocumentActions Documents(bool throwOnCollectionMismatchError = true)
+        public IDocumentActions Documents(bool throwOnCollectionMismatchError = true, BackupKind? backupKind = null)
         {
-            return new DatabaseDocumentActions(_database, _buildType, _options, isRevision: false, _log, _duplicateDocsHandler, throwOnCollectionMismatchError);
+            return new DatabaseDocumentActions(_database, _buildType, _options, isRevision: false, _log, _duplicateDocsHandler, throwOnCollectionMismatchError, backupKind);
         }
 
         public IDocumentActions RevisionDocuments()
@@ -240,10 +240,11 @@ namespace Raven.Server.Smuggler.Documents
             private readonly HashSet<string> _documentIdsOfMissingAttachments;
             private readonly DuplicateDocsHandler _duplicateDocsHandler;
             private readonly bool _throwOnCollectionMismatchError;
+            private readonly BackupKind? _backupKind;
 
             private ErrorBuilder _schemaErrorBuilder;
             
-            public DatabaseDocumentActions(DocumentDatabase database, BuildVersionType buildType, DatabaseSmugglerOptionsServerSide options, bool isRevision, RavenLogger log, DuplicateDocsHandler duplicateDocsHandler, bool throwOnCollectionMismatchError)
+            public DatabaseDocumentActions(DocumentDatabase database, BuildVersionType buildType, DatabaseSmugglerOptionsServerSide options, bool isRevision, RavenLogger log, DuplicateDocsHandler duplicateDocsHandler, bool throwOnCollectionMismatchError, BackupKind? backupKind = null)
             {
                 _database = database;
                 _buildType = buildType;
@@ -253,6 +254,7 @@ namespace Raven.Server.Smuggler.Documents
                 _enqueueThreshold = new Size(database.Is32Bits ? 2 : 32, SizeUnit.Megabytes);
                 _duplicateDocsHandler = duplicateDocsHandler;
                 _throwOnCollectionMismatchError = throwOnCollectionMismatchError;
+                _backupKind = backupKind;
 
                 _missingDocumentsForRevisions = isRevision || buildType == BuildVersionType.V3 ? new ConcurrentDictionary<string, CollectionName>() : null;
                 _documentIdsOfMissingAttachments = isRevision ? null : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -281,7 +283,7 @@ namespace Raven.Server.Smuggler.Documents
 
             private void SchemaValidateAndThrow(DocumentItem item)
             {
-                if (_isRevision)
+                if (_backupKind != BackupKind.None || _isRevision)
                     return;
                 
                 var schemaValidatorCache = _database.SchemaValidatorCache;

--- a/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/DatabaseDestination.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Exceptions.SchemaValidation;
 using Raven.Client.Extensions;
 using Raven.Client.Json.Serialization;
 using Raven.Client.Util;
@@ -21,6 +22,7 @@ using Raven.Server.Documents.Handlers;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.SchemaValidation.ErrorMessage;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents.Actions;
@@ -239,6 +241,8 @@ namespace Raven.Server.Smuggler.Documents
             private readonly DuplicateDocsHandler _duplicateDocsHandler;
             private readonly bool _throwOnCollectionMismatchError;
 
+            private ErrorBuilder _schemaErrorBuilder;
+            
             public DatabaseDocumentActions(DocumentDatabase database, BuildVersionType buildType, DatabaseSmugglerOptionsServerSide options, bool isRevision, RavenLogger log, DuplicateDocsHandler duplicateDocsHandler, bool throwOnCollectionMismatchError)
             {
                 _database = database;
@@ -269,8 +273,29 @@ namespace Raven.Server.Smuggler.Documents
                         progress.Attachments.Skipped = true;
                 }
 
+                SchemaValidateAndThrow(item);
+
                 _command.Add(item);
                 return HandleBatchOfDocumentsIfNecessaryAsync(beforeFlushing, force: false);
+            }
+
+            private void SchemaValidateAndThrow(DocumentItem item)
+            {
+                if (_isRevision)
+                    return;
+                
+                var schemaValidatorCache = _database.SchemaValidatorCache;
+                if (schemaValidatorCache == null) 
+                    return;
+                
+                _schemaErrorBuilder ??= new ErrorBuilder();
+                _schemaErrorBuilder.Reset();
+                    
+                var collection = CollectionName.GetCollectionName(item.Document.Data);
+                if (schemaValidatorCache.Validate(collection, item.Document.Data, _schemaErrorBuilder)) 
+                    return;
+
+                throw new SchemaValidationException(_schemaErrorBuilder.ToString());
             }
 
             public async ValueTask WriteTombstoneAsync(Tombstone tombstone, SmugglerProgressBase.CountsWithLastEtag progress)
@@ -350,6 +375,8 @@ namespace Raven.Server.Smuggler.Documents
 
                 if (_duplicateDocsHandler._markForDispose)
                     _duplicateDocsHandler.Dispose();
+                
+                _schemaErrorBuilder?.Dispose();
             }
 
             private async ValueTask FixDocumentMetadataIfNecessaryAsync()

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -118,7 +118,7 @@ namespace Raven.Server.Smuggler.Documents
         public ICompareExchangeActions CompareExchangeTombstones(string databaseName, JsonOperationContext context) =>
             new ShardedCompareExchangeActions(_databaseContext, _allocator, _destinations.ToDictionary(x => x.Key, x => x.Value.CompareExchangeTombstones(databaseName, context)), _options);
 
-        public IDocumentActions Documents(bool throwOnCollectionMismatchError = true) =>
+        public IDocumentActions Documents(bool throwOnCollectionMismatchError = true, BackupKind? backupKind = null) =>
             new ShardedDocumentActions(_databaseContext, _allocator, _destinations.ToDictionary(x => x.Key, x => x.Value.Documents(throwOnDuplicateCollection: false)), _options);
 
         public IDocumentActions RevisionDocuments() =>

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -524,7 +524,15 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
-                    await documentActions.WriteDocumentAsync(item, result.Documents, beforeFlush);
+                    try
+                    {
+                        await documentActions.WriteDocumentAsync(item, result.Documents, beforeFlush);
+                    }
+                    catch (Exception e)
+                    {
+                        result.Documents.ErroredCount++;
+                        result.AddError($"Could not write document {item.Document.Id}: {e.Message}");
+                    }
                 }
 
                 await TryHandleLegacyDocumentTombstonesAsync(legacyIdsToDelete, documentActions, result);

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -403,7 +403,7 @@ namespace Raven.Server.Smuggler.Documents
 
             var throwOnCollectionMismatchError = _options.OperateOnTypes.HasFlag(DatabaseItemType.Tombstones) == false;
 
-            await using (var documentActions = _destination.Documents(throwOnCollectionMismatchError))
+            await using (var documentActions = _destination.Documents(throwOnCollectionMismatchError, backupKind: BackupKind))
             await using (var compareExchangeActions = _destination.CompareExchange(_databaseName, _context, BackupKind, withDocuments: true))
             {
                 List<LazyStringValue> legacyIdsToDelete = null;

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -165,7 +165,7 @@ namespace Raven.Server.Smuggler.Documents
             return new DatabaseRecordActions(_writer, _context);
         }
 
-        public IDocumentActions Documents(bool throwOnDuplicateCollection)
+        public IDocumentActions Documents(bool throwOnDuplicateCollection, BackupKind? backupKind = null)
         {
             return new StreamDocumentActions(_writer, _context, _source, _options, _filterMetadataProperty, "Docs");
         }

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using FastTests;
 using FastTests.Utils;
 using Raven.Client;
 using Raven.Client.Documents;
@@ -13,6 +14,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Operations.SchemaValidation;
+using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
@@ -283,7 +285,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The length of the value '1234' at 'Prop' should not exceed 3, but its actual length is 4.", e.Message);
     }
     
-    [RavenFact(RavenTestCategory.JavaScript)]
+    [RavenFact(RavenTestCategory.Smuggler)]
     public async Task SchemaValidation_WhenBulkInsert_ShouldValidateAndFailInNeeded()
     {
         const string id = "random-id";
@@ -322,21 +324,57 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         Assert.True(stringException.Contains("The length of the value '1234' at 'Prop' should not exceed 3, but its actual length is 4."), $"actual: {stringException}");
     }
 
-    [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenImportInvalidDataDefinedOnTheSource_ShouldNotThrow()
+    [RavenTheory(RavenTestCategory.Replication | RavenTestCategory.Smuggler)]
+    [RavenData(true, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(false, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task SchemaValidation_WhenImportInvalidDataDocuments_ShouldSkip(Options options, bool configOnDestination)
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
 
         using var context = JsonOperationContext.ShortTermSingleUse();
         using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
-        using var source = GetDocumentStore();
-
-        const string id = "random-id";
-        using (var session = source.OpenAsyncSession())
+        
+        var modifyRecord = options.ModifyDatabaseRecord;
+        var option = new Options
         {
+            ModifyDatabaseRecord = record =>
+            {
+                record.ConflictSolverConfig = new ConflictSolver
+                {
+                    ResolveToLatest = false,
+                    ResolveByCollection = new Dictionary<string, ScriptResolver>()
+                };
+                modifyRecord?.Invoke(record);
+            }
+        };
+        using var sourceA = GetDocumentStore(option);
+        using var sourceB = GetDocumentStore(option);
+
+        await RevisionsHelper.SetupRevisionsAsync(sourceA);
+        
+        const string idConflict = "conflict-doc-id";
+        const string idRevisions = "revisions-id";
+        const string id = "random-id";
+        using (var session = sourceA.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "1234" }, idConflict);
             await session.StoreAsync(new TestObj { Prop = "1234" }, id);
+            var testObj = new TestObj { Prop = "1234" };
+            await session.StoreAsync(testObj, idRevisions);
+            await session.SaveChangesAsync();
+
+            testObj.Prop = "123";
             await session.SaveChangesAsync();
         }
+        
+        using (var session = sourceB.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj { Prop = "2234" }, idConflict);
+            await session.SaveChangesAsync();
+        }
+        
+        await SetupReplicationAsync(sourceB, sourceA);
+        WaitUntilHasConflict(sourceA, idConflict);
 
         using var destination = GetDocumentStore();
         var configuration = new SchemaValidationConfiguration
@@ -347,52 +385,32 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
                 { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
             }
         };
-        await source.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
+        
+        await (configOnDestination ? destination : sourceA).Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
 
-        var e = await Assert.ThrowsAnyAsync<Exception>(async () =>
+        var operation = await sourceA.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), destination.Smuggler);
+        await operation.WaitForCompletionAsync();
+
+        
+        using (var sourceSession = destination.OpenAsyncSession())
+        using (var destinationSession = destination.OpenAsyncSession())
         {
-            var operation = await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), destination.Smuggler);
-            await operation.WaitForCompletionAsync();
-        });
-        Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
-    }
+            Assert.Null(await destinationSession.LoadAsync<TestObj>(id));
+            Assert.NotNull(await destinationSession.LoadAsync<TestObj>(idRevisions));
 
-    [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenImportInvalidDataDefinedOnTheDestination_ShouldNotThrow()
-    {
-        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
-
-        using var context = JsonOperationContext.ShortTermSingleUse();
-        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
-        using var source = GetDocumentStore();
-
-        const string id = "random-id";
-        using (var session = source.OpenAsyncSession())
-        {
-            await session.StoreAsync(new TestObj { Prop = "1234" }, id);
-            await session.SaveChangesAsync();
+            var sourceRevisions = await GetRevisions(sourceSession);
+            var destinationRevisions = await GetRevisions(destinationSession);
+            Assert.Subset(sourceRevisions.ToHashSet(), destinationRevisions.ToHashSet());
+            
+            var conflicts = await destination.Commands().GetConflictsForAsync(idConflict);
+            Assert.Equal(2, conflicts.Length);
+            
+            async Task<IEnumerable<string>> GetRevisions(IAsyncDocumentSession asyncDocumentSession)
+                => (await asyncDocumentSession.Advanced.Revisions.GetForAsync<TestObj>(idRevisions)).Select(x => asyncDocumentSession.Advanced.GetChangeVectorFor(x));
         }
-
-        using var destination = GetDocumentStore();
-        var configuration = new SchemaValidationConfiguration
-        {
-            Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
-            {
-                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
-            }
-        };
-        await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
-
-        var e = await Assert.ThrowsAnyAsync<Exception>(async () =>
-        {
-            var operation = await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), destination.Smuggler);
-            await operation.WaitForCompletionAsync();
-        });
-        Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
     }
 
-    [RavenFact(RavenTestCategory.JavaScript)]
+    [RavenFact(RavenTestCategory.Smuggler)]
     public async Task SchemaValidation_WhenRestoreInvalidData_ShouldNotThrow()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
@@ -501,49 +519,6 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             
             return error.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"");
         }
-    }
-
-    [RavenFact(RavenTestCategory.JavaScript)]
-    public async Task SchemaValidation_WhenImportToDestinationWithSchemaValidation_ShouldValidateAndFailInNeeded()
-    {
-        var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
-
-        using var context = JsonOperationContext.ShortTermSingleUse();
-        using var schemaDefinition = context.ReadObject(schemaDefinitionObj, "test object");
-        using var source = GetDocumentStore();
-
-        const string id = "random-id";
-        using (var session = source.OpenAsyncSession())
-        {
-            await session.StoreAsync(new TestObj { Prop = "1234" }, id);
-            await session.SaveChangesAsync();
-        }
-
-        using var destination = GetDocumentStore();
-        var configuration = new SchemaValidationConfiguration
-        {
-            Disabled = false,
-            ValidatorsPerCollection = new Dictionary<string, SchemaDefinition>
-            {
-                { "TestObjs", new SchemaDefinition { Schema = schemaDefinition.ToString() } }
-            }
-        };
-        await destination.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
-
-        var e = await Assert.ThrowsAnyAsync<RavenException>(async () =>
-        {
-            var operation = await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), destination.Smuggler);
-            await operation.WaitForCompletionAsync();
-        });
-        Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
-
-        using (var session = source.OpenAsyncSession())
-        {
-            await session.StoreAsync(new TestObj { Prop = "1234" }, id);
-            await session.SaveChangesAsync();
-        }
-
-        await source.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), destination.Smuggler);
     }
 
     [RavenFact(RavenTestCategory.JavaScript)]

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -376,7 +376,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         await SetupReplicationAsync(sourceB, sourceA);
         WaitUntilHasConflict(sourceA, idConflict);
 
-        using var destination = GetDocumentStore();
+        using var destination = GetDocumentStore(option);
         var configuration = new SchemaValidationConfiguration
         {
             Disabled = false,
@@ -411,7 +411,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
     }
 
     [RavenFact(RavenTestCategory.Smuggler)]
-    public async Task SchemaValidation_WhenRestoreInvalidData_ShouldNotThrow()
+    public async Task SchemaValidation_WhenRestoreInvalidData_ShouldRestore()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
 
@@ -420,9 +420,10 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         using var source = GetDocumentStore();
 
         const string id = "random-id";
+        const string invalidValue = "1234";
         using (var session = source.OpenAsyncSession())
         {
-            await session.StoreAsync(new TestObj { Prop = "1234" }, id);
+            await session.StoreAsync(new TestObj { Prop = invalidValue }, id);
             await session.SaveChangesAsync();
         }
 
@@ -443,6 +444,12 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         using var _ = Backup.RestoreDatabase(source,
             new RestoreBackupConfiguration { DatabaseName = destinationName, BackupLocation = Directory.GetDirectories(backupPath).First(), });
         using var destination = new DocumentStore { Urls = source.Urls, Database = destinationName, }.Initialize();
+
+        using (var session = destination.OpenAsyncSession())
+        {
+            var loaded = await session.LoadAsync<TestObj>(id);
+            Assert.Equal(invalidValue, loaded.Prop);
+        }
         
         var e = await Assert.ThrowsAnyAsync<RavenException>(async () =>
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25557

### Additional description
As I see it, we have two options for placing the skip logic:
1. Wait for the validation to fail and "swallow" it.
This catch needs to be inside `MergedBatchPutCommand` to avoid failing the entire batch.
I don't like this solution because it is surprising behavior that such a failure does not fail the transaction.
We had an issue in the past with similar behavior regarding conflicts that caused a tombstone to disappear.

2. At the Smuggler level.
With this solution, the question remains: what happens if there is a bug and an invalid document manages to pass the Smuggler?
I think in such a case, it would be best to keep the existing behavior that causes the whole operation to stop.
In any case, there is a workaround, and we can simply disable schema validation.

Regarding the exact location of the preliminary validation within the Smuggler:
I debated between three options:
1. The Smuggler itself
2. DatabaseDestination
3. DatabaseDocumentActions

In the end, I chose `DatabaseDocumentActions` because it seemed the cleanest and most readable.

### Type of change
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
