### PR TITLE
RavenDB-17219 : Adjustments to flaky OLAP tests 

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/LocalTests.cs
@@ -1894,7 +1894,9 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 var r = await etlDone.WaitAsync(_defaultTimeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
-                var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
+                var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories)
+                    .OrderBy(x => x)
+                    .ToList();
 
                 Assert.Equal(5, files.Count);
 
@@ -1904,9 +1906,22 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 Assert.Contains("year=2023", files[3]);
                 Assert.Contains("year=2024", files[4]);
 
-                // add more data
-                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
+                // disable ETL while we make changes in the configuration
+                const string documentIdColumn = "order_id";
+                configuration.OlapTables = new List<OlapEtlTable>
+                {
+                    new OlapEtlTable
+                    {
+                        TableName = "Orders",
+                        DocumentIdColumn = documentIdColumn
+                    }
+                };
+                configuration.Disabled = true;
 
+                var updateResult = store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+                taskId = updateResult.TaskId;
+
+                // add more data while ETL is disabled
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 6; i <= 10; i++)
@@ -1920,32 +1935,27 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                         };
 
                         await session.StoreAsync(o);
-
                         dt = dt.AddYears(1);
                     }
 
                     await session.SaveChangesAsync();
                 }
 
-                // update
-                const string documentIdColumn = "order_id";
-                configuration.OlapTables = new List<OlapEtlTable>
-                {
-                    new OlapEtlTable
-                    {
-                        TableName = "Orders",
-                        DocumentIdColumn = documentIdColumn
-                    }
-                };
+                // re-enable ETL
+                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
 
+                configuration.Disabled = false;
                 store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
 
                 // assert that batch completed successfully and that we got new files with new name of the document id column
                 r = await etlDone.WaitAsync(_defaultTimeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
-                files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
-                Assert.Equal(10, files.Count);
+                files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories)
+                    .OrderBy(x => x)
+                    .ToList();
+
+                Assert.True(files.Count == 10, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 Assert.Contains("year=2025", files[5]);
                 Assert.Contains("year=2026", files[6]);
@@ -2059,9 +2069,14 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                 Assert.Contains("year=2023", files[3]);
                 Assert.Contains("year=2024", files[4]);
 
-                // add more data
-                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
+                // disable ETL while we make changes in the configuration
+                configuration.RunFrequency = DefaultFrequency; // every minute
+                configuration.Disabled = true;
 
+                var updateResult = store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+                taskId = updateResult.TaskId;
+
+                // add more data while ETL is disabled
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 6; i <= 10; i++)
@@ -2082,21 +2097,29 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()]),
                     await session.SaveChangesAsync();
                 }
 
-                // update 
-                configuration.RunFrequency = DefaultFrequency; // every minute
-                store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+                // re-enable ETL
+                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
+
+                configuration.Disabled = false;
+                updateResult = store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+                taskId = updateResult.TaskId;
 
                 r = await etlDone.WaitAsync(timeout);
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
 
                 files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
-                Assert.Equal(10, files.Count);
+                Assert.True(files.Count == 10, await Etl.GetEtlDebugInfo(store.Database, timeout, databaseMode));
 
                 Assert.Contains("year=2025", files[5]);
                 Assert.Contains("year=2026", files[6]);
                 Assert.Contains("year=2027", files[7]);
                 Assert.Contains("year=2028", files[8]);
                 Assert.Contains("year=2029", files[9]);
+
+                var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(taskId, OngoingTaskType.OlapEtl));
+                var olapTaskInfo = taskInfo as OngoingTaskOlapEtl;
+                Assert.NotNull(olapTaskInfo);
+                Assert.Equal(DefaultFrequency, olapTaskInfo.Configuration.RunFrequency);
             }
         }
 
@@ -2187,9 +2210,15 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                     Assert.Contains(customPartition, file);
                 }
 
-                // add more data
-                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
+                // disable ETL while we make changes in the configuration
+                const string newCustomPartition = "shop35";
+                configuration.CustomPartitionValue = newCustomPartition;
+                configuration.Disabled = true;
 
+                var updateResult = store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
+                taskId = updateResult.TaskId;
+
+                // add more data
                 using (var session = store.OpenAsyncSession())
                 {
                     for (int i = 6; i <= 10; i++)
@@ -2210,10 +2239,10 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                     await session.SaveChangesAsync();
                 }
 
-                // update
-                const string newCustomPartition = "shop35";
-                configuration.CustomPartitionValue = newCustomPartition;
+                // re enable ETL
+                etlDone = Etl.WaitForEtlToComplete(store, numOfProcessesToWaitFor: 2);
 
+                configuration.Disabled = false;
                 store.Maintenance.Send(new UpdateEtlOperation<OlapConnectionString>(taskId, configuration));
 
                 // assert that batch completed successfully with the new partition value
@@ -2221,7 +2250,7 @@ loadToOrders(partitionBy(['year', orderDate.getFullYear()], ['location', $custom
                 Assert.True(r, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToList();
-                Assert.Equal(10, files.Count);
+                Assert.True(files.Count == 10, await Etl.GetEtlDebugInfo(store.Database, _defaultTimeout, databaseMode));
 
                 foreach (var file in new[] { files[5], files[6], files[7], files[8], files[9] })
                 {

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -9,8 +9,8 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 using Tests.Infrastructure;
-using Tests.Infrastructure.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using Order = Tests.Infrastructure.Entities.Order;
@@ -87,27 +87,30 @@ loadTo(""Orders"", partitionBy(key),
 
                 var key = EtlProcessState.GenerateItemName(store.Database, configurationName, transformationName).ToLowerInvariant();
 
+                BlittableJsonReaderObject item;
                 using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    var item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
+                    item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
                     Assert.NotNull(item);
                 }
 
                 // delete task
-                var deleteTaskResult = store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
+                store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
                 var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(result.TaskId, OngoingTaskType.OlapEtl));
                 Assert.Null(ongoingTask);
 
-                // wait for RemoveEtlProcessStateCommand to complete (executed after DeleteOngoingTaskCommand)
-                await Server.ServerStore.Cluster.WaitForIndexNotification(deleteTaskResult.RaftCommandIndex + 1);
-
-                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
+                // wait for etl process state to be deleted
+                item = WaitForValue(() =>
                 {
-                    var item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
-                    Assert.Null(item);
-                }
+                    using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        return Server.ServerStore.Engine.StateMachine.GetItem(context, key);
+                    }
+                }, expectedVal: null, timeout: 30_000);
+
+                Assert.Null(item);
             }
         }
 

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -9,7 +9,6 @@ using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Server.ServerWide.Context;
-using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -87,11 +86,10 @@ loadTo(""Orders"", partitionBy(key),
 
                 var key = EtlProcessState.GenerateItemName(store.Database, configurationName, transformationName).ToLowerInvariant();
 
-                BlittableJsonReaderObject item;
                 using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
                 {
-                    item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
+                    var item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
                     Assert.NotNull(item);
                 }
 
@@ -101,16 +99,16 @@ loadTo(""Orders"", partitionBy(key),
                 Assert.Null(ongoingTask);
 
                 // wait for etl process state to be deleted
-                item = WaitForValue(() =>
+                var itemDeleted = WaitForValue(() =>
                 {
                     using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (context.OpenReadTransaction())
                     {
-                        return Server.ServerStore.Engine.StateMachine.GetItem(context, key);
+                        return Server.ServerStore.Engine.StateMachine.GetItem(context, key) == null;
                     }
-                }, expectedVal: null, timeout: 30_000);
+                }, expectedVal: true, timeout: 30_000);
 
-                Assert.Null(item);
+                Assert.True(itemDeleted);
             }
         }
 

--- a/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
+++ b/test/StressTests/Server/Documents/ETL/Olap/LocalTestsStress.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Orders;
@@ -17,10 +18,8 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.ETL;
 using Raven.Server.Documents.ETL.Providers.OLAP;
-using Tests.Infrastructure;
-using SlowTests.Server.Documents.ETL;
 using Sparrow.Server;
-using Tests.Infrastructure.Extensions;
+using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -77,11 +76,10 @@ loadToOrders(partitionBy(key), o);
 
                 var path = NewDataPath(forceCreateDir: true);
                 SetupLocalOlapEtl(store, script, path, frequency: DefaultFrequency);
-                var firstBatchTime = DateTime.UtcNow;
-                var firstBatchTimeMinutes = firstBatchTime.Minute;
+
                 Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(10)));
 
-                var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
+                var files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToArray();
                 Assert.Equal(1, files.Length);
 
                 var expectedFields = new[] { "Company", ParquetTransformedItems.DefaultIdColumn, ParquetTransformedItems.LastModifiedColumn };
@@ -143,21 +141,24 @@ loadToOrders(partitionBy(key), o);
                     await session.SaveChangesAsync();
                 }
 
-                etlDone = Etl.WaitForEtlToComplete(store);
-                Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)));
+                var secondBatchCompleted = WaitForValue(() =>
+                {
+                    files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories).OrderBy(x => x).ToArray();
+                    return files.Length == 2;
+                }, expectedVal: true, timeout: 70_000);
 
-                var secondBatchTime = DateTime.UtcNow;
-                var secondBatchTimeMinutes = secondBatchTime.Minute;
-                var oneMinuteApart = secondBatchTimeMinutes - firstBatchTimeMinutes == 1 || firstBatchTimeMinutes == 59 && secondBatchTimeMinutes == 0 ||
-                    // grant one second tolerance 
-                    (secondBatchTime - firstBatchTime).TotalSeconds >= 59 ||
-                    secondBatchTime.Second == 59 && firstBatchTimeMinutes == secondBatchTimeMinutes;
+                Assert.True(secondBatchCompleted, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(70)));
 
-                Assert.True(oneMinuteApart,
+                var firstBatchTime = File.GetLastWriteTimeUtc(files[0]);
+                var secondBatchTime = File.GetLastWriteTimeUtc(files[1]);
+
+                // compute next minute boundary
+                var expectedSecondBatchAt = new DateTime(firstBatchTime.Year, firstBatchTime.Month, firstBatchTime.Day, firstBatchTime.Hour, firstBatchTime.Minute, 0, DateTimeKind.Utc)
+                    .AddMinutes(1);
+
+                Assert.True(secondBatchTime >= expectedSecondBatchAt.AddMilliseconds(-250),
                     $"First batch time : {firstBatchTime}, second batch time : {secondBatchTime}. Files : {string.Join(", ", Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories))}");
 
-                files = Directory.GetFiles(path, searchPattern: AllFilesPattern, SearchOption.AllDirectories);
-                Assert.Equal(2, files.Length);
             }
         }
 


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-17219/StressTests.Server.Documents.ETL.Olap.LocalTestsStress.ShouldRespectEtlRunFrequency

- https://issues.hibernatingrhinos.com/issue/RavenDB-22224/SlowTests.Server.Documents.ETL.Olap.RavenDB18465.EtlProcessStateShouldBeDeletedAfterTaskRemovaloptions-DatabaseMode-Sharded

- https://issues.hibernatingrhinos.com/issue/RavenDB-25292/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateDocIdColumnNamedatabaseMode-Single

- https://issues.hibernatingrhinos.com/issue/RavenDB-25300/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateCustomPartitionValuedatabaseMode-Single

- https://issues.hibernatingrhinos.com/issue/RavenDB-25333/SlowTests.Server.Documents.ETL.Olap.LocalTests.CanUpdateRunFrequencydatabaseMode-Single

### Additional description

- `ShouldRespectEtlRunFrequency`
The test previously waited on ETL batch completion, which can race with the cron scheduling/minute boundary and lead to timeouts.
It now waits for the second parquet file to appear and validates the run frequency using the file’s last write time (next-minute boundary).

- `CanUpdateRunFrequency` / `CanUpdateCustomPartitionValue `/ `CanUpdateDocIdColumnName`
OLAP reschedules its timer only in `AfterAllBatchesCompleted`, while the tests waited for `OnBatchCompleted`. 
This allowed a race where new docs + config update caused two runs (old/new config) and extra parquet files. 
The tests now disable ETL during the config mutation window and re-enable afterwards.

- `EtlProcessStateShouldBeDeletedAfterTaskRemoval`
wait for the ETL process state to be removed after OLAP task deletion

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
