### PR TITLE
RavenDB-25349 - Reduce GenAI test flakiness

### DIFF
--- a/src/Raven.Server/Config/Categories/AiConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/AiConfiguration.cs
@@ -64,4 +64,10 @@ public sealed class AiConfiguration : ConfigurationCategory
     [DefaultValue(false)]
     [ConfigurationEntry("Ai.Assistant.DisableDataSubmission", ConfigurationEntryScope.ServerWideOnly)]
     public bool DisableDataSubmission { get; set; }
+
+    [Description("Maximum number of seconds GenAi 'SendToModel' batch will take.")]
+    [DefaultValue(60)]
+    [TimeUnit(TimeUnit.Seconds)]
+    [ConfigurationEntry("Ai.GenAi.GenAiSendToModelTimeout", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+    public TimeSetting GenAiSendToModelTimeout { get; set; }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Client.Documents.AI;
@@ -147,8 +148,10 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         
         // Prevent database unloading during long-running AI operations
         using (Database.PreventFromUnloadingByIdleOperations())
+        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken))
         {
-            exceptions = SendToModel(results, context, scope);
+            cts.CancelAfter(Database.Configuration.Ai.GenAiSendToModelTimeout.AsTimeSpan);
+            exceptions = SendToModel(results, context, scope, cts.Token);
         }
 
         ApplyUpdateScript(context, results, scope);
@@ -170,7 +173,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         return results.Count;
     }
 
-    private List<Exception> SendToModel(List<GenAiResultItem> items, DocumentsOperationContext context, GenAiStatsScope scope)
+    private List<Exception> SendToModel(List<GenAiResultItem> items, DocumentsOperationContext context, GenAiStatsScope scope, CancellationToken batchToken)
     {
         using (var statsScope = scope.For(GenAiOperations.LoadToModel))
         {
@@ -219,7 +222,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 handler.SetClient(_chatCompletionClient);
                 try
                 {
-                    task = handler.HandleRequest(CancellationToken);
+                    task = handler.HandleRequest(batchToken);
                 }
                 catch (Exception e)
                 {
@@ -314,7 +317,15 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
 
         Exception HandleItemError(Task<GenAiHandlerResult> task, GenAiResultItem item)
         {
-            var singleEx = task.Exception.ExtractSingleInnerException();
+            Exception singleEx = null;
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                singleEx = e.ExtractSingleInnerException();
+            }
 
             if (Configuration.TestMode)
                 throw new InvalidOperationException("Failed to run test", singleEx);
@@ -437,7 +448,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                     ReloadAttachmentsData(context, items);
 
                 _chatCompletionClient ??= GetClient();
-                List<Exception> exceptions = SendToModel(items, context, scope);
+                List<Exception> exceptions = SendToModel(items, context, scope, CancellationToken);
                 if (exceptions is not null)
                     throw new AggregateException(exceptions);
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -241,7 +241,8 @@ namespace FastTests
                             [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = runInMemory.ToString(),
                             [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "true",
                             [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString(),
-                            [RavenConfiguration.GetKey(x => x.Queries.RegexTimeout)] = (500).ToString()
+                            [RavenConfiguration.GetKey(x => x.Queries.RegexTimeout)] = (500).ToString(),
+                            [RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = 10.ToString()
                         }
                     };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25349/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24645.CanUseImageWithTheWrongFormatoptions-DatabaseMode-Single-config

https://issues.hibernatingrhinos.com/issue/RavenDB-25278/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24644.SelectivePdfDescriptionTransformWhenSomeAttachmentsAreMissingoptions

https://issues.hibernatingrhinos.com/issue/RavenDB-25328/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenPromptChangesoptions-DatabaseMode-Single-configuration

### Additional description
Fix NRE on the 'SendToModel' phase, when one or more tasks are cancelled.
Add cancellation by time to tasks  on the 'SendToModel' phase (token for the whole batch that cancelled after 1 minute by default (added 'Ai.GenAi.GenAiSendToModelTimeout' config).
changed the 'GenAiSendToModelTimeout' to 10 sec for all tests.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
