### PR TITLE
RavenDB-25696 - forbid import of remote attachments configuration with community/professional license

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -1237,7 +1237,7 @@ public sealed partial class ClusterStateMachine
         if (licenseStatus.HasRemoteAttachments)
             return;
 
-        if (databaseRecord.RemoteAttachments == null || databaseRecord.RemoteAttachments.HasDestination())
+        if (databaseRecord.RemoteAttachments == null || databaseRecord.RemoteAttachments.HasDestination() == false)
             return;
 
         throw new LicenseLimitException(LimitType.RemoteAttachments, "Your license doesn't support adding the remote attachments configuration.");

--- a/test/SlowTests.Issues/Issues/RavenDB-25696.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25696.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Smuggler;
+using Raven.Client.Exceptions.Commercial;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25696 : RavenTestBase
+{
+    public RavenDB_25696(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+    public async Task ExceptionWhenImportingRemoteAttachmentsWithCommunityLicense()
+    {
+        await ExceptionWhenImportingRemoteAttachmentsWithUnsupportedLicense(LicenseTestBase.RL_COMM);
+    }
+
+    [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Replication)]
+    public async Task ExceptionWhenImportingRemoteAttachmentsWithProfessionalLicense()
+    {
+        await ExceptionWhenImportingRemoteAttachmentsWithUnsupportedLicense(LicenseTestBase.RL_PRO);
+    }
+
+    private async Task ExceptionWhenImportingRemoteAttachmentsWithUnsupportedLicense(string license)
+    {
+        DoNotReuseServer();
+
+        var file = GetTempFileName();
+        var dbName = $"db/{Guid.NewGuid()}";
+        try
+        {
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.DisableRevisionCompression(Server, store);
+                await LicenseHelper.CreateRemoteAttachmentsConfiguration(dbName, store);
+
+                var operation = await store.Smuggler.ExportAsync(new DatabaseSmugglerExportOptions(), file);
+                await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(1));
+            }
+
+            using (var store = GetDocumentStore())
+            {
+                await LicenseHelper.ChangeLicenseAndDisableRevisionCompression(Server, store, license);
+
+                var exception = await Assert.ThrowsAsync<LicenseLimitException>(async () =>
+                {
+                    var importOperation = await store.Smuggler.ImportAsync(new DatabaseSmugglerImportOptions(), file);
+                    await importOperation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
+                });
+                Assert.Equal(LimitType.RemoteAttachments, exception.LimitType);
+                Assert.True(exception.Message.Contains("Your license doesn't support adding the remote attachments configuration."));
+            }
+        }
+        finally
+        {
+            IOExtensions.DeleteFile(file);
+        }
+    }
+}

--- a/test/Tests.Infrastructure/RavenTestBase.License.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.License.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.Attachments.Remote;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
@@ -224,6 +226,27 @@ namespace FastTests
                 pull.Disabled = disabled;
                 store.Maintenance.Send(new PutPullReplicationAsHubOperation(pull));
                 return pull;
+            }
+
+            internal async Task CreateRemoteAttachmentsConfiguration(string dbName, DocumentStore store, bool disabled = false)
+            {
+                var c1 = new RemoteAttachmentsConfiguration()
+                {
+                    Destinations = new Dictionary<string, RemoteAttachmentsDestinationConfiguration>()
+                    {
+                        {
+                            "S3-Users", new RemoteAttachmentsDestinationConfiguration()
+                            {
+                                S3Settings = new RemoteAttachmentsS3Settings() { BucketName = "testS3Bucket-Users" },
+                                Disabled = false
+                            }
+                        }
+                    },
+                    CheckFrequencyInSec = 1000
+                };
+
+                var result = await store.Maintenance.SendAsync(new ConfigureRemoteAttachmentsOperation(c1));
+                Assert.NotNull(result.RaftCommandIndex);
             }
 
             internal RavenEtlConfiguration CreateRavenEtlConfiguration(string csName, string dbName, DocumentStore store, out AddEtlOperationResult etl, bool disabled = false)


### PR DESCRIPTION
…
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25696

### Additional description

 forbid import of remote attachments configuration with community/professional license

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
