### PR TITLE
RavenDB-25760 Reduce EndOfStreamException logging noise in replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ src/Sparrow.Server/Utils/VxSort/codegen/__pycache__/
 .agents/
 
 .claude/
+src/.cache/

--- a/src/Raven.Server/Documents/Replication/DeescalatingWarnToDebugLogger.cs
+++ b/src/Raven.Server/Documents/Replication/DeescalatingWarnToDebugLogger.cs
@@ -1,0 +1,57 @@
+using System;
+using Sparrow.Logging;
+using Sparrow.Server.Logging;
+
+namespace Raven.Server.Documents.Replication
+{
+    /// <summary>
+    /// Logger that de-escalates from WARN to DEBUG after the first log entry.
+    /// Useful for reducing log noise from recurring transient errors.
+    /// </summary>
+    public sealed class DeescalatingWarnToDebugLogger
+    {
+        private readonly RavenLogger _logger;
+
+        // Tracks whether the first log entry has been written for this logger instance
+        private bool _logged;
+
+        /// <summary>
+        /// Creates a new de-escalating logger.
+        /// </summary>
+        /// <param name="logger">The underlying logger to use</param>
+        public DeescalatingWarnToDebugLogger(RavenLogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Returns true if logging is enabled at the current level.
+        /// For the first log entry, checks WARN level; for subsequent entries, checks DEBUG level.
+        /// </summary>
+        public bool IsEnabled => _logged == false ? _logger.IsWarnEnabled : _logger.IsDebugEnabled;
+
+        /// <summary>
+        /// Logs a message with an exception. First call logs at WARN level, 
+        /// subsequent calls log at DEBUG level.
+        /// </summary>
+        /// <param name="message">The message to log</param>
+        /// <param name="exception">The exception to log</param>
+        public void Log(string message, Exception exception)
+        {
+            if (_logged)
+            {
+                if (_logger.IsDebugEnabled)
+                    _logger.Debug(message, exception);
+            }
+            else
+            {
+                _logged = true;
+
+                if (_logger.IsWarnEnabled)
+                    _logger.Warn(message, exception);
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -60,6 +60,7 @@ namespace Raven.Server.Documents.Replication.Incoming
         protected long _lastDocumentEtag;
         protected readonly AsyncManualResetEvent _replicationFromAnotherSource;
         protected RavenLogger Logger;
+        private DeescalatingWarnToDebugLogger _endOfStreamExceptionLogger;
 
         public long LastDocumentEtag => _lastDocumentEtag;
 
@@ -89,6 +90,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             _contextPool = _parent.ContextPool;
 
             Logger = RavenLogManager.Instance.GetLoggerForDatabase(GetType(), _databaseName);
+            _endOfStreamExceptionLogger = new DeescalatingWarnToDebugLogger(Logger);
 
             ConnectionInfo = IncomingConnectionInfo.FromGetLatestEtag(replicatedLastEtag);
             SupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(tcpConnectionOptions.Operation, tcpConnectionOptions.ProtocolVersion);
@@ -333,9 +335,12 @@ namespace Raven.Server.Documents.Replication.Incoming
             }
             catch (EndOfStreamException e)
             {
-                if (Logger.IsInfoEnabled)
-                    Logger.Info("Received unexpected end of stream while receiving replication batches. " +
-                              "This might indicate an issue with network.", e);
+                if (_endOfStreamExceptionLogger.IsEnabled)
+                {
+                    _endOfStreamExceptionLogger.Log(
+                        "Received unexpected end of stream while receiving replication batches. This might indicate an issue with network.",
+                        e);
+                }
                 throw;
             }
             catch (Exception e)

--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -71,6 +71,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
         protected InterruptibleRead<TContextPool, TOperationContext> _interruptibleRead;
         protected OutgoingReplicationStatsAggregator _lastStats;
         protected RavenLogger Logger;
+        private DeescalatingWarnToDebugLogger _endOfStreamExceptionLogger;
 
         public ServerStore Server => _server;
         public long LastSentDocumentEtag => _lastSentDocumentEtag;
@@ -111,6 +112,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
             _connectionDisposed = new AsyncManualResetEvent(token);
 
             Logger = RavenLogManager.Instance.GetLoggerForDatabase(GetType(), _databaseName);
+            _endOfStreamExceptionLogger = new DeescalatingWarnToDebugLogger(Logger);
             Destination = node;
             Metrics = new ReplicationMetricsCountersManager();
         }
@@ -698,7 +700,13 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
                     if (e.InnerException is IOException ioe)
                     {
-                        HandleIOException(ioe);
+                        HandleIoException(ioe);
+                    }
+
+                    if (e.InnerException is EndOfStreamException eose)
+                    {
+                        HandleEndOfStreamException(eose);
+                        return;
                     }
                 }
 
@@ -712,9 +720,13 @@ namespace Raven.Server.Documents.Replication.Outgoing
             {
                 HandleOperationCancelException(e);
             }
+            catch (EndOfStreamException e)
+            {
+                HandleEndOfStreamException(e);
+            }
             catch (IOException e)
             {
-                HandleIOException(e);
+                HandleIoException(e);
             }
             catch (LegacyReplicationViolationException e)
             {
@@ -724,6 +736,8 @@ namespace Raven.Server.Documents.Replication.Outgoing
             {
                 HandleException(e);
             }
+
+            return;
 
             void HandleOperationCancelException(OperationCanceledException e)
             {
@@ -736,7 +750,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 }
             }
 
-            void HandleIOException(IOException e)
+            void HandleIoException(IOException e)
             {
                 if (Logger.IsDebugEnabled)
                 {
@@ -754,6 +768,17 @@ namespace Raven.Server.Documents.Replication.Outgoing
                 if (Logger.IsWarnEnabled)
                     Logger.Warn($"LegacyReplicationViolationException occurred on replication thread ({FromToString}). " +
                                 "Replication is stopped and will not continue until the violation is resolved. ", e);
+                OnFailed(e);
+            }
+
+            void HandleEndOfStreamException(EndOfStreamException e)
+            {
+                if (_endOfStreamExceptionLogger.IsEnabled)
+                {
+                    _endOfStreamExceptionLogger.Log(
+                        $"Unexpected exception occurred on replication thread ({FromToString}). Replication stopped (will be retried later).",
+                        e);
+                }
                 OnFailed(e);
             }
 

--- a/test/FastTests/Server/Replication/DeescalatingWarnToDebugLoggerTests.cs
+++ b/test/FastTests/Server/Replication/DeescalatingWarnToDebugLoggerTests.cs
@@ -103,8 +103,8 @@ namespace FastTests.Server.Replication
 
         private class NLogTestSetup : IDisposable
         {
-            private readonly LoggingConfiguration _previousConfiguration;
             private readonly TestTarget _testTarget;
+            private readonly LoggingConfiguration _config;
 
             public DeescalatingWarnToDebugLogger Logger { get; }
 
@@ -112,38 +112,36 @@ namespace FastTests.Server.Replication
             {
                 minLevel ??= LogLevel.Debug;
 
-                // Store previous configuration to restore later
-                _previousConfiguration = LogManager.Configuration;
+                // Create a pair of factory and config.
+                LogFactory factory = new();
+                _config = new LoggingConfiguration(factory);
 
-                // Create new configuration with test target
-                var configuration = new LoggingConfiguration();
                 _testTarget = new TestTarget { Name = "test" };
-                configuration.AddTarget(_testTarget);
+                _config.AddTarget(_testTarget);
 
                 // Add logging rule
-                configuration.LoggingRules.Add(new LoggingRule("*", minLevel, _testTarget));
+                _config.LoggingRules.Add(new LoggingRule("*", minLevel, _testTarget));
 
-                LogManager.Configuration = configuration;
-                var nlogLogger = LogManager.GetLogger("test");
-                Logger = new DeescalatingWarnToDebugLogger(new RavenLogger(nlogLogger));
+                // Set the configuration in the factory to reload it.
+                factory.Configuration = _config;
+
+                // Use local factory to create it.
+                Logger logger = factory.GetLogger("test");
+                Logger = new DeescalatingWarnToDebugLogger(new RavenLogger(logger));
             }
 
             public List<LogEventInfo> GetLogs()
             {
-                LogManager.Flush();
+                _config.LogFactory.Flush();
                 return _testTarget.LogEvents.ToList();
             }
 
             public void Dispose()
             {
-                LogManager.Flush();
-                // Restore previous configuration
-                LogManager.Configuration = _previousConfiguration;
             }
         }
 
-        [Target("TestTarget")]
-        private class TestTarget : TargetWithLayout
+        private class TestTarget : Target
         {
             public List<LogEventInfo> LogEvents { get; } = new();
 

--- a/test/FastTests/Server/Replication/DeescalatingWarnToDebugLoggerTests.cs
+++ b/test/FastTests/Server/Replication/DeescalatingWarnToDebugLoggerTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using Raven.Server.Documents.Replication;
+using Sparrow.Server.Logging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Replication
+{
+    public class DeescalatingWarnToDebugLoggerTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenFact(RavenTestCategory.Logging)]
+        public void FirstCall_ShouldLogAtWarnLevel()
+        {
+            // Arrange
+            using var scope = new NLogTestSetup();
+            var exception = new Exception("Test exception");
+            const string message = "Test message";
+
+            // Act
+            scope.Logger.Log(message, exception);
+
+            // Assert
+            var logs = scope.GetLogs();
+            Assert.Single(logs);
+            Assert.Equal(LogLevel.Warn, logs[0].Level);
+            Assert.Contains(message, logs[0].FormattedMessage);
+        }
+
+        [RavenFact(RavenTestCategory.Logging)]
+        public void FurtherCalls_ShouldLogAtDebugLevel()
+        {
+            // Arrange
+            using var scope = new NLogTestSetup();
+
+            // Act
+            scope.Logger.Log("Message 1", new Exception("Exception 1"));
+            scope.Logger.Log("Message 2", new Exception("Exception 2"));
+            scope.Logger.Log("Message 3", new Exception("Exception 3"));
+            scope.Logger.Log("Message 4", new Exception("Exception 4"));
+
+            // Assert
+            var logs = scope.GetLogs();
+            Assert.Equal(4, logs.Count);
+            Assert.Equal(LogLevel.Warn, logs[0].Level); // Only first call
+            Assert.Equal(LogLevel.Debug, logs[1].Level);
+            Assert.Equal(LogLevel.Debug, logs[2].Level);
+            Assert.Equal(LogLevel.Debug, logs[3].Level);
+        }
+
+        [RavenFact(RavenTestCategory.Logging)]
+        public void IsEnabled_BeforeFirstCall_ShouldCheckWarnLevel()
+        {
+            using var scope = new NLogTestSetup(minLevel: LogLevel.Warn);
+
+            Assert.True(scope.Logger.IsEnabled);
+        }
+
+        [RavenFact(RavenTestCategory.Logging)]
+        public void Enabled_When_WarnErrorIsSet()
+        {
+            using var scope = new NLogTestSetup(minLevel: LogLevel.Warn); // Warn enabled, Debug disabled
+
+            Assert.True(scope.Logger.IsEnabled, "Should be enabled before the call");
+
+            scope.Logger.Log("Test", new Exception());
+
+            Assert.False(scope.Logger.IsEnabled, "Should be disabled after the call");
+        }
+
+        [RavenFact(RavenTestCategory.Logging)]
+        public void Log_WithWarnDisabled_ShouldNotLogFirstCall()
+        {
+            using var scope = new NLogTestSetup(minLevel: LogLevel.Error); // Warn disabled
+
+            Assert.False(scope.Logger.IsEnabled, "Disabled when error level set");
+
+            scope.Logger.Log("Message", new Exception());
+
+            Assert.Empty(scope.GetLogs());
+        }
+
+        [RavenFact(RavenTestCategory.Logging)]
+        public void Log_WithDebugDisabled_ShouldNotLogSubsequentCalls()
+        {
+            // Arrange
+            using var scope = new NLogTestSetup(minLevel: LogLevel.Warn); // Warn enabled, Debug disabled
+
+            // Act
+            scope.Logger.Log("First", new Exception());
+            scope.Logger.Log("Second", new Exception());
+
+            // Assert
+            var logs = scope.GetLogs();
+            Assert.Single(logs); // Only first call logged
+            Assert.Equal(LogLevel.Warn, logs[0].Level);
+        }
+
+        private class NLogTestSetup : IDisposable
+        {
+            private readonly LoggingConfiguration _previousConfiguration;
+            private readonly TestTarget _testTarget;
+
+            public DeescalatingWarnToDebugLogger Logger { get; }
+
+            public NLogTestSetup(LogLevel minLevel = null)
+            {
+                minLevel ??= LogLevel.Debug;
+
+                // Store previous configuration to restore later
+                _previousConfiguration = LogManager.Configuration;
+
+                // Create new configuration with test target
+                var configuration = new LoggingConfiguration();
+                _testTarget = new TestTarget { Name = "test" };
+                configuration.AddTarget(_testTarget);
+
+                // Add logging rule
+                configuration.LoggingRules.Add(new LoggingRule("*", minLevel, _testTarget));
+
+                LogManager.Configuration = configuration;
+                var nlogLogger = LogManager.GetLogger("test");
+                Logger = new DeescalatingWarnToDebugLogger(new RavenLogger(nlogLogger));
+            }
+
+            public List<LogEventInfo> GetLogs()
+            {
+                LogManager.Flush();
+                return _testTarget.LogEvents.ToList();
+            }
+
+            public void Dispose()
+            {
+                LogManager.Flush();
+                // Restore previous configuration
+                LogManager.Configuration = _previousConfiguration;
+            }
+        }
+
+        [Target("TestTarget")]
+        private class TestTarget : TargetWithLayout
+        {
+            public List<LogEventInfo> LogEvents { get; } = new();
+
+            protected override void Write(LogEventInfo logEvent) => LogEvents.Add(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25760

### Additional description

Production clusters generate excessive WARN-level logs for transient `EndOfStreamException` during replication. These exceptions don't cause functional problems but create log noise. This PR introduced a de-escalating wrapper over logger that is used in the replication handlers.

This code was created with copilot. This was not a one shot and it was reviewed before asking for merge-in.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed