### PR TITLE
RavenDB-25644 Fixed all in query with empty list

### DIFF
--- a/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.In.cs
+++ b/src/Corax/Querying/MultiTermMatches/IndexSearcher.MultiTermMatches.In.cs
@@ -116,9 +116,11 @@ public partial class IndexSearcher
         var canUseUnaryMatch = field.HasBoost == false;
         var terms = _fieldsTree?.CompactTreeFor(field.FieldName);
 
-        if (terms == null)
+        if (terms == null || allInTerms.Count == 0)
         {
-            // If either the term or the field does not exist the request will be empty. 
+            // The request will be empty if either
+            // - The term or the field does not exist
+            // - List of terms given in query is empty
             return MultiTermMatch.CreateEmpty(_transaction.Allocator);
         }
 

--- a/test/SlowTests/Issues/RavenDB-25644.cs
+++ b/test/SlowTests/Issues/RavenDB-25644.cs
@@ -65,6 +65,7 @@ public class RavenDB_25644 : RavenTestBase
                 
                 var result = session.Advanced.RawQuery<Candidate>(query)
                     .AddParameter("frameworks", frameworks)
+                    .WaitForNonStaleResults()
                     .ToList();
                 
                 Assert.Equal(0, result.Count);

--- a/test/SlowTests/Issues/RavenDB-25644.cs
+++ b/test/SlowTests/Issues/RavenDB-25644.cs
@@ -1,0 +1,80 @@
+﻿using FastTests;
+using Tests.Infrastructure;
+using Xunit.Abstractions;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25644 : RavenTestBase
+{
+    public RavenDB_25644(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void AllInWithEmptyListShouldNotMatchAnything(Options options)
+    {
+        const string query = """
+                              from Candidates as c
+                              where c.frameworks all in ($frameworks)
+                              """;
+        
+        string[] frameworks = [];
+
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                var candidate1 = new Candidate()
+                {
+                    Frameworks = [],
+                    Languages = []
+                };
+
+                var candidate2 = new Candidate()
+                {
+                    Frameworks = [],
+                    Languages = ["C#"]
+                };
+
+                var candidate3 = new Candidate()
+                {
+                    Frameworks = ["React"],
+                    Languages = ["C#", "Java"]
+                };
+                
+                 var candidate4 = new Candidate()
+                 {
+                     Frameworks = ["React", "Django"],
+                     Languages = []
+                 };
+                 
+                 var candidate5 = new Candidate()
+                 {
+                     Frameworks = ["React", "Django"], 
+                     Languages = ["C#", "Java"]
+                 };
+                
+                session.Store(candidate1);
+                session.Store(candidate2);
+                session.Store(candidate3);
+                session.Store(candidate4);
+                session.Store(candidate5);
+                session.SaveChanges();
+                
+                var result = session.Advanced.RawQuery<Candidate>(query)
+                    .AddParameter("frameworks", frameworks)
+                    .ToList();
+                
+                Assert.Equal(0, result.Count);
+            }
+        }
+    }
+
+    private class Candidate
+    {
+        public string[] Frameworks { get; set; }
+        public string[] Languages { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25644/Corax-Index-was-outside-the-bounds-of-the-array.

### Additional description

We want to return empty match for all in query that has empty list as a parameter

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
