### PR TITLE
RavenDB-25326 - Remote attachments - Studio Part - Licensing (Phase 1)

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.spec.tsx
@@ -56,7 +56,7 @@ describe("RemoteAttachments", () => {
 
     it("keeps Add new enabled after toggling Remote Attachments on", async () => {
         const { screen, fireClick } = await rtlRender_WithWaitForLoad(
-            <DefaultRemoteAttachments hasRemoteAttachments={false} databaseAccess="DatabaseAdmin" />
+            <DefaultRemoteAttachments hasRemoteDestinations={false} databaseAccess="DatabaseAdmin" />
         );
 
         const enableSwitch = screen.getByRole("checkbox", { name: selectors.titles.enableRemoteAttachments });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.spec.tsx
@@ -13,29 +13,44 @@ const selectors = {
 };
 
 describe("RemoteAttachments", () => {
-    it("shows the Save button for DatabaseAdmin access", async () => {
-        const { screen } = await rtlRender_WithWaitForLoad(<DefaultRemoteAttachments databaseAccess="DatabaseAdmin" />);
+    it("shows the Save button enabled for DatabaseAdmin access", async () => {
+        const { screen, fillInput } = await rtlRender_WithWaitForLoad(
+            <DefaultRemoteAttachments databaseAccess="DatabaseAdmin" />
+        );
 
-        expect(screen.queryByRole("button", { name: selectors.titles.save })).toBeInTheDocument();
+        const saveButton = screen.queryByRole("button", { name: selectors.titles.save });
+        const checkFrequencyInput = screen.getByName("checkFrequencyInSec");
+
+        // Save button is disabled, if none of inputs are dirty
+        expect(saveButton).toBeDisabled();
+
+        await fillInput(checkFrequencyInput, "100");
+
+        expect(saveButton).toBeInTheDocument();
+        expect(saveButton).not.toBeDisabled();
     });
 
-    it("hides the Save button for access levels below DatabaseAdmin", async () => {
+    it("shows the Save button but disables it for access levels below DatabaseAdmin", async () => {
         const { screen } = await rtlRender_WithWaitForLoad(<DefaultRemoteAttachments databaseAccess="DatabaseRead" />);
 
-        expect(screen.queryByRole("button", { name: selectors.titles.save })).not.toBeInTheDocument();
+        const saveButton = screen.queryByRole("button", { name: selectors.titles.save });
+        expect(saveButton).toBeInTheDocument();
+        expect(saveButton).toBeDisabled();
     });
 
-    it("hides the Add new button when user cannot configure defaults (non-admin)", async () => {
+    it("shows the Add new button but disables it when user cannot configure defaults (non-admin)", async () => {
         const { screen } = await rtlRender_WithWaitForLoad(<DefaultRemoteAttachments databaseAccess="DatabaseRead" />);
 
         const addDefaultButton = screen.queryByRole("button", { name: selectors.titles.addNew });
-        expect(addDefaultButton).not.toBeInTheDocument();
+        expect(addDefaultButton).toBeInTheDocument();
+        expect(addDefaultButton).toBeDisabled();
     });
 
     it("enables the Add new button for admin when configuration is allowed", async () => {
         const { screen } = await rtlRender_WithWaitForLoad(<DefaultRemoteAttachments databaseAccess="DatabaseAdmin" />);
 
         const addDefaultButton = screen.getByRole("button", { name: selectors.titles.addNew });
+        expect(addDefaultButton).toBeInTheDocument();
         expect(addDefaultButton).not.toBeDisabled();
     });
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.stories.tsx
@@ -1,4 +1,4 @@
-import { databaseAccessArgType, licenseArgType, withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
+import { databaseAccessArgType, withBootstrap5, withStorybookContexts } from "test/storybookTestUtils";
 import { Meta, StoryObj } from "@storybook/react-webpack5";
 import { mockStore } from "test/mocks/store/MockStore";
 import RemoteAttachments from "components/pages/database/settings/remoteAttachments/RemoteAttachments";
@@ -18,19 +18,18 @@ export default {
 
 interface RemoteAttachmentsStoryArgs {
     databaseAccess: databaseAccessLevel;
-    licenseType: Raven.Server.Commercial.LicenseType;
+    hasProperLicense: boolean;
     hasRemoteAttachments: boolean;
 }
 
 export const DefaultRemoteAttachments: StoryObj<RemoteAttachmentsStoryArgs> = {
     name: "Remote Attachments",
     argTypes: {
-        licenseType: licenseArgType,
         databaseAccess: databaseAccessArgType,
     },
     args: {
         databaseAccess: "DatabaseAdmin",
-        licenseType: "Enterprise",
+        hasProperLicense: true,
         hasRemoteAttachments: true,
     },
     render: (args) => {
@@ -39,7 +38,7 @@ export const DefaultRemoteAttachments: StoryObj<RemoteAttachmentsStoryArgs> = {
         const db = databases.withActiveDatabase_NonSharded_SingleNode();
 
         license.with_LicenseLimited({
-            Type: args.licenseType,
+            HasRemoteAttachments: args.hasProperLicense,
         });
         databasesService.withRemoteAttachmentsConfiguration(
             args.hasRemoteAttachments

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.stories.tsx
@@ -18,8 +18,8 @@ export default {
 
 interface RemoteAttachmentsStoryArgs {
     databaseAccess: databaseAccessLevel;
-    hasProperLicense: boolean;
     hasRemoteAttachments: boolean;
+    hasRemoteDestinations: boolean;
 }
 
 export const DefaultRemoteAttachments: StoryObj<RemoteAttachmentsStoryArgs> = {
@@ -29,8 +29,8 @@ export const DefaultRemoteAttachments: StoryObj<RemoteAttachmentsStoryArgs> = {
     },
     args: {
         databaseAccess: "DatabaseAdmin",
-        hasProperLicense: true,
         hasRemoteAttachments: true,
+        hasRemoteDestinations: true,
     },
     render: (args) => {
         const { accessManager, license, databases } = mockStore;
@@ -38,10 +38,10 @@ export const DefaultRemoteAttachments: StoryObj<RemoteAttachmentsStoryArgs> = {
         const db = databases.withActiveDatabase_NonSharded_SingleNode();
 
         license.with_LicenseLimited({
-            HasRemoteAttachments: args.hasProperLicense,
+            HasRemoteAttachments: args.hasRemoteAttachments,
         });
         databasesService.withRemoteAttachmentsConfiguration(
-            args.hasRemoteAttachments
+            args.hasRemoteDestinations
                 ? DatabasesStubs.remoteAttachmentsConfiguration()
                 : DatabasesStubs.emptyRemoteAttachmentsConfiguration()
         );

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
@@ -33,9 +33,13 @@ import useConfirm from "components/common/ConfirmDialog";
 import { RemoteAttachmentsInfoHub } from "components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub";
 import { useViewSheet, ViewSheet } from "components/common/splitView/ViewSheet";
 import { EmptySet } from "components/common/EmptySet";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
+import { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
+import FeatureNotAvailableInYourLicensePopoverBody from "components/common/FeatureNotAvailableInYourLicensePopoverBody";
 
 export default function RemoteAttachments() {
-    // TODO: Add license restrictions. I cant do that at the moment because the key is missing in `LicenseStatus`
     const { reportEvent } = useEventsCollector();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const hasDatabaseAdminAccess = useAppSelector(accessManagerSelectors.getHasDatabaseAdminAccess)();
@@ -55,6 +59,17 @@ export default function RemoteAttachments() {
     });
 
     const { handleSubmit, formState, reset } = form;
+
+    const hasRemoteAttachments = useAppSelector(licenseSelectors.statusValue("HasRemoteAttachments"));
+    const featureAvailability = useLimitedFeatureAvailability({
+        defaultFeatureAvailability,
+        overwrites: [
+            {
+                featureName: defaultFeatureAvailability[0].featureName,
+                value: hasRemoteAttachments,
+            },
+        ],
+    });
 
     useDirtyFlag(formState.isDirty || isAnyModified);
 
@@ -96,24 +111,40 @@ export default function RemoteAttachments() {
                 <Form onSubmit={handleSubmit(handleSave)}>
                     <Row className="gy-sm">
                         <Col>
-                            <AboutViewHeading title="Remote Attachments" icon="remote-attachment" />
+                            <AboutViewHeading
+                                title="Remote Attachments"
+                                icon="remote-attachment"
+                                licenseBadgeText={hasRemoteAttachments ? null : "Enterprise"}
+                            />
                             {hasDatabaseAdminAccess && (
-                                <ButtonWithSpinner
-                                    type="submit"
-                                    variant="primary"
-                                    className="mb-3"
-                                    disabled={!isAnyModified && !formState.isDirty}
-                                    icon="save"
-                                    isSpinning={formState.isSubmitting}
+                                <ConditionalPopover
+                                    conditions={{
+                                        isActive: !hasRemoteAttachments,
+                                        message: <FeatureNotAvailableInYourLicensePopoverBody />,
+                                    }}
                                 >
-                                    Save
-                                </ButtonWithSpinner>
+                                    <ButtonWithSpinner
+                                        type="submit"
+                                        variant="primary"
+                                        className="mb-3"
+                                        disabled={!isAnyModified && !formState.isDirty}
+                                        icon="save"
+                                        isSpinning={formState.isSubmitting}
+                                    >
+                                        Save
+                                    </ButtonWithSpinner>
+                                </ConditionalPopover>
                             )}
-                            <RemoteAttachmentsSettingsCard />
-                            <DestinationsList />
+                            <div className={hasRemoteAttachments ? "" : "item-disabled pe-none"}>
+                                <RemoteAttachmentsSettingsCard />
+                                <DestinationsList />
+                            </div>
                         </Col>
                         <Col sm={12} lg={4}>
-                            <RemoteAttachmentsInfoHub />
+                            <RemoteAttachmentsInfoHub
+                                hasRemoteAttachments={hasRemoteAttachments}
+                                featureAvailability={featureAvailability}
+                            />
                         </Col>
                     </Row>
                 </Form>
@@ -307,3 +338,14 @@ const useRemoteAttachmentsSideEffects = ({ watch, setValue }: UseFormReturn<Remo
         return unsubscribe;
     }, [setValue, watch]);
 };
+
+const defaultFeatureAvailability: FeatureAvailabilityData[] = [
+    {
+        featureName: "Remote Attachments",
+        featureIcon: "remote-attachment",
+        community: { value: false },
+        professional: { value: false },
+        enterprise: { value: true },
+    },
+];
+

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
@@ -34,10 +34,9 @@ import { RemoteAttachmentsInfoHub } from "components/pages/database/settings/rem
 import { useViewSheet, ViewSheet } from "components/common/splitView/ViewSheet";
 import { EmptySet } from "components/common/EmptySet";
 import { licenseSelectors } from "components/common/shell/licenseSlice";
-import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
-import { FeatureAvailabilityData } from "components/common/FeatureAvailabilitySummary";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import FeatureNotAvailableInYourLicensePopoverBody from "components/common/FeatureNotAvailableInYourLicensePopoverBody";
+import { getDatabaseAccessRequiredMessage } from "components/utils/accessUtils";
 
 export default function RemoteAttachments() {
     const { reportEvent } = useEventsCollector();
@@ -61,15 +60,6 @@ export default function RemoteAttachments() {
     const { handleSubmit, formState, reset } = form;
 
     const hasRemoteAttachments = useAppSelector(licenseSelectors.statusValue("HasRemoteAttachments"));
-    const featureAvailability = useLimitedFeatureAvailability({
-        defaultFeatureAvailability,
-        overwrites: [
-            {
-                featureName: defaultFeatureAvailability[0].featureName,
-                value: hasRemoteAttachments,
-            },
-        ],
-    });
 
     useDirtyFlag(formState.isDirty || isAnyModified);
 
@@ -124,8 +114,7 @@ export default function RemoteAttachments() {
                                     },
                                     {
                                         isActive: !hasDatabaseAdminAccess,
-                                        message:
-                                            "You don't have the required permissions to save changes (Database Admin access required)",
+                                        message: getDatabaseAccessRequiredMessage("DatabaseAdmin"),
                                     },
                                 ]}
                             >
@@ -150,10 +139,7 @@ export default function RemoteAttachments() {
                             </div>
                         </Col>
                         <Col sm={12} lg={4}>
-                            <RemoteAttachmentsInfoHub
-                                hasRemoteAttachments={hasRemoteAttachments}
-                                featureAvailability={featureAvailability}
-                            />
+                            <RemoteAttachmentsInfoHub />
                         </Col>
                     </Row>
                 </Form>
@@ -210,8 +196,7 @@ function DestinationsList() {
                     <ConditionalPopover
                         conditions={{
                             isActive: !hasDatabaseAdminAccess,
-                            message:
-                                "You don't have the required permissions to add destinations (Database Admin access required)",
+                            message: getDatabaseAccessRequiredMessage("DatabaseAdmin"),
                         }}
                     >
                         <Button
@@ -354,13 +339,3 @@ const useRemoteAttachmentsSideEffects = ({ watch, setValue }: UseFormReturn<Remo
         return unsubscribe;
     }, [setValue, watch]);
 };
-
-const defaultFeatureAvailability: FeatureAvailabilityData[] = [
-    {
-        featureName: "Remote Attachments",
-        featureIcon: "remote-attachment",
-        community: { value: false },
-        professional: { value: false },
-        enterprise: { value: true },
-    },
-];

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/RemoteAttachments.tsx
@@ -116,25 +116,34 @@ export default function RemoteAttachments() {
                                 icon="remote-attachment"
                                 licenseBadgeText={hasRemoteAttachments ? null : "Enterprise"}
                             />
-                            {hasDatabaseAdminAccess && (
-                                <ConditionalPopover
-                                    conditions={{
+                            <ConditionalPopover
+                                conditions={[
+                                    {
                                         isActive: !hasRemoteAttachments,
                                         message: <FeatureNotAvailableInYourLicensePopoverBody />,
-                                    }}
+                                    },
+                                    {
+                                        isActive: !hasDatabaseAdminAccess,
+                                        message:
+                                            "You don't have the required permissions to save changes (Database Admin access required)",
+                                    },
+                                ]}
+                            >
+                                <ButtonWithSpinner
+                                    type="submit"
+                                    variant="primary"
+                                    className="mb-3"
+                                    disabled={
+                                        !hasDatabaseAdminAccess ||
+                                        !hasRemoteAttachments ||
+                                        (!isAnyModified && !formState.isDirty)
+                                    }
+                                    icon="save"
+                                    isSpinning={formState.isSubmitting}
                                 >
-                                    <ButtonWithSpinner
-                                        type="submit"
-                                        variant="primary"
-                                        className="mb-3"
-                                        disabled={!isAnyModified && !formState.isDirty}
-                                        icon="save"
-                                        isSpinning={formState.isSubmitting}
-                                    >
-                                        Save
-                                    </ButtonWithSpinner>
-                                </ConditionalPopover>
-                            )}
+                                    Save
+                                </ButtonWithSpinner>
+                            </ConditionalPopover>
                             <div className={hasRemoteAttachments ? "" : "item-disabled pe-none"}>
                                 <RemoteAttachmentsSettingsCard />
                                 <DestinationsList />
@@ -198,18 +207,25 @@ function DestinationsList() {
         <div className="mb-4">
             <HrHeader
                 right={
-                    hasDatabaseAdminAccess && (
+                    <ConditionalPopover
+                        conditions={{
+                            isActive: !hasDatabaseAdminAccess,
+                            message:
+                                "You don't have the required permissions to add destinations (Database Admin access required)",
+                        }}
+                    >
                         <Button
                             size="sm"
                             onClick={() => handleOpenSheet()}
                             variant="info"
                             className="rounded-pill"
                             title="Click to define a new destination"
+                            disabled={!hasDatabaseAdminAccess}
                         >
                             <Icon icon="plus" size="sm" />
                             Add new
                         </Button>
-                    )
+                    </ConditionalPopover>
                 }
                 count={destinationsTotal}
             >
@@ -348,4 +364,3 @@ const defaultFeatureAvailability: FeatureAvailabilityData[] = [
         enterprise: { value: true },
     },
 ];
-

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/DestinationPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/DestinationPanel.tsx
@@ -38,6 +38,7 @@ import { remoteAttachmentsConstants } from "components/pages/database/settings/r
 import { remoteAttachmentsUtils } from "components/pages/database/settings/remoteAttachments/remoteAttachmentsUtils";
 import { OptionWithIcon, SelectOptionWithIcon, SingleValueWithIcon } from "components/common/select/Select";
 import { storageClassOptions } from "components/utils/common";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
 
 interface DestinationPanelProps extends RemoteAttachmentsDestinationFormData {
     onEdit: (id: string) => void;
@@ -69,20 +70,54 @@ export function DestinationPanel({
                             {isModified && <span className="text-warning ms-1">*</span>}
                         </RichPanelName>
                     </RichPanelInfo>
-                    {hasDatabaseAdminAccess && (
-                        <RichPanelActions>
-                            <Button variant={disabled ? "success" : "secondary"} onClick={() => onToggle(identifier)}>
+                    <RichPanelActions>
+                        <ConditionalPopover
+                            conditions={{
+                                isActive: !hasDatabaseAdminAccess,
+                                message:
+                                    "You don't have the required permissions to modify destinations (Database Admin access required)",
+                            }}
+                        >
+                            <Button
+                                variant={disabled ? "success" : "secondary"}
+                                onClick={() => onToggle(identifier)}
+                                disabled={!hasDatabaseAdminAccess}
+                            >
                                 <Icon icon={disabled ? "play" : "disable"} />
                                 {disabled ? "Enable" : "Disable"}
                             </Button>
-                            <Button variant="secondary" onClick={() => onEdit(identifier)}>
+                        </ConditionalPopover>
+                        <ConditionalPopover
+                            conditions={{
+                                isActive: !hasDatabaseAdminAccess,
+                                message:
+                                    "You don't have the required permissions to edit destinations (Database Admin access required)",
+                            }}
+                        >
+                            <Button
+                                variant="secondary"
+                                onClick={() => onEdit(identifier)}
+                                disabled={!hasDatabaseAdminAccess}
+                            >
                                 <Icon icon="edit" margin="m-0" />
                             </Button>
-                            <Button variant="danger" onClick={() => onDelete(identifier)}>
+                        </ConditionalPopover>
+                        <ConditionalPopover
+                            conditions={{
+                                isActive: !hasDatabaseAdminAccess,
+                                message:
+                                    "You don't have the required permissions to delete destinations (Database Admin access required)",
+                            }}
+                        >
+                            <Button
+                                variant="danger"
+                                onClick={() => onDelete(identifier)}
+                                disabled={!hasDatabaseAdminAccess}
+                            >
                                 <Icon icon="trash" margin="m-0" />
                             </Button>
-                        </RichPanelActions>
-                    )}
+                        </ConditionalPopover>
+                    </RichPanelActions>
                 </RichPanelHeader>
                 <RichPanelDetails>
                     <RichPanelDetailItem size="sm" label="Destination">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub.tsx
@@ -3,13 +3,23 @@ import React from "react";
 import FeatureAvailabilitySummaryWrapper, {
     FeatureAvailabilityData,
 } from "components/common/FeatureAvailabilitySummary";
+import { useAppSelector } from "components/store";
+import { licenseSelectors } from "components/common/shell/licenseSlice";
+import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUtils";
 
-interface RemoteAttachmentsInfoHubProps {
-    hasRemoteAttachments: boolean;
-    featureAvailability: FeatureAvailabilityData[];
-}
+export function RemoteAttachmentsInfoHub() {
+    const hasRemoteAttachments = useAppSelector(licenseSelectors.statusValue("HasRemoteAttachments"));
 
-export function RemoteAttachmentsInfoHub({ hasRemoteAttachments, featureAvailability }: RemoteAttachmentsInfoHubProps) {
+    const featureAvailability = useLimitedFeatureAvailability({
+        defaultFeatureAvailability,
+        overwrites: [
+            {
+                featureName: defaultFeatureAvailability[0].featureName,
+                value: hasRemoteAttachments,
+            },
+        ],
+    });
+
     return (
         <AboutViewAnchored defaultOpen={hasRemoteAttachments ? null : "licensing"}>
             <AccordionItemWrapper
@@ -60,3 +70,13 @@ export function RemoteAttachmentsInfoHub({ hasRemoteAttachments, featureAvailabi
         </AboutViewAnchored>
     );
 }
+
+const defaultFeatureAvailability: FeatureAvailabilityData[] = [
+    {
+        featureName: "Remote Attachments",
+        featureIcon: "remote-attachment",
+        community: { value: false },
+        professional: { value: false },
+        enterprise: { value: true },
+    },
+];

--- a/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/remoteAttachments/partials/RemoteAttachmentsInfoHub.tsx
@@ -1,9 +1,17 @@
 import { AboutViewAnchored, AccordionItemWrapper } from "components/common/AboutView";
 import React from "react";
+import FeatureAvailabilitySummaryWrapper, {
+    FeatureAvailabilityData,
+} from "components/common/FeatureAvailabilitySummary";
 
-export function RemoteAttachmentsInfoHub() {
+interface RemoteAttachmentsInfoHubProps {
+    hasRemoteAttachments: boolean;
+    featureAvailability: FeatureAvailabilityData[];
+}
+
+export function RemoteAttachmentsInfoHub({ hasRemoteAttachments, featureAvailability }: RemoteAttachmentsInfoHubProps) {
     return (
-        <AboutViewAnchored>
+        <AboutViewAnchored defaultOpen={hasRemoteAttachments ? null : "licensing"}>
             <AccordionItemWrapper
                 targetId="about"
                 icon="about"
@@ -48,6 +56,7 @@ export function RemoteAttachmentsInfoHub() {
                     </ul>
                 </div>
             </AccordionItemWrapper>
+            <FeatureAvailabilitySummaryWrapper isUnlimited={hasRemoteAttachments} data={featureAvailability} />
         </AboutViewAnchored>
     );
 }

--- a/src/Raven.Studio/typescript/components/utils/accessUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/accessUtils.ts
@@ -1,0 +1,19 @@
+export type DatabaseAccessLevel = "DatabaseAdmin" | "DatabaseReadWrite" | "DatabaseRead";
+
+export function getDatabaseAccessRequiredMessage(requiredAccessLevel: DatabaseAccessLevel) {
+    const accessLevelText = getAccessLevelDisplayName(requiredAccessLevel);
+    return `You don't have the required permissions (${accessLevelText} access required)`;
+}
+
+function getAccessLevelDisplayName(accessLevel: DatabaseAccessLevel) {
+    switch (accessLevel) {
+        case "DatabaseAdmin":
+            return "Database Admin";
+        case "DatabaseReadWrite":
+            return "Database Write";
+        case "DatabaseRead":
+            return "Database Read";
+        default:
+            return accessLevel;
+    }
+}

--- a/src/Raven.Studio/typescript/components/utils/accessUtils.ts
+++ b/src/Raven.Studio/typescript/components/utils/accessUtils.ts
@@ -1,11 +1,11 @@
-export type DatabaseAccessLevel = "DatabaseAdmin" | "DatabaseReadWrite" | "DatabaseRead";
+import assertUnreachable from "components/utils/assertUnreachable";
 
-export function getDatabaseAccessRequiredMessage(requiredAccessLevel: DatabaseAccessLevel) {
+export function getDatabaseAccessRequiredMessage(requiredAccessLevel: databaseAccessLevel) {
     const accessLevelText = getAccessLevelDisplayName(requiredAccessLevel);
     return `You don't have the required permissions (${accessLevelText} access required)`;
 }
 
-function getAccessLevelDisplayName(accessLevel: DatabaseAccessLevel) {
+function getAccessLevelDisplayName(accessLevel: databaseAccessLevel) {
     switch (accessLevel) {
         case "DatabaseAdmin":
             return "Database Admin";
@@ -14,6 +14,6 @@ function getAccessLevelDisplayName(accessLevel: DatabaseAccessLevel) {
         case "DatabaseRead":
             return "Database Read";
         default:
-            return accessLevel;
+            assertUnreachable(accessLevel);
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -57,6 +57,7 @@ import popoverUtils = require("common/popoverUtils");
 import validateDocumentSchemaCommand = require("commands/database/documents/validateDocumentSchemaCommand");
 import getSchemaValidationCommand = require("commands/database/settings/getSchemaValidationCommand");
 import SchemaValidationConfiguration = Raven.Client.Documents.Operations.SchemaValidation.SchemaValidationConfiguration;
+import licenseModel = require("models/auth/licenseModel");
 
 class editDocument extends shardViewModelBase {
     view = require("views/database/documents/editDocument.html");
@@ -1435,6 +1436,11 @@ class editDocument extends shardViewModelBase {
     }
 
     private loadRemoteAttachmentsConfiguration() {
+        const hasRemoteAttachments = licenseModel.getStatusValue("HasRemoteAttachments");
+        if (!hasRemoteAttachments) {
+            return;
+        }
+
         if (this.db.isSharded()) {
             this.remoteAttachmentDisabledReason("Remote attachments are not supported in sharded databases");
             return;

--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1438,6 +1438,7 @@ class editDocument extends shardViewModelBase {
     private loadRemoteAttachmentsConfiguration() {
         const hasRemoteAttachments = licenseModel.getStatusValue("HasRemoteAttachments");
         if (!hasRemoteAttachments) {
+            this.remoteAttachmentDisabledReason("Remote attachments are not available in your current license");
             return;
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25326 

### Additional description

<img width="2219" height="1169" alt="image" src="https://github.com/user-attachments/assets/25fe6fbe-fd5d-4e50-9313-3a2da0184ed6" />

Without license
<img width="1164" height="1201" alt="image" src="https://github.com/user-attachments/assets/3aae0c92-b1b3-4569-b3f3-22359a4bac3a" />

with license, but database access: read
<img width="1585" height="1211" alt="image" src="https://github.com/user-attachments/assets/974dc7c5-1551-482e-92b4-69618bbf057d" />

with license and database access: admin
<img width="1598" height="1236" alt="image" src="https://github.com/user-attachments/assets/a1e05db5-74bd-44c1-b1e0-fb4c5f527934" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
