### PR TITLE
RavenDB-25786 & RavenDB-25686 - fix (editDocument): Handle undefined `remoteAttachmentsConfiguration?.Disabled` with optional chaining

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -190,7 +190,7 @@ class editDocument extends shardViewModelBase {
     canViewRelated: KnockoutComputed<boolean>;
     canViewCSharpClass: KnockoutComputed<boolean>;
 
-    remoteAttachmentsDisabled = ko.observable<boolean>(false);
+    isRemoteAttachmentsDisabled = ko.observable<boolean>(false);
 
     isFullScreenEditor = ko.observable(false);
 
@@ -1365,10 +1365,10 @@ class editDocument extends shardViewModelBase {
         new getRemoteAttachmentsConfigurationCommand(this.db)
             .execute()
             .done((remoteAttachmentsConfiguration: RemoteAttachmentsConfiguration) => {
-                this.remoteAttachmentsDisabled(!!remoteAttachmentsConfiguration?.Disabled);
+                this.isRemoteAttachmentsDisabled(!!remoteAttachmentsConfiguration?.Disabled);
             })
             .fail(() => {
-                this.remoteAttachmentsDisabled(false);
+                this.isRemoteAttachmentsDisabled(false);
             });
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -53,6 +53,7 @@ import getRemoteAttachmentsConfigurationCommand = require("commands/database/set
 import RemoteAttachmentsConfiguration = Raven.Client.Documents.Attachments.RemoteAttachmentsConfiguration;
 import storeCompat = require("components/storeCompat");
 import chatbotSlice = require("components/shell/chatbot/store/chatbotSlice");
+import popoverUtils = require("common/popoverUtils");
 
 class editDocument extends shardViewModelBase {
     view = require("views/database/documents/editDocument.html");
@@ -154,6 +155,8 @@ class editDocument extends shardViewModelBase {
     // it represents effective actions provider - normally it uses normalActionProvider, in clone document node it overrides actions on attachments/counter to 'in-memory' implementation
     private crudActionsProvider = ko.observable<editDocumentCrudActions>(this.normalActionProvider);
 
+    remoteAttachmentDisabledReason = ko.observable<string>("");
+
     connectedDocuments = new connectedDocuments(
         this.document,
         this.db,
@@ -163,7 +166,8 @@ class editDocument extends shardViewModelBase {
         this.crudActionsProvider,
         this.inReadOnlyMode,
         this.isReadOnlyAccess,
-        this.isClone
+        this.isClone,
+        this.remoteAttachmentDisabledReason
     );
 
     isSaveEnabled: KnockoutComputed<boolean>;
@@ -190,7 +194,6 @@ class editDocument extends shardViewModelBase {
     canViewRelated: KnockoutComputed<boolean>;
     canViewCSharpClass: KnockoutComputed<boolean>;
 
-    isRemoteAttachmentsDisabled = ko.observable<boolean>(false);
 
     isFullScreenEditor = ko.observable(false);
 
@@ -314,6 +317,13 @@ class editDocument extends shardViewModelBase {
         this.focusOnEditor();
 
         this.watchFullScreenCommand();
+
+        $('.edit-document [data-toggle="tooltip"]').tooltip();
+        popoverUtils.longWithHover($(".add-remote-attachment"),
+            {
+                content: this.remoteAttachmentDisabledReason(),
+                placement: "left",
+            });
     }
 
     detached() {
@@ -1362,13 +1372,20 @@ class editDocument extends shardViewModelBase {
     }
 
     private loadRemoteAttachmentsConfiguration() {
+        if (this.db.isSharded()) {
+            this.remoteAttachmentDisabledReason("Remote attachments are not supported in sharded databases");
+            return;
+        }
+
         new getRemoteAttachmentsConfigurationCommand(this.db)
             .execute()
             .done((remoteAttachmentsConfiguration: RemoteAttachmentsConfiguration) => {
-                this.isRemoteAttachmentsDisabled(!!remoteAttachmentsConfiguration?.Disabled);
+                if (remoteAttachmentsConfiguration == null || remoteAttachmentsConfiguration.Disabled) {
+                    this.remoteAttachmentDisabledReason("Remote attachments are currently disabled. To enable them, go to Settings → Remote Attachments and update the configuration accordingly.");
+                }
             })
             .fail(() => {
-                this.isRemoteAttachmentsDisabled(false);
+                this.remoteAttachmentDisabledReason("Remote attachments configuration could not be retrieved.");
             });
     }
 

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1365,7 +1365,7 @@ class editDocument extends shardViewModelBase {
         new getRemoteAttachmentsConfigurationCommand(this.db)
             .execute()
             .done((remoteAttachmentsConfiguration: RemoteAttachmentsConfiguration) => {
-                this.remoteAttachmentsDisabled(!!remoteAttachmentsConfiguration.Disabled);
+                this.remoteAttachmentsDisabled(!!remoteAttachmentsConfiguration?.Disabled);
             })
             .fail(() => {
                 this.remoteAttachmentsDisabled(false);

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocumentConnectedDocuments.ts
@@ -100,6 +100,8 @@ class connectedDocuments {
     
     uploader: editDocumentUploader;
 
+    private remoteAttachmentDisabledReason: KnockoutObservable<string>;
+
     constructor(document: KnockoutObservable<document>,
         db: database,
         loadDocument: (docId: string) => void,
@@ -108,7 +110,8 @@ class connectedDocuments {
         crudActionsProvider: () => editDocumentCrudActions,
         inReadOnlyMode: KnockoutObservable<boolean>,
         isReadOnlyAccess: KnockoutComputed<boolean>,
-        isClone: KnockoutObservable<boolean>) {
+        isClone: KnockoutObservable<boolean>,
+        remoteAttachmentDisabledReason: KnockoutObservable<string>) {
 
         _.bindAll(this, ...["toggleStar"] as Array<keyof this & string>);
 
@@ -117,6 +120,7 @@ class connectedDocuments {
         this.isReadOnlyAccess = isReadOnlyAccess;
         this.inReadOnlyMode = inReadOnlyMode;
         this.isClone = isClone;
+        this.remoteAttachmentDisabledReason = remoteAttachmentDisabledReason;
         this.document.subscribe((doc) => this.onDocumentLoaded(doc));
         this.loadDocumentAction = loadDocument;
         this.loadRevisionAction = loadRevision;
@@ -172,8 +176,8 @@ class connectedDocuments {
             }),
             new actionColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => this.downloadAttachment(x), "Name", x => x.name, "160px",
                 {
-                    extraClass: () => 'btn-link',
-                    title: (item: attachmentItem) => "Download file: " + item.name
+                    extraClass: (item) => this.remoteAttachmentDisabledReason() && item?.remoteParameters?.Flags === "Remote" ? 'btn-link disabled' : "btn-link",
+                    title: (item) => this.remoteAttachmentDisabledReason() && item?.remoteParameters?.Flags === "Remote" ? this.remoteAttachmentDisabledReason() : `Download file: ${item.name}`
                 }),
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => generalUtils.formatBytesToSize(x.size), "Size", "70px", { extraClass: () => 'filesize' }),
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters, "Remote parameters", "100px"),
@@ -192,10 +196,10 @@ class connectedDocuments {
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters?.Flags ?? "", "Remote flags", "35px", {
                 transformValue: (x: RemoteAttachmentFlags) => x === "Remote" ? `<i class="icon-remote-attachment text-info"></i>` : `<i class="icon-attachment text-primary"></i>`,
             }),
-            new actionColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => this.downloadAttachment(x), "Name", x => x.name, "195px",
+            new actionColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => this.downloadAttachment(x), "Name", x => x.name, "160px",
                 {
-                    extraClass: () => 'btn-link',
-                    title: () => "Download attachment"
+                    extraClass: (item) => this.remoteAttachmentDisabledReason() && item?.remoteParameters?.Flags === "Remote" ? 'btn-link disabled' : "btn-link",
+                    title: (item) => this.remoteAttachmentDisabledReason() && item?.remoteParameters?.Flags === "Remote" ? this.remoteAttachmentDisabledReason() : `Download file: ${item.name}`
                 }),
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => generalUtils.formatBytesToSize(x.size), "Size", "70px", { extraClass: () => 'filesize' }),
             new textColumn<attachmentItem>(this.gridController() as virtualGridController<any>, x => x?.remoteParameters, "Remote parameters", "100px"),

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -568,9 +568,9 @@
                     <span class="sr-only">Toggle Dropdown</span>
                 </button>
 
-                <ul class="dropdown-menu">
-                    <li >
-                        <a href="#" data-bind="click: () => $root.connectedDocuments.isAddAttachmentWithRemoteParametersModalVisible(true)">
+                <ul class="dropdown-menu uploader-template">
+                    <li class="add-remote-attachment">
+                    <a href="#" data-bind="click: () => $root.connectedDocuments.isAddAttachmentWithRemoteParametersModalVisible(!$root.remoteAttachmentDisabledReason()), css: { 'disabled': $root.remoteAttachmentDisabledReason() }">
                             <i class="icon-cluster"></i>
                             <span>Add attachment to remote storage</span>
                         </a>
@@ -578,9 +578,6 @@
                 </ul>
             </div>
         </div>
-        <div data-bind="visible: $root.isRemoteAttachmentsDisabled" class="bg-warning margin-top-xxs padding padding-sm">
-            <i class="icon-warning margin-right-xxs"></i><small class="mb-0">Remote attachments feature is
-            disabled</small></div>
     </div>
 </script>
 

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -578,7 +578,7 @@
                 </ul>
             </div>
         </div>
-        <div data-bind="visible: $root.remoteAttachmentsDisabled" class="bg-warning margin-top-xxs padding padding-sm">
+        <div data-bind="visible: $root.isRemoteAttachmentsDisabled" class="bg-warning margin-top-xxs padding padding-sm">
             <i class="icon-warning margin-right-xxs"></i><small class="mb-0">Remote attachments feature is
             disabled</small></div>
     </div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25786
https://issues.hibernatingrhinos.com/issue/RavenDB-25686

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
