### PR TITLE
RavenDB-25722 / RavenDB-25395 Adjust Windows path handling logic to defer `\\?\` prefix assignment until after full path resolution

### DIFF
--- a/src/Voron/Util/Settings/PathSettingBase.cs
+++ b/src/Voron/Util/Settings/PathSettingBase.cs
@@ -80,11 +80,6 @@ namespace Voron.Util.Settings
                 ? path
                 : Path.Combine(baseDataDirFullPath ?? AppContext.BaseDirectory, path);
 
-            if (result.Length >= 260 && 
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                result.StartsWith(@"\\?\") == false)
-                result = @"\\?\" + result;
-
             var resultRoot = Path.GetPathRoot(result);
             if (resultRoot != result && (result.EndsWith(@"\") || result.EndsWith("/")))
                 result = result.TrimEnd('\\', '/');
@@ -92,9 +87,18 @@ namespace Voron.Util.Settings
             if (PlatformDetails.RunningOnPosix)
                 result = PosixHelper.FixLinuxPath(result);
 
-            return result != string.Empty || resultRoot == null ? 
+            var finalFullPath = result != string.Empty || resultRoot == null ? 
                 Path.GetFullPath(result) :
                 Path.GetFullPath(resultRoot); // it will unify directory separators and sort out parent directories
+
+            if (finalFullPath.Length >= 260 &&
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                finalFullPath.StartsWith(@"\\?\") == false)
+            {
+                finalFullPath = @"\\?\" + finalFullPath;
+            }
+            
+            return finalFullPath;
         }
 
         public static bool IsSubDirectory(string userPath, string rootPath)


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25722

### Additional description

The problem was that if path got `\\?\` prefix then `Path.GetFullPath()` don't unify directory separators.

The issue got revealed after https://github.com/ravendb/ravendb/pull/22013 change since `SharpZipLib` uses slashes as separator for entries that are put in folders.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
