### PR TITLE
RavenDB-25783 Fix concurrency use and test assertion

### DIFF
--- a/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidator.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidator.cs
@@ -15,7 +15,7 @@ public class ElementSchemaRuleValidator
     private readonly string[] _publicTypesRestriction;
     protected readonly SchemaPath SchemaPath;
     
-    public BlittableJsonReaderObject SchemaDefinition { get; init; }
+    public string SchemaDefinition { get; init; }
 
     // ReSharper disable once ConvertToPrimaryConstructor
     public ElementSchemaRuleValidator(Type[] typesRestriction, ISchemaRuleValidator[] ruleValidators, SchemaPath schemaPath)

--- a/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidatorFactory.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/Validators/ElementSchemaRuleValidatorFactory.cs
@@ -10,7 +10,7 @@ public static class ElementSchemaRuleValidatorFactory
     public static ElementSchemaRuleValidator CreateElementSchemaRuleValidator(SchemaBuilderContext context, BlittableJsonReaderObject schemaDefinition, SchemaPath schemaPath)
     {
         return TryReadSchema(context, schemaDefinition, schemaPath, out Type[] typesRestriction, out ISchemaRuleValidator[] ruleValidators)
-            ? new ElementSchemaRuleValidator(typesRestriction, ruleValidators, schemaPath) {SchemaDefinition = schemaDefinition} : 
+            ? new ElementSchemaRuleValidator(typesRestriction, ruleValidators, schemaPath) {SchemaDefinition = schemaDefinition.ToString()} : 
             null;
     }
     

--- a/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
+++ b/test/SlowTests/SchemaValidation/SchemaValidationFeaturesTests.cs
@@ -385,8 +385,7 @@ public class SchemaValidationFeaturesTests : ReplicationTestBase
             }
 
             var replicationFailureInfo = await sink.Maintenance.SendAsync(new GetReplicationOutgoingsFailureInfoOperation(nodeTag: server.ServerStore.NodeTag));
-            var info = replicationFailureInfo.Stats.Single();
-            Assert.True(info.Key is PullReplicationAsSink);
+            Assert.Contains(replicationFailureInfo.Stats.Select(x => x.Key.GetType()), x => x == typeof(PullReplicationAsSink));
         }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25783

### Additional description
Serialize blittable in validator creation time.
Fix the assert in the test

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
