### PR TITLE
RavenDB-25542: QueryParser: Fixed case-insensitive for timeseries keyword.

### DIFF
--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -718,7 +718,7 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
                 QueryExpression expr;
                 if (Field(out var field))
                 {
-                    if (field.FieldValue == TimeSeries)
+                    if (string.Equals(field.FieldValue, TimeSeries, StringComparison.OrdinalIgnoreCase))
                     {
                         expr = GetTimeSeriesExpression(query);
                     }

--- a/test/SlowTests.Issues/Issues/RavenDB-25542.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25542.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using FastTests;
+using Raven.Client.Documents.Queries.TimeSeries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25542(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.TimeSeries | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanParseTimeSeriesKeywordInAnyCase(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var id = "units/1";
+            var baseline = RavenTestHelper.UtcToday;
+            var end = baseline.AddHours(1);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Unit { Id = id });
+
+                var powerTs = session.TimeSeriesFor(id, "Power");
+                var waterTs = session.TimeSeriesFor(id, "Water");
+                powerTs.Append(baseline.AddMinutes(1), 100);
+                waterTs.Append(baseline.AddMinutes(2), 200);
+                session.SaveChanges();
+                WaitForUserToContinueTheTest(store);
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var baseTestQuery = @"
+from Units
+where id() = $id
+select
+timeSeries(
+    from 'Power' between $start and $end group by '1 hours'
+    select sum()
+) as Power,
+timeSeries(
+    from 'Water' between $start and $end group by '1 hours'
+    select sum()
+) as Water
+";
+          
+                
+                var query = session.Advanced.RawQuery<TimeSeriesResult>(baseTestQuery.Replace("timeSeries", "timeseries"))
+                    .WaitForNonStaleResults()
+                    .AddParameter("id", id)
+                    .AddParameter("start", baseline)
+                    .AddParameter("end", end);
+
+                AssertResult(query.Single());
+
+                query = session.Advanced.RawQuery<TimeSeriesResult>(baseTestQuery)
+                    .AddParameter("id", id)
+                    .AddParameter("start", baseline)
+                    .AddParameter("end", end);
+                
+                AssertResult(query.Single());
+            }
+        }
+    }
+
+    private static void AssertResult(TimeSeriesResult result)
+    {
+        Assert.NotNull(result.Power);
+        Assert.NotNull(result.Water);
+
+        Assert.Equal(1, result.Power.Results.Length);
+        Assert.Equal(100, result.Power.Results[0].Sum[0]);
+
+        Assert.Equal(1, result.Water.Results.Length);
+        Assert.Equal(200, result.Water.Results[0].Sum[0]);
+    }
+
+    private class Unit
+    {
+        public string Id { get; set; }
+    }
+
+    private class TimeSeriesResult
+    {
+        public TimeSeriesAggregationResult Power { get; set; }
+        public TimeSeriesAggregationResult Water { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25542
### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
