### PR TITLE
RavenDB-25097 Disable DATAS by default. Using GC.GetConfigurationVariables() for reading GC settings and printing them.

### DIFF
--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -232,11 +232,13 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <RetainVMGarbageCollection>true</RetainVMGarbageCollection>
+    <GarbageCollectionAdaptationMode>false</GarbageCollectionAdaptationMode>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <ServerGarbageCollection>false</ServerGarbageCollection>
     <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
     <RetainVMGarbageCollection>false</RetainVMGarbageCollection>
+    <GarbageCollectionAdaptationMode>false</GarbageCollectionAdaptationMode>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RAVEN_BuildOptions)' != ''">
     <DefineConstants>$(DefineConstants);$(RAVEN_BuildOptions)</DefineConstants>

--- a/src/Raven.Server/Utils/Cli/RuntimeSettings.cs
+++ b/src/Raven.Server/Utils/Cli/RuntimeSettings.cs
@@ -13,40 +13,6 @@ namespace Raven.Server.Utils.Cli
         {
         }
 
-        private static (bool HasValue, bool Value) TryGetRetainVMSettingValue()
-        {
-            // REMARK: Whenever CoreCLR includes this we can get rid of this method.
-            var runtimeConfigurationPath = Path.Combine(AppContext.BaseDirectory, "Raven.Server.runtimeconfig.json");
-
-            // Try read runtime configuration from file
-            if (File.Exists(runtimeConfigurationPath))
-            {
-                using (var context = JsonOperationContext.ShortTermSingleUse())
-                using (FileStream f = File.OpenRead(runtimeConfigurationPath))
-                using (BlittableJsonReaderObject @object = context.Sync.ReadForMemory(f, "n"))
-                {
-                    if (@object.TryGet("runtimeOptions", out BlittableJsonReaderObject runtime) &&
-                        runtime.TryGet("configProperties", out BlittableJsonReaderObject properties) &&
-                        properties.TryGet("System.GC.RetainVM", out bool value))
-                    {
-                        return (true, value);
-                    }
-                }
-            }
-
-            // Fallback (Environment Variable)
-            string retainVM = Environment.GetEnvironmentVariable("GCRetainVM");
-            if (string.IsNullOrEmpty(retainVM) == false)
-            {
-                if (bool.TryParse(retainVM, out bool value))
-                {
-                    return (true, value);
-                }
-            }
-
-            return (false, false);
-        }
-
         public static string Describe()
         {
             var latencyMode = GCSettings.LatencyMode;
@@ -64,19 +30,26 @@ namespace Raven.Server.Utils.Cli
             {
                 serverGcConcurrentMode = "concurrent";
             }
+            
+            var retaining = IsRetainVMEnabled() ? "retaining" : "not retaining";
 
-            // https://github.com/dotnet/runtime/issues/42720
-            /*
-            var retaining = "not retaining";
-            (bool HasValue, bool Value) retainVmSettingValue = TryGetRetainVMSettingValue();
-            if (retainVmSettingValue.HasValue && retainVmSettingValue.Value)
-            {
-                retaining = "retaining";
-            }
+            var datas = IsDatasDisabled() ? "disabled" : "enabled";
+            
+            return $"Using GC in { serverGcMode } {serverGcConcurrentMode} mode {retaining} memory from the OS. DATAS {datas}.";
+        }
 
-            return $"Using GC in { serverGcMode } {serverGcConcurrentMode} mode {retaining} memory from the OS.";
-            */
-            return $"Using GC in { serverGcMode } {serverGcConcurrentMode} mode.";
+        private static bool IsRetainVMEnabled()
+        {
+            var config = GC.GetConfigurationVariables();
+
+            return config.TryGetValue("RetainVM", out var value) && Convert.ToInt32(value) == 1;
+        }
+        
+        private static bool IsDatasDisabled()
+        {
+            var config = GC.GetConfigurationVariables();
+
+            return config.TryGetValue("GCDynamicAdaptationMode", out var value) && Convert.ToInt32(value) == 0;
         }
 
         public override void Print()
@@ -104,14 +77,9 @@ namespace Raven.Server.Utils.Cli
                 paragraph.Add(new ConsoleText { Message = " concurrent", ForegroundColor = ConsoleColor.Green });
             }
 
-            paragraph.Add(new ConsoleText { Message = " mode.", ForegroundColor = ConsoleColor.Gray, IsNewLinePostPended = true });
-
-            // https://github.com/dotnet/runtime/issues/42720
-            /*
             paragraph.Add(new ConsoleText { Message = " mode ", ForegroundColor = ConsoleColor.Gray });
 
-            (bool HasValue, bool Value) retainVmSettingValue = TryGetRetainVMSettingValue();
-            if (retainVmSettingValue.HasValue && retainVmSettingValue.Value)
+            if (IsRetainVMEnabled())
             {
                 paragraph.Add(new ConsoleText { Message = "retaining", ForegroundColor = ConsoleColor.Green });
             }
@@ -120,8 +88,10 @@ namespace Raven.Server.Utils.Cli
                 paragraph.Add(new ConsoleText { Message = "not retaining", ForegroundColor = ConsoleColor.Red });
             }
 
-            paragraph.Add(new ConsoleText { Message = " memory from the OS.", ForegroundColor = ConsoleColor.Gray, IsNewLinePostPended = true });
-            */
+            paragraph.Add(new ConsoleText { Message = " memory from the OS. ", ForegroundColor = ConsoleColor.Gray });
+            
+            paragraph.Add(new ConsoleText { Message = $"DATAS {(IsDatasDisabled() ? "disabled" : "enabled")}. ", ForegroundColor = ConsoleColor.Gray, IsNewLinePostPended = true });
+            
 
             ConsoleWriteWithColor(paragraph.ToArray());
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25097

### Additional description

Based on the rules mentioned in [Preparing for the .NET 10 GC (DATAS)](https://devblogs.microsoft.com/dotnet/preparing-for-dotnet-10-gc) we are not applicable for DATAS since RavenDB is designed differently.

https://devblogs.microsoft.com/dotnet/preparing-for-dotnet-10-gc/#when-datas-might-not-be-applicable-to-your-scenario

> When DATAS might not be applicable to your scenario:
> 1) If you have no use for free memory, you don’t need DATAS
> 2) If startup perf is critical, DATAS is not for you
> 3) If you do not tolerate any throughput regression, DATAS may not be for you
> 4) If you are doing mostly gen2 GCs, DATAS may not be for you

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
