### PR TITLE
RavenDB-25787 use new request each time

### DIFF
--- a/src/Raven.Server/Commercial/ApiHttpClient.cs
+++ b/src/Raven.Server/Commercial/ApiHttpClient.cs
@@ -30,9 +30,18 @@ namespace Raven.Server.Commercial
 
         private static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy;
 
-        public static Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token = default)
+        public static Task<HttpResponseMessage> SendAsync(HttpContent content, CancellationToken token = default)
         {
-            return RetryPolicy.ExecuteAsync(t => Instance.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, t), token, continueOnCapturedContext: false);
+            return RetryPolicy.ExecuteAsync(async t =>
+            {
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                    Content = content,
+                    RequestUri = new Uri("/api/v1/ai/assist", UriKind.Relative)
+                };
+                return await Instance.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, t);
+            }, token, continueOnCapturedContext: false);
         }
 
         public static Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken token = default)

--- a/src/Raven.Server/Commercial/ApiHttpClient.cs
+++ b/src/Raven.Server/Commercial/ApiHttpClient.cs
@@ -30,24 +30,22 @@ namespace Raven.Server.Commercial
 
         private static readonly AsyncRetryPolicy<HttpResponseMessage> RetryPolicy;
 
-        public static Task<HttpResponseMessage> SendAsync(HttpContent content, CancellationToken token = default)
+        public static Task<HttpResponseMessage> PostAsync(string relativeUri, HttpContent content, HttpCompletionOption completionOption, CancellationToken token = default)
         {
-            return RetryPolicy.ExecuteAsync(async t =>
+            return RetryPolicy.ExecuteAsync(t =>
             {
                 var request = new HttpRequestMessage
                 {
                     Method = HttpMethod.Post,
                     Content = content,
-                    RequestUri = new Uri("/api/v1/ai/assist", UriKind.Relative)
+                    RequestUri = new Uri(relativeUri, UriKind.Relative)
                 };
-                return await Instance.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, t);
+                return Instance.SendAsync(request, completionOption, t);
             }, token, continueOnCapturedContext: false);
         }
 
-        public static Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken token = default)
-        {
-            return RetryPolicy.ExecuteAsync(t => Instance.PostAsync(requestUri, content, t), token, continueOnCapturedContext: false);
-        }
+        public static Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content, CancellationToken token = default) =>
+            PostAsync(requestUri, content, completionOption: HttpCompletionOption.ResponseContentRead, token);
 
         public static Task<HttpResponseMessage> GetAsync(string requestUri, CancellationToken token = default)
         {

--- a/src/Raven.Server/Documents/AI/AiAssistant/Handlers/Processors/AiAssistantAssistProcessor.cs
+++ b/src/Raven.Server/Documents/AI/AiAssistant/Handlers/Processors/AiAssistantAssistProcessor.cs
@@ -23,15 +23,8 @@ internal class AiAssistantAssistProcessor([NotNull] RequestHandler requestHandle
             FulfillRequestMetadata(modifications);
 
             using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
-            var content = new StringContent(context.ReadObject(requestBody, "ai-assist").ToString(), Encoding.UTF8, "application/json");
-            using var request = new HttpRequestMessage
-            {
-                Method = HttpMethod.Post,
-                Content = content,
-                RequestUri = new Uri("/api/v1/ai/assist", UriKind.Relative)
-            };
-
-            using var response = await ApiHttpClient.SendAsync(request, token.Token).ConfigureAwait(false);
+            using var content = new StringContent(context.ReadObject(requestBody, "ai-assist").ToString(), Encoding.UTF8, "application/json");
+            using var response = await ApiHttpClient.SendAsync(content, token.Token).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode == false)
                 HttpContext.Response.StatusCode = (int)response.StatusCode;

--- a/src/Raven.Server/Documents/AI/AiAssistant/Handlers/Processors/AiAssistantAssistProcessor.cs
+++ b/src/Raven.Server/Documents/AI/AiAssistant/Handlers/Processors/AiAssistantAssistProcessor.cs
@@ -24,7 +24,7 @@ internal class AiAssistantAssistProcessor([NotNull] RequestHandler requestHandle
 
             using var token = RequestHandler.CreateHttpRequestBoundOperationToken();
             using var content = new StringContent(context.ReadObject(requestBody, "ai-assist").ToString(), Encoding.UTF8, "application/json");
-            using var response = await ApiHttpClient.SendAsync(content, token.Token).ConfigureAwait(false);
+            using var response = await ApiHttpClient.PostAsync("/api/v1/ai/assist", content, HttpCompletionOption.ResponseHeadersRead, token.Token).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode == false)
                 HttpContext.Response.StatusCode = (int)response.StatusCode;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25787

### Additional description

If we need to retry (with Polly) we can't reuse the same request, but need to provide a new one each time

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
