### PR TITLE
RavenDB-25767 CSV Export should quote string identifiers

### DIFF
--- a/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CsvHelper;
 using Microsoft.AspNetCore.Http;
 using Raven.Client.Json;
 using Sparrow.Json;
@@ -17,13 +18,15 @@ namespace Raven.Server.Documents.Handlers
         {
             WriteCsvHeaderIfNeeded(res, false);
 
+            var csv = GetCsvWriter();
             foreach (var (_, path) in GetProperties())
             {
                 var o = new BlittablePath(path).Evaluate(res);
-                GetCsvWriter().WriteField(o?.ToString());
+                bool shouldQuote = o is string or LazyStringValue or LazyCompressedStringValue;
+                csv.WriteField(o?.ToString(), shouldQuote);
             }
 
-            await GetCsvWriter().NextRecordAsync();
+            await csv.NextRecordAsync();
         }
 
         public StreamCsvBlittableQueryResultWriter(HttpResponse response, Stream stream, string[] properties = null,

--- a/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvBlittableQueryResultWriter.cs
@@ -11,7 +11,7 @@ namespace Raven.Server.Documents.Handlers
 {
     public sealed class StreamCsvBlittableQueryResultWriter : StreamCsvResultWriter<BlittableJsonReaderObject>
     {
-        protected override (string, string)[] GetProperties(BlittableJsonReaderObject entity, bool writeIds) => 
+        protected override (string, string)[] GetProperties(BlittableJsonReaderObject entity, bool writeIds) =>
             GetPropertiesRecursive((string.Empty, string.Empty), entity, writeIds).ToArray();
 
         public override async ValueTask AddResultAsync(BlittableJsonReaderObject res, CancellationToken token)
@@ -22,8 +22,10 @@ namespace Raven.Server.Documents.Handlers
             foreach (var (_, path) in GetProperties())
             {
                 var o = new BlittablePath(path).Evaluate(res);
-                bool shouldQuote = o is string or LazyStringValue or LazyCompressedStringValue;
-                csv.WriteField(o?.ToString(), shouldQuote);
+                if (WellKnownTypeForQuoting(o))
+                    csv.WriteField(o?.ToString(), shouldQuote: true);
+                else
+                    csv.WriteField(o?.ToString());
             }
 
             await csv.NextRecordAsync();

--- a/src/Raven.Server/Documents/Handlers/StreamCsvDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvDocumentQueryResultWriter.cs
@@ -2,9 +2,11 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CsvHelper;
 using Microsoft.AspNetCore.Http;
 using Raven.Client;
 using Raven.Client.Json;
+using Sparrow.Json;
 
 namespace Raven.Server.Documents.Handlers
 {
@@ -27,22 +29,23 @@ namespace Raven.Server.Documents.Handlers
             using var tsCsvWriter = new TimeSeriesCsvWriter(res.TimeSeriesStream);
             do
             {
+                CsvWriter csvWriter = GetCsvWriter();
                 foreach (var (property, path) in GetProperties())
                 {
                     if (Constants.Documents.Metadata.Id == property)
                     {
-                        GetCsvWriter().WriteField(res.Id.ToString());
+                        csvWriter.WriteField(res.Id.ToString(), shouldQuote: true);
                     }
                     else
                     {
                         var o = path.StartsWith(TimeSeriesCsvWriter.TimeSeriesPathPrefix) ?
                             tsCsvWriter.GetValue(property) :
                             new BlittablePath(path).Evaluate(res.Data);
-
-                        GetCsvWriter().WriteField(o?.ToString());
+                        var shouldQuote = o is string or LazyStringValue or LazyCompressedStringValue;
+                        csvWriter.WriteField(o?.ToString(), shouldQuote);
                     }
                 }
-                await GetCsvWriter().NextRecordAsync();
+                await csvWriter.NextRecordAsync();
 
             } while (tsCsvWriter.MoveNext());
         }

--- a/src/Raven.Server/Documents/Handlers/StreamCsvDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvDocumentQueryResultWriter.cs
@@ -38,15 +38,18 @@ namespace Raven.Server.Documents.Handlers
                     }
                     else
                     {
-                        var o = path.StartsWith(TimeSeriesCsvWriter.TimeSeriesPathPrefix) ?
-                            tsCsvWriter.GetValue(property) :
-                            new BlittablePath(path).Evaluate(res.Data);
-                        var shouldQuote = o is string or LazyStringValue or LazyCompressedStringValue;
-                        csvWriter.WriteField(o?.ToString(), shouldQuote);
+                        var o = path.StartsWith(TimeSeriesCsvWriter.TimeSeriesPathPrefix) 
+                            ? tsCsvWriter.GetValue(property) 
+                            : new BlittablePath(path).Evaluate(res.Data);
+
+                        if (WellKnownTypeForQuoting(o))
+                            csvWriter.WriteField(o?.ToString(), shouldQuote: true);
+                        else
+                            csvWriter.WriteField(o?.ToString());
                     }
                 }
-                await csvWriter.NextRecordAsync();
 
+                await csvWriter.NextRecordAsync();
             } while (tsCsvWriter.MoveNext());
         }
 

--- a/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
+++ b/src/Raven.Server/Documents/Handlers/StreamCsvResultWriter.cs
@@ -75,6 +75,8 @@ namespace Raven.Server.Documents.Handlers
             _csvWriter.NextRecord();
         }
 
+        protected bool WellKnownTypeForQuoting(object o) => o is string or LazyStringValue or LazyCompressedStringValue;
+
         protected abstract (string, string)[] GetProperties(T entity, bool writeIds);
 
         private readonly char[] _splitter = { '.' };

--- a/test/SlowTests/Issues/RavenDB-25767.cs
+++ b/test/SlowTests/Issues/RavenDB-25767.cs
@@ -11,14 +11,14 @@ namespace SlowTests.Issues;
 
 public class RavenDB_25767(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+    [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
     public async Task WillQuoteCsvExportStringFields(Options options)
     {
         using var store = GetDocumentStore(options);
         using (var s = store.OpenSession())
         {
-            s.Store(new Item("1234",5678));
+            s.Store(new Item("1234", 5678));
             s.SaveChanges();
         }
 
@@ -27,9 +27,9 @@ public class RavenDB_25767(ITestOutputHelper output) : RavenTestBase(output)
         using var reader = new StreamReader(stream);
         string csv = await reader.ReadToEndAsync();
         Assert.Contains("""
-                     "1234",5678
-                     """.Trim('\r','\n'), csv);
+                        "1234",5678
+                        """.Trim('\r', '\n'), csv);
     }
-    
+
     private record Item(string Name, int Age);
 }

--- a/test/SlowTests/Issues/RavenDB-25767.cs
+++ b/test/SlowTests/Issues/RavenDB-25767.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Server.Extensions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25767(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task WillQuoteCsvExportStringFields(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var s = store.OpenSession())
+        {
+            s.Store(new Item("1234",5678));
+            s.SaveChanges();
+        }
+
+        using var client = new HttpClient().WithConventions(store.Conventions);
+        await using var stream = await client.GetStreamAsync($"{store.Urls[0]}/databases/{store.Database}/streams/queries?query=from Items&format=csv");
+        using var reader = new StreamReader(stream);
+        string csv = await reader.ReadToEndAsync();
+        Assert.Contains("""
+                     "1234",5678
+                     """.Trim('\r','\n'), csv);
+    }
+    
+    private record Item(string Name, int Age);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25767 

### Additional description

When exporting CSV, we'll quote all string values by default.
That allows us to roundtrip numeric values in string fields more easily.

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Low 

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works

### Testing by RavenDB QA team

- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] No UI work is needed
