### PR TITLE
RavenDB_25228 : fixed flaky test CanPassAgentParametersIntoGenAiTools

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25228.cs
@@ -29,12 +29,11 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             config.Collection = "ShoppingCarts";
 
             config.Prompt =
-                "Find items in 'recent-orders-for-customer' results. " +
-                "Subtract all items already present in 'cartItems'. " +
-                "Return every single remaining item to complete the customer's collection. " +
-                "Make sure to do not miss any item";
+                "execute tool 'recent-orders-for-customer' ONCE to fetch the list of items from the customer's recent orders.  +\n  " +
+                "FROM that list, suggest the rest of the items (the ones that are on the tool list but not on the customer shopping cart) \" +\n               " +
+                "Make sure that the items you suggest ARE NOT already in 'cartItems'. ";
 
-            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "meat" } }));
 
             config.GenAiTransformation = new GenAiTransformation
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25403/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB25228.CanPassAgentParametersIntoGenAiToolsoptions-DatabaseMode-Single-config

### Additional description

there was leak from the `config.JsonSchema` and there was a loop of tool calls. fixed by changing the prompt and the schema

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
