### PR TITLE
RavenDB-25691 - Remote attachments -  Exception when opening a document in sharding database

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1362,14 +1362,18 @@ class editDocument extends shardViewModelBase {
     }
 
     private loadRemoteAttachmentsConfiguration() {
-        new getRemoteAttachmentsConfigurationCommand(this.db)
-            .execute()
-            .done((remoteAttachmentsConfiguration: RemoteAttachmentsConfiguration) => {
-                this.remoteAttachmentsDisabled(!!remoteAttachmentsConfiguration.Disabled);
-            })
-            .fail(() => {
-                this.remoteAttachmentsDisabled(false);
-            });
+        if (!this.db.isSharded()) {
+            new getRemoteAttachmentsConfigurationCommand(this.db)
+                .execute()
+                .done((remoteAttachmentsConfiguration: RemoteAttachmentsConfiguration) => {
+                    this.remoteAttachmentsDisabled(!!remoteAttachmentsConfiguration.Disabled);
+                })
+                .fail(() => {
+                    this.remoteAttachmentsDisabled(false);
+                });
+        } else {
+            this.remoteAttachmentsDisabled(false);
+        }
     }
 
     async enterCompareModeAndCompareWithPrevious(): Promise<void> {

--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -561,7 +561,7 @@
 
                 <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown"
                         aria-haspopup="true"
-                        data-bind="disable: spinners.upload"
+                        data-bind="disable: spinners.upload, visible: !$root.db.isSharded()"
                         aria-expanded="false"
                 >
                     <span class="caret"></span>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25691

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
