### PR TITLE
RavenDB-25791 don't stringify the response

### DIFF
--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -310,7 +310,7 @@ internal class ChatCompletionClient : IDisposable
             Message = streamingContext.ReadObject(new DynamicJsonValue
             {
                 [Constants.ResponseFields.Role] = Constants.RequestFields.RoleAssistantValue,
-                [Constants.ResponseFields.Content] = message!.ToString(),
+                [Constants.ResponseFields.Content] = message,
             }, "persisted/streamed/message"),
             Result = message,
         };
@@ -351,6 +351,7 @@ internal class ChatCompletionClient : IDisposable
         }
 
         var result = responseParser.GetContent(context);
+
         return new AiResponse(AiResponseType.Result) { Result = result, Message = responseParser.Message };
     }
 
@@ -384,7 +385,6 @@ internal class ChatCompletionClient : IDisposable
 
             if (responseContent.TryGet(Constants.ResponseFields.Usage, out BlittableJsonReaderObject usageJson) == false)
                 throw UnexpectedResponseException.Create(message: "No usage in response content", response, responseContent);
-
             usage.UpdateFrom(usageJson);
         }
 
@@ -422,7 +422,11 @@ internal class ChatCompletionClient : IDisposable
                 RefusedToAnswerException.Throw(refusal, responseContent.ToString(), finishReason, GetRequestId(response.Headers));
             }
 
-            return context.Sync.ReadForMemory(content, "ai/output");
+            var result = context.Sync.ReadForMemory(content, "ai/output");
+            Message.Modifications ??= new DynamicJsonValue(Message);
+            Message.Modifications[Constants.ResponseFields.Content] = result;
+
+            return result;
         }
     }
 
@@ -1062,6 +1066,21 @@ public static class ChatCompletionClientExtensions
     {
         foreach (var message in messages)
         {
+            if (message.TryGet(ChatCompletionClient.Constants.RequestFields.Content, out object content))
+            {
+                // we need to stringify the content before sending to the model
+                if (content is BlittableJsonReaderObject blittableJson)
+                {
+                    // clone once, not to change the original, since we are going to persist it
+                    var msg = message.CloneOnTheSameContext();
+                    var modifications = msg.Modifications ??= new DynamicJsonValue(msg);
+                    modifications[ChatCompletionClient.Constants.RequestFields.Content] = blittableJson.ToString();
+                    // clone twice, so the changes will take effect
+                    yield return msg.CloneOnTheSameContext();
+                    continue;
+                }
+            }
+
             yield return message;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25791

### Additional description

We want to store the content response from the model as json and not string.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
We still able to work with the old format, when sending to the model we check if the content is string or not.
- [x] Breaking change
On the client side, if some one loading the conversation, it might be a breaking change for him
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
The `Continue Conversation` is broken (need to check the test conversation as well)
- [ ] No UI work is needed
