### PR TITLE
RavenDB-25842 When we delete a table we also need to free pre allocated pages and delete page allocator fixed size trees

### DIFF
--- a/src/Voron/Data/Tables/NewPageAllocator.cs
+++ b/src/Voron/Data/Tables/NewPageAllocator.cs
@@ -364,6 +364,11 @@ namespace Voron.Data.Tables
             return _parentTree.FixedTreeFor(AllocationStorage, valSize: BitmapSize);
         }
 
+        internal FixedSizeTree GetAllocationStorageSizeFst()
+        {
+            return _parentTree.FixedTreeFor(AllocationStorageSize, valSize: sizeof(int));
+        }
+
         [DoesNotReturn]
         private static void ThrowInvalidPageReleased(long pageNumber)
         {
@@ -443,6 +448,12 @@ namespace Voron.Data.Tables
 
                 llt.Environment.Options.DataPager.MaybePrefetchMemory(new SectionsIterator(it));
             }
+        }
+
+        public void FreePreAllocatedFreePages()
+        {
+            foreach (var page in AllPages())
+                _llt.FreePage(page);
         }
 
         public sealed class Report

--- a/src/Voron/Impl/Transaction.cs
+++ b/src/Voron/Impl/Transaction.cs
@@ -712,6 +712,13 @@ namespace Voron.Impl
             if (tableTree.Read(TableSchema.InactiveSectionSlice) != null)
                 DeleteFixedTree(table.InactiveSections, isInRoot: false);
 
+            // pre allocated pages
+
+            table.TablePageAllocator.FreePreAllocatedFreePages();
+
+            DeleteFixedTree(table.TablePageAllocator.GetAllocationStorageFst(), isInRoot: false);
+            DeleteFixedTree(table.TablePageAllocator.GetAllocationStorageSizeFst(), isInRoot: false);
+
             DeleteTree(name);
 
             using (Slice.From(Allocator, name, ByteStringType.Immutable, out var nameSlice))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25842

### Additional description

The issue was that the data pager file of System storage was very big when running tests. It applied to "Notifications.{db-name}" table.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
