### PR TITLE
RavenDB-24887 - make sub-agent reqs concurrent, Limit sub-agent tool iterations by parent

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
@@ -8,6 +8,7 @@ public class AiConversationCreationOptions : IDynamicJson
 {
     public Dictionary<string, object> Parameters { get; set; }
     public int? ExpirationInSec { get; set; }
+    public int? MaxModelIterationsPerCall { get; set; }
 
     public AiConversationCreationOptions()
     {

--- a/src/Raven.Client/Documents/Operations/AI/Agents/ConversationResult.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/ConversationResult.cs
@@ -15,6 +15,7 @@ public class ConversationResult<TAnswer>
     public AiUsage Usage { get; set; }
     public TimeSpan Elapsed { get; set; }
     public List<AiAgentActionRequest> ActionRequests { get; set; }
+    internal int ToolsIterations { get; set; }
 
     internal static ConversationResult<TAnswer> Convert(BlittableJsonReaderObject response, DocumentConventions conventions)
     {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -29,6 +29,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             var agentId = RequestHandler.GetStringQueryString("agentId");
             var streaming = RequestHandler.GetBoolValueQueryString("streaming", required: false) ?? false;
             var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
+            var maxModelIterationsPerCall = RequestHandler.GetIntValueQueryString("maxModelIterationsPerCall", required: false);
 
             AiAgentConfiguration configuration = GetAiAgentConfiguration(agentId);
 
@@ -42,14 +43,14 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
             };
 
-            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, token);
+            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, maxModelIterationsPerCall, token);
         }
 
         protected async Task ExecuteInternalAsync(ConversationHandler handler, DocumentsOperationContext context, AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector,
-            bool streaming, OperationCancelToken token)
+            bool streaming, int? maxModelIterationsPerCall, OperationCancelToken token)
         {
-            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery());
-            (BlittableJsonReaderObject Response, AiUsage Usage) r;
+            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery(), maxModelIterationsPerCall);
+            (BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations) r;
 
             if (streaming)
             {
@@ -79,7 +80,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             await using var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream());
-            var finalPayload = handler.GetConversationResponse(context, r.Response);
+            var finalPayload = handler.GetConversationResponse(context, r.Response, r.ToolsIterations);
             context.Write(writer, finalPayload);
         }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -29,7 +29,6 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             var agentId = RequestHandler.GetStringQueryString("agentId");
             var streaming = RequestHandler.GetBoolValueQueryString("streaming", required: false) ?? false;
             var changeVector = RequestHandler.GetChangeVectorStringQueryString("changeVector", required: false);
-            var maxModelIterationsPerCall = RequestHandler.GetIntValueQueryString("maxModelIterationsPerCall", required: false);
 
             AiAgentConfiguration configuration = GetAiAgentConfiguration(agentId);
 
@@ -43,14 +42,14 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
             };
 
-            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, maxModelIterationsPerCall, token);
+            await ExecuteInternalAsync(handler, context, configuration, conversationId, body, changeVector, streaming, token);
         }
 
         protected async Task ExecuteInternalAsync(ConversationHandler handler, DocumentsOperationContext context, AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector,
-            bool streaming, int? maxModelIterationsPerCall, OperationCancelToken token)
+            bool streaming, OperationCancelToken token)
         {
-            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery(), maxModelIterationsPerCall);
-            (BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations) r;
+            handler.Initialize(configuration, conversationId, body, changeVector, RequestHandler.GetRaftRequestIdFromQuery());
+            AiInternalConversationResult r;
 
             if (streaming)
             {
@@ -108,10 +107,12 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.ExpirationInSec), out int? conversationExpirationInSec);
+            optionsBlittable.TryGet(nameof(AiConversationCreationOptions.MaxModelIterationsPerCall), out int? maxModelIterationsPerCall);
 
             var options = new AiConversationCreationOptions
             {
-                ExpirationInSec = conversationExpirationInSec
+                ExpirationInSec = conversationExpirationInSec,
+                MaxModelIterationsPerCall = maxModelIterationsPerCall
             };
 
             return new RequestBody

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -43,7 +43,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         if (ServerStore.LicenseManager.LicenseStatus.HasAiAgent == false)
             throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");
 
-        await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, token: token);
+        await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, maxModelIterationsPerCall: null, token: token);
     }
 
     public class TestConversationHandler(ServerStore server, DocumentDatabase database, AiAgentTestRequest request) : ConversationHandler(server, database)
@@ -54,9 +54,9 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
             return Task.FromResult("test");
         }
 
-        public override DynamicJsonValue GetConversationResponse(JsonOperationContext context, BlittableJsonReaderObject response)
+        public override DynamicJsonValue GetConversationResponse(JsonOperationContext context, BlittableJsonReaderObject response, int toolsIterations)
         {
-            var r = base.GetConversationResponse(context, response);
+            var r = base.GetConversationResponse(context, response, toolsIterations);
             r["Document"] = _document.ToBlittable(context);
             return r;
         }
@@ -69,7 +69,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
                 return;
             }
 
-            _document = ConversationDocument.ToDocument("TestConversation", request.Document, request.Configuration);
+            _document = ConversationDocument.ToDocument("TestConversation", request.Document, request.Configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall);
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForTestConversation.cs
@@ -29,13 +29,13 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         var streaming = RequestHandler.GetBoolValueQueryString("streaming", required: false) ?? false;
         var options = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "ai-agent", token.Token);
         
-        var body = JsonDeserializationServer.AiAgentTestRequest(options);
-        var req = body.RequestBody;
+        var request = JsonDeserializationServer.AiAgentTestRequest(options);
+        var body = request.RequestBody;
 
-        AiAgentHelpers.AddDefaultValues(body.Configuration, RequestHandler.Configuration.Ai);
-        AddOrUpdateAiAgentCommand.ValidateConfiguration(context, body.Configuration);
+        AiAgentHelpers.AddDefaultValues(request.Configuration, RequestHandler.Configuration.Ai);
+        AddOrUpdateAiAgentCommand.ValidateConfiguration(context, request.Configuration);
 
-        var handler = new TestConversationHandler(ServerStore, RequestHandler.Database, body)
+        var handler = new TestConversationHandler(ServerStore, RequestHandler.Database, request)
         {
             Authentication = RequestHandler.HttpContext.Features.Get<IHttpAuthenticationFeature>() as RavenServer.AuthenticateConnection
         };
@@ -43,7 +43,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
         if (ServerStore.LicenseManager.LicenseStatus.HasAiAgent == false)
             throw new LicenseLimitException(LimitType.AiAgent, "Your license doesn't support using the AI Agent feature.");
 
-        await ExecuteInternalAsync(handler, context, body.Configuration, "TestConversation", req, changeVector: null, streaming: streaming, maxModelIterationsPerCall: null, token: token);
+        await ExecuteInternalAsync(handler, context, request.Configuration, "TestConversation", body, changeVector: null, streaming: streaming, token: token);
     }
 
     public class TestConversationHandler(ServerStore server, DocumentDatabase database, AiAgentTestRequest request) : ConversationHandler(server, database)
@@ -69,7 +69,7 @@ internal class AiAgentProcessorForTestConversation : AbstractAiAgentProcessor
                 return;
             }
 
-            _document = ConversationDocument.ToDocument("TestConversation", request.Document, request.Configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall);
+            _document = ConversationDocument.ToDocument("TestConversation", request.Document, _maxModelIterationsPerCall);
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiInternalConversationResult.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiInternalConversationResult.cs
@@ -1,0 +1,14 @@
+﻿using Raven.Client.Documents.Operations.AI;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents
+{
+    public sealed class AiInternalConversationResult
+    {
+        public static readonly AiInternalConversationResult Default = new AiInternalConversationResult { };
+
+        public BlittableJsonReaderObject Response { get; set; }
+        public AiUsage Usage { get; set; }
+        public int ToolsIterations { get; set; }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -274,7 +274,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         foreach (var callId in openToolCalls.GetPropertyNames())
         {
             var call = JsonDeserializationClient.ActionRequest(openToolCalls[callId] as BlittableJsonReaderObject);
-            openTools.TryAdd(callId, call);
+            openTools.Add(callId, call);
         }
 
         var conversation = new ConversationDocument(agent, parameters?.CloneOnTheSameContext())

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices.JavaScript;
@@ -26,7 +27,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public BlittableJsonReaderObject Parameters = parameters;
     public List<BlittableJsonReaderObject> Messages = [];
     public List<string> LinkedConversations = [];
-    public Dictionary<string, AiAgentActionRequest> OpenActionCalls = [];
+    public ConcurrentDictionary<string, AiAgentActionRequest> OpenActionCalls = [];
     public AiUsage TotalUsage = new AiUsage();
     public AiUsage CurrentUsage = new AiUsage();
     public string ChangeVector;
@@ -38,7 +39,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
     public int RemainingToolIterations;
 
-    public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, bool resetRemainingToolIterations)
+    public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, bool resetRemainingToolIterations, int maxModelIterationsPerCall)
     {
         if (Messages.Count > 0)
             throw new InvalidOperationException("conversation document is already initialized. Cannot re-initialize.");
@@ -86,7 +87,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (resetRemainingToolIterations == false)
             return;
 
-        RemainingToolIterations = configuration.MaxModelIterationsPerCall ?? ConversationHandler.DefaultMaxModelIterationsPerCall;
+        RemainingToolIterations = maxModelIterationsPerCall;
     }
 
     public List<AiToolCall> InitialOperations(JsonOperationContext context, AiAgentConfiguration configuration)
@@ -246,7 +247,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         LastMessageAt = currentDate;
     }
 
-    public static ConversationDocument ToDocument(string id, BlittableJsonReaderObject document, AiAgentConfiguration config)
+    public static ConversationDocument ToDocument(string id, BlittableJsonReaderObject document, int maxModelIterationsPerCall)
     {
         if (document.TryGet(nameof(Agent), out string agent) == false)
             throw new ArgumentException($"Missing Agent in '{id}' conversation document");
@@ -267,16 +268,16 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (document.TryGet(nameof(Expires), out TimeSpan? expires) == false)
             throw new ArgumentException($"Missing Expires in '{id}' conversation document");
         if (document.TryGet(nameof(RemainingToolIterations), out int remainingToolIterations) == false)
-            remainingToolIterations = config.MaxModelIterationsPerCall ?? ConversationHandler.DefaultMaxModelIterationsPerCall;
+            remainingToolIterations = maxModelIterationsPerCall;
 
-        var openTools = new Dictionary<string, AiAgentActionRequest>();
+        var openTools = new ConcurrentDictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
         {
             var call = JsonDeserializationClient.ActionRequest(openToolCalls[callId] as BlittableJsonReaderObject);
-            openTools.Add(callId, call);
+            openTools.TryAdd(callId, call);
         }
 
-        var conversation =  new ConversationDocument(agent, parameters?.CloneOnTheSameContext())
+        var conversation = new ConversationDocument(agent, parameters?.CloneOnTheSameContext())
         {
             Id = id,
             Messages = messages.Items.Select(m => ((BlittableJsonReaderObject)m).CloneOnTheSameContext()).ToList(),

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -27,7 +27,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public BlittableJsonReaderObject Parameters = parameters;
     public List<BlittableJsonReaderObject> Messages = [];
     public List<string> LinkedConversations = [];
-    public ConcurrentDictionary<string, AiAgentActionRequest> OpenActionCalls = [];
+    public Dictionary<string, AiAgentActionRequest> OpenActionCalls = [];
     public AiUsage TotalUsage = new AiUsage();
     public AiUsage CurrentUsage = new AiUsage();
     public string ChangeVector;
@@ -270,7 +270,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (document.TryGet(nameof(RemainingToolIterations), out int remainingToolIterations) == false)
             remainingToolIterations = maxModelIterationsPerCall;
 
-        var openTools = new ConcurrentDictionary<string, AiAgentActionRequest>();
+        var openTools = new Dictionary<string, AiAgentActionRequest>();
         foreach (var callId in openToolCalls.GetPropertyNames())
         {
             var call = JsonDeserializationClient.ActionRequest(openToolCalls[callId] as BlittableJsonReaderObject);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -47,18 +47,18 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     private AiAgentConfiguration _configuration;
     private string _changeVector;
     private string _raftId;
-    private int _maxModelIterationsPerCall;
+    protected int _maxModelIterationsPerCall;
 
     public required RavenServer.AuthenticateConnection Authentication;
 
-    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null, int? maxModelIterationsPerCall = null)
+    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null)
     {
         _conversationId = conversationId;
         _request = body;
         _configuration = configuration;
         _changeVector = changeVector;
         _raftId = raftId;
-        _maxModelIterationsPerCall = maxModelIterationsPerCall ?? configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+        _maxModelIterationsPerCall = GetMaxModelIterationsPerCall(body, configuration);
     }
 
     protected virtual async Task InitializeDocument(DocumentsOperationContext context)
@@ -140,7 +140,10 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return _client = ChatCompletionClient.CreateChatCompletionClient(database.DocumentsStorage.ContextPool, connection);
     }
 
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> StreamingTalkAsync(
+    public static int GetMaxModelIterationsPerCall(RequestBody body, AiAgentConfiguration configuration)
+        => body.CreationOptions.MaxModelIterationsPerCall ?? configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+
+    public async Task<AiInternalConversationResult> StreamingTalkAsync(
         JsonOperationContext context,
         string firstStreamPropertyPath,
         Func<Memory<byte>, Task> streaming,
@@ -150,7 +153,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return await RunInternalAsync(context, talker, token);
     }
         
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> TalkAsync(
+    public async Task<AiInternalConversationResult> TalkAsync(
         JsonOperationContext context,
         CancellationToken token = default)
     {
@@ -160,7 +163,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private TimeSpan _elapsed;
 
-    private async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> RunInternalAsync(
+    private async Task<AiInternalConversationResult> RunInternalAsync(
         JsonOperationContext context,
         Talker talker, CancellationToken token)
     {
@@ -238,7 +241,13 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             database.NotificationCenter.Add(
                 ExceededTokenThresholdDetails.CreateAlert(pendingAlertDetails, database.Name));
         }
-        return (r.Result, talker.AiUsage, toolsIterations);
+
+        return new AiInternalConversationResult
+        {
+            Response = r.Result,
+            Usage = talker.AiUsage,
+            ToolsIterations = toolsIterations,
+        };
     }
 
     private async Task<BlittableJsonReaderObject> TryReduceChatSizeAsync(JsonOperationContext context, ChatCompletionClient client, AiUsage aiUsage, CancellationToken token)
@@ -538,7 +547,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 {
                     { } td => (int)td.TotalSeconds,
                     null => null
-                }
+                },
+                [nameof(AiConversationCreationOptions.MaxModelIterationsPerCall)] = _document.RemainingToolIterations
             })));
 
         _document.OpenActionCalls.TryAdd(call.Id, new AiAgentActionRequest
@@ -786,7 +796,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         var queryString = new StringBuilder("?")
             .Append("&conversationId=").Append(Uri.EscapeDataString(conversationId))
             .Append("&agentId=").Append(Uri.EscapeDataString(agent))
-            .Append("&maxModelIterationsPerCall=").Append(_document.RemainingToolIterations)
             .ToString();
 
         return new DynamicJsonValue
@@ -943,14 +952,14 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
     }
 
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> HandleRequest(
+    public async Task<AiInternalConversationResult> HandleRequest(
         DocumentsOperationContext context,
         CancellationToken token)
     {
         await InitializeDocument(context);
 
         if (await TryHandleActionResponses(context) is false)
-            return default;
+            return AiInternalConversationResult.Default;
 
         return await TalkAsync(context, token: token);
     }
@@ -962,7 +971,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return (r.Response.ToString(), r.Usage);
     }
 
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> HandleStreamingRequest(
+    public async Task<AiInternalConversationResult> HandleStreamingRequest(
         DocumentsOperationContext context,
         Stream outputStream,
         string streamPropertyPath,

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -362,7 +362,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             if (FindToolFrom(_configuration, call.Name) is not AiAgentToolAction)
                 continue;
 
-            _document.OpenActionCalls.TryAdd(call.Id, new AiAgentActionRequest
+            _document.OpenActionCalls.Add(call.Id, new AiAgentActionRequest
             {
                 ToolId = call.Id,
                 Name = call.Name,
@@ -429,8 +429,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
-    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall, 
-        List<BlittableJsonReaderObject> messages, List<string> openToolCallsToRemove, ref int toolsIterations)
+    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall,
+        SubConversationResult result)
     {
         if (requestResult.TryGet(nameof(ConversationResult<object>.ConversationId), out string agentConversationId) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ConversationId)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
@@ -441,7 +441,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         if (requestResult.TryGet(nameof(ConversationResult<object>.ToolsIterations), out int callToolsIterations) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ToolsIterations)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
-        toolsIterations += callToolsIterations;
+        result.ToolsIterations += callToolsIterations;
 
         if (actionRequests?.Length > 0)
         {
@@ -456,25 +456,13 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     Arguments = actionRequest.Arguments,
                 };
 
-                if (_childUserCalls.TryAdd(actionRequest.ToolId, // Sub call
-                        newActionCall) == false)
-                {
-                    // Already exists
-                    var existingActionCall = _childUserCalls[actionRequest.ToolId];
-                    Debug.Assert(newActionCall.IsEqual(existingActionCall),
-                        $"Mismatch detected in OpenActionCalls for key '{actionRequest.ToolId}'.\n" +
-                        $"--- NEW ACTION CALL ---\n{newActionCall}\n\n" +
-                        $"--- EXISTING ACTION CALL ---\n{existingActionCall}\n\n" +
-                        "The existing ActionCall does not match the newly attempted ActionCall insertion.\n" +
-                        "If this mismatch is valid, ensure higher-level logic prevents conflicting ActionCalls with the same ToolId."
-                        );
-                }
+                AddChildrenUserCall(result.ChildUserCalls, actionRequest.ToolId, newActionCall);
             }
 
             return false;
         }
 
-        messages.Add(context.ReadObject(
+        result.Messages.Add(context.ReadObject(
             new DynamicJsonValue
             {
                 ["tool_call_id"] = currentCall.Id,
@@ -483,9 +471,26 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 ["subConversation"] = agentConversationId,
             }, "tool-call/response"));
 
-        openToolCallsToRemove.Add(currentCall.Id);
+        result.OpenToolCallsToRemove.Add(currentCall.Id);
 
         return true;
+    }
+
+    private static void AddChildrenUserCall(Dictionary<string, AiAgentActionRequest> childUserCalls, string subToolId, AiAgentActionRequest newActionCall)
+    {
+        if (childUserCalls.TryAdd(subToolId, // Sub call
+                newActionCall) == false)
+        {
+            // Already exists
+            var existingActionCall = childUserCalls[subToolId];
+            Debug.Assert(newActionCall.IsEqual(existingActionCall),
+                $"Mismatch detected in OpenActionCalls for key '{subToolId}'.\n" +
+                $"--- NEW ACTION CALL ---\n{newActionCall}\n\n" +
+                $"--- EXISTING ACTION CALL ---\n{existingActionCall}\n\n" +
+                "The existing ActionCall does not match the newly attempted ActionCall insertion.\n" +
+                "If this mismatch is valid, ensure higher-level logic prevents conflicting ActionCalls with the same ToolId."
+            );
+        }
     }
 
     private static void RemoveNonEssentialFieldsFromMetadata(BlittableJsonReaderArray queryResult)
@@ -663,7 +668,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
                 if (action.SubConversation == null)
                 {
-                    _document.OpenActionCalls.Remove(rootToolId, out _);
+                    _document.OpenActionCalls.Remove(rootToolId);
                     _document.AddMessage(context, context.ReadObject(
                         new DynamicJsonValue
                         {
@@ -815,7 +820,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private async Task<int> ExecuteMultiAgentAndQueryRequestsAsync(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
-        List<Task<(IDisposable Disposable, List<BlittableJsonReaderObject> Messages, List<string> OpenToolCallsToRemove, int ToolsIterations)>> tasks = [];
+        List<Task<SubConversationResult>> tasks = [];
         foreach (var (conversationId, conversationReqs) in reqs)
         {
             tasks.Add(ExecuteSingleSubConversationToolCallsAsync(conversationId, conversationReqs));
@@ -851,6 +856,11 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     {
                         _document.OpenActionCalls.Remove(callId, out _);
                     }
+
+                    foreach (var (key, value) in r.ChildUserCalls)
+                    {
+                        AddChildrenUserCall(_childUserCalls, key, value);
+                    }
                 }
             }
             catch (Exception ex)
@@ -866,7 +876,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return toolsIterations;
     }
 
-    private async Task<(IDisposable Disposable, List<BlittableJsonReaderObject> Messages, List<string> OpenToolCallsToRemove, int ToolsIterations)> ExecuteSingleSubConversationToolCallsAsync(string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
+    private async Task<SubConversationResult> ExecuteSingleSubConversationToolCallsAsync(string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
     {
         IDisposable disposable = null;
 
@@ -874,9 +884,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         {
             disposable = database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context);
 
-            var messages = new List<BlittableJsonReaderObject>();
-            var openToolCallsToRemove = new List<string>();
-            int iterations = 0;
+            var result = new SubConversationResult(disposable);
 
             await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
             {
@@ -888,14 +896,14 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 switch (toolCall)
                 {
                     case AiAgentToolSubAgent:
-                        if (TryCloseSubAgentCall(context, requestResult, currentCall, messages, openToolCallsToRemove, ref iterations) == false)
-                            return (disposable, messages, openToolCallsToRemove, iterations);
+                        if (TryCloseSubAgentCall(context, requestResult, currentCall, result) == false)
+                            return result;
                         break;
                     case AiAgentToolQuery:
                         if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
                             throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
-                        messages.Add(context.ReadObject(
+                        result.Messages.Add(context.ReadObject(
                             new DynamicJsonValue
                             {
                                 ["tool_call_id"] = currentCall.Id,
@@ -910,12 +918,26 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 }
             }
 
-            return (disposable, messages, openToolCallsToRemove, iterations);
+            return result;
         }
         catch
         {
             disposable?.Dispose();
             throw;
+        }
+    }
+
+    private sealed class SubConversationResult
+    {
+        public IDisposable Disposable { get; }
+        public List<BlittableJsonReaderObject> Messages { get; } = new();
+        public List<string> OpenToolCallsToRemove { get; } = new();
+        public Dictionary<string, AiAgentActionRequest> ChildUserCalls { get; } = new();
+        public int ToolsIterations { get; set; }
+
+        public SubConversationResult(IDisposable disposable)
+        {
+            Disposable = disposable;
         }
     }
 
@@ -987,7 +1009,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         await InitializeDocument(context);
 
         if (await TryHandleActionResponses(context) is false)
-            return default;
+            return AiInternalConversationResult.Default;
 
         await using var writer = new AsyncBlittableJsonTextWriter(context, outputStream);
         return await StreamingTalkAsync(context, streamPropertyPath, async (data) =>
@@ -1021,7 +1043,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         };
     }
 
-    private readonly ConcurrentDictionary<string, AiAgentActionRequest> _childUserCalls = [];
+    private readonly Dictionary<string, AiAgentActionRequest> _childUserCalls = [];
 
     private IEnumerable<DynamicJsonValue> GetUserActions()
     {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -429,29 +429,14 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
-    private bool TryCloseSubAgentCall(JsonOperationContext context, string conversationId, object requestResult, AiToolCall currentCall,
+    private bool TryCloseSubAgentCall(JsonOperationContext context, string conversationId, BlittableJsonReaderObject requestResult, AiToolCall currentCall,
         SubConversationResult result)
     {
-        if (requestResult is ExceptionDispatchInfo ede)
-        {
-            result.Messages.Add(context.ReadObject(
-                new DynamicJsonValue
-                {
-                    ["tool_call_id"] = currentCall.Id,
-                    ["role"] = "tool",
-                    ["content"] = "Error has been occurred during the tool call execution: " + ede.SourceException,
-                    ["subConversation"] = conversationId,
-                }, "tool-call/response"));
-            result.OpenToolCallsToRemove.Add(currentCall.Id);
-            return true;
-        }
-
-        var subAgentResult = requestResult as BlittableJsonReaderObject;
-        if (subAgentResult.TryGet(nameof(ConversationResult<object>.Response), out BlittableJsonReaderObject agentResult) is false)
+        if (requestResult.TryGet(nameof(ConversationResult<object>.Response), out BlittableJsonReaderObject agentResult) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.Response)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-        if (subAgentResult.TryGet(nameof(ConversationResult<object>.ActionRequests), out BlittableJsonReaderArray actionRequests) is false)
+        if (requestResult.TryGet(nameof(ConversationResult<object>.ActionRequests), out BlittableJsonReaderArray actionRequests) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ActionRequests)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-        if (subAgentResult.TryGet(nameof(ConversationResult<object>.ToolsIterations), out int callToolsIterations) is false)
+        if (requestResult.TryGet(nameof(ConversationResult<object>.ToolsIterations), out int callToolsIterations) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ToolsIterations)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
         result.ToolsIterations += callToolsIterations;
@@ -897,7 +882,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
             var result = new SubConversationResult(disposable);
 
-            await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
+            await foreach (var (getRequestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
             {
                 var currentCall = requests[i].Call;
                 var toolCall = FindToolFrom(_configuration, currentCall.Name);
@@ -907,17 +892,28 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 switch (toolCall)
                 {
                     case AiAgentToolSubAgent:
-                        if (TryCloseSubAgentCall(context, conversationId, requestResult, currentCall, result) == false)
-                            return result;
+                        try
+                        {
+                            var subAgentResult = getRequestResult.Invoke();
+                            if (TryCloseSubAgentCall(context, conversationId, subAgentResult, currentCall, result) == false)
+                                return result;
+                        }
+                        catch (Exception e)
+                        {
+                            result.Messages.Add(context.ReadObject(
+                                    new DynamicJsonValue
+                                    {
+                                        ["tool_call_id"] = currentCall.Id,
+                                        ["role"] = "tool",
+                                        ["content"] = "Error has been occurred during the tool call execution: " + e.Message,
+                                        ["subConversation"] = conversationId,
+                                    }, "tool-call/response"));
+                            result.OpenToolCallsToRemove.Add(currentCall.Id);
+                        }
                         break;
                     case AiAgentToolQuery:
-                        if (requestResult is ExceptionDispatchInfo ede1)
-                        {
-                            // The original stack trace is preserve.
-                            ede1.Throw();
-                        }
-
-                        if (((BlittableJsonReaderObject)requestResult).TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
+                        var requestResult = getRequestResult.Invoke();
+                        if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
                             throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
                         result.Messages.Add(context.ReadObject(
@@ -958,7 +954,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
     }
 
-    private async IAsyncEnumerable<(object, int)> ExecuteMultiRequests(JsonOperationContext context, DynamicJsonArray reqs)
+    private async IAsyncEnumerable<(Func<BlittableJsonReaderObject>, int)> ExecuteMultiRequests(JsonOperationContext context, DynamicJsonArray reqs)
     {
         var multiGetHandler = new MultiGetHandler();
         multiGetHandler.Init(new RequestHandlerContext
@@ -987,22 +983,13 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                     throw new InvalidOperationException("Missing status code");
                 if (response.TryGet(nameof(GetResponse.Result), out BlittableJsonReaderObject requestResult) is false)
                     throw new InvalidOperationException("Missing Result from query request output");
-
-                if (statusCode != 200)
+                
+                yield return (() =>
                 {
-                    ExceptionDispatchInfo edi;
-                    try
-                    {
+                    if (statusCode != 200)
                         throw ExceptionDispatcher.Get(requestResult, (HttpStatusCode)statusCode);
-                    }
-                    catch (Exception e)
-                    {
-                        edi = ExceptionDispatchInfo.Capture(e);
-                    }
-                    yield return (edi, i);
-                }
-                else
-                    yield return (requestResult, i);
+                    return requestResult;
+                }, i);
             }
         }
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -429,16 +429,29 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
-    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall,
+    private bool TryCloseSubAgentCall(JsonOperationContext context, string conversationId, object requestResult, AiToolCall currentCall,
         SubConversationResult result)
     {
-        if (requestResult.TryGet(nameof(ConversationResult<object>.ConversationId), out string agentConversationId) is false)
-            throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ConversationId)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-        if (requestResult.TryGet(nameof(ConversationResult<object>.Response), out BlittableJsonReaderObject agentResult) is false)
+        if (requestResult is ExceptionDispatchInfo ede)
+        {
+            result.Messages.Add(context.ReadObject(
+                new DynamicJsonValue
+                {
+                    ["tool_call_id"] = currentCall.Id,
+                    ["role"] = "tool",
+                    ["content"] = "Error has been occurred during the tool call execution: " + ede.SourceException,
+                    ["subConversation"] = conversationId,
+                }, "tool-call/response"));
+            result.OpenToolCallsToRemove.Add(currentCall.Id);
+            return true;
+        }
+
+        var subAgentResult = requestResult as BlittableJsonReaderObject;
+        if (subAgentResult.TryGet(nameof(ConversationResult<object>.Response), out BlittableJsonReaderObject agentResult) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.Response)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-        if (requestResult.TryGet(nameof(ConversationResult<object>.ActionRequests), out BlittableJsonReaderArray actionRequests) is false)
+        if (subAgentResult.TryGet(nameof(ConversationResult<object>.ActionRequests), out BlittableJsonReaderArray actionRequests) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ActionRequests)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
-        if (requestResult.TryGet(nameof(ConversationResult<object>.ToolsIterations), out int callToolsIterations) is false)
+        if (subAgentResult.TryGet(nameof(ConversationResult<object>.ToolsIterations), out int callToolsIterations) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ToolsIterations)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
         result.ToolsIterations += callToolsIterations;
@@ -468,7 +481,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 ["tool_call_id"] = currentCall.Id,
                 ["role"] = "tool",
                 ["content"] = agentResult.ToString(),
-                ["subConversation"] = agentConversationId,
+                ["subConversation"] = conversationId,
             }, "tool-call/response"));
 
         result.OpenToolCallsToRemove.Add(currentCall.Id);
@@ -894,19 +907,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 switch (toolCall)
                 {
                     case AiAgentToolSubAgent:
-                        if (requestResult is ExceptionDispatchInfo ede)
-                        {
-                            result.Messages.Add(context.ReadObject(
-                                new DynamicJsonValue
-                                {
-                                    ["tool_call_id"] = currentCall.Id,
-                                    ["role"] = "tool",
-                                    ["content"] = "Error has been occurred during the tool call execution: " + ede.SourceException,
-                                    ["subConversation"] = conversationId,
-                                }, "tool-call/response"));
-                            result.OpenToolCallsToRemove.Add(currentCall.Id);
-                        }
-                        else if (TryCloseSubAgentCall(context, requestResult as BlittableJsonReaderObject, currentCall, result) == false)
+                        if (TryCloseSubAgentCall(context, conversationId, requestResult, currentCall, result) == false)
                             return result;
                         break;
                     case AiAgentToolQuery:

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -17,6 +18,7 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions;
+using Raven.Client.Extensions;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Handlers.Processors.MultiGet;
@@ -48,14 +50,15 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
     private int _maxModelIterationsPerCall;
 
     public required RavenServer.AuthenticateConnection Authentication;
-    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null)
+
+    public void Initialize(AiAgentConfiguration configuration, string conversationId, RequestBody body, string changeVector, string raftId = null, int? maxModelIterationsPerCall = null)
     {
         _conversationId = conversationId;
         _request = body;
         _configuration = configuration;
         _changeVector = changeVector;
         _raftId = raftId;
-        _maxModelIterationsPerCall = configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
+        _maxModelIterationsPerCall = maxModelIterationsPerCall ?? configuration.MaxModelIterationsPerCall ?? DefaultMaxModelIterationsPerCall;
     }
 
     protected virtual async Task InitializeDocument(DocumentsOperationContext context)
@@ -91,7 +94,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 _document.Expires = TimeSpan.FromSeconds(_request.CreationOptions.ExpirationInSec.Value);
             }
 
-            _document.Initialize(context, _configuration, resetRemainingToolIterations: true);
+            _document.Initialize(context, _configuration, resetRemainingToolIterations: true, _maxModelIterationsPerCall);
             if (_document.InitialOperations(context, _configuration) is { } queries)
             {
                 // run initial tool calls...
@@ -100,7 +103,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
         else
         {
-            _document = ConversationDocument.ToDocument(_conversationId, conversation.Data, _configuration);
+            _document = ConversationDocument.ToDocument(_conversationId, conversation.Data, _maxModelIterationsPerCall);
             if (_document.Agent != agentId)
             {
                 throw new InvalidOperationException(
@@ -137,7 +140,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return _client = ChatCompletionClient.CreateChatCompletionClient(database.DocumentsStorage.ContextPool, connection);
     }
 
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage)> StreamingTalkAsync(
+    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> StreamingTalkAsync(
         JsonOperationContext context,
         string firstStreamPropertyPath,
         Func<Memory<byte>, Task> streaming,
@@ -147,7 +150,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return await RunInternalAsync(context, talker, token);
     }
         
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage)> TalkAsync(
+    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> TalkAsync(
         JsonOperationContext context,
         CancellationToken token = default)
     {
@@ -157,11 +160,12 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private TimeSpan _elapsed;
 
-    private async Task<(BlittableJsonReaderObject Response, AiUsage Usage)> RunInternalAsync(
+    private async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> RunInternalAsync(
         JsonOperationContext context,
         Talker talker, CancellationToken token)
     {
         talker.Init();
+        var toolsIterations = 0;
 
         AiResponse r = default;
         List<BlittableJsonReaderObject> historyDocs = default;
@@ -198,6 +202,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 }
             }
 
+            toolsIterations++;
             if (r.Type is AiResponseType.Result)
             {
                 _document.RemainingToolIterations = _maxModelIterationsPerCall;
@@ -205,7 +210,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             }
             else
             {
-                await HandleQueryAndAgentCallsAsync(context, r.ToolCalls);
+                var iterations = await HandleQueryAndAgentCallsAsync(context, r.ToolCalls);
+                toolsIterations += iterations;
                 if (TryGetUserTools(context, r.ToolCalls))
                 {
                     shouldContinueConversation = false;
@@ -232,7 +238,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             database.NotificationCenter.Add(
                 ExceededTokenThresholdDetails.CreateAlert(pendingAlertDetails, database.Name));
         }
-        return (r.Result, talker.AiUsage);
+        return (r.Result, talker.AiUsage, toolsIterations);
     }
 
     private async Task<BlittableJsonReaderObject> TryReduceChatSizeAsync(JsonOperationContext context, ChatCompletionClient client, AiUsage aiUsage, CancellationToken token)
@@ -326,7 +332,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
         oldChat.Messages.Clear();
 
-        oldChat.Initialize(context, configuration, resetRemainingToolIterations: false);
+        oldChat.Initialize(context, configuration, resetRemainingToolIterations: false, _maxModelIterationsPerCall);
         oldChat.AddMessage(context,
             context.ReadObject(
                 new DynamicJsonValue
@@ -347,7 +353,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             if (FindToolFrom(_configuration, call.Name) is not AiAgentToolAction)
                 continue;
 
-            _document.OpenActionCalls.Add(call.Id, new AiAgentActionRequest
+            _document.OpenActionCalls.TryAdd(call.Id, new AiAgentActionRequest
             {
                 ToolId = call.Id,
                 Name = call.Name,
@@ -389,10 +395,10 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
     }
 
-    public async Task HandleQueryAndAgentCallsAsync(JsonOperationContext context, List<AiToolCall> toolCalls)
+    public Task<int> HandleQueryAndAgentCallsAsync(JsonOperationContext context, List<AiToolCall> toolCalls)
     {
         if (toolCalls == null || toolCalls.Count == 0)
-            return;
+            return Task.FromResult(0);
 
         Dictionary<string, List<(AiToolCall, DynamicJsonValue)>> reqs = [];
         foreach (var call in toolCalls)
@@ -409,12 +415,12 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
 
         if (reqs.Count is 0)
-            return;
+            return Task.FromResult(0);
 
-        await ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
+        return ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
-    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall)
+    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall, List<BlittableJsonReaderObject> messages, ref int toolsIterations)
     {
         if (requestResult.TryGet(nameof(ConversationResult<object>.ConversationId), out string agentConversationId) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ConversationId)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
@@ -422,6 +428,10 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.Response)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
         if (requestResult.TryGet(nameof(ConversationResult<object>.ActionRequests), out BlittableJsonReaderArray actionRequests) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ActionRequests)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
+        if (requestResult.TryGet(nameof(ConversationResult<object>.ToolsIterations), out int callToolsIterations) is false)
+            throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ToolsIterations)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
+
+        toolsIterations += callToolsIterations;
 
         if (actionRequests?.Length > 0)
         {
@@ -454,16 +464,17 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             return false;
         }
 
-        _document.AddMessage(context, context.ReadObject(
+        messages.Add(context.ReadObject(
             new DynamicJsonValue
             {
                 ["tool_call_id"] = currentCall.Id,
                 ["role"] = "tool",
                 ["content"] = agentResult.ToString(),
                 ["subConversation"] = agentConversationId,
-            }, "tool-call/response"), usage: null);
+            }, "tool-call/response"));
 
-        _document.OpenActionCalls.Remove(currentCall.Id); // Parent call
+        _document.OpenActionCalls.Remove(currentCall.Id, out _); // Parent call
+
         return true;
     }
 
@@ -641,7 +652,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
                 if (action.SubConversation == null)
                 {
-                    _document.OpenActionCalls.Remove(rootToolId);
+                    _document.OpenActionCalls.Remove(rootToolId, out _);
                     _document.AddMessage(context, context.ReadObject(
                         new DynamicJsonValue
                         {
@@ -775,6 +786,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         var queryString = new StringBuilder("?")
             .Append("&conversationId=").Append(Uri.EscapeDataString(conversationId))
             .Append("&agentId=").Append(Uri.EscapeDataString(agent))
+            .Append("&maxModelIterationsPerCall=").Append(_document.RemainingToolIterations)
             .ToString();
 
         return new DynamicJsonValue
@@ -791,48 +803,103 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         };
     }
 
-    private async Task ExecuteMultiAgentAndQueryRequestsAsync(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
+    private async Task<int> ExecuteMultiAgentAndQueryRequestsAsync(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
-        // TODO: Execute ExecuteSingleSubConversationToolCallsAsync calls concurrently (use tasks and Task.WhenAll())
+        List<Task<(IDisposable, List<BlittableJsonReaderObject> Messages, int ToolsIterations)>> tasks = [];
         foreach (var (conversationId, conversationReqs) in reqs)
         {
-            await ExecuteSingleSubConversationToolCallsAsync(context, conversationId, conversationReqs);
+            tasks.Add(ExecuteSingleSubConversationToolCallsAsync(conversationId, conversationReqs));
         }
+
+        try
+        {
+            await Task.WhenAll(tasks);
+        }
+        catch
+        {
+            // explicitly ignoring this, since we'll handle the error after this
+        }
+
+        List<Exception> exceptions = new();
+        var toolsIterations = 0;
+        foreach (var t in tasks)
+        {
+            try
+            {
+                var (disposable, messages, iterations) = await t;
+                toolsIterations += iterations;
+                using (disposable)
+                {
+                    if (exceptions.Count > 0)
+                        continue; // only dispose
+                    foreach (var m in messages)
+                    {
+                        _document.AddMessage(context, m.Clone(context), usage: null);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        }
+
+        if (exceptions.Count > 0)
+            throw new AggregateException(exceptions).ExtractSingleInnerException();
+
+        _document.RemainingToolIterations -= toolsIterations;
+        return toolsIterations;
     }
 
-    private async Task ExecuteSingleSubConversationToolCallsAsync(JsonOperationContext context, string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
+    private async Task<(IDisposable, List<BlittableJsonReaderObject> Messages, int ToolsIterations)> ExecuteSingleSubConversationToolCallsAsync(string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
     {
-        await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
+        IDisposable disposable = null;
+
+        try
         {
-            var currentCall = requests[i].Call;
-            var toolCall = FindToolFrom(_configuration, currentCall.Name);
-            if (toolCall == null)
-                throw new InvalidOperationException($"Ai-Agent has no tool in name '{currentCall.Name}'");
+            disposable = database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context);
 
-            switch (toolCall)
+            var messages = new List<BlittableJsonReaderObject>();
+            int iterations = 0;
+
+            await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
             {
-                case AiAgentToolSubAgent:
-                    if (TryCloseSubAgentCall(context, requestResult, currentCall) == false)
-                        return;
-                    break;
-                case AiAgentToolQuery:
-                    if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
-                        throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
+                var currentCall = requests[i].Call;
+                var toolCall = FindToolFrom(_configuration, currentCall.Name);
+                if (toolCall == null)
+                    throw new InvalidOperationException($"Ai-Agent has no tool in name '{currentCall.Name}'");
 
-                    _document.AddMessage(context, context.ReadObject(
-                        new DynamicJsonValue
-                        {
-                            ["tool_call_id"] = currentCall.Id,
-                            ["role"] = "tool",
-                            ["content"] = GetToolResultContent(queryResult)
-                        }, "tool-call/response"), usage: null);
+                switch (toolCall)
+                {
+                    case AiAgentToolSubAgent:
+                        if (TryCloseSubAgentCall(context, requestResult, currentCall, messages, ref iterations) == false)
+                            return (disposable, messages, iterations);
+                        break;
+                    case AiAgentToolQuery:
+                        if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
+                            throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
-                    break;
-                default:
-                    throw new InvalidOperationException(
-                        $"Type mismatch for tool '{currentCall.Name}' in sub-conversation '{conversationId}'. " + 
-                        $"Expected type: '{nameof(AiAgentToolSubAgent)}' or '{nameof(AiAgentToolQuery)}', Actual type: '{toolCall.GetType().Name}'.");
+                        messages.Add(context.ReadObject(
+                            new DynamicJsonValue
+                            {
+                                ["tool_call_id"] = currentCall.Id,
+                                ["role"] = "tool",
+                                ["content"] = GetToolResultContent(queryResult)
+                            }, "tool-call/response"));
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            $"Type mismatch for tool '{currentCall.Name}' in sub-conversation '{conversationId}'. " +
+                            $"Expected type: '{nameof(AiAgentToolSubAgent)}' or '{nameof(AiAgentToolQuery)}', Actual type: '{toolCall.GetType().Name}'.");
+                }
             }
+
+            return (disposable, messages, iterations);
+        }
+        catch
+        {
+            disposable?.Dispose();
+            throw;
         }
     }
 
@@ -876,7 +943,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
     }
 
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage)> HandleRequest(
+    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> HandleRequest(
         DocumentsOperationContext context,
         CancellationToken token)
     {
@@ -895,7 +962,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return (r.Response.ToString(), r.Usage);
     }
 
-    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage)> HandleStreamingRequest(
+    public async Task<(BlittableJsonReaderObject Response, AiUsage Usage, int ToolsIterations)> HandleStreamingRequest(
         DocumentsOperationContext context,
         Stream outputStream,
         string streamPropertyPath,
@@ -923,7 +990,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         public string Answer = "Summary of the following chat messages history";
     }
 
-    public virtual DynamicJsonValue GetConversationResponse(JsonOperationContext context, BlittableJsonReaderObject response)
+    public virtual DynamicJsonValue GetConversationResponse(JsonOperationContext context, BlittableJsonReaderObject response, int toolsIterations)
     {
         return new DynamicJsonValue
         {
@@ -933,11 +1000,12 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             [nameof(ConversationResult<object>.ActionRequests)] = new DynamicJsonArray(GetUserActions()),
             [nameof(ConversationResult<object>.TotalUsage)] = _document.TotalUsage.ToJson(),
             [nameof(ConversationResult<object>.Usage)] = _document.CurrentUsage.ToJson(),
-            [nameof(ConversationResult<object>.Elapsed)] = _elapsed
+            [nameof(ConversationResult<object>.Elapsed)] = _elapsed,
+            [nameof(ConversationResult<object>.ToolsIterations)] = toolsIterations
         };
     }
 
-    private readonly Dictionary<string, AiAgentActionRequest> _childUserCalls = [];
+    private readonly ConcurrentDictionary<string, AiAgentActionRequest> _childUserCalls = [];
 
     private IEnumerable<DynamicJsonValue> GetUserActions()
     {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -429,7 +429,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return ExecuteMultiAgentAndQueryRequestsAsync(context, reqs);
     }
 
-    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall, List<BlittableJsonReaderObject> messages, ref int toolsIterations)
+    private bool TryCloseSubAgentCall(JsonOperationContext context, BlittableJsonReaderObject requestResult, AiToolCall currentCall, 
+        List<BlittableJsonReaderObject> messages, List<string> openToolCallsToRemove, ref int toolsIterations)
     {
         if (requestResult.TryGet(nameof(ConversationResult<object>.ConversationId), out string agentConversationId) is false)
             throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.ConversationId)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
@@ -482,7 +483,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 ["subConversation"] = agentConversationId,
             }, "tool-call/response"));
 
-        _document.OpenActionCalls.Remove(currentCall.Id, out _); // Parent call
+        openToolCallsToRemove.Add(currentCall.Id);
 
         return true;
     }
@@ -814,7 +815,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
     private async Task<int> ExecuteMultiAgentAndQueryRequestsAsync(JsonOperationContext context, Dictionary<string, List<(AiToolCall Call, DynamicJsonValue Req)>> reqs)
     {
-        List<Task<(IDisposable, List<BlittableJsonReaderObject> Messages, int ToolsIterations)>> tasks = [];
+        List<Task<(IDisposable Disposable, List<BlittableJsonReaderObject> Messages, List<string> OpenToolCallsToRemove, int ToolsIterations)>> tasks = [];
         foreach (var (conversationId, conversationReqs) in reqs)
         {
             tasks.Add(ExecuteSingleSubConversationToolCallsAsync(conversationId, conversationReqs));
@@ -835,15 +836,20 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         {
             try
             {
-                var (disposable, messages, iterations) = await t;
-                toolsIterations += iterations;
-                using (disposable)
+                var r = await t;
+                toolsIterations += r.ToolsIterations;
+                using (r.Disposable)
                 {
                     if (exceptions.Count > 0)
                         continue; // only dispose
-                    foreach (var m in messages)
+                    foreach (var m in r.Messages)
                     {
                         _document.AddMessage(context, m.Clone(context), usage: null);
+                    }
+
+                    foreach (var callId in r.OpenToolCallsToRemove)
+                    {
+                        _document.OpenActionCalls.Remove(callId, out _);
                     }
                 }
             }
@@ -860,7 +866,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         return toolsIterations;
     }
 
-    private async Task<(IDisposable, List<BlittableJsonReaderObject> Messages, int ToolsIterations)> ExecuteSingleSubConversationToolCallsAsync(string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
+    private async Task<(IDisposable Disposable, List<BlittableJsonReaderObject> Messages, List<string> OpenToolCallsToRemove, int ToolsIterations)> ExecuteSingleSubConversationToolCallsAsync(string conversationId, List<(AiToolCall Call, DynamicJsonValue Req)> requests)
     {
         IDisposable disposable = null;
 
@@ -869,6 +875,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
             disposable = database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context);
 
             var messages = new List<BlittableJsonReaderObject>();
+            var openToolCallsToRemove = new List<string>();
             int iterations = 0;
 
             await foreach (var (requestResult, i) in ExecuteMultiRequests(context, new DynamicJsonArray(requests.Select(x => x.Req))))
@@ -881,8 +888,8 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 switch (toolCall)
                 {
                     case AiAgentToolSubAgent:
-                        if (TryCloseSubAgentCall(context, requestResult, currentCall, messages, ref iterations) == false)
-                            return (disposable, messages, iterations);
+                        if (TryCloseSubAgentCall(context, requestResult, currentCall, messages, openToolCallsToRemove, ref iterations) == false)
+                            return (disposable, messages, openToolCallsToRemove, iterations);
                         break;
                     case AiAgentToolQuery:
                         if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
@@ -903,7 +910,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 }
             }
 
-            return (disposable, messages, iterations);
+            return (disposable, messages, openToolCallsToRemove, iterations);
         }
         catch
         {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -845,8 +845,6 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 toolsIterations += r.ToolsIterations;
                 using (r.Disposable)
                 {
-                    if (exceptions.Count > 0)
-                        continue; // only dispose
                     foreach (var m in r.Messages)
                     {
                         _document.AddMessage(context, m.Clone(context), usage: null);
@@ -896,11 +894,29 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
                 switch (toolCall)
                 {
                     case AiAgentToolSubAgent:
-                        if (TryCloseSubAgentCall(context, requestResult, currentCall, result) == false)
+                        if (requestResult is ExceptionDispatchInfo ede)
+                        {
+                            result.Messages.Add(context.ReadObject(
+                                new DynamicJsonValue
+                                {
+                                    ["tool_call_id"] = currentCall.Id,
+                                    ["role"] = "tool",
+                                    ["content"] = "Error has been occurred during the tool call execution: " + ede.SourceException,
+                                    ["subConversation"] = conversationId,
+                                }, "tool-call/response"));
+                            result.OpenToolCallsToRemove.Add(currentCall.Id);
+                        }
+                        else if (TryCloseSubAgentCall(context, requestResult as BlittableJsonReaderObject, currentCall, result) == false)
                             return result;
                         break;
                     case AiAgentToolQuery:
-                        if (requestResult.TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
+                        if (requestResult is ExceptionDispatchInfo ede1)
+                        {
+                            // The original stack trace is preserve.
+                            ede1.Throw();
+                        }
+
+                        if (((BlittableJsonReaderObject)requestResult).TryGet(nameof(QueryResult.Results), out BlittableJsonReaderArray queryResult) is false)
                             throw new InvalidOperationException($"Query output is missing the '{nameof(QueryResult.Results)}' field. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
 
                         result.Messages.Add(context.ReadObject(
@@ -941,7 +957,7 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
         }
     }
 
-    private async IAsyncEnumerable<(BlittableJsonReaderObject, int)> ExecuteMultiRequests(JsonOperationContext context, DynamicJsonArray reqs)
+    private async IAsyncEnumerable<(object, int)> ExecuteMultiRequests(JsonOperationContext context, DynamicJsonArray reqs)
     {
         var multiGetHandler = new MultiGetHandler();
         multiGetHandler.Init(new RequestHandlerContext
@@ -973,10 +989,19 @@ public class ConversationHandler(ServerStore server, DocumentDatabase database)
 
                 if (statusCode != 200)
                 {
-                    throw ExceptionDispatcher.Get(requestResult, (HttpStatusCode)statusCode);
+                    ExceptionDispatchInfo edi;
+                    try
+                    {
+                        throw ExceptionDispatcher.Get(requestResult, (HttpStatusCode)statusCode);
+                    }
+                    catch (Exception e)
+                    {
+                        edi = ExceptionDispatchInfo.Capture(e);
+                    }
+                    yield return (edi, i);
                 }
-
-                yield return (requestResult, i);
+                else
+                    yield return (requestResult, i);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -277,7 +277,6 @@ public class AiAgentErrors : RavenTestBase
 
         // Raven.Client.Exceptions.RavenException: System.IO.InvalidDataException:  Cannot have a '<' in this position at  (1,2) ...
         var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<CustomerOutputSchema>(CancellationToken.None));
-        Assert.Contains("Cannot have a '<' in this position at", e.Message);
 
         RavenTestHelper.AssertContainsRespectingNewLines("Received an unrecognized response from the server.\r\nStatus Code: NotFound\r\nResponse:\r\nStatusCode: 404, ReasonPhrase: 'Not Found'", e.Message);
     }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -12,7 +12,6 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Exceptions;
-using Raven.Server.Documents.AI;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -286,7 +285,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal(AiConversationResult.Done, r.Status);
         Assert.NotNull(r.Answer);
 
-        const string expectedFailingToolCallAnswer = "Error has been occurred during the tool call execution: Raven.Client.Exceptions.AiException: Raven.Client.Exceptions.AiException: Failed to 'talk' with the agent 'user-info-agent'";
+        const string expectedFailingToolCallAnswer = "Error has been occurred during the tool call execution: ";
         using (var session = store.OpenAsyncSession())
         {
             var doc = await session.LoadAsync<Chat>("chats/1");

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -622,6 +622,89 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task CheckMaxToolIterationsLimitOnSubAgent(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        var userAgent2 = new AiAgentConfiguration("user-info-agent-2",
+            config.ConnectionStringName,
+            "You are authorized to edit the user's name and to create movie-rating records associated with the user." +
+            "Use exclusively the 'ChangeUserName' tool for changing the user's name. " +
+            "Use exclusively the 'RateMovie' tool for adding a movie-rating record (rating a movie). " +
+            "Do not perform these actions in any other way."
+        )
+        {
+            Actions = new List<AiAgentToolAction>()
+            {
+                new AiAgentToolAction("ChangeUserName",
+                    "Updates the name of the current user interacting with the AI agent. have to send also the old name for validation.")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                },
+                new AiAgentToolAction("RateMovie",
+                    "Add movie rate required movie name and rate value between 0 to 5 (can be double, doesn't has to be integer)")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(RateToolSampleRequest.Instance)
+                },
+            }
+        };
+        userAgent2.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent2Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2, MoviesSampleObject.Instance)).Identifier;
+
+
+        var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent2Id,
+                    Description = "Use for adding movie rate for the current user you talking with OR changing user name (cannot ask for both at once)"
+                }
+            ],
+            MaxModelIterationsPerCall = 1
+        };
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(userAgent1Id, "chats/",
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-2/ChangeUserName", async (r) =>
+        {
+            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+        chat.Handle<RateToolSampleRequest>("user-info-agent-2/RateMovie", async (r) =>
+        {
+            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+
+        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 5 and change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        // check 2 conversation (1 sub-conversations)
+        Assert.Equal(2, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["@conversations"]);
+
+        // check that nothing has been changed
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Shahar Hikri", u.Name);
+        }
+        Assert.Equal(Rates.Count, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
     public async Task SubAgent2OpenActionToolsAtOnce(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -280,10 +280,33 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         var chat = store.AI.Conversation(identifier, "chats/1",
             new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
         chat.SetUserPrompt("Whats my name and my favorite genres?");
-        var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<MoviesSampleObject>());
-        Assert.Contains("Failed to 'talk' with the agent 'movies-agent'", e.Message);
-        Assert.True(e.Message.Contains("Failed to 'talk' with the agent 'user-info-agent'") ||
-                    e.Message.Contains("Failed to 'talk' with the agent 'recommendation-agent'"), e.Message);
+        var r = await chat.RunAsync<MoviesSampleObject>();
+
+        //check if the sub-agent "user-info-agent" error is consumed
+        Assert.Equal(AiConversationResult.Done, r.Status);
+        Assert.NotNull(r.Answer);
+
+        const string expectedFailingToolCallAnswer = "Error has been occurred during the tool call execution: Raven.Client.Exceptions.AiException: Raven.Client.Exceptions.AiException: Failed to 'talk' with the agent 'user-info-agent'";
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<Chat>("chats/1");
+            var toolCallsAnswers = doc.Messages.Where(m => m.Role == "tool");
+            Assert.True(toolCallsAnswers.Any(a => a.Content is string content && content.StartsWith(expectedFailingToolCallAnswer)));
+        }
+    }
+
+    private class Chat
+    {
+        public List<Message> Messages { get; set; }
+    }
+
+    private class Message
+    {
+        [JsonProperty("role")]
+        public string Role { get; set; }
+
+        [JsonProperty("content")]
+        public object Content { get; set; }
     }
 
     [RavenTheory(RavenTestCategory.Ai)]
@@ -1212,10 +1235,16 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
         // error
         throwEx = true;
         chat.SetUserPrompt("Whats my name and my favorite genres?");
-        var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<MoviesSampleObject>());
-        Assert.Contains("Failed to 'talk' with the agent 'movies-agent'", e.Message);
-        Assert.True(e.Message.Contains("Failed to 'talk' with the agent 'user-info-agent'") ||
-                    e.Message.Contains("Failed to 'talk' with the agent 'recommendation-agent'"), e.Message);
+        r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+        Assert.NotNull(r.Answer);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<Chat>("chats/1");
+            var toolCallsAnswers = doc.Messages.Where(m => m.Role == "tool").ToList();
+            Assert.True(toolCallsAnswers.Any(a => a.Content is string content && content.Contains("Failed to 'talk' with the agent 'user-info-agent'")));
+        }
 
         // Resume execution after an error
         throwEx = false;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -12,7 +12,6 @@ using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Exceptions;
-using Raven.Server.Documents.AI;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -640,6 +639,107 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
         var r = await chat.RunAsync<MoviesSampleObject>();
         Assert.Equal(AiConversationResult.Done, r.Status);
     }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task CheckMaxToolIterationsLimitOnSubAgent_Depth3(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+        await CreateMoviesDatabase(store);
+
+        var userAgent3 = new AiAgentConfiguration("user-info-agent-3",
+            config.ConnectionStringName,
+            "You are authorized to edit the user's name and to create movie-rating records associated with the user." +
+            "Use exclusively the 'ChangeUserName' tool for changing the user's name. " +
+            "Use exclusively the 'RateMovie' tool for adding a movie-rating record (rating a movie). " +
+            "Do not perform these actions in any other way."
+        )
+        {
+            Actions = new List<AiAgentToolAction>()
+            {
+                new AiAgentToolAction("ChangeUserName",
+                    "Updates the name of the current user interacting with the AI agent. have to send also the old name for validation.")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(ChangeUserNameSampleRequest.Instance)
+                },
+                new AiAgentToolAction("RateMovie",
+                    "Add movie rate required movie name and rate value between 0 to 5 (can be double, doesn't has to be integer)")
+                {
+                    ParametersSampleObject = JsonConvert.SerializeObject(RateToolSampleRequest.Instance)
+                },
+            }
+        };
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
+
+        var userAgent2 = new AiAgentConfiguration("user-info-agent-2",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent3Id,
+                    Description = "Use for adding movie rate for the current user you talking with OR changing user name (cannot ask for both at once)"
+                }
+            ],
+            MaxModelIterationsPerCall = 2
+        };
+        userAgent2.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent2Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2, MoviesSampleObject.Instance)).Identifier;
+
+        var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
+            config.ConnectionStringName,
+            "You are a User Profile Agent on movies rating system."
+        )
+        {
+            SubAgents =
+            [
+                new AiAgentToolSubAgent
+                {
+                    Identifier = userAgent2Id,
+                    Description = "Use for adding movie rate for the current user you talking with OR changing user name (cannot ask for both at once)"
+                }
+            ],
+            MaxModelIterationsPerCall = 2
+        };
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
+        var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
+
+        var chat = store.AI.Conversation(userAgent1Id, "chats/",
+            new AiConversationCreationOptions().AddParameter("userId", "Users/1"));
+        chat.Handle<ChangeUserNameSampleRequest>("user-info-agent-2/user-info-agent-3/ChangeUserName", async (r) =>
+        {
+            var res = (await ChangeUserNameAsync(store, r)) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+        chat.Handle<RateToolSampleRequest>("user-info-agent-2/user-info-agent-3/RateMovie", async (r) =>
+        {
+            var res = await RateMovieAsync(store, "Users/1", r) as ActionToolResult;
+            // Console.WriteLine(res.Answer);
+            return res;
+        });
+
+        chat.SetUserPrompt("Can you rate the movie \"Toy Story\" as 5 and change my name from 'Shahar Hikri' to 'Aviv Rachmani'?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+        Assert.Equal(AiConversationResult.Done, r.Status);
+
+        // check 3 conversation (1 sub-conversations, 1 sub-sub-conversations)
+        Assert.Equal(3, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["@conversations"]);
+
+        // check that nothing has been changed
+        using (var session = store.OpenAsyncSession())
+        {
+            var u = await session.LoadAsync<User>("Users/1");
+            Assert.Equal("Shahar Hikri", u.Name);
+        }
+        Assert.Equal(Rates.Count, (await store.Maintenance.SendAsync(new GetCollectionStatisticsOperation())).Collections["Ratings"]);
+    }
+
 
     private static async Task<object> ChangeUserNameAsync(IDocumentStore store, ChangeUserNameSampleRequest req)
     {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -629,15 +629,43 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
 
         // error
         throwEx = true;
-        chat.SetUserPrompt("Whats my name and my favorite genres?");
-        var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<MoviesSampleObject>());
-        Assert.Contains($"Failed to 'talk' with the agent '{userAgentId}'", e.Message);
+        chat.SetUserPrompt("Hey, Im the user, Whats my name and my favorite genres?");
+        var r = await chat.RunAsync<MoviesSampleObject>();
+
+        // check if the sub-agent "user-info-agent" error is consumed
+        Assert.Equal(AiConversationResult.Done, r.Status);
+        Assert.NotNull(r.Answer);
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc1 = await session.LoadAsync<Chat>("chats/1/movies-agent-1/Vsy3aOyNusK5fwwmHq4j4kuYQgrH1whMJWuce86epm8=");
+            var toolCallsAnswers1 = doc1.Messages.Where(m => m.Role == "tool").ToList();
+            Assert.True(toolCallsAnswers1.Any(a => a.Content is string content && content.Contains($"Failed to 'talk' with the agent '{userAgentId}'")));
+
+            var doc0 = await session.LoadAsync<Chat>("chats/1");
+            var toolCallsAnswers0 = doc0.Messages.Where(m => m.Role == "tool").ToList();
+            Assert.False(toolCallsAnswers0.Any(a => a.Content is string content && content.Contains($"Failed to 'talk' with the agent '{userAgentId}'")));
+        }
 
         // Resume execution after an error
         throwEx = false;
         chat.SetUserPrompt("Whats my name and my favorite genres?");
-        var r = await chat.RunAsync<MoviesSampleObject>();
+        r = await chat.RunAsync<MoviesSampleObject>();
         Assert.Equal(AiConversationResult.Done, r.Status);
+    }
+
+    private class Chat
+    {
+        public List<Message> Messages { get; set; }
+    }
+
+    private class Message
+    {
+        [JsonProperty("role")]
+        public string Role { get; set; }
+
+        [JsonProperty("content")]
+        public object Content { get; set; }
     }
 
     [RavenTheory(RavenTestCategory.Ai)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24887/AI-Agent-enable-multi-agent-scenario

### Additional description

make ExecuteMultiAgentAndQueryRequestsAsync concurrent, Limit sub-agents tool iterations by parent remaining iterations, adding tests.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
