### PR TITLE
RavenDB-25704 fixed invalid cast exception, we can get now both HttpClientHandler and SocketsHttpHandler depending on the HttpClientFactory used

### DIFF
--- a/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
+++ b/src/Raven.Client/Http/DefaultRavenHttpClientFactory.cs
@@ -221,4 +221,21 @@ internal sealed class DefaultRavenHttpClientFactory : IRavenHttpClientFactory
 
         public readonly DateTime CreatedAt;
     }
+
+#if NETCOREAPP3_1_OR_GREATER
+    internal static void AttachServerCertificateCustomValidationCallback(HttpMessageHandler httpMessageHandler, Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> serverCertificateCustomValidationCallback)
+    {
+        switch (httpMessageHandler)
+        {
+            case HttpClientHandler httpClientHandler:
+                httpClientHandler.ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback;
+                return;
+            case SocketsHttpHandler socketsHttpHandler:
+                socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => serverCertificateCustomValidationCallback(sender, certificate, chain, errors);
+                return;
+            default:
+                throw new NotSupportedException($"HttpMessageHandler type {httpMessageHandler.GetType()} is not supported.");
+        }
+    }
+#endif
 }

--- a/src/Raven.Server/ServerWide/ShardingStore.cs
+++ b/src/Raven.Server/ServerWide/ShardingStore.cs
@@ -97,8 +97,7 @@ namespace Raven.Server.ServerWide
         
         private void ConfigureHttpMessageHandlerForShard(HttpMessageHandler h)
         {
-            var handler = (HttpClientHandler)h;
-            handler.ServerCertificateCustomValidationCallback = ShardingCustomValidationCallback;
+            DefaultRavenHttpClientFactory.AttachServerCertificateCustomValidationCallback(h, ShardingCustomValidationCallback);
         }
 
         public DocumentConventions DocumentConventionsForOrchestrator => DocumentConventionsForShard;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25704

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
