### PR TITLE
RavenDB-25817 Highlighting: added support for In() method in Corax

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -174,6 +174,11 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                                 for (int i = 0; i < as1.Length; i++)
                                     nls[i] = as1[i].TrimEnd('*').TrimStart('*');
                                 break;
+                            case List<(string Term, bool Exact)> termsWithExact: // In query
+                                nls = new string[termsWithExact.Count];
+                                for (int i = 0; i < termsWithExact.Count; i++)
+                                    nls[i] = termsWithExact[i].Term.TrimEnd('*').TrimStart('*');
+                                break;
                             case null:
                                 continue;
                             default:

--- a/test/SlowTests/Issues/RavenDB-25817.cs
+++ b/test/SlowTests/Issues/RavenDB-25817.cs
@@ -1,0 +1,61 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25817(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Highlighting)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanUseHighlightingWithInMethod(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        var doc = new Document { Category = "cat1", Content = "test" };
+        new Index().Execute(store);
+        session.Store(doc);
+        session.SaveChanges();
+        Indexes.WaitForIndexing(store);
+        var categoryIds = new[] { "cat1", "cat2" };
+
+            
+        var results =  session
+            .Query<Document, Index>()
+            .Where(x => x.Category.In(categoryIds))     // ✗ In() operator
+            .Search(x => x.Content, "test")
+            .Highlight(x => x.Content, 128, 1, out var highlights)
+            .ToList();
+        Assert.NotEmpty(results);
+
+        var fragment = highlights.GetFragments(doc.Id);
+        Assert.Single(fragment);
+        Assert.Equal("<b style=\"background:yellow\">test</b>", fragment[0]);
+    }
+
+    private class Index : AbstractIndexCreationTask<Document>
+    {
+        public Index()
+        {
+            Map = documents => from doc in documents
+                select new { doc.Category, doc.Content };
+
+            Store(x => x.Content, FieldStorage.Yes);
+            Index(x => x.Content, FieldIndexing.Search);
+            TermVector(x => x.Content, FieldTermVector.WithPositionsAndOffsets);
+
+        }
+    }
+    
+    private class Document
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public string Content { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25817

### Additional description

Highlighting: added support for In() method in Corax

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
