### PR TITLE
RavenDB-25727 - Handle importing remote attachments to sharded database

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
+++ b/src/Raven.Client/Documents/Smuggler/DatabaseSmugglerOptions.cs
@@ -67,7 +67,8 @@ namespace Raven.Client.Documents.Smuggler
         internal const DatabaseRecordItemType ShardingNotSupportedDatabaseSmugglerOptions = DatabaseRecordItemType.HubPullReplications | 
                                                                                             DatabaseRecordItemType.SinkPullReplications |
                                                                                             DatabaseRecordItemType.PostgreSQLIntegration |
-                                                                                            DatabaseRecordItemType.QueueEtls;
+                                                                                            DatabaseRecordItemType.QueueEtls |
+                                                                                            DatabaseRecordItemType.RemoteAttachments;
 
         private const int DefaultMaxStepsForTransformScript = 10 * 1000;
 

--- a/src/Raven.Server/Documents/DocumentFlags.cs
+++ b/src/Raven.Server/Documents/DocumentFlags.cs
@@ -62,7 +62,8 @@ namespace Raven.Server.Documents
         AllowDataAsNull = 0x20000,
         FromResharding = 0x40000,
         Unarchive = 0x80000,
-        SkipSchemaValidation = 0x100000
+        SkipSchemaValidation = 0x100000,
+        HasRemoteAttachments = 0x200000
     }
 
     public static class EnumExtensions

--- a/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/MultiShardedDestination.cs
@@ -265,6 +265,8 @@ namespace Raven.Server.Smuggler.Documents
 
             public async ValueTask WriteDocumentAsync(DocumentItem item, SmugglerProgressBase.CountsWithLastEtagAndAttachments progress, Func<ValueTask> beforeFlushing = null)
             {
+                ThrowOnRemoteAttachmentsIfNeeded(item.Document);
+
                 var shardNumber = GetShardNumberAndHandleLegacyRevisionsIfNeeded(item.Document);
                 await _actions[shardNumber].WriteDocumentAsync(item, progress, beforeFlushing);
             }
@@ -339,6 +341,16 @@ namespace Raven.Server.Smuggler.Documents
             {
                 foreach (var kvp in _actions)
                     await kvp.Value.FlushAsync();
+            }
+
+            private void ThrowOnRemoteAttachmentsIfNeeded(Document item)
+            {
+                if (item.NonPersistentFlags.HasFlag(NonPersistentDocumentFlags.HasRemoteAttachments))
+                {
+                    throw new NotSupportedException($"Document '{item.Id}' cannot be imported because it contains remote attachments, " +
+                                                    "which are not supported in sharded databases. " +
+                                                    "Consider downloading the attachments locally before importing to a sharded database.");
+                }
             }
         }
 

--- a/src/Raven.Server/Smuggler/Documents/Processors/BuildVersion.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/BuildVersion.cs
@@ -7,13 +7,14 @@ namespace Raven.Server.Smuggler.Documents.Processors
             return buildVersion switch
             {
                 >= 80 and < 1000 => BuildVersionType.GreaterThanCurrent,
-                >= 70 and < 80 => BuildVersionType.V7,
+                >= 72 and < 80 => BuildVersionType.V72,
+                >= 70 and < 72 => BuildVersionType.V7,
                 >= 60 and < 70 => BuildVersionType.V6,
                 >= 50 and < 60 => BuildVersionType.V5,
                 >= 40 and < 50 => BuildVersionType.V4,
                 >= 80000 => BuildVersionType.GreaterThanCurrent,
-                >= 70000 and <= 71999 => BuildVersionType.V7,
                 >= 72000 and <= 79999 => BuildVersionType.V72,
+                >= 70000 and <= 71999 => BuildVersionType.V7,
                 >= 60000 and <= 69999 => BuildVersionType.V6,
                 >= 50000 and <= 59999 => BuildVersionType.V5,
                 >= 40000 and <= 49999 => BuildVersionType.V4,

--- a/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
+++ b/src/Raven.Server/Smuggler/Documents/Processors/IndexProcessor.cs
@@ -32,6 +32,7 @@ namespace Raven.Server.Smuggler.Documents.Processors
                 case BuildVersionType.V5:
                 case BuildVersionType.V6:
                 case BuildVersionType.V7:
+                case BuildVersionType.V72:
                 case BuildVersionType.GreaterThanCurrent:
                     type = ReadIndexType(reader, out reader);
                     switch (type)

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -88,6 +88,11 @@ namespace Raven.Server.Smuggler.Documents
                 AddWarning(DatabaseRecordItemType.QueueSinks);
             }
 
+            if (databaseRecord.RemoteAttachments != null && databaseRecordItemType.HasFlag(DatabaseRecordItemType.RemoteAttachments))
+            {
+                AddWarning(DatabaseRecordItemType.RemoteAttachments);
+            }
+
             //warn and remove mentor nodes
             foreach (var externalReplication in databaseRecord.ExternalReplications)
             {
@@ -216,6 +221,16 @@ namespace Raven.Server.Smuggler.Documents
             }
 
             return false;
+        }
+
+        protected override void ThrowOnRemoteAttachmentsIfNeeded(Document item)
+        {
+            if (item.NonPersistentFlags.HasFlag(NonPersistentDocumentFlags.HasRemoteAttachments))
+            {
+                throw new NotSupportedException($"Document '{item.Id}' cannot be imported because it contains remote attachments, " +
+                                                "which are not supported in sharded databases. " +
+                                                "Consider downloading the attachments locally before importing to a sharded database.");
+            }
         }
 
         protected override async Task<SmugglerProgressBase.Counts> ProcessIdentitiesAsync(SmugglerResult result, BuildVersionType buildType)

--- a/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
+++ b/src/Raven.Server/Smuggler/Documents/ShardedDatabaseSmuggler.cs
@@ -223,16 +223,6 @@ namespace Raven.Server.Smuggler.Documents
             return false;
         }
 
-        protected override void ThrowOnRemoteAttachmentsIfNeeded(Document item)
-        {
-            if (item.NonPersistentFlags.HasFlag(NonPersistentDocumentFlags.HasRemoteAttachments))
-            {
-                throw new NotSupportedException($"Document '{item.Id}' cannot be imported because it contains remote attachments, " +
-                                                "which are not supported in sharded databases. " +
-                                                "Consider downloading the attachments locally before importing to a sharded database.");
-            }
-        }
-
         protected override async Task<SmugglerProgressBase.Counts> ProcessIdentitiesAsync(SmugglerResult result, BuildVersionType buildType)
         {
             await using (var action = new DatabaseKeyValueActions(_server, _databaseRecord.DatabaseName))

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -450,8 +450,6 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
-                    ThrowOnRemoteAttachmentsIfNeeded(item.Document);
-
                     if (_options.IncludeExpired == false)
                     {
                         if (item.Document.Data.TryGetMetadata(out var metadata) &&
@@ -801,11 +799,6 @@ namespace Raven.Server.Smuggler.Documents
         {
             msg = null;
             return false;
-        }
-
-        protected virtual void ThrowOnRemoteAttachmentsIfNeeded(Document item)
-        {
-            // no-op
         }
 
         protected virtual Task<SmugglerProgressBase.Counts> ProcessIdentitiesAsync(SmugglerResult result, BuildVersionType buildType) =>
@@ -1194,6 +1187,7 @@ namespace Raven.Server.Smuggler.Documents
                 case BuildVersionType.V5:
                 case BuildVersionType.V6:
                 case BuildVersionType.V7:
+                case BuildVersionType.V72:
                 case BuildVersionType.GreaterThanCurrent:
                     {
                         if (_options.OperateOnTypes.HasFlag(DatabaseItemType.RevisionDocuments) == false)

--- a/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
+++ b/src/Raven.Server/Smuggler/Documents/SmugglerBase.cs
@@ -450,6 +450,8 @@ namespace Raven.Server.Smuggler.Documents
                         continue;
                     }
 
+                    ThrowOnRemoteAttachmentsIfNeeded(item.Document);
+
                     if (_options.IncludeExpired == false)
                     {
                         if (item.Document.Data.TryGetMetadata(out var metadata) &&
@@ -799,6 +801,11 @@ namespace Raven.Server.Smuggler.Documents
         {
             msg = null;
             return false;
+        }
+
+        protected virtual void ThrowOnRemoteAttachmentsIfNeeded(Document item)
+        {
+            // no-op
         }
 
         protected virtual Task<SmugglerProgressBase.Counts> ProcessIdentitiesAsync(SmugglerResult result, BuildVersionType buildType) =>

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -23,6 +23,7 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Documents.Queries.Sorting;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Extensions;
 using Raven.Client.Json.Serialization;
 using Raven.Client.Properties;
 using Raven.Client.ServerWide;
@@ -1916,6 +1917,25 @@ namespace Raven.Server.Smuggler.Documents
                         else
                         {
                             data.Modifications = new DynamicJsonValue(data) { [Constants.Documents.Metadata.Key] = metadata };
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray att) && att.Length > 0)
+                {
+                    foreach (BlittableJsonReaderObject attachmentInMetadata in att)
+                    {
+                        if (attachmentInMetadata.TryGet(nameof(AttachmentName.RemoteParameters), out BlittableJsonReaderObject readerObject) && readerObject != null)
+                        {
+                            RemoteAttachmentParameters current = JsonDeserializationClient.RemoteAttachmentParameters(readerObject);
+                            if (current.IsRemoteStorageAttachment())
+                            {
+                                modifier.NonPersistentFlags |= NonPersistentDocumentFlags.HasRemoteAttachments;
+                                break;
+
+                            }
                         }
                     }
                 }

--- a/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
+++ b/test/FastTests/Server/Documents/Attachments/RemoteAttachmentsBasicTests.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Attachments.Remote;
 using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.ServerWide.Operations;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -429,6 +432,46 @@ namespace FastTests.Server.Documents.Attachments
                 // Verify no compilation errors
                 var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation(index.IndexName));
                 Assert.Equal(0, indexStats.ErrorsCount);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Sharding)]
+        public async Task ShouldSkipRemoteAttachmentsConfigOnImportToShardedDatabase()
+        {
+            using (var store = GetDocumentStore())
+            using (var sharded = Sharding.GetDocumentStore())
+            {
+                await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(new RemoteAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            "S3-uSeRs", new RemoteAttachmentsDestinationConfiguration()
+                            {
+                                S3Settings = new RemoteAttachmentsS3Settings()
+                                {
+                                    BucketName = "testS3Bucket-Users"
+                                },
+                                Disabled = false,
+                            }
+                        }
+                    },
+                    MaxItemsToProcess = 1,
+                }));
+
+                using (var dest = new MemoryStream())
+                {
+                    var export = await store.Smuggler.ExportToStreamAsync(new DatabaseSmugglerExportOptions(), s => s.CopyToAsync(dest));
+                    await export.WaitForCompletionAsync();
+                    dest.Position = 0;
+                    var import = await sharded.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions()
+                    {
+                    }, dest);
+                    await import.WaitForCompletionAsync();
+                }
+
+                var shardedRecord = await sharded.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(sharded.Database));
+                Assert.Null(shardedRecord.RemoteAttachments);
             }
         }
 

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -14,6 +14,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
@@ -38,6 +39,37 @@ namespace SlowTests.Server.Documents.Attachments
     {
         public S3RemoteAttachmentsSlowTests(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [AmazonS3RetryFact]
+        public async Task ShouldThrowOnDocumentWithRemoteAttachmentsOnImportToShardedDatabase()
+        {
+            int attachmentsCount = 1;
+            int size = 3;
+            using (var store = GetDocumentStore())
+            using (var sharded = Sharding.GetDocumentStore())
+            {
+                await using (var holder = CreateCloudSettings())
+                {
+                    int docsCount = RemoteAttachmentsHolderBase.GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+                    var identifier = await CanUploadRemoteAttachmentToCloudAndGetInternal(attachmentsCount, size, store, docsCount, ids, attachmentsPerDoc, null);
+
+                    using (var dest = new MemoryStream())
+                    {
+                        var export = await store.Smuggler.ExportToStreamAsync(new DatabaseSmugglerExportOptions(), s => s.CopyToAsync(dest));
+                        await export.WaitForCompletionAsync();
+                        dest.Position = 0;
+                        var import = await sharded.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions()
+                        {
+                        }, dest);
+
+                        var e = await Assert.ThrowsAsync<RavenException>(() => import.WaitForCompletionAsync());
+
+                        Assert.Contains("System.NotSupportedException: Document 'Orders/0' cannot be imported because it contains remote attachments, which are not supported in sharded databases. Consider downloading the attachments locally before importing to a sharded database.", e.Message);
+                    }
+                }
+            }
         }
 
         [AmazonS3RetryTheory]


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25727

### Additional description

This pull request adds support for detecting and handling remote attachments during import  to sharded databases where remote attachments are not supported. The changes introduce new document non persistent flag, update the versioning logic, and add tests to ensure that remote attachments are either skipped or cause appropriate errors during import to sharded databases.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
