### PR TITLE
RavenDB-25695 - send empty stream in sql etl for remote attachment 

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseDocumentTransformerBase.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/RelationalDatabase/Common/RelationalDatabaseDocumentTransformerBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+using System.IO;
 using Jint.Native;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -81,11 +81,16 @@ where TRelationalEtlConfiguration: EtlConfiguration<TRelationalConnectionString>
                 var attachment = _loadedAttachments[attachmentName].Dequeue();
 
                 relationalColumn.Type = 0;
-                relationalColumn.Value = attachment.Stream;
 
                 if (attachment.RemoteParameters.IsLocalStorageAttachment())
                 {
+                    relationalColumn.Value = attachment.Stream;
                     _stats.IncrementBatchSize(attachment.Stream.Length);
+                }
+                else
+                {
+                    // for remote attachments, we don't stream the content to the relational db
+                    relationalColumn.Value = Stream.Null;
                 }
             }
 

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSqlEtlTests.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FastTests.Voron.Util;
+using Microsoft.Data.SqlClient;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Operations.Attachments.Remote;
+using Raven.Client.Extensions;
+using Raven.Server.SqlMigration;
+using Raven.Tests.Core.Utils.Entities;
+using SlowTests.Server.Documents.ETL.Olap;
+using SlowTests.Server.Documents.ETL.SQL;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.Attachments
+{
+    public class S3RemoteAttachmentsSqlEtlTests : SqlAwareTestBase
+    {
+        public S3RemoteAttachmentsSqlEtlTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Order
+        {
+            public Address Address { get; set; }
+            public string Id { get; set; }
+            public List<OrderLine> OrderLines { get; set; }
+        }
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class OrderLine
+        {
+            public string Product { get; set; }
+            public int Quantity { get; set; }
+            public int Cost { get; set; }
+        }
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class Address
+        {
+            public string City { get; set; }
+        }
+
+        [RequiresMsSqlRetryTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanSqlEtlRemoteAttachmentsToDestination(bool sqlRemote)
+        {
+            var s3Settings = Etl.GetS3Settings($"{Guid.NewGuid()}").ToRemoteAttachmentsS3Settings();
+
+            try
+            {
+                using var store = GetDocumentStore();
+
+                var conf = new RemoteAttachmentsConfiguration
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                   {
+                       {
+                           "conf-identifier", new RemoteAttachmentsDestinationConfiguration()
+                           {
+                               Disabled = false,
+                               S3Settings = s3Settings,
+                           }
+                       }
+                   },
+                    CheckFrequencyInSec = 1,
+                };
+                await store.Maintenance.ForDatabase(store.Database).SendAsync(new ConfigureRemoteAttachmentsOperation(conf));
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "John" }, "users/1");
+                    await session.SaveChangesAsync();
+                }
+
+                var attachmentBytes = new byte[] { 1, 2, 3 };
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Order());
+                    await session.SaveChangesAsync();
+                }
+
+                using (var ms = new MemoryStream(attachmentBytes))
+                {
+                    var parameters1 = new StoreAttachmentParameters("test-attachment", ms)
+                    {
+                        RemoteParameters = new RemoteAttachmentParameters("conf-identifier", sqlRemote ? DateTime.UtcNow : DateTime.UtcNow.AddDays(7)),
+                        ContentType = "image/png"
+                    };
+                    var putOp1 = new PutAttachmentOperation("orders/1-A", parameters1);
+                    store.Operations.Send(putOp1);
+                }
+
+                if (sqlRemote)
+                {
+                    int count = 0;
+                    var remote = await WaitForValueAsync(async () =>
+                    {
+                        var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+                        database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(3);
+                        count += await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+                        return count;
+                    }, 1, interval: 1000);
+                    Assert.Equal(1, remote);
+                }
+
+                using (WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    SqlEtlTests.CreateRdbmsSchema(connectionString, @"
+CREATE TABLE [dbo].[Orders]
+(
+    [Id] [nvarchar](50) NOT NULL,
+    [Name] [nvarchar](255) NULL,
+    [Pic] [varbinary](max) NULL
+)
+");
+                    var etlDone = Etl.WaitForEtlToComplete(store);
+
+                    SqlEtlTests.SetupSqlEtlInternal(store, Etl, connectionString, @"
+var orderData = {
+    Id: id(this),
+    Name: this['@metadata']['@attachments'][0].Name,
+    Pic: loadAttachment(this['@metadata']['@attachments'][0].Name)
+};
+
+loadToOrders(orderData);
+");
+
+                    await etlDone.WaitAsync(TimeSpan.FromMinutes(1));
+
+                    using (var con = new SqlConnection())
+                    {
+                        con.ConnectionString = connectionString;
+                        con.Open();
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = " SELECT COUNT(*) FROM Orders";
+                            Assert.Equal(1, dbCommand.ExecuteScalar());
+                        }
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = " SELECT Pic FROM Orders WHERE Id = 'orders/1-A'";
+
+                            var sqlDataReader = await dbCommand.ExecuteReaderAsync();
+
+                            Assert.True(sqlDataReader.Read());
+                            var stream = sqlDataReader.GetStream(0);
+
+                            var bytes = await stream.ReadDataAsync();
+
+                            if (sqlRemote)
+                            {
+                                Assert.Equal([], bytes);
+                            }
+                            else
+                            {
+                                Assert.Equal(attachmentBytes, bytes);
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                await S3TestsHelper.DeleteObjects(s3Settings, prefix: $"{s3Settings.RemoteFolderName}", delimiter: string.Empty);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/SqlEtlTests.cs
@@ -1444,7 +1444,12 @@ loadToOrdersWithDot(orderData);
             }
         }
 
-        protected void SetupSqlEtl(DocumentStore store, string connectionString, string script, bool insertOnly = false, List<string> collections = null, List<SqlEtlTable> tables = null)
+        private void SetupSqlEtl(DocumentStore store, string connectionString, string script, bool insertOnly = false, List<string> collections = null, List<SqlEtlTable> tables = null)
+        {
+            SetupSqlEtlInternal(store, Etl, connectionString, script, insertOnly, collections, tables);
+        }
+
+        internal static void SetupSqlEtlInternal(DocumentStore store, RavenTestBase.EtlTestBase etl, string connectionString, string script, bool insertOnly = false, List<string> collections = null, List<SqlEtlTable> tables = null)
         {
             var connectionStringName = $"{store.Database}@{store.Urls.First()} to SQL DB";
 
@@ -1454,7 +1459,7 @@ loadToOrdersWithDot(orderData);
                 new SqlEtlTable { TableName = "OrderLines", DocumentIdColumn = "OrderId", InsertOnlyMode = insertOnly },
             };
             
-            Etl.AddEtl(store, new SqlEtlConfiguration()
+            etl.AddEtl(store, new SqlEtlConfiguration()
             {
                 Name = connectionStringName,
                 ConnectionStringName = connectionStringName,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25695

### Additional description

This pull request introduces changes to improve the handling of remote attachments in SQL ETL (Extract, Transform, Load) operations. The main focus is to ensure that when attachments are stored remotely (such as on S3), their content is not streamed into the relational database, and to add a comprehensive test to verify this behavior.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
