### PR TITLE
RavenDB-25543 Avoid error message with empty path

### DIFF
--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Object/ObjectSchemaRuleValidator.cs
@@ -87,7 +87,13 @@ public class ObjectSchemaRuleValidator : SchemaRuleValidator<BlittableJsonReader
                 var (allowed, additionalPropertiesValidator) = _additionalPropertiesValidator;
                 if (allowed == false)
                 {
-                    context.ErrorBuilder?.AddError($"The property '{propName}' at '{context.ErrorBuilder.Path}' is not defined and additional properties are not allowed.");
+                    if (context.ErrorBuilder != null)
+                    {
+                        var path = context.ErrorBuilder.Path;
+                        path.StepIn(propName);
+                        context.ErrorBuilder.AddError($"The property '{propName}' is not defined in the schema and additional properties are not allowed. Full path: '{path}'.");
+                        path.StepOut();
+                    }
                     isValid = false;
                 }
                 else if (additionalPropertiesValidator != null)

--- a/test/FastTests/SchemaValidation/AdditionalPropertiesRulesSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/AdditionalPropertiesRulesSchemaValidationTests.cs
@@ -49,7 +49,7 @@ public class AdditionalPropertiesRulesSchemaValidationTests : SchemaValidationTe
                 using var ctx = ReadObjectOnNewCtx(new DynamicJsonValue { [notDefinedProp] = "1234" }, out var obj);
 
                 Assert.False(schemaValidator.Validate(obj, out var errors));
-                AssertError("The property 'notDefinedProp' at '' is not defined and additional properties are not allowed.", errors);
+                AssertError("The property 'notDefinedProp' is not defined in the schema and additional properties are not allowed. Full path: 'notDefinedProp'.", errors);
             });
     }
 

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -50,7 +50,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         {
             var additionalPropertiesDefinition = new (object, string)[]
             {
-                (false, "The property 'Prop2' at '' is not defined and additional properties are not allowed."),
+                (false, "The property 'Prop2' is not defined in the schema and additional properties are not allowed. Full path: 'Prop2'"),
                 (new DynamicJsonValue { [SVC.Type] = SchemaValidationHelper.Integer }, "'Prop2' should be of type 'integer' but actual type is 'string'.")
             };
             foreach (var additionalProperties in additionalPropertiesDefinition)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25543

### Additional description
For an additionalProperties error message, the path can be empty when it is in the root of the object.
That can look a little bit weird.
To avoid that, I changed the message to specify the full path

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
