### PR TITLE
RavenDB-25683 fix import with attachments to sharded database

### DIFF
--- a/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
+++ b/src/Raven.Server/Smuggler/Documents/Actions/DatabaseRecordActions.cs
@@ -630,7 +630,12 @@ public sealed class DatabaseRecordActions : IDatabaseRecordActions
             List<string> members;
 
             using (context.OpenReadTransaction())
-                members = _server.Cluster.ReadDatabaseTopology(context, _name).Members;
+            {
+                var raw = _server.Cluster.ReadRawDatabaseRecord(context, _name);
+                // TODO: for sharded database, this is just a quick fix not to error
+                // we need to figure out the proper whether we need to wait for all shards or just orchestrators
+                members = raw.IsSharded ? raw.Sharding.Orchestrator.Topology.Members : raw.Topology.Members;
+            }
 
             try
             {

--- a/src/Raven.Server/Smuggler/Documents/OrchestratorStreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/OrchestratorStreamSource.cs
@@ -26,26 +26,25 @@ public sealed class OrchestratorStreamSource : StreamSource
 
     public override Stream GetAttachmentStream(LazyStringValue hash, out string tag)
     {
-        using (Slice.From(_allocator, hash, out var slice))
+        using var _ = Slice.From(_allocator, hash, out var slice);
+        if (_uniqueStreams.TryGetValue(slice, out var item))
         {
-            if (_uniqueStreams.TryGetValue(slice, out var item))
+            tag = "$from-sharding-import";
+            return item.Stream.CreateDisposableReaderStream(new DisposableAction(() =>
             {
-                tag = "$from-sharding-import";
-                return item.Stream.CreateDisposableReaderStream(new DisposableAction(() =>
+                if (Interlocked.Increment(ref item.Usages) == _numberOfShards)
                 {
-                    if (Interlocked.Increment(ref item.Usages) == _numberOfShards)
+                    if (_uniqueStreams.TryRemove(item.KeySlice, out var streamValue))
                     {
-                        if (_uniqueStreams.TryRemove(slice, out var streamValue))
+                        using (streamValue)
                         {
-                            using (streamValue)
-                            {
-                                slice.Release(_allocator);
-                            }
+                            item.KeySlice.Release(_allocator);
                         }
                     }
-                }));
-            }
+                }
+            }));
         }
+
         tag = null;
         return null;
     }
@@ -61,6 +60,7 @@ public sealed class OrchestratorStreamSource : StreamSource
             var hash = r.Base64Hash.Clone(_allocator);
             _uniqueStreams.TryAdd(hash, new UniqueStreamValue
             {
+                KeySlice = hash,
                 Usages = 1,
                 Stream = inner
             });
@@ -90,7 +90,7 @@ public sealed class OrchestratorStreamSource : StreamSource
     {
         public StreamsTempFile.InnerStream Stream;
         public int Usages;
-
+        public Slice KeySlice;
         public void Dispose()
         {
             Stream?.Dispose();

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -416,59 +416,35 @@ namespace Raven.Server.Smuggler.Documents
                         await _rateGate.WaitToProceedAsync();
 
                     var isPreV4Revision = DatabaseSmuggler.IsPreV4Revision(buildType, item.Document.Id, item.Document);
-                    if (isPreV4Revision)
-                    {
-                        result.RevisionDocuments.ReadCount++;
-                        result.RevisionDocuments.SizeInBytes += item.Document.Data.Size;
-                    }
-                    else
-                    {
-                        result.Documents.ReadCount++;
-                        result.Documents.SizeInBytes += item.Document.Data.Size;
-                    }
+                    var counts = isPreV4Revision ? result.RevisionDocuments : result.Documents;
 
-                    if (item.Attachments != null)
-                    {
-                        foreach (var attachment in item.Attachments)
-                        {
-                            if (attachment.Stream != null)
-                            {
-                                if (isPreV4Revision)
-                                {
-                                    result.RevisionDocuments.Attachments.ReadCount++;
-                                    result.RevisionDocuments.Attachments.SizeInBytes += attachment.Stream.Length;
-                                }
-                                else
-                                {
-                                    result.Documents.Attachments.ReadCount++;
-                                    result.Documents.Attachments.SizeInBytes += attachment.Stream.Length;
-                                }
-                            }
-                        }
-                    }
+                    counts.ReadCount++;
+                    counts.SizeInBytes += item.Document.Data.Size;
 
-                    if (result.Documents.ReadCount % 1000 == 0)
+                    AddAttachmentsCount(counts, item);
+
+                    if (counts.ReadCount % 1000 == 0)
                     {
-                        var message = $"Documents: {result.Documents}";
+                        var message = $"Documents: {counts}";
                         AddInfoToSmugglerResult(result, message);
                     }
 
                     if (item.Document == null)
                     {
-                        result.Documents.ErroredCount++;
-                        if (result.Documents.ErroredCount % 1000 == 0)
-                            AddInfoToSmugglerResult(result, $"Error Count: {result.Documents.ErroredCount:#,#;;0}.");
+                        counts.ErroredCount++;
+                        if (counts.ErroredCount % 1000 == 0)
+                            AddInfoToSmugglerResult(result, $"Error Count: {counts.ErroredCount:#,#;;0}.");
                         continue;
                     }
 
                     if (item.Document.Id == null)
                         ThrowInvalidData();
 
-                    result.Documents.LastEtag = item.Document.Etag;
+                    counts.LastEtag = item.Document.Etag;
 
                     if (CanSkipDocument(item.Document, buildType))
                     {
-                        SkipDocument(item, result.Documents);
+                        SkipDocument(item, counts);
                         continue;
                     }
 
@@ -477,20 +453,20 @@ namespace Raven.Server.Smuggler.Documents
                         if (item.Document.Data.TryGetMetadata(out var metadata) &&
                             AbstractBackgroundWorkStorage.HasPassed(metadata, _time.GetUtcNow(), Constants.Documents.Metadata.Expires))
                         {
-                            SkipDocument(item, result.Documents);
+                            SkipDocument(item, counts);
                             continue;
                         }
                     }
 
                     if (_options.IncludeArtificial == false && item.Document.Flags.HasFlag(DocumentFlags.Artificial))
                     {
-                        SkipDocument(item, result.Documents);
+                        SkipDocument(item, counts);
                         continue;
                     }
 
                     if (_options.IncludeArchived == false && item.Document.Flags.HasFlag(DocumentFlags.Archived))
                     {
-                        SkipDocument(item, result.Documents);
+                        SkipDocument(item, counts);
                         continue;
                     }
 
@@ -499,10 +475,10 @@ namespace Raven.Server.Smuggler.Documents
                         var patchedDocument = _patcher.Transform(item.Document);
                         if (patchedDocument == null)
                         {
-                            SkipDocument(item, result.Documents);
+                            SkipDocument(item, counts);
 
-                            if (result.Documents.SkippedCount % 1000 == 0)
-                                AddInfoToSmugglerResult(result, $"Skipped {result.Documents.SkippedCount:#,#;;0} documents.");
+                            if (counts.SkippedCount % 1000 == 0)
+                                AddInfoToSmugglerResult(result, $"Skipped {counts.SkippedCount:#,#;;0} documents.");
                             continue;
                         }
 
@@ -523,7 +499,7 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
-                    await documentActions.WriteDocumentAsync(item, result.Documents, beforeFlush);
+                    await documentActions.WriteDocumentAsync(item, counts, beforeFlush);
                 }
 
                 await TryHandleLegacyDocumentTombstonesAsync(legacyIdsToDelete, documentActions, result);
@@ -556,17 +532,7 @@ namespace Raven.Server.Smuggler.Documents
                     if (item.Document != null)
                         result.RevisionDocuments.SizeInBytes += item.Document.Data.Size;
 
-                    if (item.Attachments != null)
-                    {
-                        foreach (var attachment in item.Attachments)
-                        {
-                            if (attachment.Stream != null)
-                            {
-                                result.RevisionDocuments.Attachments.ReadCount++;
-                                result.RevisionDocuments.Attachments.SizeInBytes += attachment.Stream.Length;
-                            }
-                        }
-                    }
+                    AddAttachmentsCount(result.RevisionDocuments, item);
 
                     if (result.RevisionDocuments.ReadCount % 1000 == 0)
                         AddInfoToSmugglerResult(result, $"Revisions {result.RevisionDocuments}");
@@ -1361,6 +1327,31 @@ namespace Raven.Server.Smuggler.Documents
 
                 result.AddError(errorMessage);
             }
+        }
+
+        private static void AddAttachmentsCount(SmugglerProgressBase.CountsWithSkippedCountAndLastEtagAndAttachments counts, DocumentItem item)
+        {
+            if (item.Attachments != null)
+            {
+                foreach (var attachment in item.Attachments)
+                {
+                    if (attachment.Stream != null)
+                    {
+                        counts.Attachments.ReadCount++;
+                        counts.Attachments.SizeInBytes += attachment.Stream.Length;
+                    }
+                }
+            }
+
+            if (item.Document == null)
+                return;
+
+            if (item.Document.Flags.HasFlag(DocumentFlags.HasAttachments) == false ||
+                item.Document.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
+                metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
+                return;
+
+            counts.Attachments.ReadCount += attachments.Length - (item.Attachments?.Count ?? 0);
         }
     }
 }

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1446,10 +1446,7 @@ namespace Raven.Server.Smuggler.Documents
                             foreach (var attachment in item.Attachments)
                             {
                                 attachment.Stream.Position = 0;
-                                await using (attachment.Stream)
-                                {
-                                    await WriteAttachmentStreamAsync(attachment.Base64Hash.ToString(), attachment.Stream, attachment.Tag.ToString());
-                                }
+                                await WriteAttachmentStreamAsync(attachment.Base64Hash.Content.ToString(), attachment.Stream, attachment.Tag.ToString());
                             }
                         }
                         

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1446,13 +1446,14 @@ namespace Raven.Server.Smuggler.Documents
                             foreach (var attachment in item.Attachments)
                             {
                                 attachment.Stream.Position = 0;
-                                await WriteAttachmentStreamAsync(attachment.Base64Hash.Content.ToString(), attachment.Stream, attachment.Tag.ToString());
+                                await using (attachment.Stream)
+                                {
+                                    await WriteAttachmentStreamAsync(attachment.Base64Hash.ToString(), attachment.Stream, attachment.Tag.ToString());
+                                }
                             }
                         }
-                        else
-                        {
-                            await WriteUniqueAttachmentStreamsAsync(document, progress);
-                        }
+                        
+                        await WriteUniqueAttachmentStreamsAsync(document, progress);
                     }
 
                     if (First == false)
@@ -1562,10 +1563,9 @@ namespace Raven.Server.Smuggler.Documents
                         throw new ArgumentException($"Hash field is mandatory in attachment's metadata: {attachment}");
                     }
 
-                    progress.Attachments.ReadCount++;
-
                     if (_attachmentStreamsAlreadyExported.Add(hash))
                     {
+                        progress.Attachments.ReadCount++;
                         await using (var stream = _source.GetAttachmentStream(hash, out string tag))
                         {
                             if (stream == null)

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -59,6 +59,7 @@ namespace Raven.Server.Smuggler.Documents
         private AsyncBlittableJsonTextWriter _writer;
         private DatabaseSmugglerOptionsServerSide _options;
         private Func<LazyStringValue, bool> _filterMetadataProperty;
+        private HashSet<string> _attachmentStreamsAlreadyExported;
 
         public StreamDestination(Stream stream, JsonOperationContext context, ISmugglerSource source, ExportCompressionAlgorithm compressionAlgorithm, CompressionLevel compressionLevel)
         {
@@ -163,22 +164,22 @@ namespace Raven.Server.Smuggler.Documents
 
         public IDocumentActions Documents(bool throwOnDuplicateCollection)
         {
-            return new StreamDocumentActions(_writer, _context, _source, _options, _filterMetadataProperty, "Docs");
+            return new StreamDocumentActions(this, _writer, _context, _source, _options, _filterMetadataProperty, "Docs");
         }
 
         public IDocumentActions RevisionDocuments()
         {
-            return new StreamDocumentActions(_writer, _context, _source, _options, _filterMetadataProperty, nameof(DatabaseItemType.RevisionDocuments));
+            return new StreamDocumentActions(this, _writer, _context, _source, _options, _filterMetadataProperty, nameof(DatabaseItemType.RevisionDocuments));
         }
 
         public IDocumentActions Tombstones()
         {
-            return new StreamDocumentActions(_writer, _context, _source, _options, _filterMetadataProperty, nameof(DatabaseItemType.Tombstones));
+            return new StreamDocumentActions(this, _writer, _context, _source, _options, _filterMetadataProperty, nameof(DatabaseItemType.Tombstones));
         }
 
         public IDocumentActions Conflicts()
         {
-            return new StreamDocumentActions(_writer, _context, _source, _options, _filterMetadataProperty, nameof(DatabaseItemType.Conflicts));
+            return new StreamDocumentActions(this, _writer, _context, _source, _options, _filterMetadataProperty, nameof(DatabaseItemType.Conflicts));
         }
 
         public IKeyValueActions<long> Identities()
@@ -1418,16 +1419,18 @@ namespace Raven.Server.Smuggler.Documents
 
         private sealed class StreamDocumentActions : StreamActionsBaseWithBuilder, IDocumentActions
         {
+            private readonly StreamDestination _parent;
             private readonly JsonOperationContext _context;
             private readonly ISmugglerSource _source;
             private readonly DatabaseSmugglerOptionsServerSide _options;
             private readonly Func<LazyStringValue, bool> _filterMetadataProperty;
-            private HashSet<string> _attachmentStreamsAlreadyExported;
             private Stream _attachmentStreamsTempFile;
 
-            public StreamDocumentActions(AsyncBlittableJsonTextWriter writer, JsonOperationContext context, ISmugglerSource source, DatabaseSmugglerOptionsServerSide options, Func<LazyStringValue, bool> filterMetadataProperty, string propertyName)
+            public StreamDocumentActions(StreamDestination parent, AsyncBlittableJsonTextWriter writer, JsonOperationContext context, ISmugglerSource source, DatabaseSmugglerOptionsServerSide options,
+                Func<LazyStringValue, bool> filterMetadataProperty, string propertyName)
                 : base(context, writer, propertyName)
             {
+                _parent = parent;
                 _context = context;
                 _source = source;
                 _options = options;
@@ -1548,8 +1551,7 @@ namespace Raven.Server.Smuggler.Documents
                     metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false)
                     return;
 
-                if (_attachmentStreamsAlreadyExported == null)
-                    _attachmentStreamsAlreadyExported = new HashSet<string>();
+                _parent._attachmentStreamsAlreadyExported ??= new HashSet<string>();
 
                 foreach (BlittableJsonReaderObject attachment in attachments)
                 {
@@ -1560,9 +1562,8 @@ namespace Raven.Server.Smuggler.Documents
                         throw new ArgumentException($"Hash field is mandatory in attachment's metadata: {attachment}");
                     }
 
-                    if (_attachmentStreamsAlreadyExported.Add(hash))
+                    if (_parent._attachmentStreamsAlreadyExported.Add(hash))
                     {
-                        progress.Attachments.ReadCount++;
                         await using (var stream = _source.GetAttachmentStream(hash, out string tag))
                         {
                             if (stream == null)
@@ -1595,9 +1596,8 @@ namespace Raven.Server.Smuggler.Documents
 
             private async ValueTask WriteAttachmentStreamAsync(string hash, Stream stream, string tag)
             {
-                if (_attachmentStreamsAlreadyExported == null)
-                    _attachmentStreamsAlreadyExported = new HashSet<string>();
-                _attachmentStreamsAlreadyExported.Add(hash);
+                _parent._attachmentStreamsAlreadyExported ??= new HashSet<string>();
+                _parent._attachmentStreamsAlreadyExported.Add(hash);
 
                 if (First == false)
                     Writer.WriteComma();

--- a/test/SlowTests/Client/Attachments/AttachmentsSmuggler.cs
+++ b/test/SlowTests/Client/Attachments/AttachmentsSmuggler.cs
@@ -480,7 +480,7 @@ namespace SlowTests.Client.Attachments
                         Assert.Equal(1, importResult.Documents.ReadCount);
                         Assert.True(4 == importResult.RevisionDocuments.ReadCount, $"{i} : importResult.RevisionDocuments.ReadCount = {importResult.RevisionDocuments.ReadCount}");
                         Assert.True(4 == importResult.Documents.Attachments.ReadCount, $"{i} : importResult.Documents.Attachments.ReadCount = {importResult.Documents.Attachments.ReadCount}");
-                        Assert.True(4 == importResult.RevisionDocuments.Attachments.ReadCount, $"{i} : importResult.RevisionDocuments.Attachments.ReadCount = {importResult.RevisionDocuments.Attachments.ReadCount}");
+                        Assert.True(10 == importResult.RevisionDocuments.Attachments.ReadCount, $"{i} : importResult.RevisionDocuments.Attachments.ReadCount = {importResult.RevisionDocuments.Attachments.ReadCount}");
 
                         var stats = await store2.Maintenance.SendAsync(new GetStatisticsOperation());
                         Assert.Equal(1, stats.CountOfDocuments);

--- a/test/SlowTests/Issues/RavenDB_20656.cs
+++ b/test/SlowTests/Issues/RavenDB_20656.cs
@@ -92,14 +92,14 @@ if (name == 'CF')
             Assert.Equal(1, result.Documents.SkippedCount);
             Assert.Equal(0, result.Documents.ErroredCount);
 
-            Assert.Equal(1, result.Documents.Attachments.ReadCount);
+            Assert.Equal(2, result.Documents.Attachments.ReadCount);
             Assert.Equal(0, result.Documents.Attachments.ErroredCount);
 
             Assert.Equal(2, result.RevisionDocuments.ReadCount);
             Assert.Equal(1, result.RevisionDocuments.SkippedCount);
             Assert.Equal(0, result.RevisionDocuments.ErroredCount);
 
-            Assert.Equal(1, result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(2, result.RevisionDocuments.Attachments.ReadCount);
             Assert.Equal(0, result.RevisionDocuments.Attachments.ErroredCount);
 
             Assert.Equal(2, result.Counters.ReadCount);

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.Backups.Sharding;
 using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
@@ -1263,6 +1264,39 @@ namespace SlowTests.Sharding.Backup
                             Assert.Null(order);
                         }
                     }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.BackupExportImport | RavenTestCategory.Sharding | RavenTestCategory.Attachments)]
+        public async Task CanImportAttachmentsToShardedDatabase()
+        {
+            using (var store = GetDocumentStore())
+            using (var sharded = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User(), "users/1");
+                    await session.StoreAsync(new User(), "users/2");
+
+                    using (var s1 = new MemoryStream("1"u8.ToArray()))
+                    using (var s11 = new MemoryStream("1"u8.ToArray())) // same attachment as s1
+                    using (var s2 = new MemoryStream("2"u8.ToArray()))
+                    {
+                        session.Advanced.Attachments.Store("users/1", "1.txt", s1, "text");
+                        session.Advanced.Attachments.Store("users/2", "1.txt", s11, "text"); 
+                        session.Advanced.Attachments.Store("users/2", "2.txt", s2, "text");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                using (var dest = new MemoryStream())
+                {
+                    var export = await store.Smuggler.ExportToStreamAsync(new DatabaseSmugglerExportOptions(), s => s.CopyToAsync(dest));
+                    await export.WaitForCompletionAsync();
+                    dest.Position = 0;
+                    var import = await sharded.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), dest);
+                    await import.WaitForCompletionAsync();
                 }
             }
         }

--- a/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
+++ b/test/SlowTests/Sharding/Backup/ShardedRestoreBackupTests.cs
@@ -991,7 +991,7 @@ namespace SlowTests.Sharding.Backup
             Assert.Equal(0, shardedRestoreResults[2].Result.Counters.ReadCount);
             Assert.Equal(1, shardedRestoreResults[2].Result.TimeSeries.ReadCount);
             Assert.Equal(6, shardedRestoreResults[2].Result.RevisionDocuments.ReadCount);
-            Assert.Equal(1, shardedRestoreResults[2].Result.RevisionDocuments.Attachments.ReadCount);
+            Assert.Equal(2, shardedRestoreResults[2].Result.RevisionDocuments.Attachments.ReadCount);
             Assert.Equal(0, shardedRestoreResults[2].Result.Tombstones.ReadCount);
             Assert.Equal(1, shardedRestoreResults[2].Result.Identities.ReadCount);
             Assert.Equal(1, shardedRestoreResults[2].Result.Indexes.ReadCount);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25683

### Additional description

This PR fixes 2 issues in importing of attachments to sharded database:
1. Release of the wrong slice caused an internal corruption and wrong detection of an existing streams
2. Since from non-sharded database we export the attachment once with the first document that has it we might not attach the attachment to the next document that needs it, so it goes through a different code path.
The issue was when we had both cases in the same document (new attachments + already exported ones)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
