### PR TITLE
RavenDB-25870 - in sharded replication propagate the replication version from orchestrator to shard

### DIFF
--- a/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Outgoing/AbstractOutgoingReplicationHandler.cs
@@ -217,7 +217,7 @@ namespace Raven.Server.Documents.Replication.Outgoing
                     DestinationNodeTag = GetNode(),
                     DestinationUrl = Destination.Url,
                     ReadResponseAndGetVersionCallback = ReadHeaderResponseAndThrowIfUnAuthorized,
-                    Version = TcpConnectionHeaderMessage.ReplicationTcpVersion,
+                    Version = GetReplicationTcpVersion(),
                     AuthorizeInfo = authorizationInfo,
                     DestinationServerId = info?.ServerId,
                     LicensedFeatures = new LicensedFeatures
@@ -848,6 +848,10 @@ namespace Raven.Server.Documents.Replication.Outgoing
 
         protected abstract void OnBeforeDispose();
 
+        protected virtual int GetReplicationTcpVersion()
+        {
+            return TcpConnectionHeaderMessage.ReplicationTcpVersion;
+        }
 
         private readonly SingleUseFlag _disposed = new SingleUseFlag();
 

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
                 _lastSentEtagPerDestination.Add(shardNumber, 0L);
 
-                _handlers[shardNumber] = new ShardedOutgoingReplicationHandler(parent, node, info, replicatedLastEtag.SourceDatabaseId);
+                _handlers[shardNumber] = new ShardedOutgoingReplicationHandler(parent, node, info, replicatedLastEtag.SourceDatabaseId, tcpConnectionOptions.ProtocolVersion);
                 _handlers[shardNumber].Start();
             }
         }

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedOutgoingReplicationHandler.cs
@@ -27,11 +27,12 @@ namespace Raven.Server.Documents.Sharding.Handlers
         private readonly byte[] _tempBuffer = new byte[32 * 1024];
         private long _lastEtag;
         private readonly TaskCompletionSource<(string, long)> _firstChangeVector = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly int _protocolVersion;
 
         public readonly string DestinationDatabaseName;
         public string MissingAttachmentMessage { get; set; }
 
-        public ShardedOutgoingReplicationHandler(ShardedDatabaseContext.ShardedReplicationContext parent, ShardReplicationNode node, TcpConnectionInfo connectionInfo, string sourceDatabaseId) :
+        public ShardedOutgoingReplicationHandler(ShardedDatabaseContext.ShardedReplicationContext parent, ShardReplicationNode node, TcpConnectionInfo connectionInfo, string sourceDatabaseId, int protocolVersion) :
             base(connectionInfo, parent.Server, parent.Context.DatabaseName, parent.Context.NotificationCenter, node, parent.Server.ContextPool, parent.Context.DatabaseShutdown)
         {
             _parent = parent;
@@ -41,7 +42,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 Operation = TcpConnectionHeaderMessage.OperationTypes.Replication
             };
             _sourceDatabaseId = sourceDatabaseId;
-
+            _protocolVersion = protocolVersion;
             DestinationDatabaseName = node.Database;
         }
 
@@ -79,6 +80,11 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 batch?.BatchSent?.TrySetException(e);
                 throw;
             }
+        }
+
+        protected override int GetReplicationTcpVersion()
+        {
+            return _protocolVersion;
         }
 
         private void SendDocumentsBatch(TransactionOperationContext context, ReplicationBatch batch, OutgoingReplicationStatsScope stats)


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25870/InterversionTests.ReplicationTests.ExternalReplicationBetween54XAndCurrentoptions-DatabaseMode-Sharded-SearchEngineMode-Lucene

### Additional description

This pull request introduces a protocol version override mechanism for sharded outgoing replication handlers. The main goal is to allow sharded replication to negotiate and use the correct TCP protocol version, rather than always defaulting to the global replication version. This is achieved by passing the protocol version through the handler constructors and overriding the relevant method.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
