### PR TITLE
RavenDB-25752 - fix possible NRE in test

### DIFF
--- a/test/SlowTests/Server/Documents/Attachments/RemoteAttachmentsHolder.cs
+++ b/test/SlowTests/Server/Documents/Attachments/RemoteAttachmentsHolder.cs
@@ -1112,6 +1112,11 @@ public abstract class RemoteAttachmentsHolder<TSettings> : RemoteAttachmentsHold
 
                     GetStorageAttachmentsMetadataFromAllAttachments(database2);
                     Assert.Equal(attachmentsCount, Attachments.Count);
+
+                    // Wait for RemoteAttachmentsSender to be initialized
+                    Assert.True(await WaitForValueAsync(() => database2.RemoteAttachmentsSender != null, true, timeout: 15_000),
+                        "RemoteAttachmentsSender was not initialized after restore");
+
                     // move in time & start remote
                     database2.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
                     await database2.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25752

### Additional description

Wait for database to fully load after restore in test

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
