### PR TITLE
RavenDB-25689 fix exception in remote attachments sender

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -319,7 +319,7 @@ namespace Raven.Server.Documents
                         }
 
                         size = TableValueToLong((int)AttachmentsTable.Size, ref oldValue);
-                        remoteAt = RemoteAttachmentsStorage.TryUpdateRemoteAttachment(context, remoteAtDt, TableValueToLong((int)AttachmentsTable.RemoteAt, ref oldValue), identifier, TableValueToString(context, (int)AttachmentsTable.Identifier, ref oldValue), keySlice);
+                        remoteAt = RemoteAttachmentsStorage.TryUpdateRemoteAttachment(context, documentId, name, remoteAtDt, TableValueToLong((int)AttachmentsTable.RemoteAt, ref oldValue), identifier, TableValueToString(context, (int)AttachmentsTable.Identifier, ref oldValue), keySlice);
 
                         using (SetTableValue(out TableValueBuilder tvb))
                         {
@@ -403,7 +403,7 @@ namespace Raven.Server.Documents
                             else
                             {
                                 Debug.Assert(flags == RemoteAttachmentFlags.None, "flags == AttachmentFlags.None");
-                                remoteAt = RemoteAttachmentsStorage.TryUpdateRemoteAttachment(context, remoteAtDt, currentDt: -1L, identifier, currentIdentifier: null, keySlice);
+                                remoteAt = RemoteAttachmentsStorage.TryUpdateRemoteAttachment(context, documentId, name, remoteAtDt, currentDt: -1L, identifier, currentIdentifier: null, keySlice);
                             }
                         }
                         else
@@ -574,11 +574,16 @@ namespace Raven.Server.Documents
         {
             using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out Slice lowerDocumentId))
             {
-                var exists = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: true, tvr: out TableValueReader tvr);
-                if (exists == false)
-                    return null;
-                return UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, null, extractCollectionName: false, out var _);
+                return UpdateDocumentAfterAttachmentChangeInternal(context, lowerDocumentId, documentId);
             }
+        }
+
+        internal string UpdateDocumentAfterAttachmentChangeInternal(DocumentsOperationContext context, Slice lowerDocumentId, string documentId)
+        {
+            var exists = _documentsStorage.GetTableValueReaderForDocument(context, lowerDocumentId, throwOnConflict: true, tvr: out TableValueReader tvr);
+            if (exists == false)
+                return null;
+            return UpdateDocumentAfterAttachmentChange(context, lowerDocumentId, documentId, tvr, null, extractCollectionName: false, out var _);
         }
 
         public void DeleteAttachmentBeforeRevert(DocumentsOperationContext context, LazyStringValue lowerDocId)

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -48,8 +48,8 @@ namespace Raven.Server.Documents
         // Identifier (case in-sensitive) -> AttachmentUploader
         private readonly Dictionary<string, AttachmentUploader> _uploaderByIdentifier = new(StringComparer.OrdinalIgnoreCase);
 
-        // DocumentId (case in-sensitive) -> Ticks Slice: we keep track of all documents we have seen
-        private readonly Dictionary<string, List<Slice>> _alreadySeenDocs = new(StringComparer.OrdinalIgnoreCase);
+        // LowerDocumentId Slice (case in-sensitive) -> Ticks Slice: we keep track of all documents we have seen
+        private readonly Dictionary<Slice, List<Slice>> _alreadySeenDocs = new(SliceComparer.Instance);
 
         // Identifier (case in-sensitive) -> (Hash (case sensitive) -> AttachmentRemoteInfo): we keep track of all attachments to upload
         private readonly Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> _attachmentsToUploadByIdentifier = new(StringComparer.OrdinalIgnoreCase);
@@ -229,7 +229,7 @@ namespace Raven.Server.Documents
 
                 // we add all the ticks for this document, so we can update them all at once
 
-                ref var ticks = ref CollectionsMarshal.GetValueRefOrAddDefault(_alreadySeenDocs, document.Id, out var exists);
+                ref var ticks = ref CollectionsMarshal.GetValueRefOrAddDefault(_alreadySeenDocs, document.LowerId, out var exists);
                 if (exists)
                 {
                     ticks.Add(document.Ticks);
@@ -247,6 +247,7 @@ namespace Raven.Server.Documents
                         // document or attachment was deleted, we will remove it from remote tree
                         continue;
                     case BackgroundWorkInfoStatus.Process:
+                        // in this switch case the document.Id is only used for logging or alerts!
                         foreach (Attachment attachment in _database.DocumentsStorage.AttachmentsStorage.GetAttachmentsForDocument(context, AttachmentType.Document, document.LowerId))
                         {
                             _token.ThrowIfCancellationRequested();
@@ -292,7 +293,7 @@ namespace Raven.Server.Documents
 
                             if (Logger.IsDebugEnabled)
                             {
-                                Logger.Debug($"Added a remote attachment '{attachment.Name}' with hash '{hash}' for document id '{document.LowerId}' to upload batch for identifier '{identifier}'.");
+                                Logger.Debug($"Added a remote attachment '{attachment.Name}' with hash '{hash}' for document id '{document.Id}' to upload batch for identifier '{identifier}'.");
                             }
                         }
 
@@ -473,14 +474,14 @@ namespace Raven.Server.Documents
 
         internal sealed class UpdateRemoteAttachmentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
-            private readonly Dictionary<string, List<Slice>> _seenDocs;
+            private readonly Dictionary<Slice, List<Slice>> _seenDocs;
             private readonly Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> _attachmentsToUploadByIdentifier;
             private readonly DocumentDatabase _database;
             private readonly DateTime _currentTime;
 
             public int RemoteCount;
 
-            public UpdateRemoteAttachmentsCommand(DocumentDatabase database, DateTime currentTime, Dictionary<string, List<Slice>> seenDocs, Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> attachmentsToUploadByIdentifier)
+            public UpdateRemoteAttachmentsCommand(DocumentDatabase database, DateTime currentTime, Dictionary<Slice, List<Slice>> seenDocs, Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> attachmentsToUploadByIdentifier)
             {
                 _seenDocs = seenDocs;
                 _attachmentsToUploadByIdentifier = attachmentsToUploadByIdentifier;
@@ -527,17 +528,17 @@ namespace Raven.Server.Documents
         public RemoteAttachmentsSender.UpdateRemoteAttachmentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
             // clone slices
-            var seenDocs = new Dictionary<string, List<Slice>>();
+            var seenDocs = new Dictionary<Slice, List<Slice>>();
             foreach (var item in SeenDocs)
             {
-                seenDocs[item.Key] = item.Value.Select(slice => slice.Clone(context.Allocator)).ToList();
+                seenDocs[item.Key.Clone(context.Allocator)] = item.Value.Select(slice => slice.Clone(context.Allocator)).ToList();
             }
 
             var command = new RemoteAttachmentsSender.UpdateRemoteAttachmentsCommand(database, CurrentTime, seenDocs, AttachmentsToUploadByIdentifier);
             return command;
         }
 
-        public Dictionary<string, List<Slice>> SeenDocs { get; set; }
+        public Dictionary<Slice, List<Slice>> SeenDocs { get; set; }
 
         public Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> AttachmentsToUploadByIdentifier { get; set; }
 

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -244,10 +244,18 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
         var remoteAtChanged = newRemoteAtDt.Value.Ticks != currentDt;
         var identifierChanged = HasIdentifierChanged(currentIdentifier, newIdentifier);
 
-        if (remoteAtChanged == false && identifierChanged == false)
+        if (_logger.IsDebugEnabled)
         {
-            // No changes needed
-            return currentDt;
+            var curDt = new DateTime(currentDt);
+            if (remoteAtChanged == false && identifierChanged == false)
+            {
+                // The attachment was re added, lets update the background work tree even if its the same identifier and at
+                _logger.Debug("Updated remote parameters for attachment '{0}' of document '{1}' with unchanged remote parameters (identifier '{2}', at: '{3}'). Updating background work tree entry.", name, documentId, currentIdentifier, curDt.GetDefaultRavenFormat());
+            }
+            else
+            {
+                _logger.Debug("Updated remote parameters for attachment '{0}' of document '{1}' with new remote parameters (identifier '{2}' -> '{3}', at: '{4}' -> '{5}'). Updating background work tree entry.", name, documentId, currentIdentifier, newIdentifier, curDt.GetDefaultRavenFormat(), newRemoteAtDt.Value.GetDefaultRavenFormat());
+            }
         }
 
         // Something changed - remove the old entry and add the new one

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -224,7 +224,7 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
         return downloader.StreamForDownloadDestination(Database, folderName, objKeyName);
     }
 
-    public long TryUpdateRemoteAttachment(DocumentsOperationContext context, DateTime? newRemoteAtDt, long currentDt, string newIdentifier, string currentIdentifier, Slice keySlice)
+    public long TryUpdateRemoteAttachment(DocumentsOperationContext context, string documentId, string name, DateTime? newRemoteAtDt, long currentDt, string newIdentifier, string currentIdentifier, Slice keySlice)
     {
         // Handle case where there's no current upload date
         if (currentDt == -1L)
@@ -351,13 +351,12 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
         }
     }
 
-    public int ProcessRemoteAttachments(DocumentsOperationContext context, DateTime currentTime, Dictionary<string, List<Slice>> seenDocs, Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> attachmentsToUploadByIdentifier)
+    public int ProcessRemoteAttachments(DocumentsOperationContext context, DateTime currentTime, Dictionary<Slice, List<Slice>> seenDocs, Dictionary<string, Dictionary<string, AttachmentRemoteInfo>> attachmentsToUploadByIdentifier)
     {
         var processedCount = 0;
         var docsTree = context.Transaction.InnerTransaction.ReadTree(_treeName);
-        foreach (var (docId, allTicks) in seenDocs)
+        foreach (var (lowerId, allTicks) in seenDocs)
         {
-            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, docId, out var lowerId))
             using (var doc = Database.DocumentsStorage.Get(context, lowerId, DocumentFields.Data | DocumentFields.Id, throwOnConflict: true))
             {
                 // remove all entries for processed document
@@ -412,7 +411,7 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
                                 break;
                             case BackgroundWorkInfoStatus.Process:
                                 // we uploaded this, we can mark the attachment as remote and delete its stream
-                                Database.DocumentsStorage.AttachmentsStorage.MarkAsRemoteAttachment(context, lowerId, docId, name, contentType, hash, sizeInBytes);
+                                Database.DocumentsStorage.AttachmentsStorage.MarkAsRemoteAttachment(context, lowerId, doc.Id, name, contentType, hash, sizeInBytes);
                                 processedCount++;
                                 break;
                             default:
@@ -423,7 +422,7 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
 
                 if (processedCount > 0)
                 {
-                    Database.DocumentsStorage.AttachmentsStorage.UpdateDocumentAfterAttachmentChange(context, docId);
+                    Database.DocumentsStorage.AttachmentsStorage.UpdateDocumentAfterAttachmentChangeInternal(context, lowerId, doc.Id);
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/Attachments/RemoteAttachmentsHolder.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RemoteAttachmentsHolder.cs
@@ -17,6 +17,7 @@ using Raven.Client.Documents.Operations.Attachments.Remote;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Smuggler;
 using Raven.Client.Exceptions;
 using Raven.Client.Extensions;
@@ -477,7 +478,9 @@ public abstract class RemoteAttachmentsHolder<TSettings> : RemoteAttachmentsHold
 
             // this will delete the remote entry from remote tree because the configuration identifier doesn't exist
             database2.Time.UtcDateTime = () => remoteAt.AddMinutes(1);
-            await database2.RemoteAttachmentsSender!.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+            var processed = await database2.RemoteAttachmentsSender!.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+            // the item is with Deleted status and got removed from the remote tree, but no upload happened because of different identifier
+            Assert.Equal(attachmentsCount, processed);
             await GetBlobsFromCloudAndAssertForCount(Settings, 0, 15_000);
 
             var config1 = await store2.Maintenance.SendAsync(new GetRemoteAttachmentsConfigurationOperation());
@@ -486,7 +489,37 @@ public abstract class RemoteAttachmentsHolder<TSettings> : RemoteAttachmentsHold
             Assert.Equal(2, config1.Destinations.Count);
             await store2.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(config1));
 
-            await database2.RemoteAttachmentsSender!.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+            processed = await database2.RemoteAttachmentsSender!.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+            // even after adding appropriate identifier, the item was removed from remote tree, so no upload will happen
+            Assert.Equal(0, processed);
+
+            // we "touch" the attachments inorder to re-add them to remote tree
+            var operation = await store2
+                .Operations
+                .SendAsync(new PatchByQueryOperation(new IndexQuery
+                {
+                    Query =
+                        $$"""
+                          from @all_docs 
+                          update { 
+                              var attachmentsList = this["@metadata"]["@attachments"];
+                              for (let i = 0; i < attachmentsList.length; i++){
+                                      attachments(this, attachmentsList[i].Name).remote(attachmentsList[i].RemoteParameters.Identifier, attachmentsList[i].RemoteParameters.At);
+                           
+                              }
+                          }
+                          """,
+                    QueryParameters = new Raven.Client.Parameters
+                    {
+                        { "storageIdentifier", identifier1 }
+                    }
+                }));
+            await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(10));
+
+            processed = await database2.RemoteAttachmentsSender!.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+            // even after adding appropriate identifier, the item was removed from remote tree, so no upload will happen
+            Assert.Equal(attachmentsCount, processed);
+
             GetStorageAttachmentsMetadataFromAllAttachments(database2);
 
             var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -41,6 +41,76 @@ namespace SlowTests.Server.Documents.Attachments
         {
         }
 
+        [AmazonS3RetryTheory]
+        [InlineData(1, 3)]
+        [InlineData(64, 3)]
+        public async Task CanProcessItemWithDeleteStatusInSender(int attachmentsCount, int size)
+        {
+            var srcDb = GetDatabaseName();
+            var srcRaft = await CreateRaftCluster(3);
+            var leader = srcRaft.Leader;
+            var srcNodes = await CreateDatabaseInCluster(srcDb, 3, leader.WebUrl);
+            using (var src = new DocumentStore { Urls = srcNodes.Servers.Select(s => s.WebUrl).ToArray(), Database = srcDb, }.Initialize())
+            {
+                DocumentStore store = (DocumentStore)src;
+                await using (var holder = CreateCloudSettings())
+                {
+                    int docsCount = GetDocsAndAttachmentCount(attachmentsCount, out int attachmentsPerDoc);
+                    var ids = new List<(string Id, string Collection)>();
+                    var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+                    await CreateDocs(store, docsCount, ids);
+                    await PopulateDocsWithRandomAttachments(store, identifier, size, ids, attachmentsPerDoc);
+                    Assert.Equal(true, await WaitForChangeVectorInClusterAsync(srcNodes.Servers, srcDb));
+
+                    int count = 0;
+                    DocumentDatabase database = null;
+
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database)).ConfigureAwait(false);
+
+                    // ReSharper disable once InconsistentNaming
+                    string F = record.Topology.AllNodes.FirstOrDefault();
+
+                    var remote = await WaitForValueAsync(async () =>
+                    {
+                        record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database)).ConfigureAwait(false);
+                        F = record.Topology.AllNodes.FirstOrDefault();
+                        var srv = srcRaft.Nodes.FirstOrDefault(x => x.ServerStore.NodeTag == F);
+                        database = await Databases.GetDocumentDatabaseInstanceFor(srv, store);
+
+                        GetStorageAttachmentsMetadataFromAllAttachments(database);
+                        Assert.Equal(attachmentsCount, Attachments.Count);
+
+                        database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                        count += await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                        return count;
+                    }, attachmentsCount, interval: 1000);
+
+                    Assert.Equal(attachmentsCount, remote);
+
+                    var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, attachmentsCount, 15_000);
+                    await AssertAllRemoteAttachments(store, cloudObjects, size, identifier);
+
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database)).ConfigureAwait(false);
+                    var notF = record.Topology.AllNodes.FirstOrDefault(x => x != F);
+                    var srv = srcRaft.Nodes.FirstOrDefault(x => x.ServerStore.NodeTag == notF);
+                    Assert.NotNull(srv);
+                    database = await Databases.GetDocumentDatabaseInstanceFor(srv, store);
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    var deleted = await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+                    Assert.Equal(attachmentsCount, deleted);
+
+                    var notNotF = record.Topology.AllNodes.FirstOrDefault(x => x != F && x != notF);
+                    srv = srcRaft.Nodes.FirstOrDefault(x => x.ServerStore.NodeTag == notNotF);
+                    Assert.NotNull(srv);
+                    database = await Databases.GetDocumentDatabaseInstanceFor(srv, store);
+                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                    var deleted2 = await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+                    Assert.Equal(attachmentsCount, deleted2);
+                }
+            }
+        }
+
         [AmazonS3RetryFact]
         public async Task ShouldThrowOnDocumentWithRemoteAttachmentsOnImportToShardedDatabase()
         {
@@ -1406,7 +1476,6 @@ namespace SlowTests.Server.Documents.Attachments
                     GetStorageAttachmentsMetadataFromAllAttachments(database2, settings);
 
                     Assert.Equal(attachmentsCount, Attachments.Count);
-                    WaitForUserToContinueTheTest(store1);
 
                     GetToRemoteAttachmentsCount(database2, attachmentsCount);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25689

### Additional description

The most significant changes are:

- use of lowered document IDs `Slice` in place of Document IDs, in `RemoteAttachmentsSender` which fixes the bug when item with status `Delete` has document id `null`.
- on attachment update we will update the remote attachment tree  even if the remote parameters were not changed. 
- improved logging and diagnostics for remote attachment updates

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
