### PR TITLE
RavenDB-25818 - Snapshot restore with `SkipIndexes` set to `true` shouldn't restore the indexes folder

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -260,7 +260,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     continue;
                 }
 
-                if (RestoreConfiguration.SkipIndexes && zipEntries.Key.StartsWith("Indexes"))
+                if (RestoreConfiguration.SkipIndexes && zipEntries.Key.StartsWith(Constants.Documents.PeriodicBackup.Folders.Indexes))
                 {
                     // the indexes folder isn't needed when skipping indexes
                     continue;

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -260,6 +260,12 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     continue;
                 }
 
+                if (RestoreConfiguration.SkipIndexes && zipEntries.Key.StartsWith("Indexes"))
+                {
+                    // the indexes folder isn't needed when skipping indexes
+                    continue;
+                }
+
                 var restoreDirectory = directory.StartsWith(Constants.Documents.PeriodicBackup.Folders.Documents, StringComparison.OrdinalIgnoreCase)
                     ? restorePath
                     : restorePath.Combine(directory);

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -603,13 +603,35 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                 config.SnapshotSettings = new SnapshotSettings { CompressionLevel = CompressionLevel.Fastest, ExcludeIndexes = false };
                 await Backup.UpdateConfigAndRunBackupAsync(Server, config, store);
 
-                // check that backup file consist Indexes folder
                 var backupLocation = Directory.GetDirectories(backupPath).First();
                 using (ReadOnly(backupLocation))
                 {
+                    // check that backup file consist Indexes folder
                     var backupFile = Directory.GetFiles(backupLocation).First();
                     using (ZipArchive archive = ZipFile.OpenRead(backupFile))
                         Assert.True(archive.Entries.Any(entry => entry.FullName.Contains("Indexes")));
+
+                    using (Backup.RestoreDatabase(store, new RestoreBackupConfiguration
+                           {
+                               BackupLocation = backupLocation,
+                               DatabaseName = restoredDatabaseName,
+                               SkipIndexes = true
+                           }))
+                    {
+                        var database = await GetDatabase(restoredDatabaseName);
+                        var pathToIndexes = database.Configuration.Indexing.StoragePath;
+                        Assert.Equal(0, Directory.GetDirectories(pathToIndexes.FullPath).Length);
+
+                        using (var session = store.OpenAsyncSession(restoredDatabaseName))
+                        {
+                            var users = await session.LoadAsync<User>(new[] { "users/1", "users/2" });
+                            Assert.NotNull(users["users/1"]);
+                            Assert.NotNull(users["users/2"]);
+                            Assert.True(users.Any(x => x.Value.Name == "Lev1"));
+                            Assert.True(users.Any(x => x.Value.Name == "Lev2"));
+                        }
+                    }
+                    
                 }
 
                 Directory.Delete(backupLocation, true);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25818/Snapshot-restore-without-the-indexes-restores-the-indexes-folder

### Additional description

When restoring a snapshot with `SkipIndexes` set to `true`, we currently skip restoring the indexes to the database record but continue to copy them to the `Indexes` folder. Here we updated to skip the copy step as well.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
