### PR TITLE
RavenDB-25506 added GC.KeepAlive to selfSignedCertificateBasedOnPrivateKey

### DIFF
--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Utils
                 var message = $"Cannot validate new client certificate '{userCertificate.GetDisplayName()} - ({userCertificate.Thumbprint})'," +
                               $" failed to build the chain.";
                 explanations?.Add(message);
-                if (Logger.IsInfoEnabled) 
+                if (Logger.IsInfoEnabled)
                     Logger.Info(message, e);
 
                 return false;
@@ -79,7 +79,7 @@ namespace Raven.Server.Utils
             {
                 var message = $"Cannot extract pinning hash from the client certificate's issuer '{issuerCertificate?.FriendlyName} {issuerCertificate?.Thumbprint}'.";
                 explanations?.Add(message);
-                if (Logger.IsInfoEnabled) 
+                if (Logger.IsInfoEnabled)
                     Logger.Info(message, e);
 
                 return false;
@@ -95,7 +95,7 @@ namespace Raven.Server.Utils
                 var message = $"Cannot validate new client certificate '{userCertificate.GetDisplayName()} {userCertificate.Thumbprint}'." +
                               $" Found a known certificate '{knownCertificate.Thumbprint}' with the same hash but failed to build its chain.";
                 explanations?.Add(message);
-                if (Logger.IsInfoEnabled) 
+                if (Logger.IsInfoEnabled)
                     Logger.Info(message, e);
 
                 return false;
@@ -124,7 +124,7 @@ namespace Raven.Server.Utils
                 explanations.Add($"Client certificate chain info:\n{GenerateCertificateChainDebugLog(userChain)}");
                 explanations.Add($"Known certificate chain info:\n{GenerateCertificateChainDebugLog(knownCertChain)}");
             }
-            
+
             // compare issuers pinning hashes starting from top of the chain (CA) since it's least likely to change
             // chain may have additional elements due to cross-signing, that's why we compare every issuer with each other
             for (var i = knownCertChain.ChainElements.Count - 1; i > 0; i--)
@@ -164,9 +164,9 @@ namespace Raven.Server.Utils
                 ServerCertificateForClients = Convert.ToBase64String(ServerCertificate.Export(X509ContentType.Cert));
 
                 if (SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(ServerCertificate))
-            {
+                {
                     ClientCertificate = serverCertificate;
-            }
+                }
                 else
                 {
                     var clientCertificate = CreateClientCertificateFromServerCertificate(serverCertificate, out _);
@@ -190,7 +190,7 @@ namespace Raven.Server.Utils
                 $"{commonNameValue} CA",
                 out var caSubjectName,
                 log);
-            
+
             CreateSelfSignedCertificateBasedOnPrivateKey(
                 commonNameValue: commonNameValue,
                 issuerCN: caSubjectName,
@@ -202,8 +202,9 @@ namespace Raven.Server.Utils
                 log: log,
                 sans: [commonNameValue, "localhost", $"*.{commonNameValue}"],
                 with2Eku: with2Eku);
-            
+
             var selfSignedCertificateBasedOnPrivateKey = CertificateLoaderUtil.CreateCertificate(certBytes);
+            GC.KeepAlive(selfSignedCertificateBasedOnPrivateKey); // https://github.com/dotnet/runtime/issues/122642#issuecomment-3720461147
             selfSignedCertificateBasedOnPrivateKey.Verify();
 
             // We had a problem where we didn't cleanup the user store in Linux (~/.dotnet/corefx/cryptography/x509stores/ca)
@@ -264,7 +265,7 @@ namespace Raven.Server.Utils
                 out certBytes);
 
             ValidateNoPrivateKeyInServerCert(serverCertBytes);
-            
+
             // Create a collection to hold all the certificates.
             var pfxCollection = new X509Certificate2Collection();
 
@@ -300,7 +301,7 @@ namespace Raven.Server.Utils
             if (new X509Certificate2Collection(collection).OfType<X509Certificate2>().FirstOrDefault(x => x.HasPrivateKey) != null)
                 throw new InvalidOperationException("After export of CERT, still have private key from signer in certificate, should NEVER happen");
         }
-        
+
         private static void ValidateNoPrivateKeyInServerCert(X509Certificate2 certificate)
         {
             if (certificate.HasPrivateKey)
@@ -352,6 +353,7 @@ namespace Raven.Server.Utils
                 commonNameBuilder.AddCommonName(commonNameValue);
                 subjectName = commonNameBuilder.Build();
             }
+
             log?.AppendLine($"subjectDN = {subjectName}");
             log?.AppendLine($"issuerDN = {issuerCN}");
 
@@ -401,7 +403,7 @@ namespace Raven.Server.Utils
             {
                 rng.GetBytes(serialNumberBytes);
             }
-            
+
             if (issuerCertBytes is { Length: > 0 })
             {
                 request.CertificateExtensions.Add(new X509Extension(new Oid(Constants.Certificates.ServerCertExtensionOid), issuerCertBytes, false));
@@ -627,7 +629,7 @@ namespace Raven.Server.Utils
 
             var subjectAlternativeNames = GetCertificateAlternativeNames(cert).ToList();
             var subject = subjectAlternativeNames.FirstOrDefault();
-            
+
             // fallback to common name
             if (string.IsNullOrEmpty(subject))
                 subject = cert.GetNameInfo(X509NameType.SimpleName, false);
@@ -797,7 +799,7 @@ namespace Raven.Server.Utils
         }
 
         public static string GetDisplayName(this X509Certificate2 certificate)
-            {
+        {
             if (certificate == null)
                 return "(null)";
 
@@ -824,7 +826,7 @@ namespace Raven.Server.Utils
         {
             if (privateKey == null)
                 return null;
-            
+
             const CngExportPolicies exportability = CngExportPolicies.AllowExport | CngExportPolicies.AllowPlaintextExport;
 
             // Thankfully we don't have to deal with all this on Linux


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25506

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
