### PR TITLE
RavenDB-20069 - Implement Streaming of map-reduce results

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Json;
-using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -15,7 +14,7 @@ public class AutoMapReduceIndexResultsAggregator
 {
     protected Action<DynamicJsonValue> ModifyOutputToStore;
 
-    internal AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, TransactionOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
+    internal AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, JsonOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
     {
         var aggregatedResultsByReduceKey = new Dictionary<BlittableJsonReaderObject, Dictionary<string, PropertyResult>>(ReduceKeyComparer.Instance);
 

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Auto/AutoMapReduceIndexResultsAggregator.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Json;
+using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -14,7 +15,7 @@ public class AutoMapReduceIndexResultsAggregator
 {
     protected Action<DynamicJsonValue> ModifyOutputToStore;
 
-    internal AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, JsonOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
+    internal AggregationResult AggregateOn(List<BlittableJsonReaderObject> aggregationBatch, AutoMapReduceIndexDefinition indexDefinition, TransactionOperationContext indexContext, IndexingStatsScope stats, ref BlittableJsonReaderObject currentlyProcessedResult, CancellationToken token)
     {
         var aggregatedResultsByReduceKey = new Dictionary<BlittableJsonReaderObject, Dictionary<string, PropertyResult>>(ReduceKeyComparer.Instance);
 

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -321,7 +321,7 @@ namespace Raven.Server.Documents.Queries
                 if (_fieldsToFetch.IsProjection)
                 {
                     RetrieverInput retrieverInput = new(null, QueryResultRetrieverBase.ZeroScore, null);
-                    var result = _resultsRetriever.GetProjectionFromDocument(_inner.Current, ref retrieverInput, _fieldsToFetch, _context, _token);
+                    var result = _resultsRetriever.GetProjectionFromDocument(_inner.Current, ref retrieverInput, _context, _token);
                     if (result.List != null)
                     {
                         var it = result.List.GetEnumerator();

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         protected readonly DocumentsStorage DocumentsStorage;
 
-        protected readonly FieldsToFetch FieldsToFetch;
+        public readonly FieldsToFetch FieldsToFetch;
 
         protected readonly QueryTimingsScope RetrieverScope;
 
@@ -159,7 +159,7 @@ namespace Raven.Server.Documents.Queries.Results
                         return default;
                     }
 
-                    return GetProjectionFromDocumentInternal(doc, ref retrieverInput, FieldsToFetch, _context, token);
+                    return GetProjectionFromDocumentInternal(doc, ref retrieverInput, _context, token);
                 }
 
                 var result = new DynamicJsonValue();
@@ -322,22 +322,22 @@ namespace Raven.Server.Documents.Queries.Results
             return false;
         }
 
-        public (Document Document, List<Document> List) GetProjectionFromDocument(Document doc, ref RetrieverInput retrieverInput, FieldsToFetch fieldsToFetch, JsonOperationContext context, CancellationToken token)
+        public (Document Document, List<Document> List) GetProjectionFromDocument(Document doc, ref RetrieverInput retrieverInput, JsonOperationContext context, CancellationToken token)
         {
             using (RetrieverScope?.Start())
             using (_projectionScope = _projectionScope?.Start() ?? RetrieverScope?.For(nameof(QueryTimingsScope.Names.Projection)))
             {
-                return GetProjectionFromDocumentInternal(doc, ref retrieverInput, fieldsToFetch, context, token);
+                return GetProjectionFromDocumentInternal(doc, ref retrieverInput, context, token);
             }
         }
 
-        private (Document Document, List<Document> List) GetProjectionFromDocumentInternal(Document doc, ref RetrieverInput retrieverInput, FieldsToFetch fieldsToFetch, JsonOperationContext context, CancellationToken token)
+        private (Document Document, List<Document> List) GetProjectionFromDocumentInternal(Document doc, ref RetrieverInput retrieverInput, JsonOperationContext context, CancellationToken token)
         {
             var result = new DynamicJsonValue();
 
-            foreach (var fieldToFetch in fieldsToFetch.Fields.Values)
+            foreach (var fieldToFetch in FieldsToFetch.Fields.Values)
             {
-                if (TryGetValue(fieldToFetch, doc, ref retrieverInput, fieldsToFetch.IndexFields, fieldsToFetch.AnyDynamicIndexFields, out var key, out var fieldVal, token) == false)
+                if (TryGetValue(fieldToFetch, doc, ref retrieverInput, FieldsToFetch.IndexFields, FieldsToFetch.AnyDynamicIndexFields, out var key, out var fieldVal, token) == false)
                 {
                     if (FieldsToFetch.Projection.MustExtractFromDocument)
                     {
@@ -349,7 +349,7 @@ namespace Raven.Server.Documents.Queries.Results
                         continue;
                 }
 
-                var immediateResult = AddProjectionToResult(doc, ref retrieverInput, fieldsToFetch, result, key, fieldVal);
+                var immediateResult = AddProjectionToResult(doc, ref retrieverInput, FieldsToFetch, result, key, fieldVal);
 
                 if (immediateResult.Document != null || immediateResult.List != null)
                     return immediateResult;

--- a/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
+++ b/src/Raven.Server/Documents/Queries/Results/QueryResultRetrieverBase.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Queries.Results
 
         protected readonly DocumentsStorage DocumentsStorage;
 
-        public readonly FieldsToFetch FieldsToFetch;
+        protected readonly FieldsToFetch FieldsToFetch;
 
         protected readonly QueryTimingsScope RetrieverScope;
 

--- a/src/Raven.Server/Documents/Queries/Results/Sharding/ShardedMapReduceResultRetriever.cs
+++ b/src/Raven.Server/Documents/Queries/Results/Sharding/ShardedMapReduceResultRetriever.cs
@@ -14,8 +14,8 @@ namespace Raven.Server.Documents.Queries.Results.Sharding;
 
 public sealed class ShardedMapReduceResultRetriever : QueryResultRetrieverBase
 {
-    public ShardedMapReduceResultRetriever(ScriptRunnerCache scriptRunnerCache, IndexQueryServerSide query, QueryTimingsScope queryTimings, SearchEngineType searchEngineType, FieldsToFetch fieldsToFetch, DocumentsStorage documentsStorage, JsonOperationContext context, IncludeDocumentsCommand includeDocumentsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, IncludeRevisionsCommand includeRevisionsCommand, char identitySeparator)
-        : base(scriptRunnerCache, query, queryTimings, searchEngineType, fieldsToFetch, documentsStorage, context, reduceResults: true, includeDocumentsCommand, includeCompareExchangeValuesCommand, includeRevisionsCommand, identitySeparator)
+    public ShardedMapReduceResultRetriever(ScriptRunnerCache scriptRunnerCache, IndexQueryServerSide query, QueryTimingsScope queryTimings, FieldsToFetch fieldsToFetch, DocumentsStorage documentsStorage, JsonOperationContext context, IncludeDocumentsCommand includeDocumentsCommand, IncludeCompareExchangeValuesCommand includeCompareExchangeValuesCommand, IncludeRevisionsCommand includeRevisionsCommand, char identitySeparator)
+        : base(scriptRunnerCache, query, queryTimings, SearchEngineType.None, fieldsToFetch, documentsStorage, context, reduceResults: true, includeDocumentsCommand, includeCompareExchangeValuesCommand, includeRevisionsCommand, identitySeparator)
     {
     }
 

--- a/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
@@ -73,7 +73,7 @@ namespace Raven.Server.Documents.Replication.Senders
 
         public T Current => CurrentItem;
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             foreach (var workEnumerator in WorkEnumerators)
             {

--- a/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
@@ -13,6 +13,8 @@ namespace Raven.Server.Documents.Replication.Senders
 
         protected IEnumerator<T> CurrentEnumerator;
 
+        private readonly List<IDisposable> _enumeratorsToDispose = new();
+
         public MergedEnumerator(IComparer<T> comparer)
         {
             Comparer = comparer;
@@ -69,12 +71,23 @@ namespace Raven.Server.Documents.Replication.Senders
             throw new NotSupportedException();
         }
 
+        protected void RemoveEnumerator(int index)
+        {
+            _enumeratorsToDispose.Add(WorkEnumerators[index]);
+            WorkEnumerators.RemoveAt(index);
+        }
+
         object IEnumerator.Current => Current;
 
         public T Current => CurrentItem;
 
         public virtual void Dispose()
         {
+            foreach (var workEnumerator in _enumeratorsToDispose)
+            {
+                workEnumerator.Dispose();
+            }
+
             foreach (var workEnumerator in WorkEnumerators)
             {
                 workEnumerator.Dispose();

--- a/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
@@ -44,6 +44,7 @@ namespace Raven.Server.Documents.Replication.Senders
                     using (CurrentEnumerator)
                     {
                         WorkEnumerators.Remove(CurrentEnumerator);
+                        _enumeratorsToDispose.Add(CurrentEnumerator);
                         CurrentEnumerator = null;
                     }
                 }

--- a/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MergedEnumerator.cs
@@ -13,8 +13,6 @@ namespace Raven.Server.Documents.Replication.Senders
 
         protected IEnumerator<T> CurrentEnumerator;
 
-        private readonly List<IDisposable> _enumeratorsToDispose = new();
-
         public MergedEnumerator(IComparer<T> comparer)
         {
             Comparer = comparer;
@@ -44,7 +42,6 @@ namespace Raven.Server.Documents.Replication.Senders
                     using (CurrentEnumerator)
                     {
                         WorkEnumerators.Remove(CurrentEnumerator);
-                        _enumeratorsToDispose.Add(CurrentEnumerator);
                         CurrentEnumerator = null;
                     }
                 }
@@ -72,23 +69,12 @@ namespace Raven.Server.Documents.Replication.Senders
             throw new NotSupportedException();
         }
 
-        protected void RemoveEnumerator(int index)
-        {
-            _enumeratorsToDispose.Add(WorkEnumerators[index]);
-            WorkEnumerators.RemoveAt(index);
-        }
-
         object IEnumerator.Current => Current;
 
         public T Current => CurrentItem;
 
         public virtual void Dispose()
         {
-            foreach (var workEnumerator in _enumeratorsToDispose)
-            {
-                workEnumerator.Dispose();
-            }
-
             foreach (var workEnumerator in WorkEnumerators)
             {
                 workEnumerator.Dispose();

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -140,27 +140,29 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 
     public readonly struct ShardedStreamQueryOperation : IShardedOperation<StreamResult, ShardedStreamQueryResult>
     {
-        private readonly HttpContext _httpContext;
+        private readonly ShardedDatabaseRequestHandler _requestHandler;
         private readonly Func<(JsonOperationContext, IDisposable)> _allocateJsonContext;
         private readonly IComparer<BlittableJsonReaderObject> _comparer;
         private readonly Dictionary<int, PostQueryStreamCommand> _queryStreamCommands;
+        private readonly List<OrderByField> _groupByFields;
         private readonly long _skip;
         private readonly long _take;
         private readonly CancellationToken _token;
 
-        public ShardedStreamQueryOperation(HttpContext httpContext, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, long skip, long take, CancellationToken token)
+        public ShardedStreamQueryOperation(ShardedDatabaseRequestHandler requestHandler, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, List<OrderByField> groupByFields, long skip, long take, CancellationToken token)
         {
-            _httpContext = httpContext;
+            _requestHandler = requestHandler;
             _allocateJsonContext = allocateJsonContext;
             _comparer = comparer;
             _queryStreamCommands = queryStreamCommands;
+            _groupByFields = groupByFields;
             _skip = skip;
             _take = take;
             _token = token;
             ExpectedEtag = null;
         }
 
-        public HttpRequest HttpRequest => _httpContext.Request;
+        public HttpRequest HttpRequest => _requestHandler.HttpContext.Request;
 
         public RavenCommand<StreamResult> CreateCommandForShard(int shardNumber) => _queryStreamCommands[shardNumber];
 
@@ -170,7 +172,9 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
         {
             var queryStats = new StreamQueryStatistics();
 
-            var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(_comparer);
+            var mergedEnumerator = _groupByFields != null
+                ? new ShardedMapReduceStreamingEnumerator(_groupByFields, _requestHandler, queryStats, _allocateJsonContext, _token)
+                : new MergedEnumerator<BlittableJsonReaderObject>(_comparer);
 
             foreach (var streamResult in results.Values)
             {

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -140,11 +140,12 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
 
     public readonly struct ShardedStreamQueryOperation : IShardedOperation<StreamResult, ShardedStreamQueryResult>
     {
-        private readonly ShardedDatabaseRequestHandler _requestHandler;
+        private readonly HttpContext _httpContext;
         private readonly Func<(JsonOperationContext, IDisposable)> _allocateJsonContext;
         private readonly IComparer<BlittableJsonReaderObject> _comparer;
         private readonly Dictionary<int, PostQueryStreamCommand> _queryStreamCommands;
         private readonly IndexQueryServerSide _query;
+        private readonly ShardedDatabaseContext _databaseContext;
         private readonly List<OrderByField> _groupByFields;
         private readonly bool _isProjectionFromMapReduceIndex;
         private readonly TransactionOperationContext _context;
@@ -152,13 +153,17 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
         private readonly long _take;
         private readonly CancellationToken _token;
 
-        public ShardedStreamQueryOperation(ShardedDatabaseRequestHandler requestHandler, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, IndexQueryServerSide query, List<OrderByField> groupByFields, bool isProjectionFromMapReduceIndex, TransactionOperationContext context, CancellationToken token)
+        public ShardedStreamQueryOperation(HttpContext httpContext, Func<(JsonOperationContext, IDisposable)> allocateJsonContext,
+            IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands,
+            IndexQueryServerSide query, ShardedDatabaseContext databaseContext, List<OrderByField> groupByFields,
+            bool isProjectionFromMapReduceIndex, TransactionOperationContext context, CancellationToken token)
         {
-            _requestHandler = requestHandler;
+            _httpContext = httpContext;
             _allocateJsonContext = allocateJsonContext;
             _comparer = comparer;
             _queryStreamCommands = queryStreamCommands;
             _query = query;
+            _databaseContext = databaseContext;
             _groupByFields = groupByFields;
             _isProjectionFromMapReduceIndex = isProjectionFromMapReduceIndex;
             _context = context;
@@ -168,7 +173,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
             ExpectedEtag = null;
         }
 
-        public HttpRequest HttpRequest => _requestHandler.HttpContext.Request;
+        public HttpRequest HttpRequest => _httpContext.Request;
 
         public RavenCommand<StreamResult> CreateCommandForShard(int shardNumber) => _queryStreamCommands[shardNumber];
 
@@ -179,7 +184,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
             var queryStats = new StreamQueryStatistics();
 
             var mergedEnumerator = _groupByFields != null
-                ? new ShardedMapReduceStreamingEnumerator(_query, _groupByFields, _requestHandler, _isProjectionFromMapReduceIndex, queryStats, _context, _token)
+                ? new ShardedMapReduceStreamingEnumerator(_query, _databaseContext, _groupByFields, _isProjectionFromMapReduceIndex, queryStats, _context, _token)
                 : new MergedEnumerator<BlittableJsonReaderObject>(_comparer);
 
             foreach (var streamResult in results.Values)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -144,20 +144,26 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
         private readonly Func<(JsonOperationContext, IDisposable)> _allocateJsonContext;
         private readonly IComparer<BlittableJsonReaderObject> _comparer;
         private readonly Dictionary<int, PostQueryStreamCommand> _queryStreamCommands;
+        private readonly IndexQueryServerSide _query;
         private readonly List<OrderByField> _groupByFields;
+        private readonly bool _isProjectionFromMapReduceIndex;
+        private readonly TransactionOperationContext _context;
         private readonly long _skip;
         private readonly long _take;
         private readonly CancellationToken _token;
 
-        public ShardedStreamQueryOperation(ShardedDatabaseRequestHandler requestHandler, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, List<OrderByField> groupByFields, long skip, long take, CancellationToken token)
+        public ShardedStreamQueryOperation(ShardedDatabaseRequestHandler requestHandler, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands, IndexQueryServerSide query, List<OrderByField> groupByFields, bool isProjectionFromMapReduceIndex, TransactionOperationContext context, CancellationToken token)
         {
             _requestHandler = requestHandler;
             _allocateJsonContext = allocateJsonContext;
             _comparer = comparer;
             _queryStreamCommands = queryStreamCommands;
+            _query = query;
             _groupByFields = groupByFields;
-            _skip = skip;
-            _take = take;
+            _isProjectionFromMapReduceIndex = isProjectionFromMapReduceIndex;
+            _context = context;
+            _skip = query.Offset ?? 0;
+            _take = query.Limit ?? int.MaxValue;
             _token = token;
             ExpectedEtag = null;
         }
@@ -173,7 +179,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
             var queryStats = new StreamQueryStatistics();
 
             var mergedEnumerator = _groupByFields != null
-                ? new ShardedMapReduceStreamingEnumerator(_groupByFields, _requestHandler, queryStats, _allocateJsonContext, _token)
+                ? new ShardedMapReduceStreamingEnumerator(_query, _groupByFields, _requestHandler, _isProjectionFromMapReduceIndex, queryStats, _context, _token)
                 : new MergedEnumerator<BlittableJsonReaderObject>(_comparer);
 
             foreach (var streamResult in results.Values)

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -586,7 +586,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         return queryChanges;
     }
 
-    private List<string> GetGroupByFields()
+    protected List<string> GetGroupByFields()
     {
         List<string> groupByFields;
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceQueryResultsMerger.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Documents.Sharding.Queries;
 
 public class ShardedMapReduceQueryResultsMerger
 {
-    private static readonly ShardedAutoMapReduceIndexResultsAggregator Aggregator = new();
+    internal static readonly ShardedAutoMapReduceIndexResultsAggregator Aggregator = new();
 
     protected readonly List<BlittableJsonReaderObject> CurrentResults;
     private readonly ShardedDatabaseContext.ShardedIndexesContext _indexesContext;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -28,8 +28,8 @@ namespace Raven.Server.Documents.Sharding.Queries;
 public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJsonReaderObject>
 {
     private readonly IndexQueryServerSide _query;
+    private readonly ShardedDatabaseContext _databaseContext;
     private readonly StreamQueryStatistics _queryStats;
-    private readonly ShardedDatabaseRequestHandler _requestHandler;
     private readonly ShardedQueryFilter _queryFilter;
     private readonly bool _isProjectionFromMapReduceIndex;
     private readonly TransactionOperationContext _context;
@@ -43,8 +43,8 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
     public ShardedMapReduceStreamingEnumerator(
         IndexQueryServerSide query,
+        ShardedDatabaseContext databaseContext,
         List<OrderByField> reduceKeys,
-        ShardedDatabaseRequestHandler requestHandler,
         bool isProjectionFromMapReduceIndex,
         StreamQueryStatistics queryStats,
         TransactionOperationContext context,
@@ -52,14 +52,14 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         : base(new DocumentsComparer(reduceKeys.ToArray(), extractFromData: true, hasOrderByRandom: false))
     {
         _query = query;
-        _requestHandler = requestHandler;
+        _databaseContext = databaseContext;
         _isProjectionFromMapReduceIndex = isProjectionFromMapReduceIndex;
         _queryStats = queryStats;
         _context = context;
         _token = token;
 
         if (query.Metadata.Query.Filter != null)
-            _queryFilter = new ShardedQueryFilter(query, new ShardedQueryResult(), queryTimings: null, _requestHandler.DatabaseContext.Indexes.ScriptRunnerCache, _context);
+            _queryFilter = new ShardedQueryFilter(query, new ShardedQueryResult(), queryTimings: null, _databaseContext.Indexes.ScriptRunnerCache, _context);
     }
 
     public override bool MoveNext()
@@ -174,13 +174,13 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
     private ShardedMapReduceResultRetriever InitializeRetriever()
     {
-        var index = _requestHandler.DatabaseContext.Indexes.GetIndex(_queryStats.IndexName);
+        var index = _databaseContext.Indexes.GetIndex(_queryStats.IndexName);
         if (index == null)
             IndexDoesNotExistException.ThrowFor(_queryStats.IndexName);
 
         var fieldsToFetch = new FieldsToFetch(_query, index.Definition, index.Type);
         return new ShardedMapReduceResultRetriever(
-            _requestHandler.DatabaseContext.Indexes.ScriptRunnerCache,
+            _databaseContext.Indexes.ScriptRunnerCache,
             _query,
             null,
             fieldsToFetch,
@@ -189,7 +189,7 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
             null,
             null,
             null,
-            _requestHandler.DatabaseContext.IdentityPartsSeparator);
+            _databaseContext.IdentityPartsSeparator);
     }
 
     public override void Dispose()
@@ -202,7 +202,7 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
     private IShardedBatchReducer CreateBatchReducer()
     {
-        var index = _requestHandler.DatabaseContext.Indexes.GetIndex(_queryStats.IndexName);
+        var index = _databaseContext.Indexes.GetIndex(_queryStats.IndexName);
         if (index == null)
             IndexDoesNotExistException.ThrowFor(_queryStats.IndexName);
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -72,17 +72,17 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
         while (true)
         {
-            var itemStatus = GetNextDocument(out BlittableJsonReaderObject item);
+            var itemStatus = GetNextResult(out BlittableJsonReaderObject item);
             switch (itemStatus)
             {
-                case NextItemStatus.Done:
+                case NextItemStatus.Stop:
                     CurrentItem = null;
                     return false;
 
-                case NextItemStatus.Filter:
+                case NextItemStatus.Continue:
                     continue;
 
-                case NextItemStatus.Found:
+                case NextItemStatus.Yield:
                     if (_isProjectionFromMapReduceIndex == false)
                     {
                         // simple map-reduce (no projection)
@@ -134,17 +134,17 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
     private enum NextItemStatus
     {
-        Done,
-        Filter,
-        Found
+        Yield,
+        Continue,
+        Stop
     }
 
-    private NextItemStatus GetNextDocument(out BlittableJsonReaderObject item)
+    private NextItemStatus GetNextResult(out BlittableJsonReaderObject item)
     {
         if (WorkEnumerators.Count == 0)
         {
             item = null;
-            return NextItemStatus.Done;
+            return NextItemStatus.Stop;
         }
 
         var minEnumerator = WorkEnumerators[0];
@@ -190,14 +190,14 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
             if (filterResult == FilterResult.Skipped)
             {
                 item.Dispose();
-                return NextItemStatus.Filter;
+                return NextItemStatus.Continue;
             }
 
             if (filterResult == FilterResult.LimitReached)
-                return NextItemStatus.Done;
+                return NextItemStatus.Stop;
         }
 
-        return NextItemStatus.Found;
+        return NextItemStatus.Yield;
     }
 
     public override void Dispose()

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -17,6 +17,7 @@ using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.Results.Sharding;
 using Raven.Server.Documents.Queries.Sharding;
 using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Sharding.Comparers;
 using Raven.Server.Documents.Sharding.Handlers;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -49,7 +50,7 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         StreamQueryStatistics queryStats,
         TransactionOperationContext context,
         CancellationToken token)
-        : base(new ReduceKeyComparer(reduceKeys))
+        : base(new DocumentsComparer(reduceKeys.ToArray(), extractFromData: true, hasOrderByRandom: false))
     {
         _query = query;
         _requestHandler = requestHandler;
@@ -205,74 +206,6 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         using (_reducer)
         {
             base.Dispose();
-        }
-    }
-
-    private sealed class ReduceKeyComparer : IComparer<BlittableJsonReaderObject>
-    {
-        private readonly List<OrderByField> _reduceKeys;
-
-        public ReduceKeyComparer(List<OrderByField> reduceKeys)
-        {
-            _reduceKeys = reduceKeys;
-        }
-
-        public int Compare(BlittableJsonReaderObject x, BlittableJsonReaderObject y)
-        {
-            foreach (var reduceKey in _reduceKeys)
-            {
-                if (x.TryGet(reduceKey.Name, out object valX) == false)
-                    ThrowNotFoundReduceKey(reduceKey);
-
-                if (y.TryGet(reduceKey.Name, out object valY) == false)
-                    ThrowNotFoundReduceKey(reduceKey);
-
-                if (valX == null && valY == null)
-                    continue;
-
-                if (valX == null)
-                    return -1;
-
-                if (valY == null)
-                    return 1;
-
-                int result = CompareValues(valX, valY, reduceKey.Ascending);
-                if (result != 0)
-                    return result;
-            }
-
-            return 0;
-        }
-
-        private int CompareValues(object x, object y, bool ascending)
-        {
-            int result;
-
-            if (x is IComparable comparableX)
-            {
-                try
-                {
-                    result = comparableX.CompareTo(y);
-                }
-                catch (ArgumentException)
-                {
-                    // fallback for mixed number types (e.g. comparing int to long)
-                    // this is rare in map-reduce keys but safe to handle.
-                    result = Convert.ToDouble(x).CompareTo(Convert.ToDouble(y));
-                }
-            }
-            else
-            {
-                // fallback for non-comparable types (rare for index keys)
-                result = string.Compare(x.ToString(), y.ToString(), StringComparison.Ordinal);
-            }
-
-            return ascending ? result : -result;
-        }
-
-        private static void ThrowNotFoundReduceKey(OrderByField reduceKey)
-        {
-            throw new InvalidOperationException($"Reduce key '{reduceKey}' not found in the result object.");
         }
     }
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -122,7 +122,6 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
             _requestHandler.DatabaseContext.Indexes.ScriptRunnerCache,
             _query,
             null,
-            SearchEngineType.Lucene,
             fieldsToFetch,
             null,
             _context,

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -70,45 +70,106 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
             return true;
         }
 
-        while (true)
+        while (GetNextResult(out var item))
         {
-            var itemStatus = GetNextResult(out BlittableJsonReaderObject item);
-            switch (itemStatus)
+            if (_isProjectionFromMapReduceIndex == false)
             {
-                case NextItemStatus.Stop:
-                    CurrentItem = null;
-                    return false;
-
-                case NextItemStatus.Continue:
-                    continue;
-
-                case NextItemStatus.Yield:
-                    if (_isProjectionFromMapReduceIndex == false)
-                    {
-                        // simple map-reduce (no projection)
-                        CurrentItem = item;
-                        return true;
-                    }
-
-                    _retriever ??= InitializeRetriever();
-
-                    foreach (BlittableJsonReaderObject result in ShardedQueryProcessor.GetProjectionResults(_retriever, item, _context))
-                    {
-                        _resultsBuffer.Enqueue(result);
-                    }
-
-                    if (_resultsBuffer.Count > 0)
-                    {
-                        CurrentItem = _resultsBuffer.Dequeue();
-                        return true;
-                    }
-
-                    continue;
-
-                default:
-                    throw new ArgumentOutOfRangeException();
+                // simple map-reduce (no projection)
+                CurrentItem = item;
+                return true;
             }
+
+            try
+            {
+                _retriever ??= InitializeRetriever();
+
+                foreach (BlittableJsonReaderObject result in ShardedQueryProcessor.GetProjectionResults(_retriever, item, _context))
+                {
+                    _resultsBuffer.Enqueue(result);
+                }
+            }
+            finally
+            {
+                // we are done with the map-reduce key/result 'item', so we must dispose it.
+                // we do not return it to the caller, we return the projected results instead.
+                item.Dispose();
+            }
+
+            if (_resultsBuffer.Count > 0)
+            {
+                CurrentItem = _resultsBuffer.Dequeue();
+                return true;
+            }
+
+            // if buffer is empty (projection yielded no results for this key),
+            // loop again to fetch the next key.
         }
+
+        CurrentItem = null;
+        return false;
+    }
+
+    private bool GetNextResult(out BlittableJsonReaderObject item)
+    {
+        // loop until we find a valid item or run out of data
+        while (WorkEnumerators.Count > 0)
+        {
+            var minEnumerator = WorkEnumerators[0];
+            for (var index = 1; index < WorkEnumerators.Count; index++)
+            {
+                if (Comparer.Compare(WorkEnumerators[index].Current, minEnumerator.Current) < 0)
+                {
+                    minEnumerator = WorkEnumerators[index];
+                }
+            }
+
+            var minKeyItem = minEnumerator.Current;
+
+            _currentBatch.Clear();
+
+            // iterate backwards to easily remove exhausted enumerators
+            for (int i = WorkEnumerators.Count - 1; i >= 0; i--)
+            {
+                var enumerator = WorkEnumerators[i];
+
+                if (Comparer.Compare(enumerator.Current, minKeyItem) == 0)
+                {
+                    _currentBatch.Add(enumerator.Current);
+
+                    if (enumerator.MoveNext() == false)
+                    {
+                        RemoveEnumerator(i);
+                    }
+                }
+            }
+
+            // re-reduce on this specific batch
+            _reducer ??= CreateBatchReducer();
+            item = _reducer.ReduceBatch(_currentBatch);
+
+            if (_queryFilter != null)
+            {
+                var filterResult = _queryFilter.Apply(item);
+
+                if (filterResult == FilterResult.Skipped)
+                {
+                    item.Dispose();
+                    continue;
+                }
+
+                if (filterResult == FilterResult.LimitReached)
+                {
+                    item.Dispose();
+                    item = null;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        item = null;
+        return false;
     }
 
     private ShardedMapReduceResultRetriever InitializeRetriever()
@@ -129,71 +190,6 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
             null,
             null,
             _requestHandler.DatabaseContext.IdentityPartsSeparator);
-    }
-
-    private enum NextItemStatus
-    {
-        Yield,
-        Continue,
-        Stop
-    }
-
-    private NextItemStatus GetNextResult(out BlittableJsonReaderObject item)
-    {
-        if (WorkEnumerators.Count == 0)
-        {
-            item = null;
-            return NextItemStatus.Stop;
-        }
-
-        var minEnumerator = WorkEnumerators[0];
-        for (var index = 1; index < WorkEnumerators.Count; index++)
-        {
-            if (Comparer.Compare(WorkEnumerators[index].Current, minEnumerator.Current) < 0)
-            {
-                minEnumerator = WorkEnumerators[index];
-            }
-        }
-
-        var minKeyItem = minEnumerator.Current;
-
-        _currentBatch.Clear();
-
-        // we iterate backwards so we can easily remove exhausted enumerators
-        for (int i = WorkEnumerators.Count - 1; i >= 0; i--)
-        {
-            var enumerator = WorkEnumerators[i];
-
-            if (Comparer.Compare(enumerator.Current, minKeyItem) == 0)
-            {
-                _currentBatch.Add(enumerator.Current);
-
-                if (enumerator.MoveNext() == false)
-                {
-                    // cannot dispose the WorkEnumerator here until we sent the current batch
-                    RemoveEnumerator(i);
-                }
-            }
-        }
-
-        // re-reduce on this specific batch
-        _reducer ??= CreateBatchReducer();
-        item = _reducer.ReduceBatch(_currentBatch);
-
-        if (_queryFilter != null)
-        {
-            var filterResult = _queryFilter.Apply(item);
-            if (filterResult == FilterResult.Skipped)
-            {
-                item.Dispose();
-                return NextItemStatus.Continue;
-            }
-
-            if (filterResult == FilterResult.LimitReached)
-                return NextItemStatus.Stop;
-        }
-
-        return NextItemStatus.Yield;
     }
 
     public override void Dispose()

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Session;
@@ -8,39 +9,143 @@ using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.MapReduce.Auto;
 using Raven.Server.Documents.Indexes.MapReduce.Static;
 using Raven.Server.Documents.Indexes.MapReduce.Static.Sharding;
+using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
 using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Documents.Indexes.Static.Sharding;
 using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.Results.Sharding;
+using Raven.Server.Documents.Queries.Sharding;
 using Raven.Server.Documents.Replication.Senders;
 using Raven.Server.Documents.Sharding.Handlers;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 
 namespace Raven.Server.Documents.Sharding.Queries;
 
 public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJsonReaderObject>
 {
+    private readonly IndexQueryServerSide _query;
     private readonly StreamQueryStatistics _queryStats;
     private readonly ShardedDatabaseRequestHandler _requestHandler;
-    private readonly JsonOperationContext _context;
-    private readonly IDisposable _returnContext;
+    private readonly ShardedQueryFilter _queryFilter;
+    private readonly bool _isProjectionFromMapReduceIndex;
+    private readonly TransactionOperationContext _context;
     private readonly CancellationToken _token;
+
+    private IShardedBatchReducer _reducer;
+    private ShardedMapReduceResultRetriever _retriever;
+
+    private readonly Queue<BlittableJsonReaderObject> _resultsBuffer = new();
     private readonly List<BlittableJsonReaderObject> _currentBatch = new();
     private readonly List<IDisposable> _toDispose = new();
-    private IShardedBatchReducer _reducer;
 
-    public ShardedMapReduceStreamingEnumerator(List<OrderByField> reduceKeys, ShardedDatabaseRequestHandler requestHandler, StreamQueryStatistics queryStats, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, CancellationToken token)
+    public ShardedMapReduceStreamingEnumerator(
+        IndexQueryServerSide query,
+        List<OrderByField> reduceKeys,
+        ShardedDatabaseRequestHandler requestHandler,
+        bool isProjectionFromMapReduceIndex,
+        StreamQueryStatistics queryStats,
+        TransactionOperationContext context,
+        CancellationToken token)
         : base(new ReduceKeyComparer(reduceKeys))
     {
+        _query = query;
         _requestHandler = requestHandler;
+        _isProjectionFromMapReduceIndex = isProjectionFromMapReduceIndex;
         _queryStats = queryStats;
+        _context = context;
         _token = token;
-        (_context, _returnContext) = allocateJsonContext();
+
+        if (query.Metadata.Query.Filter != null)
+            _queryFilter = new ShardedQueryFilter(query, new ShardedQueryResult(), queryTimings: null, _requestHandler.DatabaseContext.Indexes.ScriptRunnerCache, _context);
     }
 
     public override bool MoveNext()
     {
+        if (_resultsBuffer.Count > 0)
+        {
+            CurrentItem = _resultsBuffer.Dequeue();
+            return true;
+        }
+
+        while (true)
+        {
+            var itemStatus = GetNextDocument(out BlittableJsonReaderObject item);
+            switch (itemStatus)
+            {
+                case NextItemStatus.Done:
+                    CurrentItem = null;
+                    return false;
+
+                case NextItemStatus.Filter:
+                    continue;
+
+                case NextItemStatus.Found:
+                    if (_isProjectionFromMapReduceIndex == false)
+                    {
+                        // simple map-reduce (no projection)
+                        CurrentItem = item;
+                        return true;
+                    }
+
+                    _retriever ??= InitializeRetriever();
+
+                    foreach (BlittableJsonReaderObject result in ShardedQueryProcessor.GetProjectionResults(_retriever, item, _context))
+                    {
+                        _resultsBuffer.Enqueue(result);
+                    }
+
+                    if (_resultsBuffer.Count > 0)
+                    {
+                        CurrentItem = _resultsBuffer.Dequeue();
+                        return true;
+                    }
+
+                    continue;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+
+    private ShardedMapReduceResultRetriever InitializeRetriever()
+    {
+        var index = _requestHandler.DatabaseContext.Indexes.GetIndex(_queryStats.IndexName);
+        if (index == null)
+            IndexDoesNotExistException.ThrowFor(_queryStats.IndexName);
+
+        var fieldsToFetch = new FieldsToFetch(_query, index.Definition, index.Type);
+        return new ShardedMapReduceResultRetriever(
+            _requestHandler.DatabaseContext.Indexes.ScriptRunnerCache,
+            _query,
+            null,
+            SearchEngineType.Lucene,
+            fieldsToFetch,
+            null,
+            _context,
+            null,
+            null,
+            null,
+            _requestHandler.DatabaseContext.IdentityPartsSeparator);
+    }
+
+    private enum NextItemStatus
+    {
+        Done,
+        Filter,
+        Found
+    }
+
+    private NextItemStatus GetNextDocument(out BlittableJsonReaderObject item)
+    {
         if (WorkEnumerators.Count == 0)
-            return false;
+        {
+            item = null;
+            return NextItemStatus.Done;
+        }
 
         var minEnumerator = WorkEnumerators[0];
         for (var index = 1; index < WorkEnumerators.Count; index++)
@@ -56,7 +161,6 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         _toDispose.ForEach(x => x.Dispose());
         _toDispose.Clear();
         _currentBatch.Clear();
-        CurrentItem?.Dispose();
 
         // we iterate backwards so we can easily remove exhausted enumerators
         for (int i = WorkEnumerators.Count - 1; i >= 0; i--)
@@ -78,15 +182,30 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
         // re-reduce on this specific batch
         _reducer ??= CreateBatchReducer();
-        CurrentItem = _reducer.ReduceBatch(_currentBatch);
+        item = _reducer.ReduceBatch(_currentBatch);
 
-        return true;
+        if (_queryFilter != null)
+        {
+            var filterResult = _queryFilter.Apply(item);
+            if (filterResult == FilterResult.Skipped)
+            {
+                item.Dispose();
+                return NextItemStatus.Filter;
+            }
+
+            if (filterResult == FilterResult.LimitReached)
+                return NextItemStatus.Done;
+        }
+
+        return NextItemStatus.Found;
     }
 
     public override void Dispose()
     {
-        base.Dispose();
-        _returnContext.Dispose();
+        using (_reducer)
+        {
+            base.Dispose();
+        }
     }
 
     private sealed class ReduceKeyComparer : IComparer<BlittableJsonReaderObject>
@@ -176,23 +295,24 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         throw new InvalidOperationException($"Index '{_queryStats.IndexName}' is not a map-reduce index");
     }
 
-    private interface IShardedBatchReducer
+    private interface IShardedBatchReducer : IDisposable
     {
         BlittableJsonReaderObject ReduceBatch(List<BlittableJsonReaderObject> batch);
     }
 
     private class ShardedStaticBatchReducer : IShardedBatchReducer
     {
+        private readonly IndexInformationHolder _index;
+        private readonly TransactionOperationContext _context;
+
         private readonly IndexingFunc _reducingFunc;
         private readonly ReduceMapResultsOfStaticIndex.DynamicIterationOfAggregationBatchWrapper _wrapper;
-        private readonly JsonOperationContext _context;
-        private readonly IndexInformationHolder _index;
+        private readonly UnmanagedBuffersPoolWithLowMemoryHandling _unmanagedBuffersPool;
 
-        // We reuse this list to avoid allocating a new List<object> for every single key
         private readonly List<object> _singleResultContainer = new(1);
         private IPropertyAccessor _propertyAccessor;
 
-        public ShardedStaticBatchReducer(IndexInformationHolder index, JsonOperationContext context)
+        public ShardedStaticBatchReducer(IndexInformationHolder index, TransactionOperationContext context)
         {
             _index = index;
             _context = context;
@@ -204,6 +324,9 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
             // Initialize the wrapper once. We will just feed it new data in the loop.
             _wrapper = new ReduceMapResultsOfStaticIndex.DynamicIterationOfAggregationBatchWrapper();
+
+            _unmanagedBuffersPool = new UnmanagedBuffersPoolWithLowMemoryHandling($"Sharded//Indexes//{index.Name}");
+            CurrentIndexingScope.Current = new OrchestratorIndexingScope(_context, _unmanagedBuffersPool);
         }
 
         public BlittableJsonReaderObject ReduceBatch(List<BlittableJsonReaderObject> batch)
@@ -214,9 +337,8 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
             foreach (var output in _reducingFunc(_wrapper))
             {
-                _singleResultContainer.Add(output);
-
                 _propertyAccessor ??= PropertyAccessor.Create(output.GetType(), output);
+                _singleResultContainer.Add(output);
             }
 
             if (_singleResultContainer.Count == 0)
@@ -235,18 +357,26 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
             return null;
         }
+
+        public void Dispose()
+        {
+            using (_unmanagedBuffersPool)
+            using (CurrentIndexingScope.Current)
+            {
+            }
+        }
     }
 
     private class ShardedAutoBatchReducer : IShardedBatchReducer
     {
         private readonly AutoMapReduceIndexDefinition _definition;
         private readonly ShardedAutoMapReduceIndexResultsAggregator _aggregator;
-        private readonly JsonOperationContext _context;
+        private readonly TransactionOperationContext _context;
         private readonly CancellationToken _token;
 
         private BlittableJsonReaderObject _reusableResultBuffer = null;
 
-        public ShardedAutoBatchReducer(IndexInformationHolder index, ShardedAutoMapReduceIndexResultsAggregator aggregator, JsonOperationContext context, CancellationToken token)
+        public ShardedAutoBatchReducer(IndexInformationHolder index, ShardedAutoMapReduceIndexResultsAggregator aggregator, TransactionOperationContext context, CancellationToken token)
         {
             if (index.Type.IsAutoMapReduce() == false)
                 throw new InvalidOperationException($"Index '{index.Name}' is not an auto map-reduce index");
@@ -260,8 +390,12 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         public BlittableJsonReaderObject ReduceBatch(List<BlittableJsonReaderObject> batch)
         {
             _reusableResultBuffer = null;
-            _aggregator.AggregateOn(batch, _definition, _context, null, ref _reusableResultBuffer, _token);
-            return _reusableResultBuffer;
+            var aggregateOn = _aggregator.AggregateOn(batch, _definition, _context, null, ref _reusableResultBuffer, _token);
+            return aggregateOn.GetOutputsToStore().First();
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -40,7 +40,6 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
     private readonly Queue<BlittableJsonReaderObject> _resultsBuffer = new();
     private readonly List<BlittableJsonReaderObject> _currentBatch = new();
-    private readonly List<IDisposable> _toDispose = new();
 
     public ShardedMapReduceStreamingEnumerator(
         IndexQueryServerSide query,
@@ -159,8 +158,6 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
         var minKeyItem = minEnumerator.Current;
 
-        _toDispose.ForEach(x => x.Dispose());
-        _toDispose.Clear();
         _currentBatch.Clear();
 
         // we iterate backwards so we can easily remove exhausted enumerators
@@ -175,8 +172,7 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
                 if (enumerator.MoveNext() == false)
                 {
                     // cannot dispose the WorkEnumerator here until we sent the current batch
-                    _toDispose.Add(WorkEnumerators[i]);
-                    WorkEnumerators.RemoveAt(i);
+                    RemoveEnumerator(i);
                 }
             }
         }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Server.Documents.Indexes;
+using Raven.Server.Documents.Indexes.MapReduce.Auto;
+using Raven.Server.Documents.Indexes.MapReduce.Static;
+using Raven.Server.Documents.Indexes.MapReduce.Static.Sharding;
+using Raven.Server.Documents.Indexes.Persistence.Lucene.Documents;
+using Raven.Server.Documents.Indexes.Static;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Replication.Senders;
+using Raven.Server.Documents.Sharding.Handlers;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Sharding.Queries;
+
+public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJsonReaderObject>
+{
+    private readonly StreamQueryStatistics _queryStats;
+    private readonly ShardedDatabaseRequestHandler _requestHandler;
+    private readonly JsonOperationContext _context;
+    private readonly IDisposable _returnContext;
+    private readonly CancellationToken _token;
+    private readonly List<BlittableJsonReaderObject> _currentBatch = new();
+    private readonly List<IDisposable> _toDispose = new();
+    private IShardedBatchReducer _reducer;
+
+    public ShardedMapReduceStreamingEnumerator(List<OrderByField> reduceKeys, ShardedDatabaseRequestHandler requestHandler, StreamQueryStatistics queryStats, Func<(JsonOperationContext, IDisposable)> allocateJsonContext, CancellationToken token)
+        : base(new ReduceKeyComparer(reduceKeys))
+    {
+        _requestHandler = requestHandler;
+        _queryStats = queryStats;
+        _token = token;
+        (_context, _returnContext) = allocateJsonContext();
+    }
+
+    public override bool MoveNext()
+    {
+        if (WorkEnumerators.Count == 0)
+            return false;
+
+        var minEnumerator = WorkEnumerators[0];
+        for (var index = 1; index < WorkEnumerators.Count; index++)
+        {
+            if (Comparer.Compare(WorkEnumerators[index].Current, minEnumerator.Current) < 0)
+            {
+                minEnumerator = WorkEnumerators[index];
+            }
+        }
+
+        var minKeyItem = minEnumerator.Current;
+
+        _toDispose.ForEach(x => x.Dispose());
+        _toDispose.Clear();
+        _currentBatch.Clear();
+        CurrentItem?.Dispose();
+
+        // we iterate backwards so we can easily remove exhausted enumerators
+        for (int i = WorkEnumerators.Count - 1; i >= 0; i--)
+        {
+            var enumerator = WorkEnumerators[i];
+
+            if (Comparer.Compare(enumerator.Current, minKeyItem) == 0)
+            {
+                _currentBatch.Add(enumerator.Current);
+
+                if (enumerator.MoveNext() == false)
+                {
+                    // cannot dispose the WorkEnumerator here until we sent the current batch
+                    _toDispose.Add(WorkEnumerators[i]);
+                    WorkEnumerators.RemoveAt(i);
+                }
+            }
+        }
+
+        // re-reduce on this specific batch
+        _reducer ??= CreateBatchReducer();
+        CurrentItem = _reducer.ReduceBatch(_currentBatch);
+
+        return true;
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _returnContext.Dispose();
+    }
+
+    private sealed class ReduceKeyComparer : IComparer<BlittableJsonReaderObject>
+    {
+        private readonly List<OrderByField> _reduceKeys;
+
+        public ReduceKeyComparer(List<OrderByField> reduceKeys)
+        {
+            _reduceKeys = reduceKeys;
+        }
+
+        public int Compare(BlittableJsonReaderObject x, BlittableJsonReaderObject y)
+        {
+            foreach (var reduceKey in _reduceKeys)
+            {
+                if (x.TryGet(reduceKey.Name, out object valX) == false)
+                    ThrowNotFoundReduceKey(reduceKey);
+
+                if (y.TryGet(reduceKey.Name, out object valY) == false)
+                    ThrowNotFoundReduceKey(reduceKey);
+
+                if (valX == null && valY == null)
+                    continue;
+
+                if (valX == null)
+                    return -1;
+
+                if (valY == null)
+                    return 1;
+
+                int result = CompareValues(valX, valY, reduceKey.Ascending);
+                if (result != 0)
+                    return result;
+            }
+
+            return 0;
+        }
+
+        private int CompareValues(object x, object y, bool ascending)
+        {
+            int result;
+
+            if (x is IComparable comparableX)
+            {
+                try
+                {
+                    result = comparableX.CompareTo(y);
+                }
+                catch (ArgumentException)
+                {
+                    // fallback for mixed number types (e.g. comparing int to long)
+                    // this is rare in map-reduce keys but safe to handle.
+                    result = Convert.ToDouble(x).CompareTo(Convert.ToDouble(y));
+                }
+            }
+            else
+            {
+                // fallback for non-comparable types (rare for index keys)
+                result = string.Compare(x.ToString(), y.ToString(), StringComparison.Ordinal);
+            }
+
+            return ascending ? result : -result;
+        }
+
+        private static void ThrowNotFoundReduceKey(OrderByField reduceKey)
+        {
+            throw new InvalidOperationException($"Reduce key '{reduceKey}' not found in the result object.");
+        }
+    }
+
+    private IShardedBatchReducer CreateBatchReducer()
+    {
+        var index = _requestHandler.DatabaseContext.Indexes.GetIndex(_queryStats.IndexName);
+        if (index == null)
+            IndexDoesNotExistException.ThrowFor(_queryStats.IndexName);
+
+        if (index.Type.IsStaticMapReduce())
+        {
+            return new ShardedStaticBatchReducer(index, _context);
+        }
+
+        if (index.Type.IsAutoMapReduce())
+        {
+            return new ShardedAutoBatchReducer(index, ShardedMapReduceQueryResultsMerger.Aggregator, _context, _token);
+        }
+
+        throw new InvalidOperationException($"Index '{_queryStats.IndexName}' is not a map-reduce index");
+    }
+
+    private interface IShardedBatchReducer
+    {
+        BlittableJsonReaderObject ReduceBatch(List<BlittableJsonReaderObject> batch);
+    }
+
+    private class ShardedStaticBatchReducer : IShardedBatchReducer
+    {
+        private readonly IndexingFunc _reducingFunc;
+        private readonly ReduceMapResultsOfStaticIndex.DynamicIterationOfAggregationBatchWrapper _wrapper;
+        private readonly JsonOperationContext _context;
+        private readonly IndexInformationHolder _index;
+
+        // We reuse this list to avoid allocating a new List<object> for every single key
+        private readonly List<object> _singleResultContainer = new(1);
+        private IPropertyAccessor _propertyAccessor;
+
+        public ShardedStaticBatchReducer(IndexInformationHolder index, JsonOperationContext context)
+        {
+            _index = index;
+            _context = context;
+
+            if (index is not StaticIndexInformationHolder staticIndex)
+                throw new InvalidOperationException($"Index '{index.Name}' is not a static map-reduce index");
+
+            _reducingFunc = staticIndex.Compiled.Reduce;
+
+            // Initialize the wrapper once. We will just feed it new data in the loop.
+            _wrapper = new ReduceMapResultsOfStaticIndex.DynamicIterationOfAggregationBatchWrapper();
+        }
+
+        public BlittableJsonReaderObject ReduceBatch(List<BlittableJsonReaderObject> batch)
+        {
+            _wrapper.InitializeForEnumeration(batch);
+
+            _singleResultContainer.Clear();
+
+            foreach (var output in _reducingFunc(_wrapper))
+            {
+                _singleResultContainer.Add(output);
+
+                _propertyAccessor ??= PropertyAccessor.Create(output.GetType(), output);
+            }
+
+            if (_singleResultContainer.Count == 0)
+                return null;
+
+            var aggregatedObjects = new ShardedAggregatedAnonymousObjects(
+                _singleResultContainer,
+                _propertyAccessor,
+                _context,
+                skipImplicitNullInOutput: _index.Configuration.IndexMissingFieldsAsNull == false);
+
+            foreach (var result in aggregatedObjects.GetOutputsToStore())
+            {
+                return result;
+            }
+
+            return null;
+        }
+    }
+
+    private class ShardedAutoBatchReducer : IShardedBatchReducer
+    {
+        private readonly AutoMapReduceIndexDefinition _definition;
+        private readonly ShardedAutoMapReduceIndexResultsAggregator _aggregator;
+        private readonly JsonOperationContext _context;
+        private readonly CancellationToken _token;
+
+        private BlittableJsonReaderObject _reusableResultBuffer = null;
+
+        public ShardedAutoBatchReducer(IndexInformationHolder index, ShardedAutoMapReduceIndexResultsAggregator aggregator, JsonOperationContext context, CancellationToken token)
+        {
+            if (index.Type.IsAutoMapReduce() == false)
+                throw new InvalidOperationException($"Index '{index.Name}' is not an auto map-reduce index");
+
+            _definition = (AutoMapReduceIndexDefinition)index.Definition;
+            _aggregator = aggregator;
+            _context = context;
+            _token = token;
+        }
+
+        public BlittableJsonReaderObject ReduceBatch(List<BlittableJsonReaderObject> batch)
+        {
+            _reusableResultBuffer = null;
+            _aggregator.AggregateOn(batch, _definition, _context, null, ref _reusableResultBuffer, _token);
+            return _reusableResultBuffer;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -40,6 +40,7 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
     private readonly Queue<BlittableJsonReaderObject> _resultsBuffer = new();
     private readonly List<BlittableJsonReaderObject> _currentBatch = new();
+    private readonly List<IDisposable> _enumeratorsToDispose = new();
 
     public ShardedMapReduceStreamingEnumerator(
         IndexQueryServerSide query,
@@ -138,7 +139,8 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
                     if (enumerator.MoveNext() == false)
                     {
-                        RemoveEnumerator(i);
+                        _enumeratorsToDispose.Add(WorkEnumerators[i]);
+                        WorkEnumerators.RemoveAt(i);
                     }
                 }
             }
@@ -196,6 +198,13 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
     {
         using (_reducer)
         {
+            foreach (var workEnumerator in _enumeratorsToDispose)
+            {
+                workEnumerator.Dispose();
+            }
+
+            _enumeratorsToDispose.Clear();
+
             base.Dispose();
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -215,7 +215,7 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
             var currentResults = result.Results;
             result.Results = new List<BlittableJsonReaderObject>();
 
-            using (var queryFilter = new ShardedQueryFilter(Query, result, scope, RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Context))
+            using (var queryFilter = new ShardedQueryFilter(Query, result, queryTimings: null, RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Context))
             {
                 foreach (var doc in currentResults)
                 {
@@ -252,32 +252,39 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
 
             foreach (var data in currentResults)
             {
-                var retrieverInput = new RetrieverInput();
-                (Document document, List<Document> documents) = retriever.GetProjectionFromDocument(new Document
+                foreach (var projected in GetProjectionResults(retriever, data, Context))
                 {
-                    Data = data
-                }, ref retrieverInput, fieldsToFetch, Context, CancellationToken.None);
-
-                var results = result.Results;
-
-                if (document != null)
-                {
-                    AddDocument(document.Data);
-                }
-                else if (documents != null)
-                {
-                    foreach (var doc in documents)
-                    {
-                        AddDocument(doc.Data);
-                    }
-                }
-
-                void AddDocument(BlittableJsonReaderObject documentData)
-                {
-                    var doc = Context.ReadObject(documentData, "modified-map-reduce-result");
-                    results.Add(doc);
+                    result.Results.Add(projected);
                 }
             }
+        }
+    }
+
+    public static IEnumerable<BlittableJsonReaderObject> GetProjectionResults(ShardedMapReduceResultRetriever retriever, BlittableJsonReaderObject item, JsonOperationContext context)
+    {
+        var retrieverInput = new RetrieverInput();
+        (Document document, List<Document> documents) = retriever.GetProjectionFromDocument(new Document
+        {
+            Data = item
+        }, ref retrieverInput, context, CancellationToken.None);
+
+        if (document != null)
+        {
+            yield return ProcessDocument(document.Data);
+        }
+        else if (documents != null)
+        {
+            foreach (var doc in documents)
+            {
+                yield return ProcessDocument(doc.Data);
+            }
+        }
+
+        yield break;
+
+        BlittableJsonReaderObject ProcessDocument(BlittableJsonReaderObject data)
+        {
+            return context.ReadObject(data, "modified-map-reduce-result");
         }
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -270,19 +270,19 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
 
         if (document != null)
         {
-            yield return ProcessDocument(document.Data);
+            yield return ReadBlittable(document.Data);
         }
         else if (documents != null)
         {
             foreach (var doc in documents)
             {
-                yield return ProcessDocument(doc.Data);
+                yield return ReadBlittable(doc.Data);
             }
         }
 
         yield break;
 
-        BlittableJsonReaderObject ProcessDocument(BlittableJsonReaderObject data)
+        BlittableJsonReaderObject ReadBlittable(BlittableJsonReaderObject data)
         {
             return context.ReadObject(data, "modified-map-reduce-result");
         }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -244,7 +244,7 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
         using (scope?.For(nameof(QueryTimingsScope.Names.Projection)))
         {
             var fieldsToFetch = new FieldsToFetch(Query, indexDefinition, IndexType);
-            var retriever = new ShardedMapReduceResultRetriever(RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Query, null, SearchEngineType.Lucene, fieldsToFetch, null, Context, null, null, null,
+            var retriever = new ShardedMapReduceResultRetriever(RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Query, null, fieldsToFetch, null, Context, null, null, null,
                 RequestHandler.DatabaseContext.IdentityPartsSeparator);
 
             var currentResults = result.Results;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -215,7 +215,7 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
             var currentResults = result.Results;
             result.Results = new List<BlittableJsonReaderObject>();
 
-            using (var queryFilter = new ShardedQueryFilter(Query, result, queryTimings: null, RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Context))
+            using (var queryFilter = new ShardedQueryFilter(Query, result, scope, RequestHandler.DatabaseContext.Indexes.ScriptRunnerCache, Context))
             {
                 foreach (var doc in currentResults)
                 {

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Commands;
@@ -6,6 +7,7 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Commands.Streaming;
 using Raven.Server.Documents.Queries;
+using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Documents.Queries.Timings;
 using Raven.Server.Documents.Sharding.Comparers;
 using Raven.Server.Documents.Sharding.Handlers;
@@ -20,6 +22,7 @@ namespace Raven.Server.Documents.Sharding.Queries
     {
         private readonly string _debug;
         private readonly bool _ignoreLimit;
+        private List<OrderByField> _groupByFields;
 
         public ShardedQueryStreamProcessor(
             TransactionOperationContext context,
@@ -39,7 +42,31 @@ namespace Raven.Server.Documents.Sharding.Queries
             base.AssertQueryExecution();
 
             if (IsAutoMapReduceQuery || IndexType.IsMapReduce())
-                throw new NotSupportedInShardingException("MapReduce is not supported in sharded streaming queries");
+            {
+                _groupByFields = new List<OrderByField>();
+                var groupByFieldsFromIndex = GetGroupByFields();
+
+                if (Query.Metadata.OrderBy != null)
+                {
+                    foreach (var orderByField in Query.Metadata.OrderBy)
+                    {
+                        if (groupByFieldsFromIndex.Contains(orderByField.Name.Value) == false)
+                        {
+                            throw new NotSupportedInShardingException($"Ordering by field '{orderByField.Name.Value}' which is not part of the 'group by' clause is not supported in sharded streaming queries.");
+                        }
+
+                        _groupByFields.Add(orderByField);
+                    }
+                }
+
+                foreach (var groupByField in groupByFieldsFromIndex)
+                {
+                    if (Query.Metadata.OrderBy != null && Query.Metadata.OrderByFieldNames.Contains(groupByField))
+                        continue;
+
+                    _groupByFields.Add(new OrderByField(new QueryFieldName(groupByField, isQuoted: false), OrderByFieldType.Implicit, ascending: true));
+                }
+            }
 
             if (Query.Metadata.HasIncludeOrLoad)
                 throw new NotSupportedInShardingException("Includes and Loads are not supported in sharded streaming queries");
@@ -54,11 +81,11 @@ namespace Raven.Server.Documents.Sharding.Queries
 
             var commands = GetOperationCommands(null);
 
-            var op = new ShardedStreamQueryOperation(RequestHandler.HttpContext, () =>
+            var op = new ShardedStreamQueryOperation(RequestHandler, () =>
             {
                 IDisposable returnToContextPool = RequestHandler.ContextPool.AllocateOperationContext(out JsonOperationContext ctx);
                 return (ctx, returnToContextPool);
-            }, documentsComparer, commands, skip: Query.Offset ?? 0, take: Query.Limit ?? int.MaxValue, Token);
+            }, documentsComparer, commands, _groupByFields, skip: Query.Offset ?? 0, take: Query.Limit ?? int.MaxValue, Token);
 
             var shards = GetShardNumbers(commands);
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -81,11 +81,11 @@ namespace Raven.Server.Documents.Sharding.Queries
 
             var commands = GetOperationCommands(null);
 
-            var op = new ShardedStreamQueryOperation(RequestHandler, () =>
+            var op = new ShardedStreamQueryOperation(RequestHandler.HttpContext, () =>
             {
                 IDisposable returnToContextPool = RequestHandler.ContextPool.AllocateOperationContext(out JsonOperationContext ctx);
                 return (ctx, returnToContextPool);
-            }, documentsComparer, commands, Query, _groupByFields, IsProjectionFromMapReduceIndex, Context, Token);
+            }, documentsComparer, commands, Query, RequestHandler.DatabaseContext, _groupByFields, IsProjectionFromMapReduceIndex, Context, Token);
 
             var shards = GetShardNumbers(commands);
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -44,13 +44,13 @@ namespace Raven.Server.Documents.Sharding.Queries
             if (IsAutoMapReduceQuery || IndexType.IsMapReduce())
             {
                 _groupByFields = new List<OrderByField>();
-                var groupByFieldsFromIndex = GetGroupByFields();
+                var groupByFieldNames = GetGroupByFields();
 
                 if (Query.Metadata.OrderBy != null)
                 {
                     foreach (var orderByField in Query.Metadata.OrderBy)
                     {
-                        if (groupByFieldsFromIndex.Contains(orderByField.Name.Value) == false)
+                        if (groupByFieldNames.Contains(orderByField.Name.Value) == false)
                         {
                             throw new NotSupportedInShardingException($"Ordering by field '{orderByField.Name.Value}' which is not part of the 'group by' clause is not supported in sharded streaming queries.");
                         }
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Sharding.Queries
                     }
                 }
 
-                foreach (var groupByField in groupByFieldsFromIndex)
+                foreach (var groupByField in groupByFieldNames)
                 {
                     if (Query.Metadata.OrderBy != null && Query.Metadata.OrderByFieldNames.Contains(groupByField))
                         continue;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -85,7 +85,7 @@ namespace Raven.Server.Documents.Sharding.Queries
             {
                 IDisposable returnToContextPool = RequestHandler.ContextPool.AllocateOperationContext(out JsonOperationContext ctx);
                 return (ctx, returnToContextPool);
-            }, documentsComparer, commands, _groupByFields, skip: Query.Offset ?? 0, take: Query.Limit ?? int.MaxValue, Token);
+            }, documentsComparer, commands, Query, _groupByFields, IsProjectionFromMapReduceIndex, Context, Token);
 
             var shards = GetShardNumbers(commands);
 

--- a/test/FastTests/Sharding/Queries/BasicShardedMapReduceStreamingTests.cs
+++ b/test/FastTests/Sharding/Queries/BasicShardedMapReduceStreamingTests.cs
@@ -292,7 +292,6 @@ select sum(""Count"") as Sum, key() as Name");
                             queryResult.Add(stream.Current.Document);
 
                         Assert.Equal(0, queryResult.Count);
-                        //TODO: Assert.Equal(1, stats.SkippedResults);
                     }
                 }
             }
@@ -637,8 +636,6 @@ group by Name
 order by Count as long desc
 select sum(""Count"") as Sum, key() as Name");
 
-                    var queryResult = new List<UserMapReduce.Result>();
-
                     var error = Assert.Throws<NotSupportedInShardingException>(() => session.Advanced.Stream(query1));
                     Assert.Contains("Ordering by field 'Count' which is not part of the 'group by' clause is not supported in sharded streaming queries.", error.Message);
                 }
@@ -915,11 +912,12 @@ limit 1
                             @"
 from Orders
 group by Company
-order by count() desc
+order by Company desc
 select count() as Count, key() as Company");
 
                     var queryResult = new List<AutoMapReduceResult>();
-                    using (var stream = session.Advanced.Stream(query1, out var stats))
+                    StreamQueryStatistics stats;
+                    using (var stream = session.Advanced.Stream(query1, out stats))
                     {
                         while (stream.MoveNext())
                             queryResult.Add(stream.Current.Document);
@@ -933,8 +931,7 @@ select count() as Count, key() as Company");
 
                     var query2 = session.Advanced.RawQuery<AutoMapReduceResult2>(
                             $@"
-from index '{"123"}' as o
-order by o.Count
+from index '{stats.IndexName}' as o
 select {{
     NewCompanyName: o.Company + '_' + o.Company,
     NewCount: o.Count * 2
@@ -1050,7 +1047,6 @@ select project(o)");
                             x.Sum
                         });
 
-                    // Streaming dynamic/anonymous types
                     var queryResult = new List<dynamic>();
                     using (var stream = session.Advanced.Stream(query))
                     {
@@ -1062,6 +1058,50 @@ select project(o)");
                     Assert.Equal(3, queryResult[0].Sum);
                     Assert.Equal(1, queryResult[1].Sum);
                     Assert.Equal(2, queryResult[2].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Simple_Map_Reduce_With_Order_By_And_Projection2()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", Count = 1 }, "users/1");
+                    session.Store(new User { Name = "Igal", Count = 2 }, "users/2");
+                    session.Store(new User { Name = "Egor", Count = 3 }, "users/3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query = (from user in session.Query<UserMapReduce.Result, UserMapReduce>()
+                        let sum = user.Sum + 1
+                        let name = user.Name + "_" + user.Name
+                        orderby user.Name
+                        select new
+                        {
+                            Sum = sum,
+                            Name = name
+                        });
+
+                    var queryResult = new List<dynamic>();
+                    using (var stream = session.Advanced.Stream(query))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(3, queryResult.Count);
+                    Assert.Equal(2, queryResult[1].Sum);
+                    Assert.Equal("Egor_Egor", queryResult[0].Name);
+                    Assert.Equal(4, queryResult[0].Sum);
+                    Assert.Equal("Grisha_Grisha", queryResult[1].Name);
+                    Assert.Equal(3, queryResult[2].Sum);
+                    Assert.Equal("Igal_Igal", queryResult[2].Name);
                 }
             }
         }
@@ -1084,7 +1124,6 @@ select project(o)");
 
                     var query = (from user in session.Query<UserMapReduce.Result, UserMapReduce>()
                                  let sum = user.Sum
-                                 orderby user.Sum
                                  select new
                                  {
                                      Sum = sum

--- a/test/FastTests/Sharding/Queries/BasicShardedMapReduceStreamingTests.cs
+++ b/test/FastTests/Sharding/Queries/BasicShardedMapReduceStreamingTests.cs
@@ -1,0 +1,1323 @@
+﻿using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Queries;
+using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions.Documents.Indexes;
+using Raven.Client.Exceptions.Sharding;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sharding.Queries
+{
+    public class BasicShardedMapReduceStreamingTests : RavenTestBase
+    {
+        public BasicShardedMapReduceStreamingTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Simple_Map_Reduce()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 1 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 2 }, "users/2");
+                    session.Store(new User { Name = "Jane", Count = 3 }, "users/3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query = session.Query<UserMapReduce.Result, UserMapReduce>();
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query))
+                    {
+                        while (stream.MoveNext())
+                        {
+                            queryResult.Add(stream.Current.Document);
+                        }
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal(6, queryResult[0].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_With_Filter()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/5");
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/6");
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/7");
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/8");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/3");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/4");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query1 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 40);
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(40, queryResult[0].Sum);
+
+                    var query2 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 40)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(40, queryResult[0].Sum);
+
+                    var query3 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 40)
+                        .OrderBy(x => x.Name)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query3))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(40, queryResult[0].Sum);
+
+                    var query4 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 20)
+                        .OrderBy(x => x.Name);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query4))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(2, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal(36, queryResult[0].Sum);
+                    Assert.Equal("Jane", queryResult[1].Name);
+                    Assert.Equal(40, queryResult[1].Sum);
+
+                    var query5 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 20)
+                        .OrderBy(x => x.Name)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query5))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal(36, queryResult[0].Sum);
+
+                    var query6 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 20)
+                        .OrderByDescending(x => x.Name)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query6))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(40, queryResult[0].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Auto_Map_Reduce_With_Filter()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/5");
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/6");
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/7");
+                    session.Store(new User { Name = "Grisha", Count = 9 }, "users/8");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/3");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/4");
+                    session.SaveChanges();
+
+                    var query1 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+filter Count >= 40
+select sum(""Count"") as Sum, key() as Name");
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(40, queryResult[0].Sum);
+
+                    var query2 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+filter Count >= 40
+select sum(""Count"") as Sum, key() as Name
+limit 1");
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(40, queryResult[0].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_With_Filter_No_Result()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 9 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 9 }, "users/2");
+                    session.Store(new User { Name = "Jane", Count = 9 }, "users/3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Filter(x => x.Sum >= 30);
+
+                    var queryResult = new List<UserMapReduce.Result>();
+
+                    // Streaming with Statistics
+                    using (var stream = session.Advanced.Stream(query, out var stats))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+
+                        Assert.Equal(0, queryResult.Count);
+                        // Accessing stats is only safe after iteration or inside the block, 
+                        // but SkippedResults is populated as we go or at the end.
+                        //Assert.Equal(1, stats.SkippedResults);
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Auto_Map_Reduce_With_Filter_No_Result()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 9 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 9 }, "users/2");
+                    session.Store(new User { Name = "Jane", Count = 9 }, "users/3");
+                    session.SaveChanges();
+
+                    var query = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+filter Count >= 30
+select sum(""Count"") as Sum, key() as Name");
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query, out var stats))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+
+                        Assert.Equal(0, queryResult.Count);
+                        //TODO: Assert.Equal(1, stats.SkippedResults);
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_With_Limit()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+                store.ExecuteIndex(new UserMapReduceWithTwoReduceKeys());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", LastName = "Kotler", Count = 21 }, "users/3$3");
+                    session.Store(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/4$3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query1 = session.Query<UserMapReduce.Result, UserMapReduce>().Take(1);
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query2 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .Skip(1)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(30, queryResult[0].Sum);
+
+                    var query3 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                            .Take(1);
+
+                    var queryResult2 = new List<UserMapReduceWithTwoReduceKeys.Result>();
+                    using (var stream = session.Advanced.Stream(query3))
+                    {
+                        while (stream.MoveNext())
+                            queryResult2.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult2.Count);
+                    Assert.Equal("Grisha", queryResult2[0].Name);
+                    Assert.Equal("Kotler", queryResult2[0].LastName);
+                    Assert.Equal(21, queryResult2[0].Sum);
+
+                    var query4 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .Skip(1)
+                        .Take(1);
+
+                    queryResult2.Clear();
+                    using (var stream = session.Advanced.Stream(query4))
+                    {
+                        while (stream.MoveNext())
+                            queryResult2.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult2.Count);
+                    Assert.Equal("Jane", queryResult2[0].Name);
+                    Assert.Equal("Doe", queryResult2[0].LastName);
+                    Assert.Equal(30, queryResult2[0].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Auto_Map_Reduce_With_Limit()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", LastName = "Kotler", Count = 21 }, "users/3$3");
+                    session.Store(new User { Name = "Jane", LastName = "Doe", Count = 10 }, "users/4$3");
+                    session.SaveChanges();
+
+                    var query1 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+select sum(Count) as Sum, key() as Name
+limit 1");
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query2 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+select sum(Count) as Sum, key() as Name
+limit 1, 1");
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(30, queryResult[0].Sum);
+
+                    var query3 = session.Advanced.RawQuery<UserMapReduceWithTwoReduceKeys.Result>(
+                            @"
+from Users
+group by Name
+select sum(Count) as Sum, Name, LastName
+limit 1");
+
+                    var queryResult2 = new List<UserMapReduceWithTwoReduceKeys.Result>();
+                    using (var stream = session.Advanced.Stream(query3))
+                    {
+                        while (stream.MoveNext())
+                            queryResult2.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult2.Count);
+                    Assert.Equal("Grisha", queryResult2[0].Name);
+                    Assert.Equal(21, queryResult2[0].Sum);
+
+                    var query4 = session.Advanced.RawQuery<UserMapReduceWithTwoReduceKeys.Result>(
+                            @"
+from Users
+group by Name
+select sum(Count) as Sum, Name, LastName
+limit 1, 1");
+
+                    queryResult2.Clear();
+                    using (var stream = session.Advanced.Stream(query4))
+                    {
+                        while (stream.MoveNext())
+                            queryResult2.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult2.Count);
+                    Assert.Equal("Jane", queryResult2[0].Name);
+                    Assert.Equal(30, queryResult2[0].Sum);
+
+                    var query5 = session.Advanced.RawQuery<UserMapReduceWithTwoReduceKeys.CompoundResult>(
+                            @"
+from Users
+group by Name, LastName
+select sum(Count) as Sum, key() as Name
+limit 1");
+
+                    var queryResult3 = new List<UserMapReduceWithTwoReduceKeys.CompoundResult>();
+                    using (var stream = session.Advanced.Stream(query5))
+                    {
+                        while (stream.MoveNext())
+                            queryResult3.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult3.Count);
+                    var properties = (IDictionary<string, object>)queryResult3[0].Name;
+                    Assert.Equal("Grisha", properties[nameof(UserMapReduceWithTwoReduceKeys.Result.Name)]);
+                    Assert.Equal("Kotler", properties[nameof(UserMapReduceWithTwoReduceKeys.Result.LastName)]);
+                    Assert.Equal(21, queryResult3[0].Sum);
+
+                    var query6 = session.Advanced.RawQuery<UserMapReduceWithTwoReduceKeys.CompoundResult>(
+                            @"
+from Users
+group by Name, LastName
+select sum(Count) as Sum, key() as Name
+limit 1, 1");
+
+                    queryResult3.Clear();
+                    using (var stream = session.Advanced.Stream(query6))
+                    {
+                        while (stream.MoveNext())
+                            queryResult3.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult3.Count);
+                    properties = (IDictionary<string, object>)queryResult3[0].Name;
+                    Assert.Equal("Jane", properties[nameof(UserMapReduceWithTwoReduceKeys.Result.Name)]);
+                    Assert.Equal("Doe", properties[nameof(UserMapReduceWithTwoReduceKeys.Result.LastName)]);
+                    Assert.Equal(30, queryResult3[0].Sum);
+
+                    var query7 = session.Query<User>()
+                        .GroupBy(x => new { x.Name, x.LastName }).Select(x => new
+                        {
+                            Name = x.Key.Name,
+                            LastName = x.Key.LastName,
+                            Sum = x.Sum(u => u.Count)
+                        })
+                        .Take(1);
+
+                    // Note: Anonymous types in streaming come back as JObject/Expando, 
+                    // but the wrapper handles projection mapping if done via Query<T>. 
+                    // However, we need to capture statistics first to get the IndexName.
+
+                    StreamQueryStatistics stats;
+                    // We must execute this to get the stats (auto index name).
+                    // Streaming this specific anonymous projection might need a concrete type for easy List add,
+                    // but let's assume dynamic for the test or create a helper class.
+                    // The original test uses `ToList` returning anonymous objects.
+                    // Streaming supports this.
+
+                    var autoLinqResultList = new List<dynamic>();
+                    using (var stream = session.Advanced.Stream(query7, out stats))
+                    {
+                        while (stream.MoveNext())
+                            autoLinqResultList.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, autoLinqResultList.Count);
+                    // Use dynamic access or casting
+                    Assert.Equal("Grisha", autoLinqResultList[0].Name);
+                    Assert.Equal("Kotler", autoLinqResultList[0].LastName);
+                    Assert.Equal(21, autoLinqResultList[0].Sum);
+
+                    // Re-querying using the index name from stats
+                    var query8 = session.Query<User>(stats.IndexName)
+                        .Take(1)
+                        .As<AutoMapReduceResult3>();
+
+                    var autoIndexResult = new List<AutoMapReduceResult3>();
+                    using (var stream = session.Advanced.Stream(query8))
+                    {
+                        while (stream.MoveNext())
+                            autoIndexResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, autoIndexResult.Count);
+                    Assert.Equal("Grisha", autoIndexResult[0].Name);
+                    Assert.Equal("Kotler", autoIndexResult[0].LastName);
+                    Assert.Equal(21, autoIndexResult[0].Count);
+
+                    var query9 = session.Query<User>(stats.IndexName)
+                        .OrderBy(x => x.Name)
+                        .Take(1)
+                        .As<AutoMapReduceResult3>();
+
+                    autoIndexResult.Clear();
+                    using (var stream = session.Advanced.Stream(query9))
+                    {
+                        while (stream.MoveNext())
+                            autoIndexResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, autoIndexResult.Count);
+                    Assert.Equal("Grisha", autoIndexResult[0].Name);
+                    Assert.Equal("Kotler", autoIndexResult[0].LastName);
+                    Assert.Equal(21, autoIndexResult[0].Count);
+
+                    var query10 = session.Query<User>(stats.IndexName)
+                        .OrderByDescending(x => x.Name)
+                        .Take(1)
+                        .As<AutoMapReduceResult3>();
+
+                    autoIndexResult.Clear();
+                    using (var stream = session.Advanced.Stream(query10))
+                    {
+                        while (stream.MoveNext())
+                            autoIndexResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, autoIndexResult.Count);
+                    Assert.Equal("Jane", autoIndexResult[0].Name);
+                    Assert.Equal("Doe", autoIndexResult[0].LastName);
+                    Assert.Equal(30, autoIndexResult[0].Count);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_With_Order_By_On_Non_Reduce_Key()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+                store.ExecuteIndex(new UserMapReduceJs());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", Count = 21 }, "users/3$3");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/4$3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query1 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .OrderByDescending(x => x.Sum)
+                        .Take(1);
+
+                    var error = Assert.Throws<NotSupportedInShardingException>(() => session.Advanced.Stream(query1));
+                    Assert.Contains("Ordering by field 'Sum' which is not part of the 'group by' clause is not supported in sharded streaming queries.", error.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Auto_Map_Reduce_With_Order_By_On_Non_Reduce_Key()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", Count = 21 }, "users/3$3");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/4$3");
+                    session.SaveChanges();
+
+                    var query1 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+order by Count as long desc
+select sum(""Count"") as Sum, key() as Name");
+
+                    var queryResult = new List<UserMapReduce.Result>();
+
+                    var error = Assert.Throws<NotSupportedInShardingException>(() => session.Advanced.Stream(query1));
+                    Assert.Contains("Ordering by field 'Count' which is not part of the 'group by' clause is not supported in sharded streaming queries.", error.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_With_Order_By_On_Reduce_Key_With_Take()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+                store.ExecuteIndex(new UserMapReduceJs());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", Count = 21 }, "users/3$3");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/4$3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query1 = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .OrderByDescending(x => x.Name)
+                        .Take(1);
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(30, queryResult[0].Sum);
+
+                    var query2 = session.Query<UserMapReduceJs.Result, UserMapReduceJs>()
+                        .OrderByDescending(x => x.Name)
+                        .Take(1);
+
+                    var queryResultJs = new List<UserMapReduceJs.Result>();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResultJs.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResultJs.Count);
+                    Assert.Equal("Jane", queryResultJs[0].Name);
+                    Assert.Equal(30, queryResultJs[0].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Auto_Map_Reduce_With_Order_By_On_Reduce_Key_With_Take()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", Count = 21 }, "users/3$3");
+                    session.Store(new User { Name = "Jane", Count = 10 }, "users/4$3");
+                    session.SaveChanges();
+
+                    var query1 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                            @"
+from Users
+group by Name
+order by Name desc
+select sum(""Count"") as Sum, key() as Name
+limit 1");
+
+                    var queryResult = new List<UserMapReduce.Result>();
+                    StreamQueryStatistics stats;
+                    using (var stream = session.Advanced.Stream(query1, out stats))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Jane", queryResult[0].Name);
+                    Assert.Equal(30, queryResult[0].Sum);
+
+                    WaitForUserToContinueTheTest(store);
+
+                    var query2 = session.Advanced.RawQuery<UserMapReduce.Result>(
+                    $@"
+from index ""{stats.IndexName}"" as o
+order by o.Name desc
+select {{
+    Name: o.Name,
+    Sum: o.Count
+}}
+limit 1
+");
+                    var queryResult2 = new List<UserMapReduce.Result>();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult2.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult2.Count);
+                    Assert.Equal("Jane", queryResult2[0].Name);
+                    Assert.Equal(30, queryResult2[0].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_With_Order_By_On_Reduce_Keys_With_Take()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduceWithTwoReduceKeys());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", LastName = "Kotler", Count = 10 }, "users/1");
+                    session.Store(new User { Name = "Grisha", LastName = "Kotler", Count = 10 }, "users/2");
+                    session.Store(new User { Name = "Grisha", LastName = "Kotler", Count = 10 }, "users/4$3");
+                    session.Store(new User { Name = "Grisha", LastName = "A", Count = 21 }, "users/3$3");
+
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query1 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .Take(1);
+
+                    var queryResult = new List<UserMapReduceWithTwoReduceKeys.Result>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("A", queryResult[0].LastName);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query2 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .OrderByDescending(x => x.Name)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("A", queryResult[0].LastName);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query3 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .OrderBy(x => x.Name)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query3))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("A", queryResult[0].LastName);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query4 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .OrderBy(x => x.Name)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query4))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("A", queryResult[0].LastName);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query5 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .OrderByDescending(x => x.Name)
+                        .ThenBy(x => x.LastName)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query5))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("A", queryResult[0].LastName);
+                    Assert.Equal(21, queryResult[0].Sum);
+
+                    var query6 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .OrderBy(x => x.Name)
+                        .ThenByDescending(x => x.LastName)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query6))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("Kotler", queryResult[0].LastName);
+                    Assert.Equal(30, queryResult[0].Sum);
+
+                    var query7 = session.Query<UserMapReduceWithTwoReduceKeys.Result, UserMapReduceWithTwoReduceKeys>()
+                        .OrderByDescending(x => x.LastName)
+                        .Take(1);
+
+                    queryResult.Clear();
+                    using (var stream = session.Advanced.Stream(query7))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(1, queryResult.Count);
+                    Assert.Equal("Grisha", queryResult[0].Name);
+                    Assert.Equal("Kotler", queryResult[0].LastName);
+                    Assert.Equal(30, queryResult[0].Sum);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Auto_Map_Reduce_With_Order_By(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        Company = "Companies/1-A",
+                    });
+                    session.Store(new Order
+                    {
+                        Company = "Companies/2-A",
+                    });
+                    session.Store(new Order
+                    {
+                        Company = "Companies/2-A",
+                    });
+                    session.SaveChanges();
+
+                    var query1 = session.Advanced.RawQuery<AutoMapReduceResult>(
+                            @"
+from Orders
+group by Company
+order by count() desc
+select count() as Count, key() as Company");
+
+                    var queryResult = new List<AutoMapReduceResult>();
+                    using (var stream = session.Advanced.Stream(query1, out var stats))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(2, queryResult.Count);
+                    Assert.Equal("Companies/2-A", queryResult[0].Company);
+                    Assert.Equal(2, queryResult[0].Count);
+                    Assert.Equal("Companies/1-A", queryResult[1].Company);
+                    Assert.Equal(1, queryResult[1].Count);
+
+                    var query2 = session.Advanced.RawQuery<AutoMapReduceResult2>(
+                            $@"
+from index '{"123"}' as o
+order by o.Count
+select {{
+    NewCompanyName: o.Company + '_' + o.Company,
+    NewCount: o.Count * 2
+}}
+");
+                    var queryResult2 = new List<AutoMapReduceResult2>();
+                    using (var stream = session.Advanced.Stream(query2))
+                    {
+                        while (stream.MoveNext())
+                            queryResult2.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(2, queryResult2.Count);
+                    Assert.Equal("Companies/1-A_Companies/1-A", queryResult2[0].NewCompanyName);
+                    Assert.Equal(2, queryResult2[0].NewCount);
+                    Assert.Equal("Companies/2-A_Companies/2-A", queryResult2[1].NewCompanyName);
+                    Assert.Equal(4, queryResult2[1].NewCount);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        [RavenData("long", DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        [RavenData("double", DatabaseMode = RavenDatabaseMode.Sharded, SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Map_Reduce_Index_With_Order_By_Multiple_Results(Options options, string sortType)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                store.ExecuteIndex(new OrderMapReduceIndex());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Order
+                    {
+                        Freight = 20m,
+                        Lines = new List<OrderLine>
+                        {
+                            new()
+                            {
+                                Discount = 0.2m
+                            },
+                            new()
+                            {
+                                Discount = 0.4m
+                            }
+                        }
+                    });
+                    session.Store(new Order
+                    {
+                        Freight = 10m,
+                        Lines = new List<OrderLine>
+                        {
+                            new()
+                            {
+                                Discount = 0.3m
+                            },
+                            new()
+                            {
+                                Discount = 0.5m
+                            }
+                        }
+                    });
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query1 = session.Advanced.RawQuery<OrderLine>(
+                            $@"
+declare function project(o) {{
+    return o.Lines;
+}}
+
+from index 'OrderMapReduceIndex' as o
+order by Freight as {sortType}
+select project(o)");
+
+                    var queryResult = new List<OrderLine>();
+                    using (var stream = session.Advanced.Stream(query1))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(4, queryResult.Count);
+                    Assert.Equal(0.3m, queryResult[0].Discount);
+                    Assert.Equal(0.5m, queryResult[1].Discount);
+                    Assert.Equal(0.2m, queryResult[2].Discount);
+                    Assert.Equal(0.4m, queryResult[3].Discount);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Simple_Map_Reduce_With_Order_By_And_Projection()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", Count = 1 }, "users/1");
+                    session.Store(new User { Name = "Igal", Count = 2 }, "users/2");
+                    session.Store(new User { Name = "Egor", Count = 3 }, "users/3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query = session.Query<UserMapReduce.Result, UserMapReduce>()
+                        .OrderBy(x => x.Name)
+                        .Select(x => new
+                        {
+                            x.Sum
+                        });
+
+                    // Streaming dynamic/anonymous types
+                    var queryResult = new List<dynamic>();
+                    using (var stream = session.Advanced.Stream(query))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(3, queryResult.Count);
+                    Assert.Equal(3, queryResult[0].Sum);
+                    Assert.Equal(1, queryResult[1].Sum);
+                    Assert.Equal(2, queryResult[2].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Simple_Map_Reduce_With_Order_By_Projecting_New_Fields()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", Count = 1 }, "users/1");
+                    session.Store(new User { Name = "Igal", Count = 2 }, "users/2");
+                    session.Store(new User { Name = "Egor", Count = 3 }, "users/3");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query = (from user in session.Query<UserMapReduce.Result, UserMapReduce>()
+                                 let sum = user.Sum
+                                 orderby user.Sum
+                                 select new
+                                 {
+                                     Sum = sum
+                                 });
+
+                    var queryResult = new List<dynamic>();
+                    using (var stream = session.Advanced.Stream(query))
+                    {
+                        while (stream.MoveNext())
+                            queryResult.Add(stream.Current.Document);
+                    }
+
+                    Assert.Equal(3, queryResult.Count);
+                    Assert.Equal(1, queryResult[0].Sum);
+                    Assert.Equal(2, queryResult[1].Sum);
+                    Assert.Equal(3, queryResult[2].Sum);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Map_Reduce_Projection_With_Load_Not_Supported()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                store.ExecuteIndex(new UserMapReduce());
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "Grisha", Count = 1 }, "users/1");
+                    session.SaveChanges();
+
+                    Indexes.WaitForIndexing(store);
+
+                    var query = (from user in session.Query<UserMapReduce.Result, UserMapReduce>()
+                                 let anotherUser = RavenQuery.Load<User>(user.Name)
+                                 select new
+                                 {
+                                     Name = anotherUser.Name
+                                 });
+
+                    // Streaming also throws NotSupported for Load in projections with sharding/map-reduce scenarios usually
+                    var exception = Assert.Throws<NotSupportedInShardingException>(() =>
+                    {
+                        using (var stream = session.Advanced.Stream(query))
+                        {
+                            while (stream.MoveNext())
+                            { }
+                        }
+                    });
+
+                    Assert.Contains(nameof(NotSupportedInShardingException), exception.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Sharding)]
+        public void Query_An_Index_That_Doesnt_Exist()
+        {
+            using (var store = Sharding.GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    var query = session.Query<UserMapReduce.Result, UserMapReduce>();
+                    Assert.Throws<IndexDoesNotExistException>(() =>
+                    {
+                        using (var stream = session.Advanced.Stream(query))
+                        {
+                            while (stream.MoveNext())
+                            { }
+                        }
+                    });
+                }
+            }
+        }
+
+        private class OrderMapReduceIndex : AbstractIndexCreationTask<Order>
+        {
+            public class Result
+            {
+                public decimal Freight;
+                public List<OrderLine> Lines;
+            }
+
+            public OrderMapReduceIndex()
+            {
+                Map = orders =>
+                    from order in orders
+                    select new Result
+                    {
+                        Freight = order.Freight,
+                        Lines = order.Lines
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Freight into g
+                    select new Result
+                    {
+                        Freight = g.Key,
+                        Lines = g.SelectMany(x => x.Lines).ToList()
+                    };
+
+                Index(x => x.Lines, FieldIndexing.No);
+            }
+        }
+
+        private class UserMapReduce : AbstractIndexCreationTask<User, UserMapReduce.Result>
+        {
+            public class Result
+            {
+                public string Name;
+                public int Sum;
+            }
+
+            public UserMapReduce()
+            {
+                Map = users =>
+                    from user in users
+                    select new Result
+                    {
+                        Name = user.Name,
+                        Sum = user.Count
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Name
+                    into g
+                    select new Result
+                    {
+                        Name = g.Key,
+                        Sum = g.Sum(x => x.Sum)
+                    };
+            }
+        }
+
+        private class UserMapReduceJs : AbstractJavaScriptIndexCreationTask
+        {
+            public class Result
+            {
+#pragma warning disable CS0649
+                public string Name;
+                public int Sum;
+#pragma warning restore CS0649
+            }
+
+            public UserMapReduceJs()
+            {
+                Maps = new HashSet<string>
+                {
+                    @"map('Users', function (c) {
+
+                        return {
+                            Name: c.Name,
+                            Sum: c.Count
+                        };
+                    })",
+                };
+
+                Reduce = @"groupBy(x => ({
+                        Name: x.Name
+                    })).aggregate(g => {
+                    return {
+                        Name: g.key.Name,
+                        Sum: g.values.reduce((res, val) => res + val.Sum, 0)
+                    };
+                })";
+            }
+        }
+
+        private class UserMapReduceWithTwoReduceKeys : AbstractIndexCreationTask<User, UserMapReduceWithTwoReduceKeys.Result>
+        {
+            public class Result
+            {
+                public string Name;
+                public string LastName;
+                public int Sum;
+            }
+
+            public class CompoundResult
+            {
+#pragma warning disable CS0649
+                public ExpandoObject Name;
+                public int Sum;
+#pragma warning restore CS0649
+            }
+
+            public UserMapReduceWithTwoReduceKeys()
+            {
+                Map = users =>
+                    from user in users
+                    select new Result
+                    {
+                        Name = user.Name,
+                        LastName = user.LastName,
+                        Sum = user.Count
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by new { result.Name, result.LastName }
+                    into g
+                    select new Result
+                    {
+                        Name = g.Key.Name,
+                        LastName = g.Key.LastName,
+                        Sum = g.Sum(x => x.Sum)
+                    };
+            }
+        }
+
+        private class AutoMapReduceResult
+        {
+            public string Company { get; set; }
+
+            public int Count { get; set; }
+        }
+
+        private class AutoMapReduceResult2
+        {
+            public string NewCompanyName { get; set; }
+
+            public int NewCount { get; set; }
+        }
+
+        private class AutoMapReduceResult3
+        {
+            public string Name { get; set; }
+
+            public string LastName { get; set; }
+
+            public int Count { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-8646.cs
+++ b/test/SlowTests/Issues/RavenDB-8646.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Issues
         }
 
         [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void CanStreamQueryWithMapReduceResult(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -48,44 +48,6 @@ namespace SlowTests.Issues
                         }
                         Assert.True(streamNotEmpty, "Was expecting to have a result in the query stream but didn't get anything.");
                     }
-                }
-            }
-        }
-
-        [RavenTheory(RavenTestCategory.Querying)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
-        public void CanStreamShardedQueryWithMapReduceResult(Options options)
-        {
-            using (var store = GetDocumentStore(options))
-            {
-                var index = new ReduceMeByTag();
-                store.ExecuteIndex(index);
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new ReduceMe
-                    {
-                        Tag = "Foo",
-                        Amount = 2
-                    });
-                    session.Store(new ReduceMe
-                    {
-                        Tag = "Foo",
-                        Amount = 3
-                    });
-                    session.SaveChanges();
-                    Indexes.WaitForIndexing(store);
-                    var query = session.Query<ReduceMe>(index.IndexName);
-                    var notSupportedException = Assert.Throws<NotSupportedInShardingException>(() =>
-                    {
-                        using (var stream = session.Advanced.Stream(query))
-                        {
-                            while (stream.MoveNext())
-                            {
-                            }
-                        }
-                    });
-
-                    Assert.Contains("MapReduce is not supported in sharded streaming queries", notSupportedException.Message);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20069/Sharding-Querying-Streaming-of-map-reduce-results

### Additional description

### Summary

This PR implements the streaming of map-reduce results from both auto and static indexes.
**Note:** Ordering is supported strictly on reduce keys, ordering on non-reduce keys is not supported.

**Implementation Details:**

1. **Distributed Querying:** The orchestrator issues a query to all shards, enforcing an `ORDER BY` clause on all reduce keys. This ensures the results from each shard are sorted, facilitating efficient re-reduction.

2. **Result Merging & Reduction:**
* The enumerator identifies the minimum result (based on the sort order) across all active shard enumerators.
* It collects all matching results for that specific reduce key from every shard.
* A final reduction (re-reduce) is performed on this collected batch.

3. **Post-Processing:**
* Any required filtering is applied to the reduced result.
* If a projection is requested, it is applied to the final output before streaming it to the client.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
