### PR TITLE
RavenDB-25350 : Fix flaky GenAI resend-context tests

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -761,6 +761,7 @@ for(const comment of this.Comments)
 
         etlDone = Etl.WaitForEtlToComplete(store);
         long etag = 0;
+        var baselineUtc = DateTime.UtcNow;
         using (var session = store.OpenSession())
         {
             // modify the doc to trigger etl 
@@ -769,7 +770,6 @@ for(const comment of this.Comments)
 
             var doc = session.Load<Post>(docId);
             doc.Comments.Add(new Comment("spam comment", "evil bot"));
-
             etag = ChangeVectorUtils.GetEtagById(session.Advanced.GetChangeVectorFor(doc), db.DbBase64Id);
 
             session.SaveChanges();
@@ -787,7 +787,11 @@ for(const comment of this.Comments)
         value = await WaitForValueAsync(() =>
         {
             stats2 = etlProcess.GetPerformanceStats()
-                .Where(x => x != null && x.NumberOfLoadedItems > 0 && x.LastLoadedEtag == etag + 1 && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
+                .Where(x => x != null
+                            && x.Started >= baselineUtc
+                            && x.LastLoadedEtag >= etag + 1
+                            && x.NumberOfLoadedItems > 0
+                            && x.NumberOfExtractedItems[EtlItemType.Document] > 0)
                 .ToArray();
             return stats2.Length > 0;
         }, expectedVal: true, timeout: 60_000);
@@ -795,15 +799,16 @@ for(const comment of this.Comments)
         Assert.True(value, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
 
         Assert.NotEmpty(stats2);
-        Assert.Equal(1, stats2[^1].NumberOfExtractedItems[EtlItemType.Document]);
 
-        var loadDetails2 = stats2[^1].Details.Operations[^1];
-        var genAiStats2 = loadDetails2.Operations.FirstOrDefault(x => x.Name == GenAiOperations.LoadToModel) as GenAiPerformanceOperation;
-        Assert.NotNull(genAiStats2);
+        var resend = stats2.FirstOrDefault(s =>
+        {
+            var load = s.Details.Operations[^1];
+            var op = load.Operations.FirstOrDefault(x => x.Name == GenAiOperations.LoadToModel)
+                as GenAiPerformanceOperation;
+            return op is { TotalSentToModel: 1, NumberOfContextObjects: 1, TotalCachedContexts: 0 };
+        });
 
-        Assert.Equal(1, genAiStats2.NumberOfContextObjects);
-        Assert.Equal(1, genAiStats2.TotalSentToModel);
-        Assert.Equal(0, genAiStats2.TotalCachedContexts);
+        Assert.True(resend != null, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
 
         using (var session = store.OpenAsyncSession())
         {


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-25527/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenSchemaChangesoptions-DatabaseMode-Single-configuration
- https://issues.hibernatingrhinos.com/issue/RavenDB-25350/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenUpdateScriptChangesoptions-DatabaseMode-Single

### Additional description

Stabilize two GenAI resend-context tests (schema change + update script change).
The tests were flaky due to relying on an exact `LastLoadedEtag == etag + 1` match in ETL performance stats, which can be affected by ETL UpdatePhase writes.
We now filter by `LastLoadedEtag >= etag + 1` and anchor the expected run using the ETL stats `Started` timestamp, making the assertions more deterministic

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
