### PR TITLE
RavenDB-25780 Introduce UpdateStep.AllocateDocumentsOperationContext() to prevent returning not fully initialized contexts, allocated during schema upgrades to the pool

### DIFF
--- a/src/Raven.Server/Storage/Schema/UpdateStep.cs
+++ b/src/Raven.Server/Storage/Schema/UpdateStep.cs
@@ -41,5 +41,14 @@ namespace Raven.Server.Storage.Schema
         {
             _transactions.Renew();
         }
+
+        public IDisposable AllocateDocumentsOperationContext(out DocumentsOperationContext ctx)
+        {
+            var dispose = DocumentsStorage.ContextPool.AllocateOperationContext(out ctx);
+
+            ctx.DoNotReuse = true; // ctx.Environment isn't initialized yet as we're upgrading the schema, so we don't want to return it to the pool
+            
+            return dispose;
+        }
     }
 }

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
@@ -39,7 +39,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
          */
         public bool Update(UpdateStep step)
         {
-            using var e = step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx);
+            using var e = step.AllocateDocumentsOperationContext(out DocumentsOperationContext ctx);
             using var g = Slice.From(ctx.Allocator, AttachmentsEtag, out var attachmentsEtagSlice);
             using var o = Slice.From(ctx.Allocator, AttachmentsHash, out var attachmentsHashSlice);
             using var r = Slice.From(ctx.Allocator, AttachmentsFlagAndHash, out var attachmentsFlagAndHashSlice);
@@ -110,7 +110,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
             while (done == false)
             {
-                using (step.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (step.AllocateDocumentsOperationContext(out DocumentsOperationContext context))
                 {
                     if (isSharded)
                     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25780

### Additional description

This way we prevent NRE on ctx.Environment which is used explicitly by the transaction merger code for encrypted databases:

https://github.com/ravendb/ravendb/blob/685c613eeb70c54d11da7e1dc037f2117b243547/src/Raven.Server/Documents/TransactionMerger/AbstractTransactionOperationsMerger.cs#L169-L175

Note: We had the same usages in older schema upgrades <= 4.2. Since those versions are no longer supported I decided to not modify them.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
