### PR TITLE
RavenDB-25704 fixed issue with not configuring the message handler when RavenServerHttpClientFactory is used

### DIFF
--- a/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
+++ b/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
@@ -146,7 +146,7 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
     }
 
 #if NETCOREAPP3_1_OR_GREATER
-    internal static void ConfigureHttpMessageHandler(SocketsHttpHandler httpMessageHandler, X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null)
+    internal static void ConfigureHttpMessageHandler(SocketsHttpHandler httpMessageHandler, X509Certificate2 certificate, bool setSslProtocols, bool useCompression, bool hasExplicitlySetCompressionUsage = false, TimeSpan? pooledConnectionLifetime = null, TimeSpan? pooledConnectionIdleTimeout = null, Action<HttpMessageHandler> configureHttpMessageHandler = null)
     {
         httpMessageHandler.MaxConnectionsPerServer = RequestExecutor.DefaultConnectionLimit;
 
@@ -176,6 +176,8 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
 
             ValidateClientKeyUsages(certificate);
         }
+        
+        configureHttpMessageHandler?.Invoke(httpMessageHandler);
     }
 #endif
 

--- a/src/Raven.Server/Utils/RavenServerHttpClientFactory.cs
+++ b/src/Raven.Server/Utils/RavenServerHttpClientFactory.cs
@@ -82,7 +82,7 @@ internal class RavenServerHttpClientFactory : IRavenHttpClientFactory
             {
                 var h = (SocketsHttpHandler)builder.PrimaryHandler;
 
-                DefaultRavenHttpClientFactory.ConfigureHttpMessageHandler(h, key.Certificate, setSslProtocols: true, key.UseHttpDecompression, key.HasExplicitlySetDecompressionUsage, key.PooledConnectionLifetime, key.PooledConnectionIdleTimeout);
+                DefaultRavenHttpClientFactory.ConfigureHttpMessageHandler(h, key.Certificate, setSslProtocols: true, key.UseHttpDecompression, key.HasExplicitlySetDecompressionUsage, key.PooledConnectionLifetime, key.PooledConnectionIdleTimeout, key.ConfigureHttpMessageHandler);
             });
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25704

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
