### PR TITLE
RavenDB-25460 - Fix tombstone cleanup blockage on passive External Replication nodes

### DIFF
--- a/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/OutgoingExternalReplicationHandler.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             base(parent, database, node, connectionInfo)
         {
             _taskId = node.TaskId;
-            DocumentsSend += (_) => UpdateExternalReplicationInfo();
+            SuccessfulReplication += (_) => UpdateExternalReplicationInfo();
         }
 
         protected override DynamicJsonValue GetInitialHandshakeRequest()

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.Replication
                     foreach (var external in externals)
                     {
                         var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
-                        var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, Database.DbBase64Id);
+                        var myEtag = state.LastSentEtag;
                         minEtag = Math.Min(myEtag, minEtag);
                         AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, external.Name, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
                     }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -131,7 +131,7 @@ namespace Raven.Server.Documents.Replication
                     foreach (var external in externals)
                     {
                         var state = GetExternalReplicationState(_server, Database.Name, external.TaskId, ctx);
-                        var myEtag = state.LastSentEtag;
+                        var myEtag = ChangeVectorUtils.GetEtagById(state.SourceChangeVector, Database.DbBase64Id);
                         minEtag = Math.Min(myEtag, minEtag);
                         AddOrUpdateLastEtag(lastProcessedTombstonesInfo, collection, external.Name, myEtag, ITombstoneAware.TombstoneDeletionBlockerType.ExternalReplication);
                     }

--- a/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
@@ -499,6 +503,70 @@ namespace SlowTests.Server.Replication
                 Assert.Contains("foo/bar", tombstoneIDs);
 
                 Assert.False(WaitForDocument(store1, "foo/bar", 100));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Cluster)]
+        public async Task Tombstones_Should_Be_Cleaned_On_Passive_Node_With_Pinned_External_Replication()
+        {
+            var cluster1 = await CreateRaftCluster(numberOfNodes: 2);
+            var srcDbName = GetDatabaseName();
+            await CreateDatabaseInCluster(srcDbName, replicationFactor: 2, cluster1.Leader.WebUrl);
+
+            var nodeA = cluster1.Nodes.OrderBy(x => x.ServerStore.NodeTag).First();
+            var nodeB = cluster1.Nodes.OrderBy(x => x.ServerStore.NodeTag).Last();
+
+            Assert.Equal("A", nodeA.ServerStore.NodeTag);
+            Assert.Equal("B", nodeB.ServerStore.NodeTag);
+
+            var destServer = GetNewServer();
+            using (var storeDest = GetDocumentStore(new Options { Server = destServer }))
+            using (var storeA = new DocumentStore { Urls = [nodeA.WebUrl], Database = srcDbName, Conventions = { DisableTopologyUpdates = true } }.Initialize())
+            using (var storeB = new DocumentStore { Urls = [nodeB.WebUrl], Database = srcDbName, Conventions = { DisableTopologyUpdates = true } }.Initialize())
+            {
+                var externalReplicationTask = new ExternalReplication(storeDest.Database, connectionStringName: "ExternalReplication_To_Dest_Node")
+                {
+                    MentorNode = nodeB.ServerStore.NodeTag,
+                    PinToMentorNode = true
+                };
+
+                await AddWatcherToReplicationTopology(storeA, externalReplicationTask, storeDest.Urls);
+
+                const string docId = "users/1";
+                using (var session = storeA.OpenSession())
+                {
+                    session.Store(new User { Name = "Test" }, docId);
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocument(storeB, docId), "Document did not replicate to Node B");
+                Assert.True(WaitForDocument(storeDest, docId), "Document did not replicate to Dest Cluster");
+
+                using (var session = storeA.OpenSession())
+                {
+                    session.Delete(docId);
+                    session.SaveChanges();
+                }
+
+                Assert.True(WaitForDocumentDeletion(storeB, docId), "Deletion did not replicate to Node B");
+                Assert.True(WaitForDocumentDeletion(storeDest, docId), "Deletion did not replicate to Dest Cluster");
+
+                var tombstonesOnB = GetTombstones(storeB);
+                var dbB = await nodeB.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(srcDbName);
+
+                Assert.True(tombstonesOnB.Count > 0, "Tombstones should exist on Node B before cleanup");
+
+                await WaitForValueAsync(async () =>
+                    {
+                        await dbB.TombstoneCleaner.ExecuteCleanup();
+                        tombstonesOnB = GetTombstones(storeB);
+                        return tombstonesOnB.Count;
+                    },
+                    expectedVal: 0,
+                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
+                Assert.Equal(0, tombstonesOnB.Count);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25460

### Additional description

**The Issue:**
Tombstones were not being cleaned up on nodes hosting an **External Replication** task if that node was a "passive" recipient (e.g., a backup node or read-replica receiving data via internal replication).

The `TombstoneCleaner` determines if it is safe to delete tombstones by checking the `SourceChangeVector` stored in the External Replication state. It extracts the local node's Etag from this vector. However, when a node replicates a tombstone received from another node, it does not increment its own component in that specific document's Change Vector. Consequently, the extracted Etag was often `0` (or stale), causing the cleaner to assume the task had made no progress, resulting in a permanent "Blocking" status.

**The Fix:**
Еhe event subscription in `OutgoingExternalReplicationHandler` was changed to trigger the state update on `SuccessfulReplication` instead of `DocumentsSend`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
