### PR TITLE
RavenDB-25819 - Allow to set the database ID through the Admin JS console

### DIFF
--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -495,7 +495,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
-            var dbId = metadataTree.Read(StorageEnvironment.MetadataDbId);
+            var dbId = metadataTree.Read(Constants.MetadataDbId);
             if (dbId == null)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -495,7 +495,7 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
 
             Debug.Assert(metadataTree != null);
             // ReSharper disable once PossibleNullReferenceException
-            var dbId = metadataTree.Read("db-id");
+            var dbId = metadataTree.Read(StorageEnvironment.MetadataDbId);
             if (dbId == null)
                 VoronUnrecoverableErrorException.Raise(step.WriteTx.LowLevelTransaction,
                     "Could not find db id in metadata tree, possible mismatch / corruption?");

--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -95,6 +95,8 @@ namespace Voron.Global
         public const string DatabaseFilename = "Raven.voron";
         public static readonly Slice DatabaseFilenameSlice;
 
+        public const string MetadataDbId = "db-id";
+
         static Constants()
         {
             using (StorageEnvironment.GetStaticContext(out var ctx))

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -47,8 +47,6 @@ namespace Voron
 
     public sealed class StorageEnvironment : IDisposable
     {
-        public const string MetadataDbId = "db-id";
-
         internal sealed class IndirectReference
         {
             public StorageEnvironment Owner;
@@ -321,7 +319,7 @@ namespace Voron
 
                 Debug.Assert(metadataTree != null);
                 // ReSharper disable once PossibleNullReferenceException
-                var dbId = metadataTree.Read(MetadataDbId);
+                var dbId = metadataTree.Read(Constants.MetadataDbId);
                 if (dbId == null)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "Could not find db id in metadata tree, possible mismatch / corruption?");
@@ -341,7 +339,7 @@ namespace Voron
                 if (_options.GenerateNewDatabaseId)
                 {
                     // save the new database id
-                    metadataTree?.Add(MetadataDbId, DbId.ToByteArray());
+                    metadataTree?.Add(Constants.MetadataDbId, DbId.ToByteArray());
                 }
 
                 tx.Commit();
@@ -459,7 +457,7 @@ namespace Voron
                     FillBase64Id(Guid.NewGuid());
 
                     var metadataTree = treesTx.CreateTree(Constants.MetadataTreeNameSlice);
-                    metadataTree.Add(MetadataDbId, DbId.ToByteArray());
+                    metadataTree.Add(Constants.MetadataDbId, DbId.ToByteArray());
                     metadataTree.Add("schema-version", EndianBitConverter.Little.GetBytes(Options.SchemaVersion));
 
                     treesTx.PrepareForCommit();
@@ -484,7 +482,7 @@ namespace Voron
                     FillBase64Id(databaseIdGuid);
 
                     var metadataTree = treesTx.CreateTree(Constants.MetadataTreeNameSlice);
-                    metadataTree.Add(MetadataDbId, databaseIdGuid.ToByteArray());
+                    metadataTree.Add(Constants.MetadataDbId, databaseIdGuid.ToByteArray());
 
                     treesTx.PrepareForCommit();
 

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -47,6 +47,8 @@ namespace Voron
 
     public sealed class StorageEnvironment : IDisposable
     {
+        public const string MetadataDbId = "db-id";
+
         internal sealed class IndirectReference
         {
             public StorageEnvironment Owner;
@@ -319,7 +321,7 @@ namespace Voron
 
                 Debug.Assert(metadataTree != null);
                 // ReSharper disable once PossibleNullReferenceException
-                var dbId = metadataTree.Read("db-id");
+                var dbId = metadataTree.Read(MetadataDbId);
                 if (dbId == null)
                     VoronUnrecoverableErrorException.Raise(tx,
                         "Could not find db id in metadata tree, possible mismatch / corruption?");
@@ -339,7 +341,7 @@ namespace Voron
                 if (_options.GenerateNewDatabaseId)
                 {
                     // save the new database id
-                    metadataTree?.Add("db-id", DbId.ToByteArray());
+                    metadataTree?.Add(MetadataDbId, DbId.ToByteArray());
                 }
 
                 tx.Commit();
@@ -457,7 +459,7 @@ namespace Voron
                     FillBase64Id(Guid.NewGuid());
 
                     var metadataTree = treesTx.CreateTree(Constants.MetadataTreeNameSlice);
-                    metadataTree.Add("db-id", DbId.ToByteArray());
+                    metadataTree.Add(MetadataDbId, DbId.ToByteArray());
                     metadataTree.Add("schema-version", EndianBitConverter.Little.GetBytes(Options.SchemaVersion));
 
                     treesTx.PrepareForCommit();
@@ -467,6 +469,28 @@ namespace Voron
             }
 
             Options.AfterDatabaseCreation?.Invoke(this);
+        }
+
+        public void SetDatabaseId(string databaseId)
+        {
+            if (Guid.TryParse(databaseId, out var databaseIdGuid) == false)
+                throw new InvalidOperationException($"Failed to parse the database id '{databaseIdGuid}'");
+
+            var transactionPersistentContext = new TransactionPersistentContext();
+            using (var tx = NewLowLevelTransaction(transactionPersistentContext, TransactionFlags.ReadWrite))
+            {
+                using (var treesTx = new Transaction(tx))
+                {
+                    FillBase64Id(databaseIdGuid);
+
+                    var metadataTree = treesTx.CreateTree(Constants.MetadataTreeNameSlice);
+                    metadataTree.Add(MetadataDbId, databaseIdGuid.ToByteArray());
+
+                    treesTx.PrepareForCommit();
+
+                    tx.Commit();
+                }
+            }
         }
 
         public IFreeSpaceHandling FreeSpaceHandling => _freeSpaceHandling;

--- a/test/FastTests/Voron/StorageEnvironmentTests.cs
+++ b/test/FastTests/Voron/StorageEnvironmentTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+using FastTests.Voron.Optimizations;
+using Microsoft.CodeAnalysis;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Exceptions;
+using Voron.Global;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Voron
+{
+    public class StorageEnvironmentTests : StorageTest
+    {
+        public StorageEnvironmentTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanSetDatabaseId()
+        {
+            var previousDatabaseId = Env.DbId;
+            var guid = Guid.NewGuid();
+
+            Env.SetDatabaseId(guid.ToString());
+            Assert.NotEqual(previousDatabaseId, Env.DbId);
+
+            using (var readTx = Env.ReadTransaction())
+            {
+                var metadataTree = readTx.ReadTree(Constants.MetadataTreeNameSlice);
+                var dbId = metadataTree.Read(StorageEnvironment.MetadataDbId);
+                var buffer = new byte[16];
+                dbId.Reader.Read(buffer, 0, 16);
+                Assert.Equal(guid, new Guid(buffer));
+            }
+        }
+    }
+}

--- a/test/FastTests/Voron/StorageEnvironmentTests.cs
+++ b/test/FastTests/Voron/StorageEnvironmentTests.cs
@@ -29,7 +29,7 @@ namespace FastTests.Voron
             using (var readTx = Env.ReadTransaction())
             {
                 var metadataTree = readTx.ReadTree(Constants.MetadataTreeNameSlice);
-                var dbId = metadataTree.Read(StorageEnvironment.MetadataDbId);
+                var dbId = metadataTree.Read(Constants.MetadataDbId);
                 var buffer = new byte[16];
                 dbId.Reader.Read(buffer, 0, 16);
                 Assert.Equal(guid, new Guid(buffer));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25819/Allow-to-set-the-database-ID-through-the-Admin-JS-console

### Additional description

Allow to set the database ID through the Admin JS console.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
