### PR TITLE
RavenDB-25700: Apply EnableTracing changes on GenAI task update

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -151,7 +151,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             JsonSchema != other.JsonSchema ||
             SampleObject != other.SampleObject ||
             MaxConcurrency != other.MaxConcurrency ||
-            ExpirationInSec != other.ExpirationInSec)
+            ExpirationInSec != other.ExpirationInSec ||
+            EnableTracing != other.EnableTracing)
             differences |= EtlConfigurationCompareDifferences.Other;
 
         return differences;

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25700.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25700.cs
@@ -82,8 +82,6 @@ for(const comment of this.Comments)
         store.Maintenance.Send(new UpdateGenAiOperation(genAiTask.TaskId, config));
 
         // add another post to trigger the ETL again
-        etlDone = Etl.WaitForEtlToComplete(store);
-
         using (var session = store.OpenSession())
         {
             var anotherPost = new GenAiBasics.Post(
@@ -98,16 +96,17 @@ for(const comment of this.Comments)
             session.SaveChanges();
         }
 
-        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
-
         // verify that conversation documents were created this time
-        using (var session = store.OpenSession())
+        var docsCount = WaitForValue(() =>
         {
-            var docs = session.Advanced.LoadStartingWith<object>(conversationDocsPrefix);
+            using (var session = store.OpenSession())
+            {
+                var docs = session.Advanced.LoadStartingWith<object>(conversationDocsPrefix);
+                return docs?.Length;
+            }
+        }, expectedVal: 2, timeout: 30_000);
 
-            // two conversation documents should be created when tracing is enabled (one per comment)
-            Assert.Equal(2, docs.Length);
-        }
-
+        // two conversation documents should be created when tracing is enabled (one per comment)
+        Assert.True(docsCount == 2, await Etl.GetEtlDebugInfo(store.Database));
     }
 }

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25700.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25700.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_25700(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task EnablingTracingAfterTaskUpdateShouldTakeEffect(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore();
+        const string docId = "posts/1";
+
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        config.Identifier = "gen-ai-spam-detection";
+        config.Prompt = "Check if the following blog post comment is spam or not";
+        config.Collection = "Posts";
+
+        config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or ham" });
+        config.UpdateScript = @"    
+const idx = this.Comments.findIndex(c => c.Id == $input.Id);  
+if($output.Blocked)
+{
+    this.Comments.splice(idx, 1); // remove
+}";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+        };
+
+        // conversation tracing is set to False initially
+        config.EnableTracing = false;
+
+        var genAiTask = store.Maintenance.Send(new AddGenAiOperation(config));
+
+        var etlDone = Etl.WaitForEtlToComplete(store);
+
+        List<GenAiBasics.Comment> comments = [
+            new("Free crypto airdrop! Sign up now at scamcoin.fake", "evil bot"),
+            new("Great article. Helped me understand indexing in RavenDB.", "alex"),
+            new("Surefire investment property in caiman islands, win $$$$ for sure, qucik!", "homepage")
+        ];
+
+        var post = new GenAiBasics.Post(comments, "Understanding RavenDB Indexing", "Indexes in RavenDB are powerful...");
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(post, docId); 
+            session.SaveChanges();
+        }
+
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+
+        var conversationDocsPrefix = $"{config.Identifier}/";
+
+        using (var session = store.OpenSession())
+        {
+            var docs = session.Advanced.LoadStartingWith<object>(conversationDocsPrefix);
+
+            // no conversation documents should be created when tracing is disabled
+            Assert.Equal(0, docs.Length);
+        }
+
+        // update the task to enable tracing
+        config.EnableTracing = true;
+        store.Maintenance.Send(new UpdateGenAiOperation(genAiTask.TaskId, config));
+
+        // add another post to trigger the ETL again
+        etlDone = Etl.WaitForEtlToComplete(store);
+
+        using (var session = store.OpenSession())
+        {
+            var anotherPost = new GenAiBasics.Post(
+                [
+                    new("This is another spam comment, visit spammy.site.example now!", "spammer"),
+                    new("Informative post, thanks for sharing!", "reader123")
+                ],
+                "RavenDB Performance Tuning",
+                "In this post, we explore various techniques to optimize RavenDB performance..."
+            );
+            session.Store(anotherPost, "posts/2");
+            session.SaveChanges();
+        }
+
+        Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+        // verify that conversation documents were created this time
+        using (var session = store.OpenSession())
+        {
+            var docs = session.Advanced.LoadStartingWith<object>(conversationDocsPrefix);
+
+            // two conversation documents should be created when tracing is enabled (one per comment)
+            Assert.Equal(2, docs.Length);
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25700/Enable-conversation-documents-doesnt-work

### Additional description

This PR fixes a configuration update gap in GenAI tasks: toggling `EnableTracing` after a task is already defined now takes effect without requiring disable/enable or restart.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
