### PR TITLE
RavenDB-25651 - Fix test GenAiClientSanityTest

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -353,10 +353,9 @@ internal class ChatCompletionClient : IDisposable
         return new AiResponse(AiResponseType.Result) { Result = result, Message = responseParser.Message };
     }
 
-    private struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response, BlittableJsonReaderObject responseContent)
+    internal struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response, BlittableJsonReaderObject responseContent)
     {
         public BlittableJsonReaderObject Message;
-        private string _content;
         private BlittableJsonReaderObject _choice0;
 
         public void EnsureSuccessfulResponse()
@@ -377,10 +376,9 @@ internal class ChatCompletionClient : IDisposable
 
             _choice0 = (BlittableJsonReaderObject)choices[0];
 
-            if (_choice0.TryGet(Constants.ResponseFields.Message, out Message) == false ||
-                Message.TryGet(Constants.ResponseFields.Content, out _content) == false)
+            if (_choice0.TryGet(Constants.ResponseFields.Message, out Message) == false)
             {
-                throw UnexpectedResponseException.Create(message: "No message/content property in choice", response, responseContent);
+                throw UnexpectedResponseException.Create(message: "No message property in choice", response, responseContent);
             }
 
             if (responseContent.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject usageJson) == false)
@@ -413,15 +411,68 @@ internal class ChatCompletionClient : IDisposable
 
         public BlittableJsonReaderObject GetContent(JsonOperationContext context)
         {
-            if (string.IsNullOrEmpty(_content))
+            if (Message.TryGet(Constants.ResponseFields.Content, out string content) == false || string.IsNullOrEmpty(content))
             {
                 _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
-                _ = _choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal) || Message.TryGet(Constants.ResponseFields.Refusal, out refusal);
+                _ = _choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal)
+                   || Message.TryGet(Constants.ResponseFields.Refusal, out refusal);
+
+                _ = string.IsNullOrEmpty(refusal) 
+                    && _choice0.TryGet(Constants.ResponseFields.ContentFilterResults, out BlittableJsonReaderObject filtersObj) 
+                    && GetFiltersMessage(filtersObj, out refusal);
 
                 RefusedToAnswerException.Throw(refusal, responseContent.ToString(), finishReason, GetRequestId(response.Headers));
             }
 
-            return context.Sync.ReadForMemory(_content, "ai/output");
+            return context.Sync.ReadForMemory(content, "ai/output");
+        }
+
+        internal static bool GetFiltersMessage(BlittableJsonReaderObject filtersObj, out string message)
+        {
+            var filtered = false;
+
+            var reasons = filtersObj.GetPropertyNames();
+
+            var sb = new StringBuilder();
+            sb.Append("Response blocked due to content policy: ");
+            foreach (var reason in reasons)
+            {
+                if (IsFiltered(filtersObj, reason, out string severity))
+                {
+                    if (filtered)
+                        sb.Append(", ");
+                    sb.Append(reason).Append(" ").Append("(").Append(severity).Append(" severity)");
+                    filtered = true;
+                }
+            }
+            message = filtered ? sb.ToString() : string.Empty;
+
+            return filtered;
+        }
+
+        private static bool IsFiltered(BlittableJsonReaderObject filtersObj, string reason, out string severity)
+        {
+            // return true if filtered by this reason
+            severity = string.Empty;
+
+            if (filtersObj.TryGet(reason, out BlittableJsonReaderObject filterReasonObj) == false)
+                return false;
+
+            if (filterReasonObj.TryGet(Constants.ResponseFields.ContentFilterResultFiltered, out bool filtered) == false)
+                return false;
+
+            if (filtered == false)
+                return false;
+
+            if (filterReasonObj.TryGet(Constants.ResponseFields.ContentFilterResultSeverity, out severity) == false)
+            {
+                if (filterReasonObj.TryGet(Constants.ResponseFields.ContentFilterResultDetected, out bool detected) && detected)
+                    severity = Constants.ResponseFields.ContentFilterResultDetected;
+                else
+                    severity = "none";
+            }
+
+            return true;
         }
     }
 
@@ -944,6 +995,10 @@ internal class ChatCompletionClient : IDisposable
             public const string Message = "message";
             public const string Content = "content";
             public const string FinishReason = "finish_reason";
+            public const string ContentFilterResults = "content_filter_results";
+            public const string ContentFilterResultFiltered = "filtered";
+            public const string ContentFilterResultSeverity = "severity";
+            public const string ContentFilterResultDetected = "detected";
             public const string ToolCalls = "tool_calls";
             public const string Refusal = "refusal";
             public const string Usage = "usage";

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -353,7 +353,7 @@ internal class ChatCompletionClient : IDisposable
         return new AiResponse(AiResponseType.Result) { Result = result, Message = responseParser.Message };
     }
 
-    internal struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response, BlittableJsonReaderObject responseContent)
+    private struct AiResponseParser(ChatCompletionClient client, HttpResponseMessage response, BlittableJsonReaderObject responseContent)
     {
         public BlittableJsonReaderObject Message;
         private BlittableJsonReaderObject _choice0;
@@ -414,65 +414,14 @@ internal class ChatCompletionClient : IDisposable
             if (Message.TryGet(Constants.ResponseFields.Content, out string content) == false || string.IsNullOrEmpty(content))
             {
                 _choice0.TryGet(Constants.ResponseFields.FinishReason, out string finishReason);
-                _ = _choice0.TryGet(Constants.ResponseFields.Refusal, out string refusal)
-                   || Message.TryGet(Constants.ResponseFields.Refusal, out refusal);
-
-                _ = string.IsNullOrEmpty(refusal) 
-                    && _choice0.TryGet(Constants.ResponseFields.ContentFilterResults, out BlittableJsonReaderObject filtersObj) 
-                    && GetFiltersMessage(filtersObj, out refusal);
+                var refusal = client.GetRefusal(_choice0, Message);
+                if (string.IsNullOrEmpty(refusal))
+                    throw UnexpectedResponseException.Create(message: "No response content", response, responseContent);
 
                 RefusedToAnswerException.Throw(refusal, responseContent.ToString(), finishReason, GetRequestId(response.Headers));
             }
 
             return context.Sync.ReadForMemory(content, "ai/output");
-        }
-
-        internal static bool GetFiltersMessage(BlittableJsonReaderObject filtersObj, out string message)
-        {
-            var filtered = false;
-
-            var reasons = filtersObj.GetPropertyNames();
-
-            var sb = new StringBuilder();
-            sb.Append("Response blocked due to content policy: ");
-            foreach (var reason in reasons)
-            {
-                if (IsFiltered(filtersObj, reason, out string severity))
-                {
-                    if (filtered)
-                        sb.Append(", ");
-                    sb.Append(reason).Append(" ").Append("(").Append(severity).Append(" severity)");
-                    filtered = true;
-                }
-            }
-            message = filtered ? sb.ToString() : string.Empty;
-
-            return filtered;
-        }
-
-        private static bool IsFiltered(BlittableJsonReaderObject filtersObj, string reason, out string severity)
-        {
-            // return true if filtered by this reason
-            severity = string.Empty;
-
-            if (filtersObj.TryGet(reason, out BlittableJsonReaderObject filterReasonObj) == false)
-                return false;
-
-            if (filterReasonObj.TryGet(Constants.ResponseFields.ContentFilterResultFiltered, out bool filtered) == false)
-                return false;
-
-            if (filtered == false)
-                return false;
-
-            if (filterReasonObj.TryGet(Constants.ResponseFields.ContentFilterResultSeverity, out severity) == false)
-            {
-                if (filterReasonObj.TryGet(Constants.ResponseFields.ContentFilterResultDetected, out bool detected) && detected)
-                    severity = Constants.ResponseFields.ContentFilterResultDetected;
-                else
-                    severity = "none";
-            }
-
-            return true;
         }
     }
 
@@ -760,6 +709,8 @@ internal class ChatCompletionClient : IDisposable
         }
     }
 
+    private string GetRefusal(BlittableJsonReaderObject choice0, BlittableJsonReaderObject message) => _settings.GetRefusal(choice0, message);
+
     internal static string GetRequestId(HttpResponseHeaders headers)
     {
         if (headers.TryGetValues(Constants.Headers.XRequestId, out IEnumerable<string> values))
@@ -995,10 +946,6 @@ internal class ChatCompletionClient : IDisposable
             public const string Message = "message";
             public const string Content = "content";
             public const string FinishReason = "finish_reason";
-            public const string ContentFilterResults = "content_filter_results";
-            public const string ContentFilterResultFiltered = "filtered";
-            public const string ContentFilterResultSeverity = "severity";
-            public const string ContentFilterResultDetected = "detected";
             public const string ToolCalls = "tool_calls";
             public const string Refusal = "refusal";
             public const string Usage = "usage";

--- a/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
@@ -78,6 +78,14 @@ internal abstract class AbstractChatCompletionClientSettings
     }
 
     public abstract AiError ParseError(BlittableJsonReaderObject content, HttpResponseMessage response);
+
+    public virtual string GetRefusal(BlittableJsonReaderObject choice0, BlittableJsonReaderObject message)
+    {
+        _ = choice0.TryGet(ChatCompletionClient.Constants.ResponseFields.Refusal, out string refusal)
+            || message.TryGet(ChatCompletionClient.Constants.ResponseFields.Refusal, out refusal);
+
+        return refusal;
+    }
 }
 
 public class AiError

--- a/src/Raven.Server/Documents/AI/Settings/AzureOpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AzureOpenAiChatCompletionClientSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using Raven.Client.Documents.Operations.AI;
 using Sparrow.Json;
 
@@ -49,6 +50,73 @@ internal class AzureOpenAiChatCompletionClientSettings : AbstractOpenAiChatCompl
             ErrorType = errorType,
             Message = error.message
         };
+    }
+
+    public override string GetRefusal(BlittableJsonReaderObject choice0, BlittableJsonReaderObject message)
+    {
+        var refusal = base.GetRefusal(choice0, message);
+        _ = string.IsNullOrEmpty(refusal)
+            && choice0.TryGet(FiltersConstants.ContentFilterResults, out BlittableJsonReaderObject filtersObj)
+            && GetFiltersMessage(filtersObj, out refusal);
+
+        return refusal;
+    }
+
+
+    internal static bool GetFiltersMessage(BlittableJsonReaderObject filtersObj, out string message)
+    {
+        var filtered = false;
+
+        var reasons = filtersObj.GetPropertyNames();
+
+        var sb = new StringBuilder();
+        sb.Append("Response blocked due to content policy: ");
+        foreach (var reason in reasons)
+        {
+            if (IsFiltered(filtersObj, reason, out string severity))
+            {
+                if (filtered)
+                    sb.Append(", ");
+                sb.Append(reason).Append(" ").Append("(").Append(severity).Append(" severity)");
+                filtered = true;
+            }
+        }
+        message = filtered ? sb.ToString() : string.Empty;
+
+        return filtered;
+    }
+
+    private static bool IsFiltered(BlittableJsonReaderObject filtersObj, string reason, out string severity)
+    {
+        // return true if filtered by this reason
+        severity = string.Empty;
+
+        if (filtersObj.TryGet(reason, out BlittableJsonReaderObject filterReasonObj) == false)
+            return false;
+
+        if (filterReasonObj.TryGet(FiltersConstants.ContentFilterResultFiltered, out bool filtered) == false)
+            return false;
+
+        if (filtered == false)
+            return false;
+
+        if (filterReasonObj.TryGet(FiltersConstants.ContentFilterResultSeverity, out severity) == false)
+        {
+            if (filterReasonObj.TryGet(FiltersConstants.ContentFilterResultDetected, out bool detected) && detected)
+                severity = FiltersConstants.ContentFilterResultDetected;
+            else
+                severity = "none";
+        }
+
+        return true;
+    }
+
+    private static class FiltersConstants
+    {
+        public const string ContentFilterResults = "content_filter_results";
+        public const string ContentFilterResultFiltered = "filtered";
+        public const string ContentFilterResultSeverity = "severity";
+        public const string ContentFilterResultDetected = "detected";
     }
 
     private static ErrorType FindErrorFromMessage(string message)

--- a/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 using Sparrow.Logging;
 using Tests.Infrastructure;
 using Voron;
@@ -61,10 +62,96 @@ public class ChatCompletionClientTests : RavenTestBase
             var context =
                 "{\"Text\":\"Surefire investment property in caiman islands, win $$$$ for sure, qucik!\",\"Author\":\"homepage\",\"Id\":\"2236672c-b941-4855-999e-5374f41cbddd\"}";
 
-            var res = await client.TestCompleteAsync(prompt, context, defaultJsonSchema, default);
-            var answer = JsonConvert.DeserializeObject<AiCommentResult>(res.Result); // check if it can be parsed to json, if cannot parse it throws
-            Assert.NotNull(answer.Blocked);
-            Assert.False(string.IsNullOrEmpty(answer.Reason));
+            (string Result, string Message) res = (null, null);
+            bool succeeded;
+            try
+            {
+                res = await client.TestCompleteAsync(prompt, context, defaultJsonSchema, default);
+                var answer = JsonConvert.DeserializeObject<AiCommentResult>(res.Result); // check if it can be parsed to json, if cannot parse it throws
+                Assert.NotNull(answer.Blocked);
+                Assert.False(string.IsNullOrEmpty(answer.Reason));
+                succeeded = true;
+            }
+            catch (RefusedToAnswerException)
+            {
+                succeeded = true; // expected - the llm can refuse answering this because it's a violent prompt
+            }
+            Assert.True(succeeded);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public async Task FiltersRightMessageTest()
+    {
+        const string json = @"{
+        ""hate"": {
+            ""filtered"": true,
+            ""severity"": ""high""
+        },
+        ""protected_material_code"": {
+            ""filtered"": true,
+            ""detected"": true
+        },
+        ""protected_material_text"": {
+            ""filtered"": false,
+            ""detected"": false
+        },
+        ""self_harm"": {
+            ""filtered"": false,
+            ""severity"": ""safe""
+        },
+        ""sexual"": {
+            ""filtered"": false,
+            ""severity"": ""safe""
+        },
+        ""violence"": {
+            ""filtered"": true,
+            ""severity"": ""medium""
+        }
+    }";
+
+        const string json2 = @"{
+        ""hate"": {
+            ""filtered"": false,
+            ""severity"": ""safe""
+        },
+        ""protected_material_code"": {
+            ""filtered"": false,
+            ""detected"": false
+        },
+        ""protected_material_text"": {
+            ""filtered"": false,
+            ""detected"": false
+        },
+        ""self_harm"": {
+            ""filtered"": false,
+            ""severity"": ""safe""
+        },
+        ""sexual"": {
+            ""filtered"": false,
+            ""severity"": ""safe""
+        },
+        ""violence"": {
+            ""filtered"": false,
+            ""severity"": ""safe""
+        }
+    }";
+
+        using (var context = JsonOperationContext.ShortTermSingleUse())
+        {
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
+            {
+                var blt = await context.ReadForMemoryAsync(stream, "json");
+                Assert.True(ChatCompletionClient.AiResponseParser.GetFiltersMessage(blt, out var refusal));
+                Assert.Equal("Response blocked due to content policy: hate (high severity), protected_material_code (detected severity), violence (medium severity)", refusal);
+            }
+
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json2)))
+            {
+                var blt = await context.ReadForMemoryAsync(stream, "json2");
+                Assert.False(ChatCompletionClient.AiResponseParser.GetFiltersMessage(blt, out var refusal));
+                Assert.Empty(refusal);
+            }
         }
     }
 

--- a/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/ChatCompletionClientTests.cs
@@ -9,6 +9,7 @@ using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Settings;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -63,20 +64,17 @@ public class ChatCompletionClientTests : RavenTestBase
                 "{\"Text\":\"Surefire investment property in caiman islands, win $$$$ for sure, qucik!\",\"Author\":\"homepage\",\"Id\":\"2236672c-b941-4855-999e-5374f41cbddd\"}";
 
             (string Result, string Message) res = (null, null);
-            bool succeeded;
             try
             {
                 res = await client.TestCompleteAsync(prompt, context, defaultJsonSchema, default);
                 var answer = JsonConvert.DeserializeObject<AiCommentResult>(res.Result); // check if it can be parsed to json, if cannot parse it throws
                 Assert.NotNull(answer.Blocked);
                 Assert.False(string.IsNullOrEmpty(answer.Reason));
-                succeeded = true;
             }
             catch (RefusedToAnswerException)
             {
-                succeeded = true; // expected - the llm can refuse answering this because it's a violent prompt
+                // expected - the llm can refuse answering this because it's a violent prompt
             }
-            Assert.True(succeeded);
         }
     }
 
@@ -142,14 +140,14 @@ public class ChatCompletionClientTests : RavenTestBase
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json)))
             {
                 var blt = await context.ReadForMemoryAsync(stream, "json");
-                Assert.True(ChatCompletionClient.AiResponseParser.GetFiltersMessage(blt, out var refusal));
+                Assert.True(AzureOpenAiChatCompletionClientSettings.GetFiltersMessage(blt, out var refusal));
                 Assert.Equal("Response blocked due to content policy: hate (high severity), protected_material_code (detected severity), violence (medium severity)", refusal);
             }
 
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(json2)))
             {
                 var blt = await context.ReadForMemoryAsync(stream, "json2");
-                Assert.False(ChatCompletionClient.AiResponseParser.GetFiltersMessage(blt, out var refusal));
+                Assert.False(AzureOpenAiChatCompletionClientSettings.GetFiltersMessage(blt, out var refusal));
                 Assert.Empty(refusal);
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25651/SlowTests.Server.Documents.AI.ChatCompletionClientTests.GenAiClientSanityTestoptions-DatabaseMode-Single-configuration

### Additional description

Fix test GenAiClientSanityTest, move "content" field check to the right place in AiResponseParser, and add info related on 'content_filter_results' to RefusedToAnswerException

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
