### PR TITLE
RavenDB-25693 - Remove newly created `TermInfosReader` cache entries on transaction abort

### DIFF
--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -207,7 +207,14 @@ namespace Raven.Server.Indexing
             var state = s as VoronState;
             if (state == null)
                 throw new ArgumentNullException(nameof(s));
-            
+
+            if (name.EndsWith(IndexFileNames.TERMS_INDEX_EXTENSION, StringComparison.OrdinalIgnoreCase))
+            {
+                // the cache consists only of files with the TERMS_INDEX_EXTENSION.
+                // https://github.com/ravendb/lucenenet/blob/e30e8f94f6895197913d091a61e7e831398ce3fb/src/Lucene.Net/Index/TermInfosReader.cs#L107
+                state.Transaction.LowLevelTransaction.OnRollBack += _ => RemoveFromTermsIndexCache(name);
+            }
+
             return new VoronIndexOutput(_tempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25693/IndexOutOfRangeException-during-ApplyDeletes

### Additional description

Fix `IndexOutOfRangeException` in `TermInfosReader` caused by stale cache after aborted merge.

## 📝 Description

This PR addresses a critical issue where `System.IndexOutOfRangeException` occurs during `ApplyDeletes` in the `TermInfosReader`. This error persists in a loop, preventing further indexing and requiring a full service restart to resolve (an index or database restart also works).

Investigation confirmed this is an in-memory state issue rather than physical index corruption. It occurs specifically when an indexing transaction is aborted due to resource constraints (OOM or Out of Disk Space) during a segment merge.

## 🐛 Bug Context

The `TermInfosReader` acts as an in-memory cache for terms to enable fast access during queries and indexing (specifically during `ApplyDeletes` and segment merges). Because Lucene segments are immutable, this cache is designed to be computed once and never changed.

However, if a transaction aborts *after* this cache has been generated but *before* the segment is fully committed, the cache remains in memory. Subsequent transactions interacting with that segment will crash because the cached state does not match the new indexing batch's expectations.

## 🔍 Root Cause Analysis

The error is triggered by a specific chronological sequence of events involving index merges and resource exhaustion:

1. **Segment Creation:** An indexing batch creates a new segment.
2. **Merge Triggered:** Lucene initiates a merge that includes this new segment.
3. **Cache Initialization:** The merge process reads the segment, initializing the `TermInfosReader` cache.
4. **Resource Failure:** An `OutOfDiskSpace` or `OutOfMemory` exception occurs during the merge.
5. **Transaction Abort:** The transaction for the current batch is aborted due to the exception.
6. **State Leak:** Crucially, the in-memory cache created in Step 3 is **not cleared**. It persists because the system assumes the segment is immutable and the cache is valid.
7. **New Transaction:** A new indexing batch begins with **new** documents.
8. **The Crash:** When the new batch attempts to access the segment, it hits the stale in-memory cache. The index required for the new data is outside the bounds of the stale cache, resulting in `System.IndexOutOfRangeException`.

## 🛠️ The Fix

We have modified the transaction rollback logic. Now, if an indexing transaction is aborted, we explicitly remove any segments created during that batch. This ensures that the stale in-memory cache associated with the aborted segment is discarded, preventing it from polluting subsequent transactions.

## 🧪 How Has This Been Tested?

* Reproduced the crash by artificially injecting `OutOfMemory` exceptions during the segment merge phase.
* Verified that with the fix applied, the system correctly cleans up the aborted segment state and the next indexing batch proceeds without throwing `IndexOutOfRangeException`.

---

### Would you like me to...

* Draft the **Commit Message** that would go along with this PR?
* Create a flowchart or diagram description to include in the PR comments for visual clarity?

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
