### PR TITLE
RavenDB-25642 - retry with delay on remote attachments items with errors or bad configuration

### DIFF
--- a/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
+++ b/src/Raven.Server/Documents/AbstractBackgroundWorkStorage.cs
@@ -35,24 +35,35 @@ public abstract unsafe class AbstractBackgroundWorkStorage<TWorkInfo> : Abstract
     protected abstract TWorkInfo GetBackgroundWorkInfo(BackgroundWorkParameters options, Slice clonedId, Slice ticksSlice);
 
     [DoesNotReturn]
-    protected void ThrowWrongDateFormat(Slice treeKey, string expirationDate)
+    protected static void ThrowWrongDateFormat(DocumentDatabase database, Slice treeKey, string expirationDate)
     {
         throw new InvalidOperationException(
-            $"The due date format for document '{treeKey}' is not valid: '{expirationDate}'. Use the following format: {Database.Time.GetUtcNow():O}");
+            $"The due date format for document '{treeKey}' is not valid: '{expirationDate}'. Use the following format: {database.Time.GetUtcNow():O}");
     }
 
     public void Put(DocumentsOperationContext context, Slice lowerId, string processDateString)
     {
+        DateTime processDateUniversalTime = ProcessDateUniversalTime(Database, lowerId, processDateString);
+        PutTicksDirectly(context, lowerId, processDateUniversalTime.Ticks);
+    }
+
+    internal static DateTime ProcessDateUniversalTime(DocumentDatabase database, Slice lowerId, string processDateString)
+    {
         if (DateTime.TryParseExact(processDateString, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind,
                 out DateTime processDate) == false)
-            ThrowWrongDateFormat(lowerId, processDateString);
+            ThrowWrongDateFormat(database, lowerId, processDateString);
 
         // We explicitly enable adding items that have already been expired, we have to, because if the time lag is short, it is possible
         // that we add an item that expire in 1 second, but by the time we process it, it already expired. The user did nothing wrong here
         // and we'll use the normal cleanup routine to clean things up later.
 
         var processDateUniversalTime = processDate.ToUniversalTime();
-        var ticksBigEndian = Bits.SwapBytes(processDateUniversalTime.Ticks);
+        return processDateUniversalTime;
+    }
+
+    internal void PutTicksDirectly(DocumentsOperationContext context, Slice lowerId, long processDateUniversalTimeTicks)
+    {
+        var ticksBigEndian = Bits.SwapBytes(processDateUniversalTimeTicks);
 
         var tree = context.Transaction.InnerTransaction.ReadTree(_treeName);
         using (Slice.External(context.Allocator, (byte*)&ticksBigEndian, sizeof(long), out Slice ticksSlice))

--- a/src/Raven.Server/Documents/Attachments/AttachmentRemoteInfo.cs
+++ b/src/Raven.Server/Documents/Attachments/AttachmentRemoteInfo.cs
@@ -14,6 +14,8 @@ public class AttachmentRemoteInfo
 
     public string Hash;
 
+    public long RetryCount;
+
     public AttachmentRemoteInfo()
     {
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Attachments/Remote/RemoteAttachmentHandlerProcessorForGetRemoteConfig.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Attachments/Remote/RemoteAttachmentHandlerProcessorForGetRemoteConfig.cs
@@ -24,11 +24,6 @@ internal sealed class RemoteAttachmentHandlerProcessorForGetRemoteConfig : Abstr
                 configuration = rawRecord?.RemoteAttachmentsConfiguration;
             }
 
-            if (RavenLogManager.Instance.IsAuditEnabled)
-            {
-                RequestHandler.LogAuditForDatabase("GET", "remote-attachment configurations");
-            }
-
             return ValueTask.FromResult(configuration);
         }
     }

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -14,9 +14,8 @@ using Raven.Server.Documents.BackgroundWork;
 using Raven.Server.Documents.Expiration;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.TransactionMerger.Commands;
-using Raven.Server.Exceptions.Attachments;
 using Raven.Server.Extensions;
-using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow;
@@ -38,9 +37,6 @@ namespace Raven.Server.Documents
         private readonly DocumentDatabase _database;
         private readonly TimeSpan _remotePeriod;
         private readonly OperationCancelToken _token;
-
-        // Identifier (case in-sensitive) -> (Hash (case sensitive) -> Exception): we keep the exceptions to alert at the end of the batch
-        private readonly Dictionary<string, Dictionary<string, UploadAttachmentException>> _batchExceptionsByIdentifier = new(StringComparer.OrdinalIgnoreCase);
 
         // Identifier (case in-sensitive) -> (Hash (case sensitive) -> RetryCount): we keep track of how many times we retried uploading an attachment
         private readonly Dictionary<string, Dictionary<string, long>> _inMemoryStateErrorsByIdentifier = new(StringComparer.OrdinalIgnoreCase);
@@ -134,8 +130,6 @@ namespace Raven.Server.Documents
                         await UploadAttachmentsBatch(attachmentsToUpload);
                     }
 
-                    AlertAndLogOnBatchErrorsIfNeeded();
-
                     var command = new UpdateRemoteAttachmentsCommand(_database, currentTime, _alreadySeenDocs, _attachmentsToUploadByIdentifier);
                     await _database.TxMerger.Enqueue(command);
 
@@ -144,7 +138,6 @@ namespace Raven.Server.Documents
                         Logger.Debug($"Processed remote attachments batch. Uploaded: {new Size(_totalUploadedInBytes, SizeUnit.Bytes)}, Remote Count: {command.RemoteCount}.");
                     }
 
-                    ForTestingPurposes?.BeforeEndOfTheBatch?.Invoke(_batchExceptionsByIdentifier);
                 }
             }
             catch (OperationCanceledException)
@@ -167,7 +160,6 @@ namespace Raven.Server.Documents
             context.Renew();
 
             _totalUploadedInBytes = 0L;
-            _batchExceptionsByIdentifier.Clear();
             _alreadySeenDocs.Clear();
             _attachmentsToUploadByIdentifier.Clear();
         }
@@ -306,55 +298,9 @@ namespace Raven.Server.Documents
             return attachmentsToUpload;
         }
 
-        private void AlertAndLogOnBatchErrorsIfNeeded()
-        {
-            if (_batchExceptionsByIdentifier.Count <= 0) 
-                return;
-
-            foreach (var (identifier, hashPerError) in _batchExceptionsByIdentifier)
-            {
-                _token.ThrowIfCancellationRequested();
-
-                var hashes = new HashSet<string>();
-                var exceptions = new List<Exception>(hashPerError.Count);
-                
-                foreach ((string key, UploadAttachmentException exception) in hashPerError)
-                {
-                    hashes.Add(key);
-                    exceptions.Add(exception);
-                }
-
-                var msg = $"Failed to upload remote attachment for identifier '{identifier}' after multiple attempts. Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'.";
-
-                if (Logger.IsDebugEnabled)
-                {
-                    AggregateException ex = new AggregateException($"Failed to upload remote attachment for identifier '{identifier}' too many times.", exceptions);
-                    Logger.Debug(ex, "{0}{1}Failed Hashes: {2}", msg, Environment.NewLine, string.Join(", ", hashes));
-                }
-
-                var alert = AlertRaised.Create(_database.Name, AlertTitleError, msg, AlertReason.Attachments_RemoteAttachmentErroredIdentifier, NotificationSeverity.Error, key: nameof(AlertReason.Attachments_RemoteAttachmentErroredIdentifier));
-                _database.NotificationCenter.Add(alert);
-            }
-        }
-
-        private const string AlertTitleSkip = "Remote attachment upload was skipped.";
-        private const string AlertTitleError = "Remote attachment upload failed.";
-        private long _counter = 0;
-        private DateTime _lastAlertTime = DateTime.MinValue;
-        private static readonly long AlertThresholdTicks = TimeSpan.FromMinutes(15).Ticks;
-
         private void HandleSkippedItem(string documentId, Attachment item, RemoteAttachmentsDestinationConfiguration destination)
         {
-            var now = _database.Time.GetUtcNow();
-            var timeSinceLastAlert = now.Ticks - _lastAlertTime.Ticks;
-
-            // on first skip or each 128th time or if last alert was more than 15 minutes ago
-            var shouldAlert = (_counter++ % 128 == 0) || (timeSinceLastAlert > AlertThresholdTicks);
-
-            if (shouldAlert == false && Logger.IsDebugEnabled == false)
-            {
-                return;
-            }
+            // for now we just log the skipped item and alert
 
             var destinationStr = destination == null ? "destination is null." : destination.Disabled ? "destination is disabled." : "destination doesn't have uploader configured.";
             var msg = $"Skipping uploading remote attachment '{item.Name}' with identifier '{item.RemoteParameters.Identifier}' for document id '{documentId}'. Reason: {destinationStr}";
@@ -364,13 +310,7 @@ namespace Raven.Server.Documents
                 Logger.Debug(msg);
             }
 
-            if (shouldAlert)
-            {
-                // update the last alert time only if we are sending an alert
-                _lastAlertTime = now;
-                var alert = AlertRaised.Create(_database.Name, AlertTitleSkip, msg, AlertReason.Attachments_RemoteAttachmentWithoutIdentifier, NotificationSeverity.Warning, key: nameof(AlertReason.Attachments_RemoteAttachmentWithoutIdentifier));
-                _database.NotificationCenter.Add(alert);
-            }
+            _database.NotificationCenter.RemoteAttachmentsNotifications.AddConfigurationAlerts(new RemoteAttachmentsErrorInfo(msg, item.RemoteParameters.Identifier, item.Base64Hash.ToString(), [documentId]));
         }
 
         private void HandleUploadTaskException(AttachmentRemoteInfo info)
@@ -381,25 +321,27 @@ namespace Raven.Server.Documents
 
             // we always try to retry the upload with delay
             info.Status = BackgroundWorkInfoStatus.Retry;
-
             var count = errors.GetOrAdd(hash);
+
+            if (Logger.IsDebugEnabled)
+            {
+                Logger.Debug($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}' attempt '{count}'. " +
+                             $"Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'." +
+                             $"Will retry in the next batch. Affected documents: [{string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}]");
+            }
+
             if (count < 3)
             {
                 errors[hash] = ++count;
-
-                if (Logger.IsDebugEnabled)
-                {
-                    Logger.Debug($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}' attempt '{count}'. " +
-                                 $"Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'." +
-                                 $"Will retry in the next batch. Affected documents: [{string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}]");
-                }
             }
             else
             {
                 // we have tried enough times, we need to alert
-                var ex = new UploadAttachmentException($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}', the attachment belong to following documents: {string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}", info.Exception);
-                _batchExceptionsByIdentifier.GetOrAdd(identifier).TryAdd(hash, ex);
                 errors.Remove(hash);
+                var msg = $"Failed to upload remote attachment for identifier '{identifier}' after multiple attempts. Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'.";
+                _database.NotificationCenter.RemoteAttachmentsNotifications.AddUploadErrors(msg, identifier, new RemoteAttachmentsErrorInfo(info.Exception.ToString(), identifier, hash, info.DocumentIds));
+
+                ForTestingPurposes?.BeforeEndOfTheBatch?.Invoke(msg);
             }
         }
 
@@ -526,7 +468,7 @@ namespace Raven.Server.Documents
 
         internal sealed class TestingStuff
         {
-            internal Action<Dictionary<string, Dictionary<string, UploadAttachmentException>>> BeforeEndOfTheBatch;
+            internal Action<string> BeforeEndOfTheBatch;
         }
     }
 

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -37,6 +37,7 @@ namespace Raven.Server.Documents
         private readonly DocumentDatabase _database;
         private readonly TimeSpan _remotePeriod;
         private readonly OperationCancelToken _token;
+        private static readonly string MisconfigurationAlertMessage = $"Failed to upload the attachments to remote storage due to misconfiguration.";
 
         // Identifier (case in-sensitive) -> (Hash (case sensitive) -> RetryCount): we keep track of how many times we retried uploading an attachment
         private readonly Dictionary<string, Dictionary<string, long>> _inMemoryStateErrorsByIdentifier = new(StringComparer.OrdinalIgnoreCase);
@@ -310,7 +311,7 @@ namespace Raven.Server.Documents
                 Logger.Debug(msg);
             }
 
-            _database.NotificationCenter.RemoteAttachmentsNotifications.AddConfigurationAlerts(new RemoteAttachmentsErrorInfo(msg, item.RemoteParameters.Identifier, item.Base64Hash.ToString(), [documentId]));
+            _database.NotificationCenter.RemoteAttachmentsNotifications.AddUploadErrors(MisconfigurationAlertMessage, item.RemoteParameters.Identifier, new RemoteAttachmentsErrorInfo(msg, item.RemoteParameters.Identifier, item.Base64Hash.ToString(), [documentId]));
         }
 
         private void HandleUploadTaskException(AttachmentRemoteInfo info)
@@ -319,30 +320,24 @@ namespace Raven.Server.Documents
             string identifier = info.AttachmentUploader.Identifier;
             var errors = _inMemoryStateErrorsByIdentifier.GetOrAdd(identifier);
 
+            var count = errors.GetOrAdd(hash);
+            errors[hash] = ++count;
+
             // we always try to retry the upload with delay
             info.Status = BackgroundWorkInfoStatus.Retry;
-            var count = errors.GetOrAdd(hash);
+            info.RetryCount = count;
 
             if (Logger.IsDebugEnabled)
             {
                 Logger.Debug($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}' attempt '{count}'. " +
                              $"Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'." +
-                             $"Will retry in the next batch. Affected documents: [{string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}]");
+                             $"Will retry in the next batch. Affected documents: [{string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}]", info.Exception);
             }
 
-            if (count < 3)
-            {
-                errors[hash] = ++count;
-            }
-            else
-            {
-                // we have tried enough times, we need to alert
-                errors.Remove(hash);
-                var msg = $"Failed to upload remote attachment for identifier '{identifier}' after multiple attempts. Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'.";
-                _database.NotificationCenter.RemoteAttachmentsNotifications.AddUploadErrors(msg, identifier, new RemoteAttachmentsErrorInfo(info.Exception.ToString(), identifier, hash, info.DocumentIds));
+            var msg = $"Failed to upload remote attachment for identifier '{identifier}' after multiple attempts. Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'.";
+            _database.NotificationCenter.RemoteAttachmentsNotifications.AddUploadErrors(msg, identifier, new RemoteAttachmentsErrorInfo(info.Exception.ToString(), identifier, hash, info.DocumentIds));
 
-                ForTestingPurposes?.BeforeEndOfTheBatch?.Invoke(msg);
-            }
+            ForTestingPurposes?.BeforeEndOfTheBatch?.Invoke(msg);
         }
 
         private async Task<long> CreateUploadTaskAsync(AttachmentUploader uploader, string hash)

--- a/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsSender.cs
@@ -324,7 +324,7 @@ namespace Raven.Server.Documents
                     exceptions.Add(exception);
                 }
 
-                var msg = $"Failed to upload remote attachment for identifier '{identifier}' after multiple attempts. Skipping further attempts for this attachment. Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for '{identifier}'.";
+                var msg = $"Failed to upload remote attachment for identifier '{identifier}' after multiple attempts. Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'.";
 
                 if (Logger.IsDebugEnabled)
                 {
@@ -341,15 +341,15 @@ namespace Raven.Server.Documents
         private const string AlertTitleError = "Remote attachment upload failed.";
         private long _counter = 0;
         private DateTime _lastAlertTime = DateTime.MinValue;
-        private static readonly long AlertThresholdTicks = TimeSpan.FromMinutes(1).Ticks;
+        private static readonly long AlertThresholdTicks = TimeSpan.FromMinutes(15).Ticks;
 
         private void HandleSkippedItem(string documentId, Attachment item, RemoteAttachmentsDestinationConfiguration destination)
         {
             var now = _database.Time.GetUtcNow();
             var timeSinceLastAlert = now.Ticks - _lastAlertTime.Ticks;
 
-            // on first skip or each 16th time or if last alert was more than a minute ago
-            var shouldAlert = (_counter++ % 16 == 0) || (timeSinceLastAlert > AlertThresholdTicks);
+            // on first skip or each 128th time or if last alert was more than 15 minutes ago
+            var shouldAlert = (_counter++ % 128 == 0) || (timeSinceLastAlert > AlertThresholdTicks);
 
             if (shouldAlert == false && Logger.IsDebugEnabled == false)
             {
@@ -379,20 +379,27 @@ namespace Raven.Server.Documents
             string identifier = info.AttachmentUploader.Identifier;
             var errors = _inMemoryStateErrorsByIdentifier.GetOrAdd(identifier);
 
+            // we always try to retry the upload with delay
+            info.Status = BackgroundWorkInfoStatus.Retry;
+
             var count = errors.GetOrAdd(hash);
             if (count < 3)
             {
                 errors[hash] = ++count;
 
-                info.Status = BackgroundWorkInfoStatus.Retry;
+                if (Logger.IsDebugEnabled)
+                {
+                    Logger.Debug($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}' attempt '{count}'. " +
+                                 $"Please check the {nameof(RemoteAttachmentsConfiguration)}.{nameof(RemoteAttachmentsConfiguration.Destinations)} configuration for identifier '{identifier}'." +
+                                 $"Will retry in the next batch. Affected documents: [{string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}]");
+                }
             }
             else
             {
-                // we have tried enough times, we need to remove it from background tree and alert
-                var ex = new UploadAttachmentException($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}', the attachment belong to following documents: {string.Join(", ", info.DocumentIds.Select(x => $"{x}"))}", info.Exception);
+                // we have tried enough times, we need to alert
+                var ex = new UploadAttachmentException($"Failed to upload remote attachment with identifier '{identifier}' and hash '{hash}', the attachment belong to following documents: {string.Join(", ", info.DocumentIds.Select(x => $"'{x}'"))}", info.Exception);
                 _batchExceptionsByIdentifier.GetOrAdd(identifier).TryAdd(hash, ex);
                 errors.Remove(hash);
-                info.Status = BackgroundWorkInfoStatus.Skip;
             }
         }
 

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -35,7 +35,6 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
 {
     private readonly RavenLogger _logger;
     private const string AttachmentsByRemote = "AttachmentsByRemote";
-    private static readonly long TicksPer15Minutes = 15 * TimeSpan.TicksPerMinute;
 
     public RemoteAttachmentsConfiguration Configuration;
 
@@ -409,10 +408,21 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
                         switch (info.Status)
                         {
                             case BackgroundWorkInfoStatus.Retry:
-                                // this upload errored lets add back to the tree and put current time ticks increased by 15 minutes
-                                var newTicks = currentTime.Ticks + TicksPer15Minutes;
-                                PutTicksDirectly(context, lowerId, newTicks);
+                                // this upload errored lets add back to the tree with recalculated ticks
+                                var newTicks = CalculateRetryTicks(currentTime, info.RetryCount);
 
+                                if (_logger.IsDebugEnabled)
+                                {
+                                    remoteParamsObject.TryGet(nameof(RemoteAttachmentParameters.At), out LazyStringValue dateFromMetadata);
+                                    var dt = ProcessDateUniversalTime(Database, lowerId, dateFromMetadata);
+                                    var nextRetryTime = new DateTime(newTicks);
+                                    var deltaTicks = currentTime.Ticks - dt.Ticks;
+                                    var deltaTimeSpan = new TimeSpan(deltaTicks);
+                                    _logger.Debug($"Scheduling retry #{info.RetryCount + 1} for attachment '{name}' (hash: '{hash}', identifier: '{identifierFromMetadata}') in document '{doc.Id}'. " +
+                                                  $"Time elapsed since original: {deltaTimeSpan}, Next attempt: {nextRetryTime.GetDefaultRavenFormat()}, original time: {dt.GetDefaultRavenFormat()}.");
+                                }
+
+                                PutTicksDirectly(context, lowerId, newTicks);
                                 break;
                             case BackgroundWorkInfoStatus.Process:
                                 // we uploaded this, we can mark the attachment as remote and delete its stream
@@ -433,5 +443,45 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
         }
 
         return processedCount;
+    }
+
+    private static readonly long TicksPer15Minutes = 15 * TimeSpan.TicksPerMinute;
+    private static readonly long TicksPer1Hour = TimeSpan.TicksPerHour;
+    private static readonly long TicksPer3Hours = 3 * TimeSpan.TicksPerHour;
+    private static readonly long TicksPer12Hours = 12 * TimeSpan.TicksPerHour;
+    private static readonly long TicksPer24Hours = 24 * TimeSpan.TicksPerHour;
+
+    private static long CalculateRetryTicks(DateTime currentTime, long retryCount)
+    {
+        long delay;
+
+        // Simple tiered delays based on retry count
+        if (retryCount < 4)
+        {
+            // First 3 retries: every 15 minutes (likely transient issues)
+            delay = TicksPer15Minutes;
+        }
+        else if (retryCount < 12)
+        {
+            // Retries 4-11: every 1 hour (persistent issue, slow down)
+            delay = TicksPer1Hour;
+        }
+        else if (retryCount < 24)
+        {
+            // Retries 12-23: every 3 hours (long-term issue)
+            delay = TicksPer3Hours;
+        }
+        else if (retryCount < 48)
+        {
+            // Retries 24-47: every 12 hours (very persistent)
+            delay = TicksPer12Hours;
+        }
+        else
+        {
+            // Retry 48+: once per day (maximum backoff)
+            delay = TicksPer24Hours;
+        }
+
+        return currentTime.Ticks + delay;
     }
 }

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -35,6 +35,8 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
 {
     private readonly RavenLogger _logger;
     private const string AttachmentsByRemote = "AttachmentsByRemote";
+    private static readonly long TicksPer15Minutes = 15 * TimeSpan.TicksPerMinute;
+    private static readonly long TicksPer14Days = 14 * TimeSpan.TicksPerDay;
 
     public RemoteAttachmentsConfiguration Configuration;
 
@@ -410,12 +412,23 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
                             case BackgroundWorkInfoStatus.Retry:
                                 // this upload errored lets add back to the tree
                                 remoteParamsObject.TryGet(nameof(RemoteAttachmentParameters.At), out LazyStringValue dateFromMetadata);
-                                base.Put(context, lowerId, dateFromMetadata);
 
-                                break;
-                            case BackgroundWorkInfoStatus.Skip:
-                                // this upload errored max retries, we are skipping it
-                                // we already alerted on this item, when we iterated on it in RemoteAttachmentsSender._batchExceptionsByIdentifier so nothing to do here
+                                var dt = ProcessDateUniversalTime(Database, lowerId, dateFromMetadata);
+                                var maxTicks = dt.Ticks + TicksPer14Days;
+                                var currentTicks = currentTime.Ticks;
+
+                                if (currentTicks >= maxTicks)
+                                {
+                                    // we cannot delay this further, lets put the original ticks back, so we make sure the next batch will alert on this
+                                    PutTicksDirectly(context, lowerId, dt.Ticks);
+                                }
+                                else
+                                {
+                                    // put current time ticks increased by 15 minutes
+                                    var newTicks = currentTicks + TicksPer15Minutes;
+                                    PutTicksDirectly(context, lowerId, newTicks);
+                                }
+
                                 break;
                             case BackgroundWorkInfoStatus.Process:
                                 // we uploaded this, we can mark the attachment as remote and delete its stream

--- a/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/RemoteAttachmentsStorage.cs
@@ -36,7 +36,6 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
     private readonly RavenLogger _logger;
     private const string AttachmentsByRemote = "AttachmentsByRemote";
     private static readonly long TicksPer15Minutes = 15 * TimeSpan.TicksPerMinute;
-    private static readonly long TicksPer14Days = 14 * TimeSpan.TicksPerDay;
 
     public RemoteAttachmentsConfiguration Configuration;
 
@@ -410,24 +409,9 @@ public class RemoteAttachmentsStorage : AbstractBackgroundWorkStorage<DocumentEx
                         switch (info.Status)
                         {
                             case BackgroundWorkInfoStatus.Retry:
-                                // this upload errored lets add back to the tree
-                                remoteParamsObject.TryGet(nameof(RemoteAttachmentParameters.At), out LazyStringValue dateFromMetadata);
-
-                                var dt = ProcessDateUniversalTime(Database, lowerId, dateFromMetadata);
-                                var maxTicks = dt.Ticks + TicksPer14Days;
-                                var currentTicks = currentTime.Ticks;
-
-                                if (currentTicks >= maxTicks)
-                                {
-                                    // we cannot delay this further, lets put the original ticks back, so we make sure the next batch will alert on this
-                                    PutTicksDirectly(context, lowerId, dt.Ticks);
-                                }
-                                else
-                                {
-                                    // put current time ticks increased by 15 minutes
-                                    var newTicks = currentTicks + TicksPer15Minutes;
-                                    PutTicksDirectly(context, lowerId, newTicks);
-                                }
+                                // this upload errored lets add back to the tree and put current time ticks increased by 15 minutes
+                                var newTicks = currentTime.Ticks + TicksPer15Minutes;
+                                PutTicksDirectly(context, lowerId, newTicks);
 
                                 break;
                             case BackgroundWorkInfoStatus.Process:

--- a/src/Raven.Server/NotificationCenter/AbstractDatabaseNotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/AbstractDatabaseNotificationCenter.cs
@@ -52,6 +52,7 @@ public abstract class AbstractDatabaseNotificationCenter : AbstractNotificationC
         Indexing?.Dispose();
         RequestLatency?.Dispose();
         SlowWrites?.Dispose();
+        RemoteAttachmentsNotifications?.Dispose();
 
         base.Dispose();
     }

--- a/src/Raven.Server/NotificationCenter/AbstractDatabaseNotificationCenter.cs
+++ b/src/Raven.Server/NotificationCenter/AbstractDatabaseNotificationCenter.cs
@@ -18,6 +18,7 @@ public abstract class AbstractDatabaseNotificationCenter : AbstractNotificationC
     public readonly RequestLatency RequestLatency;
     public readonly EtlNotifications EtlNotifications;
     public readonly QueueSinkNotifications QueueSinkNotifications;
+    public readonly RemoteAttachmentsNotifications RemoteAttachmentsNotifications;
     public readonly SlowWriteNotifications SlowWrites;
 
     protected AbstractDatabaseNotificationCenter(ServerStore serverStore, string database, RavenConfiguration configuration, CancellationToken shutdown)
@@ -37,6 +38,7 @@ public abstract class AbstractDatabaseNotificationCenter : AbstractNotificationC
         EtlNotifications = new EtlNotifications(this);
         SlowWrites = new SlowWriteNotifications(this);
         QueueSinkNotifications = new QueueSinkNotifications(this);
+        RemoteAttachmentsNotifications = new RemoteAttachmentsNotifications(this);
 
         PostponedNotificationSender = new PostponedNotificationsSender(database, Storage, Watchers, RavenLogManager.Instance.GetLoggerForDatabase<PostponedNotificationsSender>(database), shutdown);
     }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/RemoteAttachmentsErrorInfo.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/RemoteAttachmentsErrorInfo.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public class RemoteAttachmentsErrorInfo : IDynamicJson
+    {
+        public RemoteAttachmentsErrorInfo(string error, string identifier, string hash, List<string> ids)
+        {
+            Date = DateTime.UtcNow;
+            Error = error;
+            Identifier = identifier;
+            Hash = hash;
+            Ids = ids;
+        }
+
+        public DateTime Date { get; set; }
+        public string Error { get; set; }
+        public string Identifier { get; set; }
+        public string Hash { get; set; }
+        public List<string> Ids { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            var djv = new DynamicJsonValue
+            {
+                [nameof(Date)] = Date,
+                [nameof(Error)] = Error,
+                [nameof(Identifier)] = Identifier,
+                [nameof(Hash)] = Hash
+            };
+
+            if (Ids is { Count: > 0 })
+            {
+                djv[nameof(Ids)] = new DynamicJsonArray(Ids);
+            }
+
+            return djv;
+        }
+    }
+}

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/RemoteAttachmentsErrorsDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/RemoteAttachmentsErrorsDetails.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public class RemoteAttachmentsErrorsDetails : INotificationDetails
+    {
+        public const int MaxNumberOfErrors = 100;
+
+        public Queue<RemoteAttachmentsErrorInfo> Errors { get; set; }
+
+        public RemoteAttachmentsErrorsDetails()
+        {
+            Errors = new Queue<RemoteAttachmentsErrorInfo>();
+        }
+
+        public void Add(RemoteAttachmentsErrorInfo error)
+        {
+            Errors.Enqueue(error);
+
+            if (Errors.Count > MaxNumberOfErrors)
+                Errors.TryDequeue(out _);
+        }
+
+        public void Update(List<RemoteAttachmentsErrorInfo> errors)
+        {
+            var local = new Queue<RemoteAttachmentsErrorInfo>();
+
+            foreach (var existing in Errors)
+            {
+                local.Enqueue(existing);
+            }
+
+            foreach (var newError in errors)
+            {
+                local.Enqueue(newError);
+            }
+
+            Errors = local;
+
+            while (Errors.Count > MaxNumberOfErrors)
+            {
+                Errors.TryDequeue(out _);
+            }
+        }
+
+        public DynamicJsonValue ToJson()
+        {
+            var result = new DynamicJsonValue();
+
+            var errors = new DynamicJsonArray();
+
+            foreach (var details in Errors)
+            {
+                errors.Add(details.ToJson());
+            }
+
+            result[nameof(Errors)] = errors;
+
+            return result;
+        }
+    }
+}

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/RemoteAttachmentsErrorsDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/RemoteAttachmentsErrorsDetails.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.NotificationCenter.Notifications.Details
@@ -7,11 +7,11 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
     {
         public const int MaxNumberOfErrors = 100;
 
-        public Queue<RemoteAttachmentsErrorInfo> Errors { get; set; }
+        public ConcurrentQueue<RemoteAttachmentsErrorInfo> Errors { get; set; }
 
         public RemoteAttachmentsErrorsDetails()
         {
-            Errors = new Queue<RemoteAttachmentsErrorInfo>();
+            Errors = new ConcurrentQueue<RemoteAttachmentsErrorInfo>();
         }
 
         public void Add(RemoteAttachmentsErrorInfo error)
@@ -20,28 +20,6 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
 
             if (Errors.Count > MaxNumberOfErrors)
                 Errors.TryDequeue(out _);
-        }
-
-        public void Update(List<RemoteAttachmentsErrorInfo> errors)
-        {
-            var local = new Queue<RemoteAttachmentsErrorInfo>();
-
-            foreach (var existing in Errors)
-            {
-                local.Enqueue(existing);
-            }
-
-            foreach (var newError in errors)
-            {
-                local.Enqueue(newError);
-            }
-
-            Errors = local;
-
-            while (Errors.Count > MaxNumberOfErrors)
-            {
-                Errors.TryDequeue(out _);
-            }
         }
 
         public DynamicJsonValue ToJson()

--- a/src/Raven.Server/NotificationCenter/RemoteAttachmentsNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/RemoteAttachmentsNotifications.cs
@@ -1,65 +1,91 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
 using Raven.Client.Documents.Conventions;
+using Raven.Server.Logging;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Sparrow.Json;
+using Sparrow.Logging;
+using Sparrow.Server.Logging;
 
 namespace Raven.Server.NotificationCenter
 {
-    public class RemoteAttachmentsNotifications
+    public class RemoteAttachmentsNotifications : IDisposable
     {
         private readonly AbstractDatabaseNotificationCenter _notificationCenter;
+        private Timer _timer;
+        private  AlertRaised _alert;
+        private readonly Lock _locker = new();
+        private volatile bool _needsSync;
+        private readonly RavenLogger _logger;
+        private RemoteAttachmentsErrorsDetails _details;
 
         public RemoteAttachmentsNotifications(AbstractDatabaseNotificationCenter notificationCenter)
         {
             _notificationCenter = notificationCenter;
+            _logger = RavenLogManager.Instance.GetLoggerForDatabase<RemoteAttachmentsNotifications>(notificationCenter.Database);
         }
 
         private static readonly string AlertTitleError = "Remote attachment upload failed.";
-        private static readonly string MisconfigurationAlertMessage = $"Failed to upload the attachments to remote storage due to misconfiguration. (last {RemoteAttachmentsErrorsDetails.MaxNumberOfErrors} errors are shown)";
 
-        public AlertRaised AddConfigurationAlerts(RemoteAttachmentsErrorInfo error)
+        public void AddUploadErrors(string msg, string identifier, RemoteAttachmentsErrorInfo error)
         {
-            var alert = GetOrCreateAlert<RemoteAttachmentsErrorsDetails>(AlertTitleError,
-                MisconfigurationAlertMessage,
-                AlertReason.Attachments_RemoteAttachmentWithoutIdentifier,
-                nameof(AlertReason.Attachments_RemoteAttachmentWithoutIdentifier),
-                identifier: null,
-                out var details);
+            lock (_locker)
+            {
+                if (_alert == null)
+                {
+                    _alert = GetOrCreateAlert(AlertTitleError,
+                        $"{msg} (last {RemoteAttachmentsErrorsDetails.MaxNumberOfErrors} errors are shown)",
+                        AlertReason.Attachments_RemoteAttachmentErroredIdentifier,
+                        nameof(AlertReason.Attachments_RemoteAttachmentErroredIdentifier),
+                        identifier,
+                        out _details);
+                }
 
-            return AddErrorAlert(error, details, alert);
+                _details.Add(error);
+
+                _needsSync = true;
+
+                if (_timer != null)
+                    return;
+
+                _timer = new Timer(PublishErrorAlerts, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+            }
+
         }
 
-        public AlertRaised AddUploadErrors(string msg, string identifier, RemoteAttachmentsErrorInfo error)
+        internal void PublishErrorAlerts(object state)
         {
-            var alert = GetOrCreateAlert<RemoteAttachmentsErrorsDetails>($"{AlertTitleError} for '{identifier}'",
-                $"{msg} (last {RemoteAttachmentsErrorsDetails.MaxNumberOfErrors} errors are shown)",
-                AlertReason.Attachments_RemoteAttachmentErroredIdentifier,
-                nameof(AlertReason.Attachments_RemoteAttachmentErroredIdentifier),
-                identifier,
-                out var details);
+            try
+            {
+                if (_needsSync == false)
+                    return;
 
-            return AddErrorAlert(error, details, alert);
+                lock (_locker)
+                {
+                    _needsSync = false;
+
+                    _alert.RefreshCreatedAt();
+                    _notificationCenter.Add(_alert);
+                }
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info("Error in a request latency timer", e);
+            }
         }
 
-        private AlertRaised AddErrorAlert(RemoteAttachmentsErrorInfo error, RemoteAttachmentsErrorsDetails details, AlertRaised alert)
-        {
-            details.Add(error);
-
-            _notificationCenter.Add(alert);
-
-            return alert;
-        }
-
-        private AlertRaised GetOrCreateAlert<T>(string title, string message, AlertReason alertReason, string tag, string identifier, out T details) where T : INotificationDetails, new()
+        private AlertRaised GetOrCreateAlert(string title, string message, AlertReason alertReason, string tag, string identifier, out RemoteAttachmentsErrorsDetails details)
         {
             Debug.Assert(alertReason == AlertReason.Attachments_RemoteAttachmentWithoutIdentifier || alertReason == AlertReason.Attachments_RemoteAttachmentErroredIdentifier);
 
-            string key = GetAlertId<T>(alertReason, tag, identifier, out string id);
+            string key = GetAlertId<RemoteAttachmentsErrorsDetails>(alertReason, tag, identifier, out string id);
 
             using (_notificationCenter.Storage.Read(id, out NotificationTableValue ntv))
             {
-                details = GetDetails<T>(ntv);
+                details = GetDetails<RemoteAttachmentsErrorsDetails>(ntv);
 
                 return AlertRaised.Create(
                     _notificationCenter.Database,
@@ -86,7 +112,6 @@ namespace Raven.Server.NotificationCenter
 
             string key = GetAlertId<T>(alertReason, tag, identifier, out string id);
 
-
             using (_notificationCenter.Storage.Read(id, out NotificationTableValue ntv))
             {
                 return GetDetails<T>(ntv);
@@ -99,6 +124,12 @@ namespace Raven.Server.NotificationCenter
                 return new T();
 
             return DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<T>(detailsJson);
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+            _timer = null;
         }
     }
 }

--- a/src/Raven.Server/NotificationCenter/RemoteAttachmentsNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/RemoteAttachmentsNotifications.cs
@@ -1,0 +1,104 @@
+﻿using System.Diagnostics;
+using Raven.Client.Documents.Conventions;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Sparrow.Json;
+
+namespace Raven.Server.NotificationCenter
+{
+    public class RemoteAttachmentsNotifications
+    {
+        private readonly AbstractDatabaseNotificationCenter _notificationCenter;
+
+        public RemoteAttachmentsNotifications(AbstractDatabaseNotificationCenter notificationCenter)
+        {
+            _notificationCenter = notificationCenter;
+        }
+
+        private static readonly string AlertTitleError = "Remote attachment upload failed.";
+        private static readonly string MisconfigurationAlertMessage = $"Failed to upload the attachments to remote storage due to misconfiguration. (last {RemoteAttachmentsErrorsDetails.MaxNumberOfErrors} errors are shown)";
+
+        public AlertRaised AddConfigurationAlerts(RemoteAttachmentsErrorInfo error)
+        {
+            var alert = GetOrCreateAlert<RemoteAttachmentsErrorsDetails>(AlertTitleError,
+                MisconfigurationAlertMessage,
+                AlertReason.Attachments_RemoteAttachmentWithoutIdentifier,
+                nameof(AlertReason.Attachments_RemoteAttachmentWithoutIdentifier),
+                identifier: null,
+                out var details);
+
+            return AddErrorAlert(error, details, alert);
+        }
+
+        public AlertRaised AddUploadErrors(string msg, string identifier, RemoteAttachmentsErrorInfo error)
+        {
+            var alert = GetOrCreateAlert<RemoteAttachmentsErrorsDetails>($"{AlertTitleError} for '{identifier}'",
+                $"{msg} (last {RemoteAttachmentsErrorsDetails.MaxNumberOfErrors} errors are shown)",
+                AlertReason.Attachments_RemoteAttachmentErroredIdentifier,
+                nameof(AlertReason.Attachments_RemoteAttachmentErroredIdentifier),
+                identifier,
+                out var details);
+
+            return AddErrorAlert(error, details, alert);
+        }
+
+        private AlertRaised AddErrorAlert(RemoteAttachmentsErrorInfo error, RemoteAttachmentsErrorsDetails details, AlertRaised alert)
+        {
+            details.Add(error);
+
+            _notificationCenter.Add(alert);
+
+            return alert;
+        }
+
+        private AlertRaised GetOrCreateAlert<T>(string title, string message, AlertReason alertReason, string tag, string identifier, out T details) where T : INotificationDetails, new()
+        {
+            Debug.Assert(alertReason == AlertReason.Attachments_RemoteAttachmentWithoutIdentifier || alertReason == AlertReason.Attachments_RemoteAttachmentErroredIdentifier);
+
+            string key = GetAlertId<T>(alertReason, tag, identifier, out string id);
+
+            using (_notificationCenter.Storage.Read(id, out NotificationTableValue ntv))
+            {
+                details = GetDetails<T>(ntv);
+
+                return AlertRaised.Create(
+                    _notificationCenter.Database,
+                    title,
+                    message,
+                    alertReason,
+                    NotificationSeverity.Warning,
+                    key: key,
+                    details: details);
+            }
+        }
+
+        private static string GetAlertId<T>(AlertReason alertReason, string tag, string identifier, out string id) where T : INotificationDetails, new()
+        {
+            var key = string.IsNullOrEmpty(identifier) ? tag : $"{tag}/{identifier}";
+            id = AlertRaised.GetKey(alertReason, key: key);
+            return key;
+        }
+
+        public T GetAlert<T>(string tag, string identifier, AlertReason alertReason) where T : INotificationDetails, new()
+        {
+            Debug.Assert(
+                alertReason is AlertReason.Attachments_RemoteAttachmentWithoutIdentifier or AlertReason.Attachments_RemoteAttachmentErroredIdentifier, $"Got type: {alertReason}");
+
+            string key = GetAlertId<T>(alertReason, tag, identifier, out string id);
+
+
+            using (_notificationCenter.Storage.Read(id, out NotificationTableValue ntv))
+            {
+                return GetDetails<T>(ntv);
+            }
+        }
+
+        private T GetDetails<T>(NotificationTableValue ntv) where T : INotificationDetails, new()
+        {
+            if (ntv == null || ntv.Json.TryGet(nameof(AlertRaised.Details), out BlittableJsonReaderObject detailsJson) == false || detailsJson == null)
+                return new T();
+
+            return DocumentConventions.DefaultForServer.Serialization.DefaultConverter.FromBlittable<T>(detailsJson);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -492,14 +492,11 @@ namespace SlowTests.Server.Documents.Attachments
 
                     var oldDt = DateTime.UtcNow;
 
-                    for (int i = 0; i < 4; i++)
-                    {
-                        oldDt = oldDt.AddMinutes(16);
+                        oldDt = oldDt.AddMinutes(15);
 
                         // move in time & start remote
                         database.Time.UtcDateTime = () => oldDt;
                         await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
-                    }
 
                     // nothing was uploaded because we had a faulty identifier
                     if (uploadAdditional)

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -21,7 +21,6 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Documents;
 using Raven.Server.Documents.BackgroundWork;
-using Raven.Server.Exceptions.Attachments;
 using Raven.Server.ServerWide.Context;
 using Raven.Tests.Core.Utils.Entities;
 using SlowTests.Client.Attachments;
@@ -347,10 +346,10 @@ namespace SlowTests.Server.Documents.Attachments
                     GetStorageAttachmentsMetadataFromAllAttachments(database);
                     Assert.Equal(attachmentsCount + 1, Attachments.Count);
 
-                    Dictionary<string, Dictionary<string, UploadAttachmentException>> myExceptions = null;
+                    List<string> myExceptions = new List<string>();
                     database.RemoteAttachmentsSender.ForTestingPurposesOnly().BeforeEndOfTheBatch = exceptions =>
                     {
-                        myExceptions = exceptions;
+                        myExceptions.Add(exceptions);
                     };
 
                     // move in time & start remote
@@ -484,10 +483,10 @@ namespace SlowTests.Server.Documents.Attachments
                         Assert.Equal(attachmentsCount + 1, Attachments.Count);
                     }
 
-                    List<Exception> myExceptions = new List<Exception>();
+                    List<string> myExceptions = new List<string>();
                     database.RemoteAttachmentsSender.ForTestingPurposesOnly().BeforeEndOfTheBatch = exceptions =>
                     {
-                        myExceptions.AddRange(exceptions.Values.SelectMany(x => x.Values));
+                        myExceptions.Add(exceptions);
                     };
 
 
@@ -540,7 +539,7 @@ namespace SlowTests.Server.Documents.Attachments
 
                     var exception = myExceptions.FirstOrDefault();
                     Assert.NotNull(exception);
-                    Assert.Contains("Failed to upload remote attachment with identifier", exception.Message);
+                    Assert.Contains("Failed to upload remote attachment for identifier", exception);
 
                     using AttachmentResult bad = await store.Operations.SendAsync(new GetAttachmentOperation(id, "att-bad-identifier.png", AttachmentType.Document, null));
 
@@ -634,10 +633,10 @@ namespace SlowTests.Server.Documents.Attachments
                     ModifyRemoteAttachmentsConfig = null;
                     identifier = await PutRemoteAttachmentsConfiguration(store, Settings); // rewrite the config without 2nd identifier
 
-                    Dictionary<string, Dictionary<string, UploadAttachmentException>> myExceptions = null;
+                    List<string> myExceptions = new List<string>();
                     database.RemoteAttachmentsSender.ForTestingPurposesOnly().BeforeEndOfTheBatch = exceptions =>
                     {
-                        myExceptions = exceptions;
+                        myExceptions.Add(exceptions);
                     };
 
                     // move in time & start remote

--- a/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/S3RemoteAttachmentsSlowTests.cs
@@ -490,9 +490,17 @@ namespace SlowTests.Server.Documents.Attachments
                         myExceptions.AddRange(exceptions.Values.SelectMany(x => x.Values));
                     };
 
-                    // move in time & start remote
-                    database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
-                    await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                    var oldDt = DateTime.UtcNow;
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        oldDt = oldDt.AddMinutes(16);
+
+                        // move in time & start remote
+                        database.Time.UtcDateTime = () => oldDt;
+                        await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+                    }
 
                     // nothing was uploaded because we had a faulty identifier
                     if (uploadAdditional)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25642

### Additional description

This pull request refactors and improves the Remote Attachment Upload Retry Logic by instead of retrying 3 times, and then  skip the item, now we will delay it by 15 min on each error during remote attachment uploads in the RavenDB server. also replaced the previous batch-based error tracking and added an alerting system with a more granular and robust notification mechanism, as well as simplified related code paths and improving error retry logic.

**Remote Attachment Upload Retry Logic:**

* Simplified the retry mechanism: after three failed upload attempts, the system now immediately raises an alert and removes the error from retry tracking, instead of accumulating batch exceptions.
* When a retry is scheduled due to an error, the next attempt is now explicitly delayed by 15 minutes, improving the handling of transient issues. 

**Error Handling and Notification Improvements:**

* Introduced `RemoteAttachmentsErrorInfo` and `RemoteAttachmentsErrorsDetails` classes to encapsulate remote attachment upload errors and maintain a capped queue of recent errors for notifications.
* Added a `RemoteAttachmentsNotifications` member to the `AbstractDatabaseNotificationCenter`, allowing remote attachment upload errors and configuration issues to be surfaced as structured notifications.

**Code Cleanup and Simplification:**

* Updated the test hook in `RemoteAttachmentsSender` to pass error messages directly instead of exception dictionaries, reflecting the new notification model.

**Other Notable Changes:**

* Improved date/time handling for scheduling retries by introducing a helper method and using a constant for the 15-minute delay. 
* Removed unnecessary audit logging for remote attachment configuration fetches.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
