### PR TITLE
RavenDB-25735 Added mapping for notification prettified reasons

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/DatabaseNotifications/NotificationSummaryItem.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/DatabaseNotifications/NotificationSummaryItem.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Raven.Server.NotificationCenter.Notifications;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Dashboard.Cluster.Notifications.DatabaseNotifications;
@@ -21,7 +22,52 @@ public class NotificationSummaryItem
     
     public static string PrettifyReason(string reason)
     {
-        var parts = reason.Split(['_'], 2);
+        return reason switch
+        {
+            // Performance hints
+            nameof(PerformanceHintReason.Paging) => "Requests: Page size too big",
+            nameof(PerformanceHintReason.RequestLatency) => "Requests: Latency is too high",
+            
+            nameof(PerformanceHintReason.Indexing) => "Indexing: Definition issues",
+            nameof(PerformanceHintReason.Indexing_References) => "Indexing: High load reference rate",
+            
+            nameof(PerformanceHintReason.SlowIO) => "Storage: An extremely slow write to disk",
+            
+            nameof(PerformanceHintReason.UnusedCapacity) => "System: Not all cores are used",
+            
+            nameof(PerformanceHintReason.Replication) => "Replication: Disabled destination",
+            
+            nameof(PerformanceHintReason.SqlEtl_SlowSql) => "ETL: Slow SQL detected",
+            
+            nameof(PerformanceHintReason.HugeDocuments) => "Huge documents impacting performance",
+            
+            // Alerts
+            nameof(AlertReason.QueueSink_Error) => "Queue Sink: Invalid configuration",
+            nameof(AlertReason.QueueSink_ScriptError) => "Queue Sink: Could not parse script",
+            nameof(AlertReason.QueueSink_ConsumeError) => "Queue Sink: Messages consumption has failed",
+            nameof(AlertReason.QueueSink_ConsumerCreationError) => "Queue Sink: Failed to create consumer",
+            
+            nameof(AlertReason.OutOfMemoryException) => "System: Out of memory occurred",
+            nameof(AlertReason.ServerLimits) => "System: Server is running close to OS limits",
+            
+            nameof(AlertReason.LowDiskSpace) => "Storage: Low free disk space",
+            
+            nameof(AlertReason.MismatchedReferenceLoad) => "Indexing: Loading documents with mismatched collection",
+            
+            nameof(AlertReason.Etl_LoadError) => "ETL: Loading transformed data to the destination has failed",
+            
+            nameof(AlertReason.BlockingTombstones) => "Blockage in tombstone deletion",
+            nameof(AlertReason.PeriodicBackup) => "Failed to run backup",
+            nameof(AlertReason.ConflictRevisionsExceeded) => "Excess number of Conflict Revisions",
+            nameof(AlertReason.ReplicationMissingAttachments) => "Detected missing attachments for a document",
+            
+            _ => DefaultPrettify(reason)
+        };
+    }
+    
+    private static string DefaultPrettify(string reason)
+    {
+        var parts = reason.Split('_', 2);
         
         if (parts.Length < 2)
         {

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
@@ -67,6 +67,7 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         LowDiskSpace,
 
+        // Required for backward compatibility
         UnexpectedIndexingThreadError,
 
         Indexing_UnexpectedIndexingThreadError,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25735/Cluster-Dashboard-Enhance-PrettifiedReason-for-database-notifications

### Additional description

We want to display more informative notification reasons in the database notifications studio widget when possible

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
