### PR TITLE
RavenDB-25838 Expose storage report endpoint and add paging to index errors

### DIFF
--- a/src/Raven.Server/Documents/Commands/Storage/GetEnvironmentStorageReportCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Storage/GetEnvironmentStorageReportCommand.cs
@@ -12,18 +12,20 @@ internal sealed class GetEnvironmentStorageReportCommand : RavenCommand
     private readonly string _name;
     private readonly StorageEnvironmentWithType.StorageEnvironmentType _type;
     private readonly bool _details;
+    private readonly bool _flat;
 
-    public GetEnvironmentStorageReportCommand([NotNull] string name, [NotNull] StorageEnvironmentWithType.StorageEnvironmentType type, bool details, string nodeTag)
+    public GetEnvironmentStorageReportCommand([NotNull] string name, [NotNull] StorageEnvironmentWithType.StorageEnvironmentType type, bool details, string nodeTag, bool flat)
     {
         _name = name ?? throw new ArgumentNullException(nameof(name));
         _type = type;
         _details = details;
+        _flat = flat;
         SelectedNodeTag = nodeTag;
     }
 
     public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
     {
-        url = $"{node.Url}/databases/{node.Database}/debug/storage/environment/report?name={Uri.EscapeDataString(_name)}&type={Uri.EscapeDataString(_type.ToString())}&details={_details}";
+        url = $"{node.Url}/databases/{node.Database}/debug/storage/environment/report?name={Uri.EscapeDataString(_name)}&type={Uri.EscapeDataString(_type.ToString())}&details={_details}&flat={_flat}";
 
         return new HttpRequestMessage
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/AbstractStorageHandlerProcessorForGetEnvironmentReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/AbstractStorageHandlerProcessorForGetEnvironmentReport.cs
@@ -24,8 +24,9 @@ internal abstract class AbstractStorageHandlerProcessorForGetEnvironmentReport<T
         var name = GetName();
         var type = GetEnvironmentType();
         var details = GetDetails();
+        var flat = UseFlatFormat();
 
-        return new GetEnvironmentStorageReportCommand(name, type, details, nodeTag);
+        return new GetEnvironmentStorageReportCommand(name, type, details, nodeTag, flat);
     }
 
     protected string GetName() => RequestHandler.GetStringQueryString("name");
@@ -41,8 +42,9 @@ internal abstract class AbstractStorageHandlerProcessorForGetEnvironmentReport<T
     }
 
     protected bool GetDetails() => RequestHandler.GetBoolValueQueryString("details", required: false) ?? false;
+    protected bool UseFlatFormat() => RequestHandler.GetBoolValueQueryString("flat", required: false) ?? false;
 
-    protected virtual DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de)
+    protected virtual DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de, bool flat)
     {
         throw new NotSupportedException();
     }
@@ -77,14 +79,14 @@ internal abstract class AbstractStorageHandlerProcessorForGetEnvironmentReport<T
         writer.WriteEndObject();
     }
 
-    public void WriteReport(AsyncBlittableJsonTextWriter writer, StorageEnvironmentWithType env, DocumentsOperationContext context, bool detailed = false)
+    public void WriteReport(AsyncBlittableJsonTextWriter writer, StorageEnvironmentWithType env, DocumentsOperationContext context, bool detailed = false, bool flat = false)
     {
         if (env == null)
             return;
         
         using (var tx = context.OpenWriteTransaction())
         {
-            var djv = GetJsonReport(env, tx.InnerTransaction.LowLevelTransaction, detailed);
+            var djv = GetJsonReport(env, tx.InnerTransaction.LowLevelTransaction, detailed, flat);
             writer.WriteStartObject();
             writer.WritePropertyName("Report");
             writer.WriteObject(context.ReadObject(djv, env.Name));

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetEnvironmentReport.cs
@@ -28,6 +28,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentReport : AbstractS
         var name = GetName();
         var type = GetEnvironmentType();
         var details = GetDetails();
+        var flat = UseFlatFormat();
 
         var env = RequestHandler.Database.GetAllStoragesEnvironment()
             .FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase) && x.Type == type);
@@ -42,7 +43,7 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentReport : AbstractS
         {
             await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
             {
-                WriteReport(writer, env, context, details);
+                WriteReport(writer, env, context, details, flat);
             }
         }
     }
@@ -63,8 +64,14 @@ internal sealed class StorageHandlerProcessorForGetEnvironmentReport : AbstractS
         return index.GenerateStorageReport(details);
     }
 
-    protected override DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de)
+    protected override DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de, bool flat)
     {
-        return (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(GetDetailedReport(env, de));
+        var report = GetDetailedReport(env, de);
+        if (flat)
+        {
+            return (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(FlatStorageReport.From(report));
+        }
+
+        return (DynamicJsonValue)TypeConverter.ToBlittableSupportedType(report);
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetScratchBufferReport.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Debugging/StorageHandlerProcessorForGetScratchBufferReport.cs
@@ -62,7 +62,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Debugging
 
         protected override Task HandleRemoteNodeAsync(ProxyCommand<object> command, OperationCancelToken token) => RequestHandler.ExecuteRemoteAsync(command, token.Token);
 
-        protected override DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de)
+        protected override DynamicJsonValue GetJsonReport(StorageEnvironmentWithType env, LowLevelTransaction lowTx, bool de, bool flat)
         {
             //Opening a write transaction to avoid concurrency problems (Issue #21088)
             var sc = env.Environment.ScratchBufferPool.InfoForDebug(env.Environment.PossibleOldestReadTransaction(lowTx));

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForGetErrors.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForGetErrors.cs
@@ -25,6 +25,8 @@ internal sealed class IndexHandlerProcessorForGetErrors : AbstractIndexHandlerPr
     protected override ValueTask HandleCurrentNodeAsync()
     {
         var names = GetIndexNames();
+        var pageSize = RequestHandler.GetPageSize();
+        var start = RequestHandler.GetStart();
 
         List<Index> indexes;
         if (names == null || names.Length == 0)
@@ -45,7 +47,7 @@ internal sealed class IndexHandlerProcessorForGetErrors : AbstractIndexHandlerPr
         var indexErrors = indexes.Select(x => new IndexErrors
         {
             Name = x.Name,
-            Errors = x.GetErrors().ToArray()
+            Errors = x.GetErrors(start, pageSize).ToArray()
         }).ToArray();
 
         return WriteResultAsync(indexErrors);

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioIndexHandlerProcessorForGetIndexErrorsCount.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioIndexHandlerProcessorForGetIndexErrorsCount.cs
@@ -25,6 +25,8 @@ internal sealed class StudioIndexHandlerProcessorForGetIndexErrorsCount : Abstra
     protected override ValueTask HandleCurrentNodeAsync()
     {
         var names = GetIndexNames();
+        var pageSize = RequestHandler.GetPageSize();
+        var start = RequestHandler.GetStart();
 
         List<Index> indexes;
         if (names == null || names.Length == 0)
@@ -45,7 +47,7 @@ internal sealed class StudioIndexHandlerProcessorForGetIndexErrorsCount : Abstra
         var indexErrorsCounts = indexes.Select(x => new GetIndexErrorsCountCommand.IndexErrorsCount
         {
             Name = x.Name,
-            Errors = x.GetErrors()
+            Errors = x.GetErrors(start, pageSize)
                 .GroupBy(y => y.Action)
                 .Select(y => new GetIndexErrorsCountCommand.IndexingErrorCount
                 {

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -93,7 +93,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             // no-op
         }
 
-        public override List<IndexingError> GetErrors()
+        public override List<IndexingError> GetErrors(int start = 0, int pageSize = int.MaxValue)
         {
             return new List<IndexingError>
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2728,14 +2728,14 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public virtual List<IndexingError> GetErrors()
+        public virtual List<IndexingError> GetErrors(int start = 0, int pageSize = int.MaxValue)
         {
             using (CurrentlyInUse(out var valid))
             {
                 if (valid == false)
                     return new List<IndexingError>();
 
-                return _indexStorage.ReadErrors();
+                return _indexStorage.ReadErrors(start, pageSize);
             }
         }
 

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -337,7 +337,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public unsafe List<IndexingError> ReadErrors()
+        public unsafe List<IndexingError> ReadErrors(int start, int pageSize)
         {
             var errors = new List<IndexingError>();
 
@@ -346,8 +346,11 @@ namespace Raven.Server.Documents.Indexes
             {
                 var table = tx.InnerTransaction.OpenTable(_errorsSchema, "Errors");
 
-                foreach (var tvr in table.SeekForwardFrom(_errorsSchema.Indexes[IndexSchema.ErrorTimestampsSlice], Slices.BeforeAllKeys, 0))
+                foreach (var tvr in table.SeekForwardFrom(_errorsSchema.Indexes[IndexSchema.ErrorTimestampsSlice], Slices.BeforeAllKeys, start))
                 {
+                    if (pageSize-- <= 0)
+                        break;
+
                     var error = new IndexingError();
 
                     var ptr = tvr.Result.Reader.Read(0, out int size);

--- a/src/Raven.Studio/typescript/components/shell/chatbot/utils/chatbotConstants.ts
+++ b/src/Raven.Studio/typescript/components/shell/chatbot/utils/chatbotConstants.ts
@@ -137,7 +137,7 @@ const endpointsWhitelist: EndpointEntry[] = [
     { path: "/topology" },
     { path: "/databases/{database}/task" },
     { path: "/databases/{database}/task" },
-
+    { path: "/databases/{database}/debug/storage/environment/report" },
     // Additional (not listed in debug endpoints)
     { path: "/databases/{database}/docs", paramToDisplay: "id", isDataSubmission: true },
     { path: "/databases/{database}/collections/docs/ids" },

--- a/src/Voron/Debugging/FlatStorageReport.cs
+++ b/src/Voron/Debugging/FlatStorageReport.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Voron.Debugging
+{
+    public class FlatStorageReport
+    {
+        public DataFileReport DataFile { get; set; }
+        public List<FlatTreeReport> Trees { get; set; }
+        public List<FlatTableReport> Tables { get; set; }
+
+        public static FlatStorageReport From(DetailedStorageReport report) =>
+            new()
+            {
+                DataFile = report.DataFile,
+                Trees = report.Trees?.Select(tree => new FlatTreeReport
+                {
+                    Name = tree.Name,
+                    NumberOfEntries = tree.NumberOfEntries,
+                    Depth = tree.Depth,
+                    AllocatedSpaceInBytes = tree.AllocatedSpaceInBytes,
+                    StreamReport = tree.Streams != null
+                        ? new FlatStreamReport
+                        {
+                            NumberOfStreams = tree.Streams.NumberOfStreams,
+                            TotalNumberOfAllocatedPages = tree.Streams.TotalNumberOfAllocatedPages,
+                            AllocatedSpaceInBytes = tree.Streams.AllocatedSpaceInBytes
+                        }
+                        : null
+                }).ToList(),
+                Tables = report.Tables?.Select(table => new FlatTableReport
+                {
+                    Name = table.Name,
+                    NumberOfEntries = table.NumberOfEntries,
+                    DataSizeInBytes = table.DataSizeInBytes,
+                    AllocatedSpaceInBytes = table.AllocatedSpaceInBytes,
+                }).ToList()
+            };
+    }
+    public class FlatTableReport
+    {
+        public string Name { get; set; }
+        public long NumberOfEntries { get; set; }
+        public long DataSizeInBytes { get; set; }
+        public long AllocatedSpaceInBytes { get; set; }
+    }
+    public class FlatTreeReport
+    {
+        public string Name { get; set; }
+        public long NumberOfEntries { get; set; }
+        public int Depth { get; set; }
+        public long AllocatedSpaceInBytes { get; set; }
+        public FlatStreamReport StreamReport { get; set; }
+    }
+
+    public class FlatStreamReport
+    {
+        public long NumberOfStreams { get; set; }
+        public long TotalNumberOfAllocatedPages { get; set; }
+        public long AllocatedSpaceInBytes { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25838

### Additional description

- Expose storage report endpoint for the ai assistant, it has to be compact and flat to reduce the request size and tokens count  
- Add paging to index errors

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
