### PR TITLE
RavenDB-22142 ConstantSchemaRuleValidator, Serialize value for error in the constructor to avoid concurrency read.

### DIFF
--- a/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ConstantSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/Untyped/ConstantSchemaRuleValidator.cs
@@ -12,7 +12,7 @@ public class ConstantSchemaRuleValidator : FixedValueSchemaRuleValidator
     public ConstantSchemaRuleValidator(object constantValue)
     {
         _constantValue = ConvertTypeForComparison(constantValue, cloneAsRoot: true);
-        _constantValueForError = IsString(_constantValue) ? $"\"{_constantValue}\"" : _constantValue;
+        _constantValueForError = IsString(_constantValue) ? $"\"{_constantValue}\"" : $"{_constantValue}";
     }
 
     public override bool Validate(SchemaValidationContext context, object value)

--- a/test/FastTests/SchemaValidation/ConstantSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/ConstantSchemaValidationTests.cs
@@ -18,8 +18,6 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateStringConstant()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {
@@ -50,8 +48,6 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateIntConstant()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {
@@ -88,8 +84,6 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateDoubleConstant()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {
@@ -120,8 +114,6 @@ public class ConstantSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateObjectConstant()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {

--- a/test/FastTests/SchemaValidation/TypeSchemaValidationTests.cs
+++ b/test/FastTests/SchemaValidation/TypeSchemaValidationTests.cs
@@ -230,8 +230,6 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateBoolean()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {
@@ -268,8 +266,6 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateNull()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {
@@ -300,8 +296,6 @@ public class TypeSchemaValidationTests : SchemaValidationTestsBase
     [RavenFact(RavenTestCategory.JavaScript)]
     public async Task SchemaValidation_WhenValidateArray()
     {
-        using var context = JsonOperationContext.ShortTermSingleUse();
-
         var schemaValidator = new SchemaValidator();
         var schemaDefinition = new DynamicJsonValue
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22142

### Additional description
It should be part of https://github.com/ravendb/ravendb/pull/22012
But apparently, I accidentally reverted it.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior
- [x] Not relevant

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
