### PR TITLE
RavenDB-25795 / RavenDB-25780 Fixing slices lifecycle for table schemas in remote attachment upgrade

### DIFF
--- a/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/72000/From62000.cs
@@ -32,6 +32,20 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
         private static readonly int _oldSchemaSize = 7;
 
         internal static int NumberOfAttachmentsToMigrateInSingleTransaction = PlatformDetails.Is32Bits ? 2048 : 32768;
+        
+        private static readonly Slice AttachmentsEtagSlice;
+        private static readonly Slice AttachmentsHashSlice;
+        private static readonly Slice AttachmentsFlagAndHashSlice;
+
+        static From62000()
+        {
+            using (StorageEnvironment.GetStaticContext(out var ctx))
+            {
+                Slice.From(ctx, AttachmentsEtag, ByteStringType.Immutable, out AttachmentsEtagSlice);
+                Slice.From(ctx, AttachmentsHash, ByteStringType.Immutable, out AttachmentsHashSlice);
+                Slice.From(ctx, AttachmentsFlagAndHash, ByteStringType.Immutable, out AttachmentsFlagAndHashSlice);
+            }
+        }
 
         /*
          *  We are only updating the attachments table, so we can add missing fields in the table, and correctly populate the dynamic index.
@@ -39,16 +53,11 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
          */
         public bool Update(UpdateStep step)
         {
-            using var e = step.AllocateDocumentsOperationContext(out DocumentsOperationContext ctx);
-            using var g = Slice.From(ctx.Allocator, AttachmentsEtag, out var attachmentsEtagSlice);
-            using var o = Slice.From(ctx.Allocator, AttachmentsHash, out var attachmentsHashSlice);
-            using var r = Slice.From(ctx.Allocator, AttachmentsFlagAndHash, out var attachmentsFlagAndHashSlice);
-
             var isSharded = step.DocumentsStorage is ShardedDocumentsStorage;
-            step.WriteTx.CreateTree(attachmentsFlagAndHashSlice, isIndexTree: true);
-
+            step.WriteTx.CreateTree(AttachmentsFlagAndHashSlice, isIndexTree: true);
+            
             TableSchema attachmentsSchemaBase = new TableSchema();
-
+            
             attachmentsSchemaBase.DefineKey(new TableSchema.IndexDef
             {
                 StartIndex = (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType,
@@ -57,20 +66,20 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             attachmentsSchemaBase.DefineFixedSizeIndex(new TableSchema.FixedSizeKeyIndexDef
             {
                 StartIndex = (int)AttachmentsTable.Etag,
-                Name = attachmentsEtagSlice
+                Name = AttachmentsEtagSlice
             });
             attachmentsSchemaBase.DefineIndex(new TableSchema.IndexDef
             {
                 StartIndex = (int)AttachmentsTable.Hash,
                 Count = 1,
-                Name = attachmentsHashSlice
+                Name = AttachmentsHashSlice
             });
 
             var dynamicIndex = new TableSchema.DynamicKeyIndexDef
             {
                 GenerateKey = GenerateFlagAndHashForAttachments,
                 IsGlobal = true,
-                Name = attachmentsFlagAndHashSlice,
+                Name = AttachmentsFlagAndHashSlice,
                 SupportDuplicateKeys = true
             };
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25795 

### Additional description

This got revealed by PR #22086. Setting `DoNotReuse = true` caused the slices used for table schema index names to be disposed immediately, making them unavailable during the transaction commit phase.

Previously, this lifecycle issue was masked because the slices often remained valid in the memory pool long enough to complete the commit. However, relying on the pool retention was unsafe, and this change ensures the slices persist correctly throughout the transaction.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
