### PR TITLE
RavenDB-25741 - Use the current time as the default value if no backup has been performed

### DIFF
--- a/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioTasksHandler.cs
@@ -298,11 +298,15 @@ namespace Raven.Server.Web.Studio
                 {
                     var backupStatus = BackupUtils.GetBackupStatusFromCluster(context, databaseName, taskId.Value);
                     if (backupStatus == null)
-                        throw new InvalidOperationException($"No backup status found for task ID '{taskId}' in database '{databaseName}'.");
-
-                    baseValue = isFull.Value
-                        ? (backupStatus.LastFullBackup ?? SystemTime.UtcNow).ToLocalTime()
-                        : (backupStatus.LastIncrementalBackup ?? SystemTime.UtcNow).ToLocalTime();
+                    {
+                        baseValue = SystemTime.UtcNow.ToLocalTime();
+                    }
+                    else
+                    {
+                        baseValue = isFull.Value
+                            ? (backupStatus.LastFullBackup ?? SystemTime.UtcNow).ToLocalTime()
+                            : (backupStatus.LastIncrementalBackup ?? SystemTime.UtcNow).ToLocalTime();
+                    }
                 }
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25741/Failed-to-get-next-occurrence-of-cron-expression

### Additional description

Use the current time as the default value if no backup has been performed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
