### PR TITLE
RavenDB-25342 Add 1EKU support to rvn put-client-certificate

### DIFF
--- a/tools/rvn/CommandLineApp.cs
+++ b/tools/rvn/CommandLineApp.cs
@@ -8,7 +8,10 @@ using McMaster.Extensions.CommandLineUtils;
 using Newtonsoft.Json;
 using Raven.Client.Documents;
 using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Client.Util;
 using Raven.Server.Commercial;
+using Raven.Server.ServerWide;
+using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Platform;
 using Voron.Global;
@@ -340,11 +343,15 @@ namespace rvn
 
                     
                     X509Certificate2 clientCertificate = new(clientCertificatePathArg.Value);
-                    X509Certificate2 serverCertificate = new(serverCertificatePathArg.Value);
+                    var serverCertForCommunication = CertificateLoaderUtil.CreateCertificate(serverCertificatePathArg.Value, null, CertificateLoaderUtil.FlagsForExport);
+                    if (SecretProtection.HasCertificateClientAuthEnhancedKeyUsage(serverCertForCommunication) == false)
+                    {
+                        serverCertForCommunication = CertificateUtils.CreateClientCertificateFromServerCertificate(serverCertForCommunication, out _);
+                    }
                     var name = Path.GetFileNameWithoutExtension(clientCertificatePathArg.Value);
                     try
                     {
-                        DocumentStore store = new() {Certificate = serverCertificate, Urls = new[] {ravenServerUrlArg.Value}};
+                        DocumentStore store = new() {Certificate = serverCertForCommunication, Urls = new[] {ravenServerUrlArg.Value}};
                         store.Initialize();
                         var operation = new PutClientCertificateOperation(name, clientCertificate, new Dictionary<string,DatabaseAccess>(), SecurityClearance.ClusterAdmin);
                         store.Maintenance.Server.Send(operation);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25342 

### Additional description

Use correct certificate when communicating with server in `rvn` `put-client-certificate` command.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
