### PR TITLE
RavenDB-22674 Fixing ocassionally failing ETL test

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6711_RavenEtl.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_6711_RavenEtl.cs
@@ -56,8 +56,6 @@ namespace SlowTests.Server.Documents.ETL.Raven
             {
                 Etl.AddEtl(src, dest, collections: new string[0], script: null, applyToAllDocuments: true);
 
-                //var etlDone = Etl.WaitForEtlToComplete(src, numOfProcessesToWaitFor: 2);
-
                 using (var session = src.OpenSession())
                 {
                     session.Store(new User
@@ -104,8 +102,6 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 // update
 
-                var etlDone = Etl.WaitForEtlToComplete(src);
-
                 using (var session = src.OpenSession())
                 {
                     var user = session.Load<User>("users/1-A");
@@ -115,21 +111,20 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
-
-                using (var session = dest.OpenSession())
+                await Etl.AssertEtlReachedDestination(() =>
                 {
-                    var stats = dest.Maintenance.Send(new GetStatisticsOperation());
+                    using (var session = dest.OpenSession())
+                    {
+                        var stats = dest.Maintenance.Send(new GetStatisticsOperation());
 
-                    Assert.Equal(5, stats.CountOfDocuments); // 3 docs and 2 HiLo 
+                        Assert.Equal(5, stats.CountOfDocuments); // 3 docs and 2 HiLo 
 
-                    var user = session.Load<User>("users/1-A");
-                    Assert.Equal("James Doe", user.Name);
-                }
+                        var user = session.Load<User>("users/1-A");
+                        Assert.Equal("James Doe", user.Name);
+                    }
+                });
 
                 // delete
-
-                etlDone.Reset();
 
                 using (var session = src.OpenSession())
                 {
@@ -140,17 +135,18 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
-                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
-
-                using (var session = dest.OpenSession())
+                await Etl.AssertEtlReachedDestination(() =>
                 {
-                    var stats = dest.Maintenance.Send(new GetStatisticsOperation());
+                    using (var session = dest.OpenSession())
+                    {
+                        var stats = dest.Maintenance.Send(new GetStatisticsOperation());
 
-                    Assert.Equal(4, stats.CountOfDocuments); // 2 docs and 2 HiLo 
+                        Assert.Equal(4, stats.CountOfDocuments); // 2 docs and 2 HiLo 
 
-                    var user = session.Load<User>("users/1-A");
-                    Assert.Null(user);
-                }
+                        var user = session.Load<User>("users/1-A");
+                        Assert.Null(user);
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22674

### Additional description

Somehow to related to refactoring made in tests during sharding work - https://github.com/ravendb/ravendb/pull/16500

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
