### PR TITLE
RavenDB-22347 Fix dictionary patching with variable keys and special characters

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -253,7 +253,8 @@ namespace Raven.Client.Documents.Session
                 case nameof(JavaScriptDictionary<TKey, TValue>.Add):
                     object value;
                     (key, value) = GetKeyAndValue<TKey, TValue>(call);
-                    patchRequest.Script = $"this.{pathScript}.{key} = args.val_{_valsCount};";
+                    var formattedKey = FormatKeyForJavaScript(key);
+                    patchRequest.Script = $"this.{pathScript}[{formattedKey}] = args.val_{_valsCount};";
                     if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
                     {
                         value = Convert.ToInt32(value);
@@ -263,7 +264,8 @@ namespace Raven.Client.Documents.Session
                     break;
                 case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
                     key = GetKey(call);
-                    patchRequest.Script = $"delete this.{pathScript}.{key};";
+                    formattedKey = FormatKeyForJavaScript(key);
+                    patchRequest.Script = $"delete this.{pathScript}[{formattedKey}];";
                     break;
                 default:
                     throw new InvalidOperationException("Unsupported method: " + call.Method.Name);
@@ -400,6 +402,14 @@ namespace Raven.Client.Documents.Session
         private static void ThrowUnsupportedExpression(Expression expression)
         {
             throw new InvalidOperationException("Unsupported expression: " + expression);
+        }
+
+        private static string FormatKeyForJavaScript(object key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key), "Dictionary key cannot be null");
+
+            return $"\"{JavascriptConversionExtensions.EscapeForJsString(key.ToString())}\"";
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -310,6 +310,7 @@ namespace Raven.Client.Documents.Session
                     JavascriptConversionExtensions.LinqMethodsSupport.Instance,
                     JavascriptConversionExtensions.NullableSupport.Instance,
                     JavascriptConversionExtensions.PatchDictionaryEnumSupport.Instance,
+                    JavascriptConversionExtensions.PatchPathWrappedConstantSupport.Instance,
                 ])
             {
                 CustomMetadataProvider = new PropertyNameConventionJSMetadataProvider(RequestExecutor.Conventions)

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2878,19 +2878,72 @@ namespace Raven.Client.Util
                 return flags;
             }
 
-            private static string EscapeForJsString(string pattern)
-            {
-                if (pattern == null)
-                    return string.Empty;
+        }
 
-                return pattern
-                    .Replace("\\", "\\\\")        // Must be first!
-                    .Replace("\"", "\\\"")        // Escape quotes
-                    .Replace("\r", "\\r")         // Escape CR
-                    .Replace("\n", "\\n")         // Escape LF
-                    .Replace("\u2028", "\\u2028") // CRITICAL: Escape Line Separator
-                    .Replace("\u2029", "\\u2029") // CRITICAL: Escape Paragraph Separator
-                    .Replace("\t", "\\t");        // Optional: nice for debugging readablity
+        internal static string EscapeForJsString(string value)
+        {
+            if (value == null)
+                return string.Empty;
+
+            return value
+                .Replace("\\", "\\\\")        // Must be first!
+                .Replace("\"", "\\\"")        // Escape quotes
+                .Replace("\r", "\\r")         // Escape CR
+                .Replace("\n", "\\n")         // Escape LF
+                .Replace("\u2028", "\\u2028") // CRITICAL: Escape Line Separator
+                .Replace("\u2029", "\\u2029") // CRITICAL: Escape Paragraph Separator
+                .Replace("\t", "\\t");        // Optional: nice for debugging readability
+        }
+
+        internal sealed class PatchPathWrappedConstantSupport : JavascriptConversionExtension
+        {
+            public static readonly PatchPathWrappedConstantSupport Instance = new PatchPathWrappedConstantSupport();
+
+            private PatchPathWrappedConstantSupport()
+            {
+            }
+
+            public override void ConvertToJavascript(JavascriptConversionContext context)
+            {
+                if (context.Node is not MemberExpression memberExpression ||
+                    IsWrappedConstantExpression(memberExpression) == false)
+                    return;
+
+                LinqPathProvider.GetValueFromExpressionWithoutConversion(memberExpression, out var value);
+                var writer = context.GetWriter();
+                context.PreventDefault();
+
+                using (writer.Operation(JavascriptOperationTypes.Literal))
+                {
+                    if (value == null)
+                    {
+                        writer.Write("null");
+                        return;
+                    }
+
+                    // For string values, write them as quoted strings
+                    if (value is string stringValue)
+                    {
+                        writer.Write("\"");
+                        writer.Write(EscapeForJsString(stringValue));
+                        writer.Write("\"");
+                        return;
+                    }
+
+                    // For numeric values, write them directly
+                    if (value is int || value is long || value is short || value is byte ||
+                        value is uint || value is ulong || value is ushort || value is sbyte ||
+                        value is float || value is double || value is decimal)
+                    {
+                        writer.Write(value.ToInvariantString());
+                        return;
+                    }
+
+                    // For any other type, convert to string and quote it
+                    writer.Write("\"");
+                    writer.Write(EscapeForJsString(value.ToString()));
+                    writer.Write("\"");
+                }
             }
         }
 

--- a/test/FastTests/Issues/RavenDB-22347.cs
+++ b/test/FastTests/Issues/RavenDB-22347.cs
@@ -1,0 +1,220 @@
+using System.Collections.Generic;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_22347 : RavenTestBase
+    {
+        public RavenDB_22347(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryValueWithIndexerAndKeyFromObjectProperty()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var obj = new { Key = "Key1" };
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[obj.Key], "UpdatedValue");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet("Key1", out string value));
+                Assert.Equal("UpdatedValue", value);
+                Assert.True(values.TryGet("Key2", out value));
+                Assert.Equal("Value2", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryValueWithIndexerAndKeyFromVariable()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var key = "Key1";
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[key], "UpdatedValue");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet("Key1", out string value));
+                Assert.Equal("UpdatedValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithAdderAndKeyFromObjectProperty()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var keyHolder = new KeyHolder { Key = "Key3" };
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyHolder.Key, "Value3"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(3, values.Count);
+
+                Assert.True(values.TryGet("Key3", out string value));
+                Assert.Equal("Value3", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanRemoveDictionaryKeyWithAdderAndKeyFromObjectProperty()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" },
+                        { "Key3", "Value3" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var keyHolder = new KeyHolder { Key = "Key2" };
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(keyHolder.Key));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet("Key1", out string _));
+                Assert.True(values.TryGet("Key3", out string _));
+                Assert.False(values.TryGet("Key2", out string _));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithKeyContainingSpecialCharacters()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var specialKeys = new[] { "key-with-dash", "key with space", "key.with", "key\"with\"quotes" };
+
+            foreach (var key in specialKeys)
+            {
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<Document>("docs/1");
+                    session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, $"Value for {key}"));
+                    session.SaveChanges();
+                }
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(5, values.Count);
+
+                foreach (var key in specialKeys)
+                {
+                    Assert.True(values.TryGet(key, out string value), $"Key '{key}' should exist");
+                    Assert.Equal($"Value for {key}", value);
+                }
+            }
+        }
+
+        private class Document
+        {
+            public Dictionary<string, string> Values { get; set; }
+        }
+
+        private class KeyHolder
+        {
+            public string Key { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Use bracket notation instead of dot notation for dictionary access in patches to support keys with special characters (dashes, spaces, dots)
- Add `PatchPathWrappedConstantSupport` to handle dictionary keys from variables or object properties

## Test plan
- [x] Added tests in `RavenDB-22347.cs` covering:
  - Dictionary patching with key from object property
  - Dictionary patching with key from variable
  - Dictionary Add with key from object property
  - Dictionary Remove with key from object property
  - Dictionary keys with special characters (dashes, spaces, dots)