### PR TITLE
RavenDB-25856 - Allow `ClusterAdmin` access when using SSL Termination (HTTPS) without Client Certs

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -348,31 +348,21 @@ class shell extends viewModelBase {
 
                 this.connectToRavenServer();
                 
-                // "http"
-                if (location.protocol === "http:") {
+                if (!certificate) {
                     this.accessManager.securityClearance("ClusterAdmin");
                     this.accessManager.secureServer(false);
                 } else {
-                    // "https"
-                    if (certificate) {
-                        this.accessManager.securityClearance(certificate.SecurityClearance);
-                        accessManager.clientCertificateThumbprint(certificate.Thumbprint);
+                    this.accessManager.securityClearance(certificate.SecurityClearance);
+                    accessManager.clientCertificateThumbprint(certificate.Thumbprint);
 
-                        const databasesAccess: dictionary<databaseAccessLevel> = {};
-                        for (const key in certificate.Permissions) {
-                            const access = certificate.Permissions[key];
-                            databasesAccess[`${key}`] = `Database${access}` as databaseAccessLevel;
-                        }
-                        accessManager.databasesAccess = databasesAccess;
-                        storeCompat.globalDispatch(accessManagerSlice.accessManagerActions.onDatabaseAccessLoaded(databasesAccess));
-                        this.accessManager.secureServer(true);
-                        
-                    } else {
-                        // we are on HTTPS, but no client certificate was found.
-                        // this implies we are behind an SSL termination proxy and the backend is unsecured.
-                        this.accessManager.securityClearance("ClusterAdmin");
-                        this.accessManager.secureServer(false);
+                    const databasesAccess: dictionary<databaseAccessLevel> = {};
+                    for (const key in certificate.Permissions) {
+                        const access = certificate.Permissions[key];
+                        databasesAccess[`${key}`] = `Database${access}` as databaseAccessLevel;
                     }
+                    accessManager.databasesAccess = databasesAccess;
+                    storeCompat.globalDispatch(accessManagerSlice.accessManagerActions.onDatabaseAccessLoaded(databasesAccess));
+                    this.accessManager.secureServer(true);
                 }
             })
             .then(() => this.onBootstrapFinishedTask.resolve(), () => this.onBootstrapFinishedTask.reject());

--- a/src/Raven.Studio/typescript/viewmodels/shell.ts
+++ b/src/Raven.Studio/typescript/viewmodels/shell.ts
@@ -368,7 +368,9 @@ class shell extends viewModelBase {
                         this.accessManager.secureServer(true);
                         
                     } else {
-                        this.accessManager.securityClearance("ValidUser");
+                        // we are on HTTPS, but no client certificate was found.
+                        // this implies we are behind an SSL termination proxy and the backend is unsecured.
+                        this.accessManager.securityClearance("ClusterAdmin");
                         this.accessManager.secureServer(false);
                     }
                 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25856/Studio-Access-Denied-when-using-SSL-Termination-HTTPS-with-Unsecured-Backend

### Additional description

**The Problem**
Currently, users running RavenDB in **Unsecured Mode** behind a Reverse Proxy (like Kubernetes Ingress or Nginx) are unable to manage the database via the Studio.

* **Network Path:** `Client (HTTPS) -> Ingress (SSL Termination) -> RavenDB (HTTP)`
* **Current Logic:** The Studio detects `location.protocol === 'https:'`. It assumes that HTTPS implies "Secure Mode" (requiring X.509 Client Certs).
* **The Bug:** Because the backend is actually Unsecured, no client certificate is requested or present. The code falls into an `else` block that sets the security clearance to `ValidUser`. This grants a valid session but removes all administrative privileges, effectively locking the user out of a database they own.

**The Fix**
I have updated the authentication logic to handle the "HTTPS without Certificate" scenario.
If `https:` is in use but **no certificate** is present, the Studio now assumes the server is running in Unsecured Mode (similar to how it handles `http:`).

* **Clearance:** Sets to `ClusterAdmin`.
* **SecureServer:** Sets to `false`.

**Why this is Safe (Security Analysis)**
This change modifies **Client-Side UI state only**. It does not bypass any actual server security.

1. **If the Backend IS Unsecured:** The user is already an Admin by definition (trusted network). This fix simply updates the UI to reflect that reality so the buttons work.
2. **If the Backend IS Secure:** If a user accesses a truly Secure server without a certificate, the RavenDB backend will reject all API requests with `401/403` errors. Even if the UI displays "ClusterAdmin" buttons, clicking them will fail at the API level.

**Conclusion**
This change aligns the Studio's frontend logic with standard Reverse Proxy patterns, ensuring that users protecting their Unsecured instances with an HTTPS Ingress can still administer their database.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
