### PR TITLE
Ravendb-25353: Investigate broken resharding

### DIFF
--- a/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDocumentDatabase.cs
@@ -124,7 +124,7 @@ public sealed class ShardedDocumentDatabase : DocumentDatabase
                     using (context.OpenReadTransaction())
                     {
                         var current = ShardedDocumentsStorage.GetMergedChangeVectorInBucket(context, process.Bucket);
-                        var status = ChangeVector.GetConflictStatusForDocument(context.GetChangeVector(process.LastSourceChangeVector), current);
+                        var status = ChangeVector.GetConflictStatusForBucket(context.GetChangeVector(process.LastSourceChangeVector), current, ShardedDocumentsStorage.UnusedDatabaseIds);
                         if (status == ConflictStatus.AlreadyMerged)
                         {
                             index = process.MigrationIndex;

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -418,8 +418,9 @@ namespace Raven.Server.ServerWide.Maintenance
                 return;
 
             var databaseName = rawRecord.DatabaseName;
+            var record = _engine.StateMachine.ReadDatabase(context, databaseName);
             var sharding = rawRecord.Sharding;
-            var currentMigration = sharding.BucketMigrations.SingleOrDefault(pair => pair.Value.Status == MigrationStatus.Moved).Value;
+            var currentMigration = sharding.BucketMigrations.Values.SingleOrDefault(x => x.Status == MigrationStatus.Moved);
             if (currentMigration == null)
                 return;
 
@@ -443,7 +444,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                     var lastFromSrc = context.GetChangeVector(currentMigration.LastSourceChangeVector);
                     var currentFromDest = context.GetChangeVector(lastChangeVector);
-                    var status = ChangeVector.GetConflictStatusForDocument(lastFromSrc, currentFromDest);
+                    var status = ChangeVector.GetConflictStatusForBucket(lastFromSrc, currentFromDest, record.UnusedDatabaseIds);
                     if (status == ConflictStatus.AlreadyMerged)
                     {
                         confirmCommands ??= new List<DestinationMigrationConfirmCommand>();

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -418,9 +418,8 @@ namespace Raven.Server.ServerWide.Maintenance
                 return;
 
             var databaseName = rawRecord.DatabaseName;
-            var record = _engine.StateMachine.ReadDatabase(context, databaseName);
             var sharding = rawRecord.Sharding;
-            var currentMigration = sharding.BucketMigrations.Values.SingleOrDefault(x => x.Status == MigrationStatus.Moved);
+            var currentMigration = sharding.BucketMigrations.Values.FirstOrDefault(x => x.Status == MigrationStatus.Moved);
             if (currentMigration == null)
                 return;
 
@@ -444,7 +443,7 @@ namespace Raven.Server.ServerWide.Maintenance
 
                     var lastFromSrc = context.GetChangeVector(currentMigration.LastSourceChangeVector);
                     var currentFromDest = context.GetChangeVector(lastChangeVector);
-                    var status = ChangeVector.GetConflictStatusForBucket(lastFromSrc, currentFromDest, record.UnusedDatabaseIds);
+                    var status = ChangeVector.GetConflictStatusForBucket(lastFromSrc, currentFromDest, rawRecord.UnusedDatabaseIds);
                     if (status == ConflictStatus.AlreadyMerged)
                     {
                         confirmCommands ??= new List<DestinationMigrationConfirmCommand>();

--- a/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
+++ b/src/Raven.Server/ServerWide/RawDatabaseRecord.cs
@@ -1436,6 +1436,30 @@ namespace Raven.Server.ServerWide
             }
         }
 
+        private HashSet<string> _unusedDatabaseIds;
+
+        public HashSet<string> UnusedDatabaseIds
+        {
+            get
+            {
+                if (_materializedRecord != null)
+                    return _materializedRecord.UnusedDatabaseIds;
+
+                if (_unusedDatabaseIds == null)
+                {
+                    _unusedDatabaseIds = new HashSet<string>(StringComparer.Ordinal);
+                    if (_record.TryGet(nameof(DatabaseRecord.UnusedDatabaseIds), out BlittableJsonReaderArray bjra) && bjra != null)
+                    {
+                        foreach (LazyStringValue id in bjra)
+                        {
+                            _unusedDatabaseIds.Add(id);
+                        }
+                    }
+                }
+                return _unusedDatabaseIds;
+            }
+        }
+
         internal bool IsShardBeingDeletedOnAnyNode(int shardNumber)
         {
             foreach (var deletion in DeletionInProgress)

--- a/src/Raven.Server/Utils/ChangeVector.cs
+++ b/src/Raven.Server/Utils/ChangeVector.cs
@@ -126,7 +126,16 @@ public sealed class ChangeVector
         return context.GetChangeVector(version, Order);
     }
 
-    public static ConflictStatus GetConflictStatusForDocument(ChangeVector remote, ChangeVector local) => GetConflictStatusInternal(remote?.Version, local?.Version);
+    public static ConflictStatus GetConflictStatusForBucket(ChangeVector remote, ChangeVector local, HashSet<string> exclude = null)
+    {
+        var remoteVersion = remote?.Version;
+        var localVersion = local?.Version;
+
+        remoteVersion?.EnsureValid();
+        localVersion?.EnsureValid();
+
+        return ChangeVectorUtils.GetConflictStatus(remoteVersion?.AsString(), localVersion?.AsString(), exclude);
+    }
     
     public static ConflictStatus GetConflictStatus(IChangeVectorOperationContext context, string remote, string local) => 
         GetConflictStatusInternal(context.GetChangeVector(remote)?.Version, context.GetChangeVector(local)?.Version);

--- a/test/SlowTests/Sharding/Cluster/RavenDB-25353.cs
+++ b/test/SlowTests/Sharding/Cluster/RavenDB-25353.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Sharding;
+using Raven.Client.Util;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Commands.Sharding;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Sharding.Cluster
+{
+    public class RavenDB_25353 : ClusterTestBase
+    {
+        public RavenDB_25353(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Cluster | RavenTestCategory.Sharding)]
+        public async Task Resharding_Simple_Move_1_To_0()
+        {
+            DefaultClusterSettings[RavenConfiguration.GetKey(x => x.Replication.MaxItemsCount)] = 1.ToString();
+
+            var (nodes, leader) = await CreateRaftCluster(4, watcherCluster: true);
+            var dbName = GetDatabaseName();
+
+            var o = new Options
+            {
+                Server = leader,
+                DatabaseMode = RavenDatabaseMode.Sharded,
+                ModifyDatabaseRecord = r => r.Sharding = new ShardingConfiguration
+                {
+                    Orchestrator = new OrchestratorConfiguration
+                    {
+                        Topology = new OrchestratorTopology
+                        {
+                            Members = new List<string> { "A", "B", "C", "D" },
+                        }
+                    },
+                    Shards = new Dictionary<int, DatabaseTopology>
+                    {
+                        {
+                            0, new DatabaseTopology
+                            {
+                                Members = new List<string> { "A", "B" }
+                            }
+                        },
+                        {
+                            1, new DatabaseTopology
+                            {
+                                Members = new List<string> { "D", "C" }
+                            }
+                        }
+                    }
+                }
+            };
+
+            using (var store = GetDocumentStore(o, dbName))
+            {
+                var id = "items/0$items/anchor";
+                var bucketToMove = 0;
+                using (var session = store.OpenAsyncSession())
+                {
+                    bucketToMove = await Sharding.GetBucketAsync(store, id);
+                    await session.StoreAsync(new User { Name = $"User 0" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                var SrcShard = await Sharding.GetShardNumberForAsync(store, id);
+                for (int i = 0; i < 5; i++)
+                {
+                    var destShard = SrcShard == 1 ? 0 : 1;
+                    var bringBackNode = SrcShard == 1 ? "D" : "B";
+
+                    await MoveBucketAndDeleteSourceNodeAsync(store, leader, bucketToMove, SrcShard, destShard, store.Database, bringBackNode);
+
+                    await store.Maintenance.Server.SendAsync(new AddDatabaseNodeOperation(store.Database, SrcShard, bringBackNode));
+
+                    var added = await WaitForValueAsync(async () =>
+                    {
+                        var res = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                        var topology = res.Sharding.Shards[SrcShard];
+
+                        return topology.Members.Contains(bringBackNode);
+                    }, true, timeout: 30_000);
+                    Assert.True(added, $"didn't revive node {bringBackNode} on time");
+
+                    SrcShard = destShard;
+                }
+            }
+        }
+
+        private async Task MoveBucketAndDeleteSourceNodeAsync(DocumentStore store, RavenServer leader, int bucket, int src, int dest, string dbName, string bringBackNode)
+        {
+            var moveCmd = new StartBucketMigrationCommand(
+                bucket,
+                src,
+                dest,
+                store.Database,
+                prefix: null,
+                raftId: RaftIdGenerator.NewId());
+
+            var result = await leader.ServerStore.SendToLeaderAsync(moveCmd);
+
+            var shardDbName = $"{dbName}${src}";
+
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Anchor for migration" }, "items/0$items/anchor");
+                    session.SaveChanges();
+                    store.Maintenance.Server.Send(new DeleteDatabasesOperation(
+                        shardDbName,
+                        hardDelete: true,
+                        fromNode: bringBackNode,
+                        timeToWaitForConfirmation: TimeSpan.FromSeconds(10)
+                    ));
+                }
+
+                await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(result.Index, TimeSpan.FromSeconds(15));
+                var finished = await WaitForValueAsync(async () =>
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.BucketMigrations.Count == 0;
+                }, expectedVal: true, timeout: 15000);
+
+                Assert.True(finished, "The migration didn't finish in time.");
+            }
+        }
+
+        private class User
+        {
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25353/Investigate-broken-resharding
### Additional description

Reproduced the customer issue by moving back and forward from shard to shard while editing and deleting docs from the source database. the problem is originally because we filter the destination CV with `UnusedDatabaseIds `but we are not doing it on the source shard too. that way the source shard had db changes of dbs that are not relevant anymore, and if the source has value the destination don't the status will get stuck on `ConflictStatus `update forever. by adding the `UnusedDatabaseIds `to the exclusion list of `GetConflictStatus `we didn't gave any meaning to the unused Ids on the source and the conflict status will be `AlreadyMerged `as expected.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
