### PR TITLE
RavenDB-25623 - Switch Pull Replication idle logic to Configuration-Based Intent and implement Smart Wakeup

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -1,4 +1,4 @@
-namespace Raven.Client
+﻿namespace Raven.Client
 {
     public static class Constants
     {

--- a/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
@@ -10,14 +10,14 @@ namespace Raven.Client.Documents.Commands
         private readonly string _remoteDatabase;
         private readonly string _databaseGroupId;
         private readonly string _remoteTask;
-        private readonly string _tag;
+        private readonly string _changeVector;
 
-        public GetRemoteTaskTopologyCommand(string remoteDatabase, string databaseGroupId, string remoteTask, string tag)
+        public GetRemoteTaskTopologyCommand(string remoteDatabase, string databaseGroupId, string remoteTask, string changeVector = null)
         {
             _remoteDatabase = remoteDatabase ?? throw new ArgumentNullException(nameof(remoteDatabase));
             _databaseGroupId = databaseGroupId ?? throw new ArgumentNullException(nameof(databaseGroupId));
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
-            _tag = tag;
+            _changeVector = changeVector;
             Timeout = TimeSpan.FromSeconds(15);
         }
 
@@ -26,8 +26,10 @@ namespace Raven.Client.Documents.Commands
             url = $"{node.Url}/info/remote-task/topology?" +
                   $"database={Uri.EscapeDataString(_remoteDatabase)}" +
                   $"&remote-task={Uri.EscapeDataString(_remoteTask)}" +
-                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}" +
-                  $"&tag={Uri.EscapeDataString(_tag)}";
+                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}";
+
+            if (_changeVector != null)
+                url += $"&change-vector={Uri.EscapeDataString(_changeVector)}";
 
             RequestedNode = node;
             var request = new HttpRequestMessage
@@ -54,5 +56,4 @@ namespace Raven.Client.Documents.Commands
 
         public override bool IsReadRequest => true;
     }
-
 }

--- a/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetRemoteTaskTopologyCommand.cs
@@ -18,6 +18,7 @@ namespace Raven.Client.Documents.Commands
             _databaseGroupId = databaseGroupId ?? throw new ArgumentNullException(nameof(databaseGroupId));
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
             _changeVector = changeVector;
+
             Timeout = TimeSpan.FromSeconds(15);
         }
 
@@ -26,16 +27,18 @@ namespace Raven.Client.Documents.Commands
             url = $"{node.Url}/info/remote-task/topology?" +
                   $"database={Uri.EscapeDataString(_remoteDatabase)}" +
                   $"&remote-task={Uri.EscapeDataString(_remoteTask)}" +
-                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}";
-
-            if (_changeVector != null)
-                url += $"&change-vector={Uri.EscapeDataString(_changeVector)}";
+                  $"&groupId={Uri.EscapeDataString(_databaseGroupId)}" +
+                  $"&tag=wakeup"; // for backward compatibility only
 
             RequestedNode = node;
             var request = new HttpRequestMessage
             {
                 Method = HttpMethod.Get
             };
+
+            if (_changeVector != null)
+                request.Headers.Add("change-vector", _changeVector);
+
             return request;
         }
 

--- a/src/Raven.Client/Documents/Commands/GetTcpInfoForRemoteTaskCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetTcpInfoForRemoteTaskCommand.cs
@@ -27,10 +27,8 @@ namespace Raven.Client.Documents.Commands
         {
             url = $"{node.Url}/info/remote-task/tcp?" +
                   $"database={Uri.EscapeDataString(_remoteDatabase)}" +
-                  $"&remote-task={Uri.EscapeDataString(_remoteTask)}";
-
-            if (_changeVector != null)
-                url += $"&change-vector={Uri.EscapeDataString(_changeVector)}";
+                  $"&remote-task={Uri.EscapeDataString(_remoteTask)}" +
+                  $"&tag=wakeup"; // for backward compatibility only
 
             if (_verifyDatabase)
                 url += "&verify-database=true";
@@ -40,6 +38,10 @@ namespace Raven.Client.Documents.Commands
             {
                 Method = HttpMethod.Get
             };
+
+            if (_changeVector != null)
+                request.Headers.Add("change-vector", _changeVector);
+
             return request;
         }
 

--- a/src/Raven.Client/Documents/Commands/GetTcpInfoForRemoteTaskCommand.cs
+++ b/src/Raven.Client/Documents/Commands/GetTcpInfoForRemoteTaskCommand.cs
@@ -11,14 +11,14 @@ namespace Raven.Client.Documents.Commands
     {
         private readonly string _remoteDatabase;
         private readonly string _remoteTask;
-        private readonly string _tag;
-        private bool _verifyDatabase;
+        private readonly string _changeVector;
+        private readonly bool _verifyDatabase;
 
-        public GetTcpInfoForRemoteTaskCommand(string tag, string remoteDatabase, string remoteTask, bool verifyDatabase = false)
+        public GetTcpInfoForRemoteTaskCommand(string remoteDatabase, string remoteTask, string changeVector = null, bool verifyDatabase = false)
         {
             _remoteDatabase = remoteDatabase ?? throw new ArgumentNullException(nameof(remoteDatabase));
             _remoteTask = remoteTask ?? throw new ArgumentNullException(nameof(remoteTask));
-            _tag = tag;
+            _changeVector = changeVector;
             _verifyDatabase = verifyDatabase;
             Timeout = TimeSpan.FromSeconds(15);
         }
@@ -27,12 +27,13 @@ namespace Raven.Client.Documents.Commands
         {
             url = $"{node.Url}/info/remote-task/tcp?" +
                   $"database={Uri.EscapeDataString(_remoteDatabase)}" +
-                  $"&remote-task={Uri.EscapeDataString(_remoteTask)}" +
-                  $"&tag={Uri.EscapeDataString(_tag)}";
+                  $"&remote-task={Uri.EscapeDataString(_remoteTask)}";
+
+            if (_changeVector != null)
+                url += $"&change-vector={Uri.EscapeDataString(_changeVector)}";
+
             if (_verifyDatabase)
-            {
                 url += "&verify-database=true";
-            }
 
             RequestedNode = node;
             var request = new HttpRequestMessage

--- a/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
+++ b/src/Raven.Client/Documents/Subscriptions/AbstractSubscriptionWorker.cs
@@ -176,7 +176,7 @@ namespace Raven.Client.Documents.Subscriptions
 
         internal async Task<Stream> ConnectToServerAsync(CancellationToken token)
         {
-            var command = new GetTcpInfoForRemoteTaskCommand("Subscription/" + _dbName, _dbName, _options?.SubscriptionName, verifyDatabase: true);
+            var command = new GetTcpInfoForRemoteTaskCommand(_dbName, remoteTask: _options?.SubscriptionName, verifyDatabase: true);
 
             var requestExecutor = GetRequestExecutor();
 

--- a/src/Raven.Client/Http/RavenCommand.cs
+++ b/src/Raven.Client/Http/RavenCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -206,6 +207,9 @@ namespace Raven.Client.Http
             cache.Set(url, changeVector, responseJson);
         }
 
+#if !NETSTANDARD2_0
+        [DoesNotReturn]
+#endif
         protected static void ThrowInvalidResponse()
         {
             throw new InvalidDataException("Response is invalid.");

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
@@ -19,7 +18,6 @@ using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.NotificationCenter.Notifications.Server;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
-using Raven.Server.ServerWide.Commands.PeriodicBackup;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Raven.Server.Web.System;
@@ -42,8 +40,6 @@ namespace Raven.Server.Documents
 
         public readonly ConcurrentDictionary<StringSegment, DateTime> LastRecentlyUsed =
             new ConcurrentDictionary<StringSegment, DateTime>(StringSegmentComparer.OrdinalIgnoreCase);
-
-        private readonly ConcurrentDictionary<string, Lazy<DatabaseWakeupTimer>> _wakeupTimers = new ConcurrentDictionary<string, Lazy<DatabaseWakeupTimer>>();
 
         public readonly ResourceCache<DocumentDatabase> DatabasesCache = new ResourceCache<DocumentDatabase>();
         public readonly ResourceCache<ShardedDatabaseContext> ShardedDatabasesCache = new ResourceCache<ShardedDatabaseContext>();
@@ -102,15 +98,13 @@ namespace Raven.Server.Documents
             internal bool PreventNodePromotion = false;
             internal Func<ServerStore, Task> BeforeHandleClusterTransactionOnDatabaseChanged;
             internal Action DelayNotifyFeaturesAboutStateChange;
-            internal ManualResetEventSlim AfterDatabaseRemovedFromIdle = null;
-            internal bool SkipShouldContinueDisposeCheck = false;
         }
 
         private async Task HandleClusterDatabaseChanged(string databaseName, long index, string type, ClusterDatabaseChangeType changeType, object changeState)
         {
             ForTestingPurposes?.BeforeHandleClusterDatabaseChanged?.Invoke(_serverStore);
 
-            if (PreventWakeUpIdleDatabase(databaseName, type))
+            if (_serverStore.DatabaseIdleManager.ShouldPreventWakeUpIdleDatabase(databaseName, type))
                 return;
 
             if (_disposing.TryEnter(out var idx) == false)
@@ -298,21 +292,143 @@ namespace Raven.Server.Documents
             }
         }
 
-        private bool PreventWakeUpIdleDatabase(string databaseName, string type)
+        public bool CanUnloadDatabase(StringSegment databaseName, DateTime lastRecentlyUsed, DatabasesDebugHandler.IdleDatabaseStatistics statistics, out DocumentDatabase database)
         {
-            if (_serverStore.IdleDatabases.ContainsKey(databaseName) == false)
-                return false;
+            database = null;
+            var now = SystemTime.UtcNow;
 
-            switch (type)
+            if (statistics != null)
+                statistics.LastRecentlyUsed = lastRecentlyUsed;
+
+            var diff = now - lastRecentlyUsed;
+
+            if (_serverStore.DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out Task<DocumentDatabase> resourceTask) == false
+                || resourceTask == null
+                || resourceTask.Status != TaskStatus.RanToCompletion)
             {
-                case nameof(PutServerWideBackupConfigurationCommand):
-                case nameof(UpdatePeriodicBackupStatusCommand):
-                case nameof(UpdateResponsibleNodeForTasksCommand):
-                    return true;
+                if (statistics != null)
+                {
+                    statistics.IsLoaded = false;
+                    statistics.Explanations.Add("Cannot unload database because it is not loaded yet.");
+                }
 
-                default:
-                    return false;
+                return false;
             }
+
+            database = resourceTask.Result;
+
+            var maxTimeDatabaseCanBeIdle = database.Configuration.Databases.MaxIdleTime.AsTimeSpan;
+
+            if (statistics != null)
+                statistics.MaxIdleTime = maxTimeDatabaseCanBeIdle;
+
+            if (diff <= maxTimeDatabaseCanBeIdle)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last recently used ({lastRecentlyUsed}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
+            }
+
+            if (statistics != null)
+                statistics.IsLoaded = true;
+
+            // intentionally inside the loop, so we get better concurrency overall
+            // since shutting down a database can take a while
+            if (database.Configuration.Core.RunInMemory)
+            {
+                if (statistics != null)
+                {
+                    statistics.RunInMemory = true;
+                    statistics.Explanations.Add("Cannot unload database because it is running in memory.");
+                }
+
+                return false;
+            }
+
+            var canUnload = database.CanUnload;
+
+            if (statistics != null)
+                statistics.CanUnload = canUnload;
+
+            if (canUnload == false)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add("Cannot unload database because it explicitly cannot be unloaded.");
+            }
+
+            var lastWork = _serverStore.DatabasesLandlord.LastWork(database);
+            if (statistics != null)
+                statistics.LastWork = lastWork;
+
+            diff = now - lastWork;
+
+            if (diff <= maxTimeDatabaseCanBeIdle)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last work time ({lastWork}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
+            }
+
+            var numberOfChangesApiConnections = database.Changes.Connections.Values.Count(x => x.IsDisposed == false && x.IsChangesConnectionOriginatedFromStudio == false);
+            if (statistics != null)
+                statistics.NumberOfChangesApiConnections = numberOfChangesApiConnections;
+
+            if (numberOfChangesApiConnections > 0)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because number of Changes API connections ({numberOfChangesApiConnections}) is greater than 0");
+            }
+
+            var numberOfSubscriptionConnections = database.SubscriptionStorage.GetNumberOfRunningSubscriptions();
+            if (statistics != null)
+                statistics.NumberOfSubscriptionConnections = numberOfSubscriptionConnections;
+
+            if (numberOfSubscriptionConnections > 0)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
+            }
+
+            var numberOfActivePullReplicationAsSinkConnections = database.ReplicationLoader.GetNumberActivePullReplicationAsSinkConnections();
+            if (statistics != null)
+                statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
+
+            var numberOfActiveHubToSinkConfigurations = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
+            if (statistics != null)
+                statistics.NumberOfActiveHubToSinkConfigurations = numberOfActiveHubToSinkConfigurations;
+
+            if (numberOfActiveHubToSinkConfigurations > 0)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveHubToSinkConfigurations}) Pull Replication Hub or Sink configurations with 'HubToSink' mode enabled. The database must remain active to ensure data can be replicated.");
+            }
+
+            var hasActiveOperations = database.Operations.HasActive;
+            if (statistics != null)
+                statistics.HasActiveOperations = hasActiveOperations;
+
+            if (hasActiveOperations)
+            {
+                if (statistics == null)
+                    return false;
+
+                statistics.Explanations.Add("Cannot unload database because it has active operations");
+            }
+
+            if (statistics != null)
+                return statistics.Explanations.Count == 0;
+
+            return true;
         }
 
         private void UnloadDatabase(string databaseName, bool dbRecordIsNull = false)
@@ -384,7 +500,6 @@ namespace Raven.Server.Documents
                 });
             }
         }
-
 
         public bool ShouldDeleteDatabase(TransactionOperationContext context, string dbName, RawDatabaseRecord rawRecord, bool fromReplication = false)
         {
@@ -579,39 +694,6 @@ namespace Raven.Server.Documents
                     _logger.Info("Failed to dispose resource semaphore", e);
             }
 
-            // we don't want to wake up database during dispose.
-            var handles = new List<WaitHandle>();
-            foreach (var timer in _wakeupTimers.Values)
-            {
-                if (timer.IsValueCreated == false)
-                    continue;
-
-                var handle = new ManualResetEvent(false);
-                timer.Value.Dispose(handle);
-                handles.Add(handle);
-            }
-
-            if (handles.Count > 0)
-            {
-                var count = handles.Count;
-                var batchSize = Math.Min(64, count);
-
-                var numberOfBatches = count / batchSize;
-                if (count % batchSize != 0)
-                {
-                    // if we have a reminder, we need another batch
-                    numberOfBatches++;
-                }
-
-                var batch = new WaitHandle[batchSize];
-                for (var i = 0; i < numberOfBatches; i++)
-                {
-                    var toCopy = Math.Min(64, count - i * batchSize);
-                    handles.CopyTo(i * batchSize, batch, 0, toCopy);
-                    WaitHandle.WaitAll(batch);
-                }
-            }
-
             // shut down all databases in parallel, avoid having to wait for each one
             Parallel.ForEach(DatabasesCache.Values, new ParallelOptions
             {
@@ -795,12 +877,11 @@ namespace Raven.Server.Documents
 
         public Task<DocumentDatabase> TryGetOrCreateResourceStore(StringSegment databaseName, DateTime? wakeup = null, bool ignoreDisabledDatabase = false, bool ignoreBeenDeleted = false, bool ignoreNotRelevant = false, Action<string> addToInitLog = null, [CallerMemberName] string caller = null)
         {
-            if (_wakeupTimers.TryRemove(databaseName.Value, out var timer) && timer.IsValueCreated)
-            {
-                timer.Value.Dispose();
-            }
+            _serverStore.DatabaseIdleManager.DisposeWakeupTimer(databaseName.Value);
+
             if (_disposing.TryEnter(out var idx) == false)
                 ThrowServerIsBeingDisposed(databaseName);
+
             try
             {
                 if (TryGetResourceStore(databaseName, out var database))
@@ -905,6 +986,8 @@ namespace Raven.Server.Documents
             try
             {
                 var task = new Task<DocumentDatabase>(() => ActuallyCreateDatabase(databaseName, config, wakeup, addToInitLog), TaskCreationOptions.RunContinuationsAsynchronously);
+
+                // Atomicity key: IdleDatabasesManager logic based on the presence of the database in the cache, ignoring idle databases' dictionary.
                 var database = DatabasesCache.GetOrAdd(databaseName, task);
                 if (database == task)
                 {
@@ -918,10 +1001,7 @@ namespace Raven.Server.Documents
                     {
                         ForTestingPurposes?.AfterDatabaseCreation?.Invoke((t.GetAwaiter().GetResult(), caller));
 
-                        _serverStore.IdleDatabases.TryRemove(databaseName.Value, out _);
-                        _serverStore.IdleDatabasesChangeVectors.TryRemove(databaseName.Value, out _);
-
-                        ForTestingPurposes?.AfterDatabaseRemovedFromIdle?.Set();
+                        _serverStore.DatabaseIdleManager.RemoveFromIdleDatabases(databaseName.Value);
                     }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else
@@ -1302,7 +1382,7 @@ namespace Raven.Server.Documents
 
         public bool UnloadDirectly(StringSegment databaseName, IdleDatabaseActivity idleDatabaseActivity, [CallerMemberName] string caller = null)
         {
-            if (ShouldContinueDispose(databaseName.Value, idleDatabaseActivity) == false)
+            if (_serverStore.DatabaseIdleManager.ShouldContinueDispose(databaseName.Value, idleDatabaseActivity) == false)
             {
                 LogUnloadFailureReason(databaseName, $"{nameof(IdleDatabaseActivity.DueTime)} is {idleDatabaseActivity?.DueTime} ms which is less than {TimeSpan.FromMinutes(5).TotalMilliseconds} ms.");
                 return false;
@@ -1334,7 +1414,7 @@ namespace Raven.Server.Documents
                 // DateTime should be only null in tests
                 if (idleDatabaseActivity is { DateTime: not null })
                 {
-                    AddOrUpdateWakeupTimer(databaseName.Value, idleDatabaseActivity);
+                    _serverStore.DatabaseIdleManager.RescheduleNextIdleDatabaseActivity(databaseName.Value, idleDatabaseActivity);
                 }
 
                 if (_logger.IsOperationsEnabled)
@@ -1367,172 +1447,10 @@ namespace Raven.Server.Documents
             }
         }
 
-        private void AddOrUpdateWakeupTimer(string databaseName, IdleDatabaseActivity idleDatabaseActivity)
-        {
-            // in case the DueTime is negative or zero, the callback will be called immediately and database will be loaded.
-            
-            _ = _wakeupTimers.AddOrUpdate(databaseName,
-                _ => new Lazy<DatabaseWakeupTimer>(() => new DatabaseWakeupTimer(databaseName, idleDatabaseActivity, NextScheduledActivityCallback)),
-                (_, timer) =>
-                {
-                    timer.Value.Update(idleDatabaseActivity);
-                    return timer;
-                }).Value;
-        }
-
         private void LogUnloadFailureReason(StringSegment databaseName, string reason)
         {
             if (_logger.IsOperationsEnabled)
                 _logger.Operations($"Could not unload database '{databaseName}', reason: {reason}");
-        }
-
-        public void RescheduleNextIdleDatabaseActivity(string databaseName, IdleDatabaseActivity idleDatabaseActivity)
-        {
-            if (idleDatabaseActivity == null)
-            {
-                if (_wakeupTimers.TryRemove(databaseName, out var oldTimer) && oldTimer.IsValueCreated)
-                    oldTimer.Value.Dispose();
-
-                return;
-            }
-
-            AddOrUpdateWakeupTimer(databaseName, idleDatabaseActivity);
-        }
-
-        private void NextScheduledActivityCallback(string databaseName, IdleDatabaseActivity nextIdleDatabaseActivity)
-        {
-            try
-            {
-                if (_disposing.TryEnter(out var idx) == false)
-                    ThrowServerIsBeingDisposed(databaseName);
-                try
-                {
-                    if (_serverStore.ServerShutdown.IsCancellationRequested)
-                        return;
-
-                    switch (nextIdleDatabaseActivity.Type)
-                    {
-                        case IdleDatabaseActivityType.UpdateBackupStatusOnly:
-
-                            PeriodicBackupStatus backupStatus = _serverStore.DatabaseInfoCache.BackupStatusStorage.GetBackupStatus(databaseName, nextIdleDatabaseActivity.TaskId);
-
-                            backupStatus.LastIncrementalBackup = backupStatus.LastIncrementalBackupInternal = nextIdleDatabaseActivity.DateTime;
-                            backupStatus.LocalBackup.LastIncrementalBackup = nextIdleDatabaseActivity.DateTime;
-                            backupStatus.LocalBackup.IncrementalBackupDurationInMs = 0;
-
-                            var backupResult = new BackupResult();
-                            backupResult.AddMessage($"Skipping incremental backup because no changes were made from last full backup on {backupStatus.LastFullBackup}.");
-                            
-                            BackupUtils.SaveBackupStatus(backupStatus, databaseName, _serverStore, _logger, backupResult);
-
-                            // choose the next backup that will arrive the earliest
-                            nextIdleDatabaseActivity = BackupUtils.GetEarliestIdleDatabaseActivity(new BackupUtils.EarliestIdleDatabaseActivityParameters
-                            {
-                                DatabaseName = databaseName,
-                                LastEtag = nextIdleDatabaseActivity.LastEtag,
-                                Logger = _logger,
-                                ServerStore = _serverStore,
-                                IsIdle = true
-                            });
-
-                            RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
-                            break;
-
-                        case IdleDatabaseActivityType.WakeUpDatabase:
-                            if (_serverStore.ConcurrentBackupsCounter.CanRunBackup(ShardHelper.ToDatabaseName(databaseName)) == false)
-                            {
-                                // reached max concurrent backups
-                                var delayInMs = RescheduleDatabaseWakeup();
-                                if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached " +
-                                                 $"max concurrent backups ({_serverStore.ConcurrentBackupsCounter.MaxNumberOfConcurrentBackups}), will retry the wakeup in {delayInMs:#,#;;0}ms");
-                                break;
-                            }
-
-                            if (BackupUtils.CanServerRunBackup(_serverStore) == false)
-                            {
-                                // the server cannot run the backup anyway (low memory, low cpu credits or high dirty memory state)
-                                var delayInMs = RescheduleDatabaseWakeup();
-                                if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we are in a low memory state, " +
-                                                 $"will retry the wakeup in {delayInMs:#,#;;0}ms");
-                                break;
-                            }
-
-                            var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
-                            if (startDatabaseForBackup == null)
-                            {
-                                // reached max concurrent loading of databases for backup
-                                var delayInMs = RescheduleDatabaseWakeup();
-                                if (_logger.IsInfoEnabled)
-                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases " +
-                                                 $"for backup ({_serverStore.ConcurrentBackupsCounter.MaxNumberOfConcurrentBackups}), will retry the wakeup in {delayInMs:#,#;;0}ms");
-                            }
-                            else
-                            {
-                                _ = TryGetOrCreateResourceStore(databaseName, nextIdleDatabaseActivity.DateTime).ContinueWith(t =>
-                                {
-                                    startDatabaseForBackup.Dispose();
-
-                                    var ex = t.Exception.ExtractSingleInnerException();
-                                    if (ex is DatabaseConcurrentLoadTimeoutException e)
-                                    {
-                                        // database failed to load
-                                        var delayInMs = RescheduleDatabaseWakeup();
-                                        if (_logger.IsInfoEnabled)
-                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in {delayInMs:#,#;;0}ms", e);
-                                    }
-                                });
-                            }
-                            break;
-
-                            int RescheduleDatabaseWakeup()
-                            {
-                                ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
-
-                                var delayInMs = _dueTimeOnRetry + Random.Shared.Next(0, _dueTimeOnRetry);
-                                nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(delayInMs);
-                                RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
-                                return delayInMs;
-                            }
-                    }
-                }
-                finally
-                {
-                    _disposing.Exit(idx);
-                }
-            }
-            catch (Exception e)
-            {
-                // we have to swallow any exception here.
-
-                if (_logger.IsOperationsEnabled)
-                    _logger.Operations($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
-
-                ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e, databaseName);
-            }
-        }
-
-        private bool ShouldContinueDispose(string name, IdleDatabaseActivity idleDatabaseActivity)
-        {
-            if (name == null)
-                return true;
-
-            if (_wakeupTimers.TryRemove(name, out var timer) && timer.IsValueCreated)
-                timer.Value.Dispose();
-
-            if (idleDatabaseActivity == null)
-                return true;
-
-            if (idleDatabaseActivity.DateTime.HasValue == false)
-                return true;
-
-            if (ForTestingPurposes?.SkipShouldContinueDisposeCheck == true)
-                return true;
-
-            // Unloading and then loading a database can use a lot of resources.
-            // Therefore, we don't want to unload the database unless we're sure it will be loaded again soon.
-            return idleDatabaseActivity.DueTime > TimeSpan.FromMinutes(5).TotalMilliseconds;
         }
 
         private void CompleteDatabaseUnloading(DocumentDatabase database)
@@ -1736,81 +1654,5 @@ namespace Raven.Server.Documents
                 Locker = new SemaphoreSlim(1, 1);
             }
         }
-
-        private sealed class DatabaseWakeupTimer : IDisposable
-        {
-            private IdleDatabaseActivity _activity;
-
-            private readonly string _databaseName;
-            private readonly Action<string, IdleDatabaseActivity> _callback;
-            private readonly Timer _timer;
-
-            public DatabaseWakeupTimer([NotNull] string databaseName, [NotNull] IdleDatabaseActivity activity, [NotNull] Action<string, IdleDatabaseActivity> callback)
-            {
-                _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
-                _activity = activity ?? throw new ArgumentNullException(nameof(activity));
-                _callback = callback ?? throw new ArgumentNullException(nameof(callback));
-
-                _timer = new Timer(TimerCallback, null, _activity.DueTime, Timeout.Infinite);
-            }
-
-            public void Update(IdleDatabaseActivity activity)
-            {
-                _activity = activity;
-                _timer.Change(activity.DueTime, Timeout.Infinite);
-            }
-
-            private void TimerCallback(object state)
-            {
-                _callback(_databaseName, _activity);
-            }
-
-            public void Dispose()
-            {
-                _timer?.Dispose();
-            }
-
-            public void Dispose(WaitHandle notifyObject)
-            {
-                _timer?.Dispose(notifyObject);
-            }
-        }
-    }
-
-    public sealed class IdleDatabaseActivity
-    {
-        public long LastEtag { get; }
-        public IdleDatabaseActivityType Type { get; }
-        public DateTime? DateTime { get; internal set; }
-        public long TaskId { get; }
-        public int DueTime => DateTime.HasValue
-            ? (int)Math.Min(int.MaxValue, Math.Max(0, (DateTime.Value - System.DateTime.UtcNow).TotalMilliseconds))
-            : 0;
-
-        public IdleDatabaseActivity(IdleDatabaseActivityType type)
-        {
-            LastEtag = 0;
-            Type = type;
-            TaskId = 0;
-
-            // DateTime should be only null in tests
-            DateTime = null;
-        }
-
-        public IdleDatabaseActivity(IdleDatabaseActivityType type, DateTime timeOfActivity, long taskId = 0, long lastEtag = 0)
-        {
-            LastEtag = lastEtag;
-            Type = type;
-            TaskId = taskId;
-
-            Debug.Assert(timeOfActivity.Kind != DateTimeKind.Unspecified);
-            DateTime = timeOfActivity.ToUniversalTime();
-        }
-    }
-
-    public enum IdleDatabaseActivityType
-    {
-        WakeUpDatabase,
-        UpdateBackupStatusOnly
     }
 }

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -401,16 +401,17 @@ namespace Raven.Server.Documents
             if (statistics != null)
                 statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
 
-            var numberOfActiveHubToSinkConfigurations = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
+            var numberOfActiveSinkPullConfigurations = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
             if (statistics != null)
-                statistics.NumberOfActiveHubToSinkConfigurations = numberOfActiveHubToSinkConfigurations;
+                statistics.NumberOfActiveSinkPullReplicationConfigurations = numberOfActiveSinkPullConfigurations;
 
-            if (numberOfActiveHubToSinkConfigurations > 0)
+            if (numberOfActiveSinkPullConfigurations > 0)
             {
                 if (statistics == null)
                     return false;
 
-                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveHubToSinkConfigurations}) Pull Replication Hub or Sink configurations with 'HubToSink' mode enabled. The database must remain active to ensure data can be replicated.");
+                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveSinkPullConfigurations}) active Sink Pull Replication configuration{(numberOfActiveSinkPullConfigurations > 1 ? "s" : string.Empty)}. " +
+                                            $"The Sink must remain active to avoid data loss when the Hub is offline.");
             }
 
             var hasActiveOperations = database.Operations.HasActive;

--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -919,6 +919,8 @@ namespace Raven.Server.Documents
                         ForTestingPurposes?.AfterDatabaseCreation?.Invoke((t.GetAwaiter().GetResult(), caller));
 
                         _serverStore.IdleDatabases.TryRemove(databaseName.Value, out _);
+                        _serverStore.IdleDatabasesChangeVectors.TryRemove(databaseName.Value, out _);
+
                         ForTestingPurposes?.AfterDatabaseRemovedFromIdle?.Set();
                     }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 }

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
@@ -306,7 +306,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             }
             protected override bool TryUpdateChangeVector(DocumentsOperationContext context)
             {
-                if (_pullReplicationParams.Mode == PullReplicationMode.SinkToHub)
+                if (_pullReplicationParams.Mode.HasFlag(PullReplicationMode.SinkToHub))
                     return false;
 
                 return base.TryUpdateChangeVector(context);

--- a/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/IncomingPullReplicationHandler.cs
@@ -188,49 +188,34 @@ namespace Raven.Server.Documents.Replication.Incoming
 
             internal static string ReplaceUnknownEntriesWithSinkTag(DocumentsOperationContext context, ref string changeVector)
             {
-                var globalDbIds = context.LastDatabaseChangeVector?.AsString().ToChangeVectorList()?.Select(x => x.DbId).ToList();
-                var incoming = changeVector.ToChangeVectorList();
-                var knownEntries = new List<ChangeVectorEntry>();
-                var newIncoming = new List<ChangeVectorEntry>();
+                HashSet<string> hubKnownDbIds = context.LastDatabaseChangeVector?.AsString().ToChangeVectorList()?.Select(changeVectorEntry => changeVectorEntry.DbId).ToHashSet();
+                List<ChangeVectorEntry> incoming = changeVector.ToChangeVectorList();
 
-                foreach (var entry in incoming)
+                ChangeVectorUtils.ClassifyHubIncomingEntries(
+                    incoming,
+                    hubKnownDbIds,
+                    context.DocumentDatabase.ClusterTransactionId,
+                    out List<ChangeVectorEntry> hubKnownEntries,
+                    out List<ChangeVectorEntry> sinkOriginEntries,
+                    out List<ChangeVectorEntry> trxnEntries);
+
+                var newIncoming = new List<ChangeVectorEntry>(incoming?.Count ?? 0);
+                newIncoming.AddRange(hubKnownEntries);
+
+                foreach (var entry in sinkOriginEntries)
                 {
-                    if (globalDbIds?.Contains(entry.DbId) == true)
-                    {
-                        newIncoming.Add(entry);
-                        knownEntries.Add(entry);
-                    }
-                    else if (entry.DbId == context.DocumentDatabase.ClusterTransactionId)
-                    {
-                        // TRXN
-                        newIncoming.Add(new ChangeVectorEntry
-                        {
-                            DbId = entry.DbId,
-                            Etag = entry.Etag,
-                            NodeTag = ChangeVectorParser.TrxnInt
-                        });
-
-                        continue;
-                    }
-                    else
-                    {
-                        newIncoming.Add(new ChangeVectorEntry
-                        {
-                            DbId = entry.DbId,
-                            Etag = entry.Etag,
-                            NodeTag = ChangeVectorParser.SinkInt
-                        });
-
-                        context.DbIdsToIgnore ??= new HashSet<string>();
-                        context.DbIdsToIgnore.Add(entry.DbId);
-                    }
+                    newIncoming.Add(entry with { NodeTag = ChangeVectorParser.SinkInt });
+                    context.DbIdsToIgnore ??= [];
+                    context.DbIdsToIgnore.Add(entry.DbId);
                 }
+
+                newIncoming.AddRange(trxnEntries.Select(entry => entry with { NodeTag = ChangeVectorParser.TrxnInt }));
 
                 changeVector = newIncoming.SerializeVector();
 
-                return knownEntries.Count > 0 ? 
-                    knownEntries.SerializeVector() : 
-                    null;
+                return hubKnownEntries.Count > 0
+                    ? hubKnownEntries.SerializeVector()
+                    : null;
             }
 
             private static void ReplaceKnownSinkEntries(DocumentsOperationContext context, ref string changeVector)

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1522,7 +1522,7 @@ namespace Raven.Server.Documents.Replication
         private TcpConnectionInfo GetPullReplicationTcpInfo(PullReplicationAsSink pullReplicationAsSink, X509Certificate2 certificate, string database)
         {
             var remoteTask = pullReplicationAsSink.HubName;
-            var (_, currentChangeVector) = Database.ReadLastEtagAndChangeVector();
+            (_, string currentChangeVector) = Database.ReadLastEtagAndChangeVector();
 
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             {
@@ -1577,7 +1577,7 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        private static readonly string ExternalReplicationTag = "external-replication";
+        private const string ExternalReplicationTag = "external-replication";
 
         private TcpConnectionInfo GetExternalReplicationTcpInfo(ExternalReplication exNode, X509Certificate2 certificate, string database)
         {
@@ -2051,7 +2051,7 @@ namespace Raven.Server.Documents.Replication
                     continue;
                 if (dest is not PullReplicationAsSink sink)
                     continue;
-                if (sink.Mode == PullReplicationMode.HubToSink)
+                if ((sink.Mode & PullReplicationMode.HubToSink) != 0)
                     c++;
             }
 
@@ -2066,7 +2066,7 @@ namespace Raven.Server.Documents.Replication
                     continue;
                 }
 
-                if (hub.Mode == (PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub))
+                if ((hub.Mode & PullReplicationMode.HubToSink) != 0)
                     c++;
             }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1522,6 +1522,8 @@ namespace Raven.Server.Documents.Replication
         private TcpConnectionInfo GetPullReplicationTcpInfo(PullReplicationAsSink pullReplicationAsSink, X509Certificate2 certificate, string database)
         {
             var remoteTask = pullReplicationAsSink.HubName;
+            var (_, currentChangeVector) = Database.ReadLastEtagAndChangeVector();
+
             using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
             {
                 string[] remoteDatabaseUrls;
@@ -1530,7 +1532,7 @@ namespace Raven.Server.Documents.Replication
                 using (var requestExecutor = RequestExecutor.CreateForShortTermUse(pullReplicationAsSink.ConnectionString.TopologyDiscoveryUrls, pullReplicationAsSink.ConnectionString.Database,
                     certificate, DocumentConventions.DefaultForServer))
                 {
-                    var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask, PullReplicationAsSinkTag);
+                    var cmd = new GetRemoteTaskTopologyCommand(database, Database.DatabaseGroupId, remoteTask, changeVector: currentChangeVector);
 
                     try
                     {
@@ -1558,7 +1560,7 @@ namespace Raven.Server.Documents.Replication
                 using (var requestExecutor = RequestExecutor.CreateForShortTermUse(remoteDatabaseUrls,
                     pullReplicationAsSink.ConnectionString.Database, certificate, DocumentConventions.DefaultForServer))
                 {
-                    var cmd = new GetTcpInfoForRemoteTaskCommand(PullReplicationAsSinkTag, database, remoteTask);
+                    var cmd = new GetTcpInfoForRemoteTaskCommand(database, remoteTask, changeVector: currentChangeVector);
 
                     try
                     {
@@ -1576,7 +1578,6 @@ namespace Raven.Server.Documents.Replication
         }
 
         private static readonly string ExternalReplicationTag = "external-replication";
-        public static readonly string PullReplicationAsSinkTag = "pull-replication-as-sink";
 
         private TcpConnectionInfo GetExternalReplicationTcpInfo(ExternalReplication exNode, X509Certificate2 certificate, string database)
         {
@@ -2041,7 +2042,7 @@ namespace Raven.Server.Documents.Replication
             }
         }
 
-        public int HasActivePullReplicationAsSinkConnections()
+        public int GetNumberActivePullReplicationAsSinkConnections()
         {
             var c = 0;
             foreach (var dest in _externalDestinations)
@@ -2070,6 +2071,28 @@ namespace Raven.Server.Documents.Replication
             }
 
             return c;
+        }
+
+        public int GetNumberOfPullReplicationsPreventingIdle()
+        {
+            using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            using (var rawDatabase = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name))
+            {
+                if (rawDatabase == null)
+                    return 0;
+
+                var count = 0;
+
+                if (rawDatabase.SinkPullReplications != null)
+                {
+                    count += rawDatabase.SinkPullReplications
+                        .Where(asSink => asSink.Disabled == false)
+                        .Count(asSink => (asSink.Mode & PullReplicationMode.HubToSink) != 0);
+                }
+
+                return count;
+            }
         }
     }
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2079,19 +2079,10 @@ namespace Raven.Server.Documents.Replication
             using (ctx.OpenReadTransaction())
             using (var rawDatabase = _server.Cluster?.ReadRawDatabaseRecord(ctx, Database.Name))
             {
-                if (rawDatabase == null)
+                if (rawDatabase?.SinkPullReplications == null || rawDatabase.SinkPullReplications.Count == 0)
                     return 0;
 
-                var count = 0;
-
-                if (rawDatabase.SinkPullReplications != null)
-                {
-                    count += rawDatabase.SinkPullReplications
-                        .Where(asSink => asSink.Disabled == false)
-                        .Count(asSink => (asSink.Mode & PullReplicationMode.HubToSink) != 0);
-                }
-
-                return count;
+                return rawDatabase.SinkPullReplications.Count(asSink => asSink.Disabled == false);
             }
         }
     }

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -14,7 +14,6 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -26,13 +25,9 @@ using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using OpenTelemetry;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
-using Raven.Client;
 using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.Replication;
@@ -83,7 +78,6 @@ using DateTime = System.DateTime;
 using Raven.Server.Monitoring.OpenTelemetry;
 using Constants = Sparrow.Global.Constants;
 using TelemetryConstants = Raven.Server.Monitoring.OpenTelemetry.Constants;
-using ClientConstants = Raven.Client.Constants;
 
 namespace Raven.Server
 {
@@ -2810,9 +2804,20 @@ namespace Raven.Server
             return false;
         }
 
-        private async Task<bool> DispatchDatabaseTcpConnection(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header,
+        private async Task DispatchDatabaseTcpConnection(TcpConnectionOptions tcp, TcpConnectionHeaderMessage header,
             JsonOperationContext.MemoryBuffer bufferToCopy, X509Certificate2 cert)
         {
+            if (header.Operation == TcpConnectionHeaderMessage.OperationTypes.Replication)
+            {
+                var databaseActivityState = ServerStore.DatabaseIdleManager.GetActivityState(header.DatabaseName);
+                if (databaseActivityState is DatabaseIdleManager.DatabaseActivityState.Idle)
+                {
+                    tcp.Dispose();
+                    tcp = null;
+                    return;
+                }
+            }
+
             var result = ServerStore.DatabasesLandlord.TryGetOrCreateDatabase(header.DatabaseName);
             switch (result.DatabaseStatus)
             {
@@ -2831,7 +2836,7 @@ namespace Raven.Server
                     if (databaseLoadingTask == null)
                     {
                         DatabaseDoesNotExistException.Throw(header.DatabaseName);
-                        return true;
+                        break;
                     }
 
                     var databaseLoadTimeout = ServerStore.DatabasesLandlord.DatabaseLoadTimeout;
@@ -2857,7 +2862,7 @@ namespace Raven.Server
                     break;
                 case DatabasesLandlord.DatabaseSearchResult.Status.Missing:
                     DatabaseDoesNotExistException.Throw(header.DatabaseName);
-                    return true;
+                    break;
                 default:
                     throw new InvalidOperationException("Unexpected " + nameof(DatabasesLandlord.DatabaseSearchResult));
             }
@@ -2891,7 +2896,6 @@ namespace Raven.Server
             // This way the responders are responsible to dispose the connection and the context.
             // ReSharper disable once RedundantAssignment
             tcp = null;
-            return false;
         }
 
         private static void CreateSubscriptionConnection(ServerStore server, DatabasesLandlord.DatabaseSearchResult databaseResult,

--- a/src/Raven.Server/Routing/RouteInformation.cs
+++ b/src/Raven.Server/Routing/RouteInformation.cs
@@ -119,14 +119,14 @@ namespace Raven.Server.Routing
                 throw new NodeIsPassiveException($"Can't perform actions on the database '{databaseName}' while the node is passive.");
             }
 
-            if (context.RavenServer.ServerStore.IdleDatabases.TryGetValue(databaseName.Value, out var replicationsDictionary))
+            if (context.RavenServer.ServerStore.DatabaseIdleManager.TryGetIdleInfo(databaseName.Value, out var idleDatabaseInfo))
             {
                 if (context.HttpContext.Request.Query.TryGetValue("from-outgoing", out var dbId) && context.HttpContext.Request.Query.TryGetValue("etag", out var replicationEtag))
                 {
                     var hasChanges = false;
                     var etag = Convert.ToInt64(replicationEtag);
 
-                    if (replicationsDictionary.TryGetValue(dbId, out var storedEtag))
+                    if (idleDatabaseInfo.ReplicationInfo.TryGetValue(dbId, out var storedEtag))
                     {
                         if (storedEtag < etag)
                             hasChanges = true;

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -1680,13 +1680,13 @@ namespace Raven.Server.ServerWide
                     }
 
                     // shardNumber can be idle when we are deleting it
-                    serverStore?.IdleDatabases.TryRemove(shard, out _);
+                    serverStore?.DatabaseIdleManager.RemoveFromIdleDatabases(shard);
                 }
             }
             else
             {
                 // db can be idle when we are deleting it
-                serverStore?.IdleDatabases.TryRemove(record.DatabaseName, out _);
+                serverStore?.DatabaseIdleManager.RemoveFromIdleDatabases(record.DatabaseName);
             }
 
             var databaseLowered = $"{record.DatabaseName.ToLowerInvariant()}/";
@@ -1703,7 +1703,7 @@ namespace Raven.Server.ServerWide
             }
 
             // db can be idle when we are deleting it
-            serverStore?.IdleDatabases.TryRemove(record.DatabaseName, out _);
+            serverStore?.DatabaseIdleManager.RemoveFromIdleDatabases(record.DatabaseName);
         }
 
         internal static unsafe void UpdateValue(long index, Table items, Slice lowerKey, Slice key, BlittableJsonReaderObject updated)

--- a/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
+++ b/src/Raven.Server/ServerWide/Context/DocumentsOperationContext.cs
@@ -24,17 +24,7 @@ namespace Raven.Server.ServerWide.Context
                 if (value.IsSingle == false)
                     throw new InvalidOperationException($"The global change vector '{value}' cannot contain pipe");
 
-                value = value.StripSinkTags(this);
-                value = value.StripTrxnTags(this);
-
-                if (DbIdsToIgnore == null || DbIdsToIgnore.Count == 0 || value.IsNullOrEmpty)
-                {
-                    _lastDatabaseChangeVector = value;
-                    return;
-                }
-
-                value.TryRemoveIds(DbIdsToIgnore, this, out value);
-                _lastDatabaseChangeVector = value;
+                _lastDatabaseChangeVector = ChangeVectorUtils.CleanHubGlobalCv(value, context: this, DbIdsToIgnore);
             }
         }
 

--- a/src/Raven.Server/ServerWide/DatabaseIdleManager.cs
+++ b/src/Raven.Server/ServerWide/DatabaseIdleManager.cs
@@ -17,7 +17,6 @@ using Sparrow.Logging;
 using Sparrow.Server.Threading;
 using System.Linq;
 using System.Threading.Tasks;
-using Jint;
 using NCrontab.Advanced;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Util;
@@ -27,7 +26,9 @@ using Raven.Server.Web.System;
 
 namespace Raven.Server.ServerWide
 {
-    public record IdleDatabaseInfo(Dictionary<string, long> ReplicationInfo, string ChangeVector, string HubVoronDbId = null);
+    /// <param name="ReplicationInfo">Base64-22 DbId → last etag Hub replicated from that source.
+    /// Keys must be Base64-22; <see cref="DatabaseIdleManager.IdleOperations"/> normalizes GUID storage keys to Base64 before constructing this record.</param>
+    public record IdleDatabaseInfo(Dictionary<string, long> ReplicationInfo, string ChangeVector, string DbBase64Id = null);
 
     public sealed class DatabaseIdleManager : IDisposable
     {
@@ -467,23 +468,14 @@ namespace Raven.Server.ServerWide
                             var dbIdEtagDictionary = new Dictionary<string, long>();
                             foreach (var kvp in DocumentsStorage.GetAllReplicatedEtags(documentsContext))
                             {
-                                if (Guid.TryParse(kvp.Key, out Guid parsedGuid))
-                                    dbIdEtagDictionary[parsedGuid.ToBase64Unpadded()] = kvp.Value;
-                                else
-                                    dbIdEtagDictionary[kvp.Key] = kvp.Value;
+                                if (Guid.TryParse(kvp.Key, out Guid parsedGuid) == false)
+                                    throw new InvalidOperationException($"Invalid GUID in database '{database.Name}': {kvp.Key}");
+
+                                dbIdEtagDictionary[parsedGuid.ToBase64Unpadded()] = kvp.Value;
                             }
 
                             var changeVector = DocumentsStorage.GetDatabaseChangeVector(tx.InnerTransaction);
                             idleInfo = new IdleDatabaseInfo(dbIdEtagDictionary, changeVector, database.DbBase64Id);
-                        }
-
-                        var repInfoStr = idleInfo.ReplicationInfo != null && idleInfo.ReplicationInfo.Count > 0
-                            ? string.Join(", ", idleInfo.ReplicationInfo.Select(kvp => $"{kvp.Key}={kvp.Value}"))
-                            : "(empty)";
-
-                        if (_logger.IsOperationsEnabled)
-                        {
-                            _logger.Operations($"[IdleInfo] {database.Name}: CV='{idleInfo.ChangeVector}' ReplicationInfo={repInfoStr}");
                         }
 
                         var nextActivity = database.PeriodicBackupRunner.GetNextIdleDatabaseActivity(database.Name);
@@ -600,13 +592,14 @@ namespace Raven.Server.ServerWide
         }
 
         /// <summary>
-        /// Keeping these two vectors separate prevents cross-contamination: Sink's own entries must not
-        /// influence the HubToSink check, and Hub's echoed entries must not influence the SinkToHub check.
+        /// Splits Sink's CV into two filtered vectors used for idle wake-up decisions.
+        /// Idle-path augmentation over write-path <see cref="ChangeVectorUtils.ClassifyHubIncomingEntries"/>:
+        /// Hub-origin entries are additionally capped; Sink-origin entries filtered by ReplicationInfo.
         /// </summary>
-        /// <param name="sinkCvForHubToSink">contains only Hub-origin entries from Sink's CV (capped to Hub's local etag).
-        /// Used to answer: "Does Sink already have everything Hub has?" (HubToSink direction)</param>
-        /// <param name="sinkCvForSinkToHub">contains only non-Hub entries from Sink's CV that Hub hasn't replicated yet.
-        /// Used to answer: "Does Sink have new data Hub hasn't received?" (SinkToHub direction)</param>
+        /// <param name="sinkCvForHubToSink">Hub-origin entries from Sink's CV, capped to Hub's local etag.
+        /// Answers: "Does Sink already have everything Hub has?" (HubToSink direction)</param>
+        /// <param name="sinkCvForSinkToHub">Non-Hub entries from Sink's CV not yet replicated to Hub.
+        /// Answers: "Does Sink have new data Hub hasn't seen?" (SinkToHub direction)</param>
         internal static void FilterIrrelevantEntries(
             string sinkChangeVector,
             IdleDatabaseInfo idleInfo,
@@ -625,50 +618,53 @@ namespace Raven.Server.ServerWide
 
                 var sinkList = sinkChangeVector.ToChangeVectorList();
 
-                var localEtags = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+                // Hub identity = topology ID + DbBase64Id only, never all CV entries.
+                // Using the full CV causes Identity Crisis: Sink's own DbIds appear in Hub's CV
+                // after SinkToHub replication -> misclassified as Hub-origin -> Hub stays asleep incorrectly.
+                var localEtags = new Dictionary<string, long>(StringComparer.Ordinal);
 
                 if (string.IsNullOrEmpty(hubDbId) == false)
+                    localEtags[hubDbId] = HubEtag(idleInfo, hubDbId);
+
+                if (string.IsNullOrEmpty(idleInfo.DbBase64Id) == false)
+                    localEtags[idleInfo.DbBase64Id] = HubEtag(idleInfo, idleInfo.DbBase64Id);
+
+                HashSet<string> hubKnownDbIds = localEtags.Count > 0
+                    ? new HashSet<string>(localEtags.Keys, StringComparer.Ordinal)
+                    : null;
+
+                // Step 1: Classify
+                // clusterTransactionId=null -> TRXN entries land in trxnEntries (treated as Sink-origin below).
+                ChangeVectorUtils.ClassifyHubIncomingEntries(
+                    sinkList,
+                    hubKnownDbIds,
+                    clusterTransactionId: null,
+                    out List<ChangeVectorEntry> hubKnownEntries,
+                    out List<ChangeVectorEntry> sinkOriginEntries,
+                    out List<ChangeVectorEntry> trxnEntries);
+
+                // Step 2: Cap Hub-known entries to Hub's actual etag.
+                // Backup/restore safety: Sink may carry Hub's DbId with etag higher than Hub's own record.
+                var cappedHubEntries = new List<ChangeVectorEntry>(hubKnownEntries.Count);
+                foreach (var entry in hubKnownEntries)
                 {
-                    long etag = string.IsNullOrEmpty(idleInfo.ChangeVector) ? 0 : ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, hubDbId);
-                    localEtags[hubDbId] = etag;
-                    if (ChangeVectorUtils.TryBase64ToGuid(hubDbId, out var guid))
-                        localEtags[guid] = etag;
+                    localEtags.TryGetValue(entry.DbId, out long localEtag);
+                    cappedHubEntries.Add(entry with { Etag = Math.Min(entry.Etag, localEtag) });
                 }
 
-                if (string.IsNullOrEmpty(idleInfo.HubVoronDbId) == false)
+                // Step 3: Filter Sink+TRXN entries; exclude already-replicated ones.
+                // TRXN entries carry no Sink data relevant to Hub's HubToSink/SinkToHub wake-up decision.
+                var filteredSinkEntries = new List<ChangeVectorEntry>(sinkOriginEntries.Count + trxnEntries.Count);
+                foreach (var entry in sinkOriginEntries.Concat(trxnEntries))
                 {
-                    long etag = string.IsNullOrEmpty(idleInfo.ChangeVector) ? 0 : ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, idleInfo.HubVoronDbId);
-                    localEtags[idleInfo.HubVoronDbId] = etag;
-                    if (ChangeVectorUtils.TryBase64ToGuid(idleInfo.HubVoronDbId, out var guid))
-                        localEtags[guid] = etag;
+                    if (idleInfo.ReplicationInfo == null ||
+                        idleInfo.ReplicationInfo.TryGetValue(entry.DbId, out long lastReplicated) == false ||
+                        entry.Etag > lastReplicated)
+                        filteredSinkEntries.Add(entry);
                 }
 
-                // ReplicationInfo keys may be GUID strings (from DbId.ToString()) while CV DbIds are Base64.
-                // Build a normalized lookup that accepts both representations.
-                Dictionary<string, long> normalizedReplicationInfo = null;
-                if (idleInfo.ReplicationInfo != null && idleInfo.ReplicationInfo.Count > 0)
-                {
-                    normalizedReplicationInfo = new Dictionary<string, long>(idleInfo.ReplicationInfo.Count * 2, StringComparer.OrdinalIgnoreCase);
-                    foreach (var kvp in idleInfo.ReplicationInfo)
-                    {
-                        normalizedReplicationInfo[kvp.Key] = kvp.Value;
-                        if (Guid.TryParse(kvp.Key, out var g))
-                        {
-                            var base64 = Convert.ToBase64String(g.ToByteArray()).TrimEnd('=');
-                            normalizedReplicationInfo[base64] = kvp.Value;
-                        }
-                        else if (ChangeVectorUtils.TryBase64ToGuid(kvp.Key, out var g2))
-                        {
-                            normalizedReplicationInfo[g2] = kvp.Value;
-                        }
-                    }
-                }
-
-                ChangeVectorUtils.ClassifyEntriesByOrigin(sinkList, localEtags, normalizedReplicationInfo,
-                    out var hubOriginEntries, out var sinkOriginEntries);
-
-                sinkCvForHubToSink = hubOriginEntries.Count == 0 ? string.Empty : hubOriginEntries.SerializeVector();
-                sinkCvForSinkToHub = sinkOriginEntries.Count == 0 ? string.Empty : sinkOriginEntries.SerializeVector();
+                sinkCvForHubToSink = cappedHubEntries.Count == 0 ? string.Empty : cappedHubEntries.SerializeVector();
+                sinkCvForSinkToHub = filteredSinkEntries.Count == 0 ? string.Empty : filteredSinkEntries.SerializeVector();
             }
             catch
             {
@@ -676,6 +672,11 @@ namespace Raven.Server.ServerWide
                 sinkCvForSinkToHub = sinkChangeVector;
             }
         }
+
+        private static long HubEtag(IdleDatabaseInfo idleInfo, string dbId) =>
+            string.IsNullOrEmpty(idleInfo.ChangeVector)
+                ? 0
+                : ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, dbId);
 
         public void Dispose()
         {

--- a/src/Raven.Server/ServerWide/DatabaseIdleManager.cs
+++ b/src/Raven.Server/ServerWide/DatabaseIdleManager.cs
@@ -1,0 +1,891 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Exceptions.Database;
+using Raven.Client.Extensions;
+using Sparrow.Server;
+using Raven.Server.Documents;
+using Raven.Server.ServerWide.Commands;
+using Raven.Server.ServerWide.Commands.PeriodicBackup;
+using Raven.Server.Utils;
+using Sparrow;
+using Sparrow.Logging;
+using Sparrow.Server.Threading;
+using System.Linq;
+using System.Threading.Tasks;
+using Jint;
+using NCrontab.Advanced;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Util;
+using Raven.Server.Documents.Replication;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Web.System;
+
+namespace Raven.Server.ServerWide
+{
+    public record IdleDatabaseInfo(Dictionary<string, long> ReplicationInfo, string ChangeVector, string HubVoronDbId = null);
+
+    public sealed class DatabaseIdleManager : IDisposable
+    {
+        private readonly ServerStore _serverStore;
+        private readonly Logger _logger;
+        private readonly AsyncGuard _disposing = new();
+        private readonly Timer _timer;
+
+        private readonly TimeSpan _frequencyToCheckForIdleDatabases;
+
+        private readonly ConcurrentDictionary<string, IdleDatabaseInfo> _idleDatabases = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, Lazy<DatabaseWakeupTimer>> _wakeupTimers = new(StringComparer.OrdinalIgnoreCase);
+
+        private readonly int _dueTimeOnRetry = (int)TimeSpan.FromSeconds(5).TotalMilliseconds;
+
+        private bool _isDisposed;
+
+
+        public DatabaseIdleManager(ServerStore serverStore)
+        {
+            _serverStore = serverStore ?? throw new ArgumentNullException(nameof(serverStore));
+            _logger = LoggingSource.Instance.GetLogger<DatabaseIdleManager>(nameof(DatabaseIdleManager));
+            _timer = new Timer(IdleOperationsCallback, state: null, dueTime: _frequencyToCheckForIdleDatabases, period: TimeSpan.FromDays(7));
+            _frequencyToCheckForIdleDatabases = serverStore.Configuration.Databases.FrequencyToCheckForIdle.AsTimeSpan;
+        }
+
+        public enum DatabaseActivityState
+        {
+            /// <summary>
+            /// Database is physically in memory (Loaded), currently waking up (Loading), or currently performing an unloading.
+            /// Action: Traffic should wait for the task or proceed.
+            /// </summary>
+            Active,
+
+            /// <summary>
+            /// Database is strictly unloaded and marked as idle.
+            /// Action: Traffic should be rejected (TCP) or trigger specific wakeup logic (REST).
+            /// </summary>
+            Idle,
+
+            /// <summary>
+            /// Database does not exist or is in an undefined state.
+            /// </summary>
+            Missing
+        }
+
+        /// <summary>
+        /// The Single Source of Truth for database state.
+        /// Resolves race conditions between physical loading status and logical idle status.
+        /// </summary>
+        public DatabaseActivityState GetActivityState(string databaseName)
+        {
+            if (_serverStore.DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out var task) &&
+                task.IsFaulted == false &&
+                task.IsCanceled == false)
+                return DatabaseActivityState.Active;
+
+            if (_idleDatabases.ContainsKey(databaseName))
+                return DatabaseActivityState.Idle;
+
+            return DatabaseActivityState.Missing;
+        }
+
+        /// <summary>
+        /// Atomically attempts to move a database to Idle state.
+        /// </summary>
+        internal bool TryEnterIdleState(string databaseName, IdleDatabaseInfo idleInfo, IdleDatabaseActivity nextActivity)
+        {
+            // 1. Optimistic Lock (Logical Idle)
+            // State Machine still returns 'Active' here because Landlord has priority (Task is still in cache).
+            _idleDatabases[databaseName] = idleInfo;
+
+            // 2. Physical Unload
+            // This blocks until the database is disposed and removed from Landlord cache.
+            // The moment this returns true, GetActivityState() stops seeing the Task
+            // and starts seeing the _idleDatabases entry -> State flips to 'Idle'.
+            if (_serverStore.DatabasesLandlord.UnloadDirectly(databaseName, nextActivity))
+            {
+                if (_logger.IsInfoEnabled)
+                    _logger.Info($"Database '{databaseName}' successfully entered idle state. ChangeVector: '{idleInfo.ChangeVector}'.");
+
+                return true;
+            }
+
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"Failed to unload database '{databaseName}' for idle state.");
+
+            // Rollback
+            _idleDatabases.TryRemove(databaseName, out _);
+            
+            if (_logger.IsInfoEnabled)
+                _logger.Info($"Database '{databaseName}' failed to unload. Reverted idle status.");
+
+            return false;
+        }
+
+        /// <summary>
+        /// Called ONLY by DatabasesLandlord when a database creation task is started and on database deletion.
+        /// Cleans up the idle state to reflect that the database is now officially waking up.
+        /// </summary>
+        public void RemoveFromIdleDatabases(string databaseName)
+        {
+            if (_idleDatabases.TryRemove(databaseName, out _) == false)
+                return;
+
+            if (_logger.IsInfoEnabled)
+                _logger.Info($"Database '{databaseName}' marked as waking up (removed from idle state).");
+
+            ForTestingPurposes?.AfterDatabaseRemovedFromIdle?.Invoke(databaseName);
+        }
+
+        /// <summary>
+        /// Safe accessor for Idle Info.
+        /// Returns false if the database is effectively Active (Loading/Loaded), 
+        /// protecting against race conditions where the dictionary entry still exists during wakeup.
+        /// </summary>
+        public bool TryGetIdleInfo(string databaseName, out IdleDatabaseInfo info)
+        {
+            // We want to return Idle info only if the database is strictly Idle.
+            if (GetActivityState(databaseName) is DatabaseActivityState.Idle)
+                return _idleDatabases.TryGetValue(databaseName, out info);
+
+            info = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Prevents waking up an idle database for specific commands that are safe to execute without loading the database.
+        /// </summary>
+        /// <param name="databaseName">Database name to check</param>
+        /// <param name="commandType">Command type to check</param>
+        /// <returns>True if the command should prevent waking up the idle database, otherwise false</returns>
+        internal bool ShouldPreventWakeUpIdleDatabase(string databaseName, string commandType)
+        {
+            if (GetActivityState(databaseName) is not DatabaseActivityState.Idle)
+                return false;
+
+            switch (commandType)
+            {
+                case nameof(PutServerWideBackupConfigurationCommand):
+                case nameof(UpdatePeriodicBackupStatusCommand):
+                case nameof(UpdateResponsibleNodeForTasksCommand):
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        public void RescheduleNextIdleDatabaseActivity(string databaseName, IdleDatabaseActivity idleDatabaseActivity)
+        {
+            if (idleDatabaseActivity == null)
+            {
+                DisposeWakeupTimer(databaseName);
+                return;
+            }
+
+            // in case the DueTime is negative or zero, the callback will be called immediately and the database will be loaded.
+            _ = _wakeupTimers.AddOrUpdate(databaseName,
+                _ => new Lazy<DatabaseWakeupTimer>(() => new DatabaseWakeupTimer(databaseName, idleDatabaseActivity, NextScheduledActivityCallback)),
+                (_, timer) =>
+                {
+                    timer.Value.Update(idleDatabaseActivity);
+                    return timer;
+                }).Value;
+        }
+
+        internal void RescheduleTimerIfDatabaseIdleOnUpdatedResponsibleNode(string databaseName)
+        {
+            if (GetActivityState(databaseName) is not DatabaseIdleManager.DatabaseActivityState.Idle)
+                return;
+
+            var nextIdleDatabaseActivity = BackupUtils.GetEarliestIdleDatabaseActivity(new BackupUtils.EarliestIdleDatabaseActivityParameters()
+            {
+                DatabaseName = databaseName,
+                NotificationCenter = _serverStore.NotificationCenter,
+                Logger = _logger,
+                ServerStore = _serverStore,
+                IsIdle = true
+            });
+
+            RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
+        }
+
+        internal void RescheduleTimerIfDatabaseIdle(string db, object state)
+        {
+            if (GetActivityState(db) is not DatabaseActivityState.Idle)
+                return;
+
+            if (state is long taskId == false)
+            {
+                Debug.Assert(state == null,
+                    $"This is probably a bug. This method should be called only for {nameof(PutServerWideBackupConfigurationCommand)} and the state should be the database periodic backup task id.");
+                //The database is excluded from the server-wide backup.
+                return;
+            }
+
+            PeriodicBackupConfiguration backupConfig;
+            using (_serverStore.ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            using (var rawRecord = _serverStore.Cluster.ReadRawDatabaseRecord(ctx, db))
+            {
+                backupConfig = rawRecord.GetPeriodicBackupConfiguration(taskId);
+
+                if (backupConfig == null)
+                {
+                    //`indexPerDatabase` was collected from the previous transaction. The database can be excluded in the meantime.
+                    if (_logger.IsInfoEnabled)
+                        _logger.Info($"Could not reschedule the wakeup timer for idle database '{db}', because there is no backup task with id '{taskId}'.");
+                    return;
+                }
+            }
+
+            var tag = BackupUtils.GetResponsibleNodeTag(_serverStore, db, backupConfig.TaskId);
+            if (_serverStore.Engine.Tag != tag)
+            {
+                if (_logger.IsOperationsEnabled && tag != null)
+                    _logger.Operations($"Could not reschedule the wakeup timer for idle database '{db}', because backup task '{backupConfig.Name}' with id '{taskId}' belongs to node '{tag}' current node is '{_serverStore.Engine.Tag}'.");
+                return;
+            }
+
+            if (backupConfig.Disabled || backupConfig.FullBackupFrequency == null && backupConfig.IncrementalBackupFrequency == null)
+                return;
+
+            var now = SystemTime.UtcNow;
+            DateTime wakeup;
+            if (backupConfig.FullBackupFrequency == null)
+            {
+                wakeup = CrontabSchedule.Parse(backupConfig.IncrementalBackupFrequency).GetNextOccurrence(now);
+            }
+            else
+            {
+                wakeup = CrontabSchedule.Parse(backupConfig.FullBackupFrequency).GetNextOccurrence(now);
+                if (backupConfig.IncrementalBackupFrequency != null)
+                {
+                    var incremental = CrontabSchedule.Parse(backupConfig.IncrementalBackupFrequency).GetNextOccurrence(now);
+                    wakeup = new DateTime(Math.Min(wakeup.Ticks, incremental.Ticks));
+                }
+            }
+
+            wakeup = DateTime.SpecifyKind(wakeup, DateTimeKind.Utc);
+            var nextIdleDatabaseActivity = new IdleDatabaseActivity(IdleDatabaseActivityType.WakeUpDatabase, wakeup);
+            RescheduleNextIdleDatabaseActivity(db, nextIdleDatabaseActivity);
+
+            if (_logger.IsOperationsEnabled)
+                _logger.Operations($"Rescheduling the wakeup timer for idle database '{db}', because backup task '{backupConfig.Name}' with id '{taskId}' which belongs to node '{_serverStore.Engine.Tag}', new timer is set to: '{nextIdleDatabaseActivity.DateTime}', with dueTime: {nextIdleDatabaseActivity.DueTime} ms.");
+        }
+
+        public void DisposeWakeupTimer(string databaseName)
+        {
+            if (_wakeupTimers.TryRemove(databaseName, out Lazy<DatabaseWakeupTimer> oldTimer) && oldTimer.IsValueCreated)
+                oldTimer.Value.Dispose();
+        }
+
+        private void NextScheduledActivityCallback(string databaseName, IdleDatabaseActivity nextIdleDatabaseActivity)
+        {
+            try
+            {
+                if (_disposing.TryEnter(out var idx) == false)
+                    throw new ObjectDisposedException(nameof(DatabasesLandlord), $"The server is being disposed, cannot access to database '{databaseName}'.");
+
+                try
+                {
+                    if (_serverStore.ServerShutdown.IsCancellationRequested)
+                        return;
+
+                    switch (nextIdleDatabaseActivity.Type)
+                    {
+                        case IdleDatabaseActivityType.UpdateBackupStatusOnly:
+
+                            PeriodicBackupStatus backupStatus = _serverStore.DatabaseInfoCache.BackupStatusStorage.GetBackupStatus(databaseName, nextIdleDatabaseActivity.TaskId);
+
+                            backupStatus.LastIncrementalBackup = backupStatus.LastIncrementalBackupInternal = nextIdleDatabaseActivity.DateTime;
+                            backupStatus.LocalBackup.LastIncrementalBackup = nextIdleDatabaseActivity.DateTime;
+                            backupStatus.LocalBackup.IncrementalBackupDurationInMs = 0;
+
+                            var backupResult = new BackupResult();
+                            backupResult.AddMessage($"Skipping incremental backup because no changes were made from last full backup on {backupStatus.LastFullBackup}.");
+                            
+                            BackupUtils.SaveBackupStatus(backupStatus, databaseName, _serverStore, _logger, backupResult);
+
+                            // choose the next backup that will arrive the earliest
+                            nextIdleDatabaseActivity = BackupUtils.GetEarliestIdleDatabaseActivity(new BackupUtils.EarliestIdleDatabaseActivityParameters
+                            {
+                                DatabaseName = databaseName,
+                                LastEtag = nextIdleDatabaseActivity.LastEtag,
+                                Logger = _logger,
+                                ServerStore = _serverStore,
+                                IsIdle = true
+                            });
+
+                            RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
+                            break;
+
+                        case IdleDatabaseActivityType.WakeUpDatabase:
+                            if (_serverStore.ConcurrentBackupsCounter.CanRunBackup(ShardHelper.ToDatabaseName(databaseName)) == false)
+                            {
+                                // reached max concurrent backups
+                                var delayInMs = RescheduleDatabaseWakeup();
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached " +
+                                                 $"max concurrent backups ({_serverStore.ConcurrentBackupsCounter.MaxNumberOfConcurrentBackups}), will retry the wakeup in {delayInMs:#,#;;0}ms");
+                                break;
+                            }
+
+                            if (BackupUtils.CanServerRunBackup(_serverStore) == false)
+                            {
+                                // the server cannot run the backup anyway (low memory, low cpu credits or high dirty memory state)
+                                var delayInMs = RescheduleDatabaseWakeup();
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we are in a low memory state, " +
+                                                 $"will retry the wakeup in {delayInMs:#,#;;0}ms");
+                                break;
+                            }
+
+                            var startDatabaseForBackup = _serverStore.ConcurrentBackupsCounter.TryStartDatabaseForBackup();
+                            if (startDatabaseForBackup == null)
+                            {
+                                // reached max concurrent loading of databases for backup
+                                var delayInMs = RescheduleDatabaseWakeup();
+                                if (_logger.IsInfoEnabled)
+                                    _logger.Info($"Delaying the start of the database '{databaseName}' for running a backup because we reached max concurrent loading of databases " +
+                                                 $"for backup ({_serverStore.ConcurrentBackupsCounter.MaxNumberOfConcurrentBackups}), will retry the wakeup in {delayInMs:#,#;;0}ms");
+                            }
+                            else
+                            {
+                                _ = _serverStore.DatabasesLandlord.TryGetOrCreateResourceStore(databaseName, nextIdleDatabaseActivity.DateTime).ContinueWith(t =>
+                                {
+                                    startDatabaseForBackup.Dispose();
+
+                                    var ex = t.Exception.ExtractSingleInnerException();
+                                    if (ex is DatabaseConcurrentLoadTimeoutException e)
+                                    {
+                                        // database failed to load
+                                        var delayInMs = RescheduleDatabaseWakeup();
+                                        if (_logger.IsInfoEnabled)
+                                            _logger.Info($"Failed to start database '{databaseName}' for running a backup, will retry the wakeup in {delayInMs:#,#;;0}ms", e);
+                                    }
+                                });
+                            }
+                            break;
+
+                            int RescheduleDatabaseWakeup()
+                            {
+                                ForTestingPurposes?.RescheduleDatabaseWakeupMre?.Set();
+
+                                var delayInMs = _dueTimeOnRetry + Random.Shared.Next(0, _dueTimeOnRetry);
+                                nextIdleDatabaseActivity.DateTime = DateTime.UtcNow.AddMilliseconds(delayInMs);
+                                RescheduleNextIdleDatabaseActivity(databaseName, nextIdleDatabaseActivity);
+                                return delayInMs;
+                            }
+                    }
+                }
+                finally
+                {
+                    _disposing.Exit(idx);
+                }
+            }
+            catch (Exception e)
+            {
+                // we have to swallow any exception here.
+
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations($"Failed to schedule the next activity for the idle database '{databaseName}'.", e);
+
+                ForTestingPurposes?.OnFailedRescheduleNextScheduledActivity?.Invoke(e, databaseName);
+            }
+        }
+
+        internal bool ShouldContinueDispose(string name, IdleDatabaseActivity idleDatabaseActivity)
+        {
+            if (name == null)
+                return true;
+
+            if (_wakeupTimers.TryRemove(name, out var timer) && timer.IsValueCreated)
+                timer.Value.Dispose();
+
+            if (idleDatabaseActivity == null)
+                return true;
+
+            if (idleDatabaseActivity.DateTime.HasValue == false)
+                return true;
+
+            if (ForTestingPurposes?.SkipShouldContinueDisposeCheck == true)
+                return true;
+
+            // Unloading and then loading a database can use a lot of resources.
+            // Therefore, we don't want to unload the database unless we're sure it will be loaded again soon.
+            return idleDatabaseActivity.DueTime > TimeSpan.FromMinutes(5).TotalMilliseconds;
+        }
+
+        private void IdleOperationsCallback(object state) => IdleOperations();
+
+        public void IdleOperations(Dictionary<StringSegment, DatabasesDebugHandler.IdleDatabaseStatistics> stats = null)
+        {
+            try
+            {
+                foreach (var db in _serverStore.DatabasesLandlord.DatabasesCache)
+                {
+                    try
+                    {
+                        if (db.Value.Status != TaskStatus.RanToCompletion)
+                            continue;
+
+                        var database = db.Value.Result;
+
+                        if (DatabaseNeedsToRunIdleOperations(database, out var mode))
+                            database.RunIdleOperations(mode);
+                    }
+                    catch (Exception e)
+                    {
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info("Error during idle operation run for " + db.Key, e);
+                    }
+                }
+
+                try
+                {
+                    _serverStore.Server.Statistics.MaybePersist(_serverStore.ContextPool, _logger);
+
+                    foreach (var databaseKvp in _serverStore.DatabasesLandlord.LastRecentlyUsed.ForceEnumerateInThreadSafeManner())
+                    {
+                        DatabasesDebugHandler.IdleDatabaseStatistics statistics = null;
+                        if (stats != null)
+                        {
+                            if (stats.TryGetValue(databaseKvp.Key, out statistics) == false)
+                                stats[databaseKvp.Key] = statistics = new DatabasesDebugHandler.IdleDatabaseStatistics();
+                        }
+                        
+                        if (_serverStore.DatabasesLandlord.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics: statistics, out DocumentDatabase database) == false)
+                            continue;
+
+                        IdleDatabaseInfo idleInfo;
+                        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
+                        using (var tx = documentsContext.OpenReadTransaction())
+                        {
+                            var dbIdEtagDictionary = new Dictionary<string, long>();
+                            foreach (var kvp in DocumentsStorage.GetAllReplicatedEtags(documentsContext))
+                            {
+                                if (Guid.TryParse(kvp.Key, out Guid parsedGuid))
+                                    dbIdEtagDictionary[parsedGuid.ToBase64Unpadded()] = kvp.Value;
+                                else
+                                    dbIdEtagDictionary[kvp.Key] = kvp.Value;
+                            }
+
+                            var changeVector = DocumentsStorage.GetDatabaseChangeVector(tx.InnerTransaction);
+                            idleInfo = new IdleDatabaseInfo(dbIdEtagDictionary, changeVector, database.DbBase64Id);
+                        }
+
+                        var repInfoStr = idleInfo.ReplicationInfo != null && idleInfo.ReplicationInfo.Count > 0
+                            ? string.Join(", ", idleInfo.ReplicationInfo.Select(kvp => $"{kvp.Key}={kvp.Value}"))
+                            : "(empty)";
+
+                        if (_logger.IsOperationsEnabled)
+                        {
+                            _logger.Operations($"[IdleInfo] {database.Name}: CV='{idleInfo.ChangeVector}' ReplicationInfo={repInfoStr}");
+                        }
+
+                        var nextActivity = database.PeriodicBackupRunner.GetNextIdleDatabaseActivity(database.Name);
+
+                        if (TryEnterIdleState(database.Name, idleInfo, nextActivity))
+                        {
+                            if (_logger.IsOperationsEnabled)
+                                _logger.Operations($"{database.Name} was unloaded due to idleness with change-vector `{idleInfo.ChangeVector}`");
+                        }
+                        else
+                        {
+                            if (_logger.IsOperationsEnabled)
+                                _logger.Operations($"{database.Name} could not be unloaded due to idleness with change-vector `{idleInfo.ChangeVector}`");
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (_logger.IsOperationsEnabled)
+                        _logger.Operations("Error during idle operations for the server", e);
+                }
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations("Unexpected error during idle operations for the server", e);
+            }
+            finally
+            {
+                try
+                {
+                    if (_isDisposed == false)
+                        _timer.Change(dueTime: _frequencyToCheckForIdleDatabases, period: TimeSpan.FromDays(7));
+                }
+                catch (ObjectDisposedException)
+                {
+                }
+            }
+        }
+
+        private bool DatabaseNeedsToRunIdleOperations(DocumentDatabase database, out DatabaseCleanupMode mode)
+        {
+            var now = DateTime.UtcNow;
+
+            var envs = database.GetAllStoragesEnvironment();
+
+            var maxLastWork = DateTime.MinValue;
+
+            foreach (var env in envs)
+            {
+                if (env.Environment.LastWorkTime > maxLastWork)
+                    maxLastWork = env.Environment.LastWorkTime;
+            }
+
+            if ((now - maxLastWork).CompareTo(database.Configuration.Databases.DeepCleanupThreshold.AsTimeSpan) > 0)
+            {
+                mode = DatabaseCleanupMode.Deep;
+                return true;
+            }
+
+            if ((now - database.LastIdleTime).CompareTo(database.Configuration.Databases.RegularCleanupThreshold.AsTimeSpan) > 0)
+            {
+                mode = DatabaseCleanupMode.Regular;
+                return true;
+            }
+
+            mode = DatabaseCleanupMode.None;
+            return false;
+        }
+
+        internal void ThrowIfIdleAndUpToDate(string database, string sinkChangeVector, PullReplicationDefinition pullReplication, TransactionOperationContext context)
+        {
+            if (TryGetIdleInfo(database, out var idleDatabaseInfo) == false)
+                return;
+
+            if (idleDatabaseInfo.ChangeVector == null)
+                return;
+
+            if (_serverStore.DatabasesLandlord.IsDatabaseLoaded(database))
+                return;
+
+            var dbRecord = _serverStore.Cluster.ReadRawDatabaseRecord(context, database);
+            var hubDbId = dbRecord?.Topology?.DatabaseTopologyIdBase64;
+
+            FilterIrrelevantEntries(sinkChangeVector, idleDatabaseInfo, hubDbId, out var sinkCvForHubToSink, out var sinkCvForSinkToHub);
+
+            if ((pullReplication.Mode & PullReplicationMode.HubToSink) != 0)
+            {
+                // Hub must wake up only if it has data the Sink doesn't have yet.
+                // We compare Hub's full CV against only the Hub-origin entries from Sink's CV.
+                var sinkStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: idleDatabaseInfo.ChangeVector, localAsString: sinkCvForHubToSink);
+                if (sinkStatus is not ConflictStatus.AlreadyMerged)
+                {
+                    _serverStore.DatabasesLandlord.TryGetOrCreateDatabase(database);
+                    return;
+                }
+            }
+
+            if ((pullReplication.Mode & PullReplicationMode.SinkToHub) != 0)
+            {
+                // Hub must wake up only if Sink has new data Hub hasn't received yet.
+                // We compare only the non-Hub, not-yet-replicated entries from Sink's CV against Hub's CV.
+                var hubStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: sinkCvForSinkToHub, localAsString: idleDatabaseInfo.ChangeVector);
+                if (hubStatus is not ConflictStatus.AlreadyMerged)
+                {
+                    _serverStore.DatabasesLandlord.TryGetOrCreateDatabase(database);
+                    return;
+                }
+            }
+
+            throw new DatabaseIdleException($"The database '{database}' is currently idle. " +
+                                            $"The request was rejected to avoid waking up the database unnecessarily, " +
+                                            $"as there are no new changes to replicate for the change vector '{sinkChangeVector}'.");
+        }
+
+        /// <summary>
+        /// Keeping these two vectors separate prevents cross-contamination: Sink's own entries must not
+        /// influence the HubToSink check, and Hub's echoed entries must not influence the SinkToHub check.
+        /// </summary>
+        /// <param name="sinkCvForHubToSink">contains only Hub-origin entries from Sink's CV (capped to Hub's local etag).
+        /// Used to answer: "Does Sink already have everything Hub has?" (HubToSink direction)</param>
+        /// <param name="sinkCvForSinkToHub">contains only non-Hub entries from Sink's CV that Hub hasn't replicated yet.
+        /// Used to answer: "Does Sink have new data Hub hasn't received?" (SinkToHub direction)</param>
+        internal static void FilterIrrelevantEntries(
+            string sinkChangeVector,
+            IdleDatabaseInfo idleInfo,
+            string hubDbId,
+            out string sinkCvForHubToSink,
+            out string sinkCvForSinkToHub)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(sinkChangeVector))
+                {
+                    sinkCvForHubToSink = sinkChangeVector;
+                    sinkCvForSinkToHub = sinkChangeVector;
+                    return;
+                }
+
+                var sinkList = sinkChangeVector.ToChangeVectorList();
+
+                var localEntries = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+                // Retrieve topology ID securely. We bypass conditional optimization.
+                // hubDbId is passed as an argument.
+
+                // For newly created databases, the local Change Vector might not yet contain the node's Topology ID,
+                // but the Sink will report the Hub's real Storage Voron ID if it received echoing replication info.
+                // It is CRITICAL to register `hubDbId` and `idleInfo.HubVoronDbId` so Hub correctly identifies echoed data.
+
+                if (string.IsNullOrEmpty(hubDbId) == false)
+                {
+                    long etag = 0;
+                    if (string.IsNullOrEmpty(idleInfo.ChangeVector) == false)
+                        etag = ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, hubDbId);
+
+                    localEntries[hubDbId] = etag;
+                    if (TryBase64ToGuid(hubDbId, out var guid))
+                        localEntries[guid] = etag;
+                }
+
+                if (string.IsNullOrEmpty(idleInfo.HubVoronDbId) == false)
+                {
+                    long etag = 0;
+                    if (string.IsNullOrEmpty(idleInfo.ChangeVector) == false)
+                        etag = ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, idleInfo.HubVoronDbId);
+
+                    localEntries[idleInfo.HubVoronDbId] = etag;
+                    if (TryBase64ToGuid(idleInfo.HubVoronDbId, out var guid))
+                        localEntries[guid] = etag;
+                }
+
+                // ReplicationInfo keys may be GUID strings (from DbId.ToString()) while CV DbIds are Base64.
+                // Build a normalized lookup that accepts both representations.
+                Dictionary<string, long> replicationInfoLookup = null;
+                if (idleInfo.ReplicationInfo != null && idleInfo.ReplicationInfo.Count > 0)
+                {
+                    replicationInfoLookup = new Dictionary<string, long>(idleInfo.ReplicationInfo.Count * 2, StringComparer.OrdinalIgnoreCase);
+                    foreach (var kvp in idleInfo.ReplicationInfo)
+                    {
+                        replicationInfoLookup[kvp.Key] = kvp.Value;
+                        // If the stored key is a GUID, also register its Base64 equivalent.
+                        if (Guid.TryParse(kvp.Key, out var g))
+                        {
+                            var base64 = Convert.ToBase64String(g.ToByteArray()).TrimEnd('=');
+                            replicationInfoLookup[base64] = kvp.Value;
+                        }
+                        // If the stored key is Base64, also register its GUID equivalent.
+                        else if (TryBase64ToGuid(kvp.Key, out var g2))
+                        {
+                            replicationInfoLookup[g2] = kvp.Value;
+                        }
+                    }
+                }
+
+                var hubToSinkList = new List<ChangeVectorEntry>();
+                var sinkToHubList = new List<ChangeVectorEntry>();
+
+                foreach (var entry in sinkList)
+                {
+                    bool isHubEntry = localEntries.TryGetValue(entry.DbId, out long hubLocalEtag);
+
+                    if (isHubEntry == false && TryBase64ToGuid(entry.DbId, out var entryGuid))
+                        isHubEntry = localEntries.TryGetValue(entryGuid, out hubLocalEtag);
+
+                    if (isHubEntry)
+                    {
+                        // Hub-origin entry: belongs in HubToSink vector only.
+                        // Cap it to Hub's local etag — Sink may report a higher value if it received
+                        // data from Hub that Hub itself has since rolled back or hasn't committed yet.
+                        var cappedEtag = Math.Min(entry.Etag, hubLocalEtag);
+                        hubToSinkList.Add(new ChangeVectorEntry { DbId = entry.DbId, Etag = cappedEtag, NodeTag = entry.NodeTag });
+                        continue;
+                    }
+
+                    // Non-Hub entry: belongs in SinkToHub vector only, unless Hub already replicated it.
+                    bool alreadyReplicated = replicationInfoLookup != null &&
+                                            replicationInfoLookup.TryGetValue(entry.DbId, out long lastReplicated) &&
+                                            entry.Etag <= lastReplicated;
+
+                    if (alreadyReplicated == false)
+                        sinkToHubList.Add(entry);
+                }
+
+                sinkCvForHubToSink = hubToSinkList.Count == 0 ? string.Empty : hubToSinkList.SerializeVector();
+                sinkCvForSinkToHub = sinkToHubList.Count == 0 ? string.Empty : sinkToHubList.SerializeVector();
+            }
+            catch
+            {
+                sinkCvForHubToSink = sinkChangeVector;
+                sinkCvForSinkToHub = sinkChangeVector;
+            }
+        }
+
+        private static bool TryBase64ToGuid(string base64, out string guidString)
+        {
+            guidString = null;
+            if (string.IsNullOrEmpty(base64) || base64.Length > 24)
+                return false;
+            try
+            {
+                // Base64 DbIds are 22 chars (16 bytes without padding); add padding if needed
+                var padded = base64.Length % 4 == 0 ? base64 : base64.PadRight(base64.Length + (4 - base64.Length % 4), '=');
+                var bytes = Convert.FromBase64String(padded);
+                if (bytes.Length != 16)
+                    return false;
+                guidString = new Guid(bytes).ToString();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+                return;
+
+            _disposing.CloseAndLock();
+
+            try
+            {
+                var exceptionAggregator = new ExceptionAggregator(_logger, errorMsg: "Failure to dispose landlord");
+                exceptionAggregator.Execute(() =>
+                {
+                    var handles = new List<WaitHandle>();
+                    foreach (var timer in _wakeupTimers.Values)
+                    {
+                        if (timer.IsValueCreated == false)
+                            continue;
+
+                        var handle = new ManualResetEvent(false);
+                        timer.Value.Dispose(handle);
+                        handles.Add(handle);
+                    }
+
+                    if (handles.Count <= 0)
+                        return;
+
+                    var count = handles.Count;
+                    var batchSize = Math.Min(64, count);
+
+                    var numberOfBatches = count / batchSize;
+                    if (count % batchSize != 0)
+                    {
+                        // if we have a reminder, we need another batch
+                        numberOfBatches++;
+                    }
+
+                    var batch = new WaitHandle[batchSize];
+                    for (var i = 0; i < numberOfBatches; i++)
+                    {
+                        var toCopy = Math.Min(64, count - i * batchSize);
+                        handles.CopyTo(i * batchSize, batch, 0, toCopy);
+                        WaitHandle.WaitAll(batch);
+                    }
+                });
+
+                exceptionAggregator.Execute(() => _timer?.Dispose());
+                exceptionAggregator.Execute(_disposing.Dispose);
+                exceptionAggregator.ThrowIfNeeded();
+            }
+            finally
+            {
+                _isDisposed = true;
+            }
+        }
+
+        private sealed class DatabaseWakeupTimer : IDisposable
+        {
+            private IdleDatabaseActivity _activity;
+
+            private readonly string _databaseName;
+            private readonly Action<string, IdleDatabaseActivity> _callback;
+            private readonly Timer _timer;
+
+            public DatabaseWakeupTimer([NotNull] string databaseName, [NotNull] IdleDatabaseActivity activity, [NotNull] Action<string, IdleDatabaseActivity> callback)
+            {
+                _databaseName = databaseName ?? throw new ArgumentNullException(nameof(databaseName));
+                _activity = activity ?? throw new ArgumentNullException(nameof(activity));
+                _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+
+                _timer = new Timer(TimerCallback, state: null, _activity.DueTime, period: Timeout.Infinite);
+            }
+
+            public void Update(IdleDatabaseActivity activity)
+            {
+                _activity = activity;
+                _timer.Change(activity.DueTime, Timeout.Infinite);
+            }
+
+            private void TimerCallback(object state)
+            {
+                _callback(_databaseName, _activity);
+            }
+
+            public void Dispose()
+            {
+                _timer?.Dispose();
+            }
+
+            public void Dispose(WaitHandle notifyObject)
+            {
+                _timer?.Dispose(notifyObject);
+            }
+        }
+
+        internal TestingStuff ForTestingPurposes;
+
+        internal TestingStuff ForTestingPurposesOnly()
+        {
+            if (ForTestingPurposes != null)
+                return ForTestingPurposes;
+
+            return ForTestingPurposes = new TestingStuff();
+        }
+
+        internal sealed class TestingStuff
+        {
+            internal bool SkipShouldContinueDisposeCheck = false;
+            internal ManualResetEventSlim RescheduleDatabaseWakeupMre = null;
+            internal Action<Exception, string> OnFailedRescheduleNextScheduledActivity = null;
+            internal Action<string> AfterDatabaseRemovedFromIdle = null;
+        }
+    }
+
+    public sealed class IdleDatabaseActivity
+    {
+        public long LastEtag { get; }
+        public IdleDatabaseActivityType Type { get; }
+        public DateTime? DateTime { get; internal set; }
+        public long TaskId { get; }
+        public int DueTime => DateTime.HasValue
+            ? (int)Math.Min(int.MaxValue, Math.Max(0, (DateTime.Value - System.DateTime.UtcNow).TotalMilliseconds))
+            : 0;
+
+        public IdleDatabaseActivity(IdleDatabaseActivityType type)
+        {
+            LastEtag = 0;
+            Type = type;
+            TaskId = 0;
+
+            // DateTime should be only null in tests
+            DateTime = null;
+        }
+
+        public IdleDatabaseActivity(IdleDatabaseActivityType type, DateTime timeOfActivity, long taskId = 0, long lastEtag = 0)
+        {
+            LastEtag = lastEtag;
+            Type = type;
+            TaskId = taskId;
+
+            Debug.Assert(timeOfActivity.Kind != DateTimeKind.Unspecified);
+            DateTime = timeOfActivity.ToUniversalTime();
+        }
+    }
+
+    public enum IdleDatabaseActivityType
+    {
+        WakeUpDatabase,
+        UpdateBackupStatusOnly
+    }
+}

--- a/src/Raven.Server/ServerWide/DatabaseIdleManager.cs
+++ b/src/Raven.Server/ServerWide/DatabaseIdleManager.cs
@@ -625,117 +625,55 @@ namespace Raven.Server.ServerWide
 
                 var sinkList = sinkChangeVector.ToChangeVectorList();
 
-                var localEntries = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
-
-                // Retrieve topology ID securely. We bypass conditional optimization.
-                // hubDbId is passed as an argument.
-
-                // For newly created databases, the local Change Vector might not yet contain the node's Topology ID,
-                // but the Sink will report the Hub's real Storage Voron ID if it received echoing replication info.
-                // It is CRITICAL to register `hubDbId` and `idleInfo.HubVoronDbId` so Hub correctly identifies echoed data.
+                var localEtags = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
 
                 if (string.IsNullOrEmpty(hubDbId) == false)
                 {
-                    long etag = 0;
-                    if (string.IsNullOrEmpty(idleInfo.ChangeVector) == false)
-                        etag = ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, hubDbId);
-
-                    localEntries[hubDbId] = etag;
-                    if (TryBase64ToGuid(hubDbId, out var guid))
-                        localEntries[guid] = etag;
+                    long etag = string.IsNullOrEmpty(idleInfo.ChangeVector) ? 0 : ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, hubDbId);
+                    localEtags[hubDbId] = etag;
+                    if (ChangeVectorUtils.TryBase64ToGuid(hubDbId, out var guid))
+                        localEtags[guid] = etag;
                 }
 
                 if (string.IsNullOrEmpty(idleInfo.HubVoronDbId) == false)
                 {
-                    long etag = 0;
-                    if (string.IsNullOrEmpty(idleInfo.ChangeVector) == false)
-                        etag = ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, idleInfo.HubVoronDbId);
-
-                    localEntries[idleInfo.HubVoronDbId] = etag;
-                    if (TryBase64ToGuid(idleInfo.HubVoronDbId, out var guid))
-                        localEntries[guid] = etag;
+                    long etag = string.IsNullOrEmpty(idleInfo.ChangeVector) ? 0 : ChangeVectorUtils.GetEtagById(idleInfo.ChangeVector, idleInfo.HubVoronDbId);
+                    localEtags[idleInfo.HubVoronDbId] = etag;
+                    if (ChangeVectorUtils.TryBase64ToGuid(idleInfo.HubVoronDbId, out var guid))
+                        localEtags[guid] = etag;
                 }
 
                 // ReplicationInfo keys may be GUID strings (from DbId.ToString()) while CV DbIds are Base64.
                 // Build a normalized lookup that accepts both representations.
-                Dictionary<string, long> replicationInfoLookup = null;
+                Dictionary<string, long> normalizedReplicationInfo = null;
                 if (idleInfo.ReplicationInfo != null && idleInfo.ReplicationInfo.Count > 0)
                 {
-                    replicationInfoLookup = new Dictionary<string, long>(idleInfo.ReplicationInfo.Count * 2, StringComparer.OrdinalIgnoreCase);
+                    normalizedReplicationInfo = new Dictionary<string, long>(idleInfo.ReplicationInfo.Count * 2, StringComparer.OrdinalIgnoreCase);
                     foreach (var kvp in idleInfo.ReplicationInfo)
                     {
-                        replicationInfoLookup[kvp.Key] = kvp.Value;
-                        // If the stored key is a GUID, also register its Base64 equivalent.
+                        normalizedReplicationInfo[kvp.Key] = kvp.Value;
                         if (Guid.TryParse(kvp.Key, out var g))
                         {
                             var base64 = Convert.ToBase64String(g.ToByteArray()).TrimEnd('=');
-                            replicationInfoLookup[base64] = kvp.Value;
+                            normalizedReplicationInfo[base64] = kvp.Value;
                         }
-                        // If the stored key is Base64, also register its GUID equivalent.
-                        else if (TryBase64ToGuid(kvp.Key, out var g2))
+                        else if (ChangeVectorUtils.TryBase64ToGuid(kvp.Key, out var g2))
                         {
-                            replicationInfoLookup[g2] = kvp.Value;
+                            normalizedReplicationInfo[g2] = kvp.Value;
                         }
                     }
                 }
 
-                var hubToSinkList = new List<ChangeVectorEntry>();
-                var sinkToHubList = new List<ChangeVectorEntry>();
+                ChangeVectorUtils.ClassifyEntriesByOrigin(sinkList, localEtags, normalizedReplicationInfo,
+                    out var hubOriginEntries, out var sinkOriginEntries);
 
-                foreach (var entry in sinkList)
-                {
-                    bool isHubEntry = localEntries.TryGetValue(entry.DbId, out long hubLocalEtag);
-
-                    if (isHubEntry == false && TryBase64ToGuid(entry.DbId, out var entryGuid))
-                        isHubEntry = localEntries.TryGetValue(entryGuid, out hubLocalEtag);
-
-                    if (isHubEntry)
-                    {
-                        // Hub-origin entry: belongs in HubToSink vector only.
-                        // Cap it to Hub's local etag — Sink may report a higher value if it received
-                        // data from Hub that Hub itself has since rolled back or hasn't committed yet.
-                        var cappedEtag = Math.Min(entry.Etag, hubLocalEtag);
-                        hubToSinkList.Add(new ChangeVectorEntry { DbId = entry.DbId, Etag = cappedEtag, NodeTag = entry.NodeTag });
-                        continue;
-                    }
-
-                    // Non-Hub entry: belongs in SinkToHub vector only, unless Hub already replicated it.
-                    bool alreadyReplicated = replicationInfoLookup != null &&
-                                            replicationInfoLookup.TryGetValue(entry.DbId, out long lastReplicated) &&
-                                            entry.Etag <= lastReplicated;
-
-                    if (alreadyReplicated == false)
-                        sinkToHubList.Add(entry);
-                }
-
-                sinkCvForHubToSink = hubToSinkList.Count == 0 ? string.Empty : hubToSinkList.SerializeVector();
-                sinkCvForSinkToHub = sinkToHubList.Count == 0 ? string.Empty : sinkToHubList.SerializeVector();
+                sinkCvForHubToSink = hubOriginEntries.Count == 0 ? string.Empty : hubOriginEntries.SerializeVector();
+                sinkCvForSinkToHub = sinkOriginEntries.Count == 0 ? string.Empty : sinkOriginEntries.SerializeVector();
             }
             catch
             {
                 sinkCvForHubToSink = sinkChangeVector;
                 sinkCvForSinkToHub = sinkChangeVector;
-            }
-        }
-
-        private static bool TryBase64ToGuid(string base64, out string guidString)
-        {
-            guidString = null;
-            if (string.IsNullOrEmpty(base64) || base64.Length > 24)
-                return false;
-            try
-            {
-                // Base64 DbIds are 22 chars (16 bytes without padding); add padding if needed
-                var padded = base64.Length % 4 == 0 ? base64 : base64.PadRight(base64.Length + (4 - base64.Length % 4), '=');
-                var bytes = Convert.FromBase64String(padded);
-                if (bytes.Length != 16)
-                    return false;
-                guidString = new Guid(bytes).ToString();
-                return true;
-            }
-            catch
-            {
-                return false;
             }
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -124,8 +124,7 @@ namespace Raven.Server.ServerWide
 
         private readonly NotificationsStorage _notificationsStorage;
         private readonly OperationsStorage _operationsStorage;
-        public readonly ConcurrentDictionary<string, string> IdleDatabasesChangeVectors;
-        public ConcurrentDictionary<string, Dictionary<string, long>> IdleDatabases;
+        public readonly DatabaseIdleManager DatabaseIdleManager;
 
         private RequestExecutor _leaderRequestExecutor;
         internal long _lastClusterTopologyIndex = -1;
@@ -143,8 +142,6 @@ namespace Raven.Server.ServerWide
         public readonly AsyncManualResetEvent InitializationCompleted;
         public readonly GlobalIndexingScratchSpaceMonitor GlobalIndexingScratchSpaceMonitor;
         public bool Initialized;
-
-        private readonly TimeSpan _frequencyToCheckForIdleDatabases;
 
         private Lazy<ClusterRequestExecutor> _clusterRequestExecutor;
 
@@ -185,11 +182,9 @@ namespace Raven.Server.ServerWide
 
             _clusterRequestExecutor = CreateClusterRequestExecutor();
 
-            IdleDatabases = new ConcurrentDictionary<string, Dictionary<string, long>>(StringComparer.OrdinalIgnoreCase);
-
-            IdleDatabasesChangeVectors = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             DatabasesLandlord = new DatabasesLandlord(this);
+
+            DatabaseIdleManager = new DatabaseIdleManager(this);
 
             _notificationsStorage = new ServerStoreNotificationStorage(this);
 
@@ -219,8 +214,6 @@ namespace Raven.Server.ServerWide
 
             if (Configuration.Indexing.GlobalScratchSpaceLimit != null)
                 GlobalIndexingScratchSpaceMonitor = new GlobalIndexingScratchSpaceMonitor(Configuration.Indexing.GlobalScratchSpaceLimit.Value);
-
-            _frequencyToCheckForIdleDatabases = Configuration.Databases.FrequencyToCheckForIdle.AsTimeSpan;
 
             _server.ServerCertificateChanged += OnServerCertificateChanged;
 
@@ -305,7 +298,6 @@ namespace Raven.Server.ServerWide
 
         public bool Disposed => _disposed;
 
-        private Timer _timer;
         private RachisConsensus<ClusterStateMachine> _engine;
         private bool _disposed;
         public RachisConsensus<ClusterStateMachine> Engine => _engine;
@@ -845,16 +837,8 @@ namespace Raven.Server.ServerWide
 
             _server.Statistics.Load(ContextPool, Logger);
 
-            _timer = new Timer(IdleOperationsCallback, null, _frequencyToCheckForIdleDatabases, TimeSpan.FromDays(7));
-
             _operationsStorage.Initialize(_env, ContextPool);
             DatabaseInfoCache.Initialize(_env, ContextPool);
-            return;
-
-            void IdleOperationsCallback(object state)
-            {
-                IdleOperations();
-            }
         }
 
         public void Initialize()
@@ -1317,10 +1301,10 @@ namespace Raven.Server.ServerWide
                     NotificationCenter.Add(DatabaseChanged.Create(databaseName, DatabaseChangeType.RemoveNode));
                     break;
                 case nameof(PutServerWideBackupConfigurationCommand):
-                    RescheduleTimerIfDatabaseIdle(databaseName, state);
+                    DatabaseIdleManager.RescheduleTimerIfDatabaseIdle(databaseName, state);
                     break;
                 case nameof(UpdateResponsibleNodeForTasksCommand):
-                    RescheduleTimerIfDatabaseIdleOnUpdatedResponsibleNode(databaseName, state);
+                    DatabaseIdleManager.RescheduleTimerIfDatabaseIdleOnUpdatedResponsibleNode(databaseName);
                     break;
             }
 
@@ -1391,88 +1375,6 @@ namespace Raven.Server.ServerWide
         }
 
         public PublishedServerUrls PublishedServerUrls;
-
-        private void RescheduleTimerIfDatabaseIdle(string db, object state)
-        {
-            if (IdleDatabases.ContainsKey(db) == false)
-                return;
-
-            if (state is long taskId == false)
-            {
-                Debug.Assert(state == null,
-                    $"This is probably a bug. This method should be called only for {nameof(PutServerWideBackupConfigurationCommand)} and the state should be the database periodic backup task id.");
-                //The database is excluded from the server-wide backup.
-                return;
-            }
-
-            PeriodicBackupConfiguration backupConfig;
-            using (ContextPool.AllocateOperationContext(out TransactionOperationContext ctx))
-            using (ctx.OpenReadTransaction())
-            using (var rawRecord = Cluster.ReadRawDatabaseRecord(ctx, db))
-            {
-                backupConfig = rawRecord.GetPeriodicBackupConfiguration(taskId);
-
-                if (backupConfig == null)
-                {
-                    //`indexPerDatabase` was collected from the previous transaction. The database can be excluded in the meantime. 
-                    if (Logger.IsInfoEnabled)
-                        Logger.Info($"Could not reschedule the wakeup timer for idle database '{db}', because there is no backup task with id '{taskId}'.");
-                    return;
-                }
-            }
-
-            var tag = BackupUtils.GetResponsibleNodeTag(Server.ServerStore, db, backupConfig.TaskId);
-            if (Engine.Tag != tag)
-            {
-                if (Logger.IsOperationsEnabled && tag != null)
-                    Logger.Operations($"Could not reschedule the wakeup timer for idle database '{db}', because backup task '{backupConfig.Name}' with id '{taskId}' belongs to node '{tag}' current node is '{Engine.Tag}'.");
-                return;
-            }
-
-            if (backupConfig.Disabled || backupConfig.FullBackupFrequency == null && backupConfig.IncrementalBackupFrequency == null)
-                return;
-
-            var now = SystemTime.UtcNow;
-            DateTime wakeup;
-            if (backupConfig.FullBackupFrequency == null)
-            {
-                wakeup = CrontabSchedule.Parse(backupConfig.IncrementalBackupFrequency).GetNextOccurrence(now);
-            }
-            else
-            {
-                wakeup = CrontabSchedule.Parse(backupConfig.FullBackupFrequency).GetNextOccurrence(now);
-                if (backupConfig.IncrementalBackupFrequency != null)
-                {
-                    var incremental = CrontabSchedule.Parse(backupConfig.IncrementalBackupFrequency).GetNextOccurrence(now);
-                    wakeup = new DateTime(Math.Min(wakeup.Ticks, incremental.Ticks));
-                }
-            }
-
-            wakeup = DateTime.SpecifyKind(wakeup, DateTimeKind.Utc);
-            var nextIdleDatabaseActivity = new IdleDatabaseActivity(IdleDatabaseActivityType.WakeUpDatabase, wakeup);
-            DatabasesLandlord.RescheduleNextIdleDatabaseActivity(db, nextIdleDatabaseActivity);
-
-            if (Logger.IsOperationsEnabled)
-                Logger.Operations($"Rescheduling the wakeup timer for idle database '{db}', because backup task '{backupConfig.Name}' with id '{taskId}' which belongs to node '{Engine.Tag}', new timer is set to: '{nextIdleDatabaseActivity.DateTime}', with dueTime: {nextIdleDatabaseActivity.DueTime} ms.");
-
-        }
-
-        private void RescheduleTimerIfDatabaseIdleOnUpdatedResponsibleNode(string db, object state)
-        {
-            if (IdleDatabases.ContainsKey(db) == false)
-                return;
-
-            var nextIdleDatabaseActivity = BackupUtils.GetEarliestIdleDatabaseActivity(new BackupUtils.EarliestIdleDatabaseActivityParameters()
-            {
-                DatabaseName = db,
-                NotificationCenter = NotificationCenter,
-                Logger = Logger,
-                ServerStore = Server.ServerStore,
-                IsIdle = true
-            });
-
-            DatabasesLandlord.RescheduleNextIdleDatabaseActivity(db, nextIdleDatabaseActivity);
-        }
 
         private void ConfirmCertificateReplacedValueChanged(long index, string type)
         {
@@ -2716,6 +2618,7 @@ namespace Raven.Server.ServerWide
                         ServerLimitsMonitor,
                         NotificationCenter,
                         LicenseManager,
+                        DatabaseIdleManager,
                         DatabasesLandlord,
                         _env,
                         _leaderRequestExecutor,
@@ -2743,8 +2646,6 @@ namespace Raven.Server.ServerWide
 
                     exceptionAggregator.Execute(_shutdownNotification.Dispose);
 
-                    exceptionAggregator.Execute(() => _timer?.Dispose());
-
                     exceptionAggregator.Execute(() =>
                     {
                         if (_clusterRequestExecutor?.IsValueCreated == true)
@@ -2758,264 +2659,6 @@ namespace Raven.Server.ServerWide
                     _disposed = true;
                 }
             }
-        }
-
-        public void IdleOperations(Dictionary<StringSegment, DatabasesDebugHandler.IdleDatabaseStatistics> stats = null)
-        {
-            try
-            {
-                foreach (var db in DatabasesLandlord.DatabasesCache)
-                {
-                    try
-                    {
-                        if (db.Value.Status != TaskStatus.RanToCompletion)
-                            continue;
-
-                        var database = db.Value.Result;
-
-                        if (DatabaseNeedsToRunIdleOperations(database, out var mode))
-                            database.RunIdleOperations(mode);
-                    }
-                    catch (Exception e)
-                    {
-                        if (Logger.IsInfoEnabled)
-                            Logger.Info("Error during idle operation run for " + db.Key, e);
-                    }
-                }
-
-                try
-                {
-                    _server.Statistics.MaybePersist(ContextPool, Logger);
-
-                    foreach (var databaseKvp in DatabasesLandlord.LastRecentlyUsed.ForceEnumerateInThreadSafeManner())
-                    {
-                        DatabasesDebugHandler.IdleDatabaseStatistics statistics = null;
-                        if (stats != null)
-                        {
-                            if (stats.TryGetValue(databaseKvp.Key, out statistics) == false)
-                                stats[databaseKvp.Key] = statistics = new DatabasesDebugHandler.IdleDatabaseStatistics();
-                        }
-                        
-                        if (CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics: statistics, out DocumentDatabase database) == false)
-                            continue;
-
-                        var dbIdEtagDictionary = new Dictionary<string, long>();
-                        (_, string changeVector) = database.ReadLastEtagAndChangeVector();
-
-                        using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
-                        using (documentsContext.OpenReadTransaction())
-                        {
-                            foreach (var kvp in DocumentsStorage.GetAllReplicatedEtags(documentsContext))
-                                dbIdEtagDictionary[kvp.Key] = kvp.Value;
-                        }
-
-                        if (DatabasesLandlord.UnloadDirectly(databaseKvp.Key, database.PeriodicBackupRunner.GetNextIdleDatabaseActivity(database.Name)))
-                        {
-                            IdleDatabases[database.Name] = dbIdEtagDictionary;
-
-                            if (changeVector != null)
-                                IdleDatabasesChangeVectors[database.Name] = changeVector;
-                        }
-                    }
-                }
-                catch (Exception e)
-                {
-                    if (Logger.IsOperationsEnabled)
-                        Logger.Operations("Error during idle operations for the server", e);
-                }
-            }
-            catch (Exception e)
-            {
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations("Unexpected error during idle operations for the server", e);
-            }
-            finally
-            {
-                try
-                {
-                    _timer.Change(_frequencyToCheckForIdleDatabases, TimeSpan.FromDays(7));
-                }
-                catch (ObjectDisposedException)
-                {
-                }
-            }
-        }
-
-        public bool CanUnloadDatabase(StringSegment databaseName, DateTime lastRecentlyUsed, DatabasesDebugHandler.IdleDatabaseStatistics statistics, out DocumentDatabase database)
-        {
-            database = null;
-            var now = SystemTime.UtcNow;
-
-            if (statistics != null)
-                statistics.LastRecentlyUsed = lastRecentlyUsed;
-
-            var diff = now - lastRecentlyUsed;
-
-            if (DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out Task<DocumentDatabase> resourceTask) == false
-                || resourceTask == null
-                || resourceTask.Status != TaskStatus.RanToCompletion)
-            {
-                if (statistics != null)
-                {
-                    statistics.IsLoaded = false;
-                    statistics.Explanations.Add("Cannot unload database because it is not loaded yet.");
-                }
-
-                return false;
-            }
-
-            database = resourceTask.Result;
-
-            var maxTimeDatabaseCanBeIdle = database.Configuration.Databases.MaxIdleTime.AsTimeSpan;
-
-            if (statistics != null)
-                statistics.MaxIdleTime = maxTimeDatabaseCanBeIdle;
-
-            if (diff <= maxTimeDatabaseCanBeIdle)
-            {
-                if (statistics == null)
-                    return false;
-
-                statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last recently used ({lastRecentlyUsed}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
-            }
-
-            if (statistics != null)
-                statistics.IsLoaded = true;
-
-            // intentionally inside the loop, so we get better concurrency overall
-            // since shutting down a database can take a while
-            if (database.Configuration.Core.RunInMemory)
-            {
-                if (statistics != null)
-                {
-                    statistics.RunInMemory = true;
-                    statistics.Explanations.Add("Cannot unload database because it is running in memory.");
-                }
-
-                return false;
-            }
-
-            var canUnload = database.CanUnload;
-
-            if (statistics != null)
-                statistics.CanUnload = canUnload;
-
-            if (canUnload == false)
-            {
-                if (statistics == null)
-                    return false;
-                else
-                {
-                    statistics.Explanations.Add("Cannot unload database because it explicitly cannot be unloaded.");
-                }
-            }
-
-            var lastWork = DatabasesLandlord.LastWork(database);
-            if (statistics != null)
-                statistics.LastWork = lastWork;
-
-            diff = now - lastWork;
-
-            if (diff <= maxTimeDatabaseCanBeIdle)
-            {
-                if (statistics == null)
-                    return false;
-                else
-                {
-                    statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last work time ({lastWork}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
-                }
-            }
-
-            var numberOfChangesApiConnections = database.Changes.Connections.Values.Count(x => x.IsDisposed == false && x.IsChangesConnectionOriginatedFromStudio == false);
-            if (statistics != null)
-                statistics.NumberOfChangesApiConnections = numberOfChangesApiConnections;
-
-            if (numberOfChangesApiConnections > 0)
-            {
-                if (statistics == null)
-                    return false;
-                else
-                {
-                    statistics.Explanations.Add($"Cannot unload database because number of Changes API connections ({numberOfChangesApiConnections}) is greater than 0");
-                }
-            }
-
-            var numberOfSubscriptionConnections = database.SubscriptionStorage.GetNumberOfRunningSubscriptions();
-            if (statistics != null)
-                statistics.NumberOfSubscriptionConnections = numberOfSubscriptionConnections;
-
-            if (numberOfSubscriptionConnections > 0)
-            {
-                if (statistics == null)
-                    return false;
-
-                statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
-            }
-
-            var numberOfActivePullReplicationAsSinkConnections = database.ReplicationLoader.GetNumberActivePullReplicationAsSinkConnections();
-            if (statistics != null)
-                statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
-
-            var numberOfActiveHubToSinkConfigurations = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
-            if (statistics != null)
-                statistics.NumberOfActiveHubToSinkConfigurations = numberOfActiveHubToSinkConfigurations;
-
-            if (numberOfActiveHubToSinkConfigurations > 0)
-            {
-                if (statistics == null)
-                    return false;
-
-                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveHubToSinkConfigurations}) Pull Replication Sink configurations with 'HubToSink' mode enabled. The database must remain active to poll the Hub.");
-            }
-
-            var hasActiveOperations = database.Operations.HasActive;
-            if (statistics != null)
-                statistics.HasActiveOperations = hasActiveOperations;
-
-            if (hasActiveOperations)
-            {
-                if (statistics == null)
-                    return false;
-                else
-                {
-                    statistics.Explanations.Add("Cannot unload database because it has active operations");
-                }
-            }
-
-            if (statistics != null)
-                return statistics.Explanations.Count == 0;
-
-            return true;
-        }
-
-        private bool DatabaseNeedsToRunIdleOperations(DocumentDatabase database, out DatabaseCleanupMode mode)
-        {
-            var now = DateTime.UtcNow;
-
-            var envs = database.GetAllStoragesEnvironment();
-
-            var maxLastWork = DateTime.MinValue;
-
-            foreach (var env in envs)
-            {
-                if (env.Environment.LastWorkTime > maxLastWork)
-                    maxLastWork = env.Environment.LastWorkTime;
-            }
-
-            if ((now - maxLastWork).CompareTo(database.Configuration.Databases.DeepCleanupThreshold.AsTimeSpan) > 0)
-            {
-                mode = DatabaseCleanupMode.Deep;
-                return true;
-            }
-
-            if ((now - database.LastIdleTime).CompareTo(database.Configuration.Databases.RegularCleanupThreshold.AsTimeSpan) > 0)
-            {
-                mode = DatabaseCleanupMode.Regular;
-                return true;
-            }
-
-            mode = DatabaseCleanupMode.None;
-            return false;
         }
 
         public void AssignNodesToDatabase(ClusterTopology clusterTopology, string name, bool encrypted, DatabaseTopology databaseTopology)
@@ -3696,7 +3339,7 @@ namespace Raven.Server.ServerWide
                     };
                     var journalIoStatsResult = Server.DiskStatsGetter.Get(driveInfo?.JournalPath.DriveName);
                     if (journalIoStatsResult != null)
-                        journalUsage.IoStatsResult = FillIoStatsResult(journalIoStatsResult);
+                        usage.IoStatsResult = FillIoStatsResult(ioStatsResult);
 
                     yield return journalUsage;
                 }
@@ -3722,7 +3365,7 @@ namespace Raven.Server.ServerWide
                         };
                         var tempBufferIoStatsResult = Server.DiskStatsGetter.Get(driveInfo?.TempPath.DriveName);
                         if (tempBufferIoStatsResult != null)
-                            tempBuffersUsage.IoStatsResult = FillIoStatsResult(tempBufferIoStatsResult);
+                            tempBuffersUsage.IoStatsResult = FillIoStatsResult(ioStatsResult);
 
                         yield return tempBuffersUsage;
                     }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -33,7 +33,6 @@ using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
-using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.Integrations.PostgreSQL;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
@@ -125,6 +124,7 @@ namespace Raven.Server.ServerWide
 
         private readonly NotificationsStorage _notificationsStorage;
         private readonly OperationsStorage _operationsStorage;
+        public readonly ConcurrentDictionary<string, string> IdleDatabasesChangeVectors;
         public ConcurrentDictionary<string, Dictionary<string, long>> IdleDatabases;
 
         private RequestExecutor _leaderRequestExecutor;
@@ -186,6 +186,8 @@ namespace Raven.Server.ServerWide
             _clusterRequestExecutor = CreateClusterRequestExecutor();
 
             IdleDatabases = new ConcurrentDictionary<string, Dictionary<string, long>>(StringComparer.OrdinalIgnoreCase);
+
+            IdleDatabasesChangeVectors = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             DatabasesLandlord = new DatabasesLandlord(this);
 
@@ -2798,6 +2800,8 @@ namespace Raven.Server.ServerWide
                             continue;
 
                         var dbIdEtagDictionary = new Dictionary<string, long>();
+                        (_, string changeVector) = database.ReadLastEtagAndChangeVector();
+
                         using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext documentsContext))
                         using (documentsContext.OpenReadTransaction())
                         {
@@ -2806,7 +2810,12 @@ namespace Raven.Server.ServerWide
                         }
 
                         if (DatabasesLandlord.UnloadDirectly(databaseKvp.Key, database.PeriodicBackupRunner.GetNextIdleDatabaseActivity(database.Name)))
+                        {
                             IdleDatabases[database.Name] = dbIdEtagDictionary;
+
+                            if (changeVector != null)
+                                IdleDatabasesChangeVectors[database.Name] = changeVector;
+                        }
                     }
                 }
                 catch (Exception e)
@@ -2866,10 +2875,8 @@ namespace Raven.Server.ServerWide
             {
                 if (statistics == null)
                     return false;
-                else
-                {
-                    statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last recently used ({lastRecentlyUsed}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
-                }
+
+                statistics.Explanations.Add($"Cannot unload database because the difference ({diff}) between now ({now}) and last recently used ({lastRecentlyUsed}) is lower or equal to max idle time ({maxTimeDatabaseCanBeIdle}).");
             }
 
             if (statistics != null)
@@ -2945,16 +2952,17 @@ namespace Raven.Server.ServerWide
                 statistics.Explanations.Add($"Cannot unload database because number of Subscriptions connections ({numberOfSubscriptionConnections}) is greater than 0");
             }
 
-            var numberOfActivePullReplicationAsSinkConnections = database.ReplicationLoader.HasActivePullReplicationAsSinkConnections();
+            var numberOfActivePullReplicationAsSinkConnections = database.ReplicationLoader.GetNumberActivePullReplicationAsSinkConnections();
             if (statistics != null)
                 statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
 
-            if (numberOfActivePullReplicationAsSinkConnections > 0)
+            var numberOfActiveHubToSinkConfigs = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
+            if (numberOfActiveHubToSinkConfigs > 0)
             {
                 if (statistics == null)
                     return false;
 
-                statistics.Explanations.Add($"Cannot unload database because number of active PullReplication as Sink Connections ({numberOfActivePullReplicationAsSinkConnections}) is greater than 0");
+                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveHubToSinkConfigs}) Pull Replication Sink configurations with 'HubToSink' mode enabled. The database must remain active to poll the Hub.");
             }
 
             var hasActiveOperations = database.Operations.HasActive;
@@ -3685,7 +3693,7 @@ namespace Raven.Server.ServerWide
                     };
                     var journalIoStatsResult = Server.DiskStatsGetter.Get(driveInfo?.JournalPath.DriveName);
                     if (journalIoStatsResult != null)
-                        usage.IoStatsResult = FillIoStatsResult(ioStatsResult);
+                        journalUsage.IoStatsResult = FillIoStatsResult(journalIoStatsResult);
 
                     yield return journalUsage;
                 }
@@ -3711,7 +3719,7 @@ namespace Raven.Server.ServerWide
                         };
                         var tempBufferIoStatsResult = Server.DiskStatsGetter.Get(driveInfo?.TempPath.DriveName);
                         if (tempBufferIoStatsResult != null)
-                            tempBuffersUsage.IoStatsResult = FillIoStatsResult(ioStatsResult);
+                            tempBuffersUsage.IoStatsResult = FillIoStatsResult(tempBufferIoStatsResult);
 
                         yield return tempBuffersUsage;
                     }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2956,13 +2956,16 @@ namespace Raven.Server.ServerWide
             if (statistics != null)
                 statistics.NumberOfActivePullReplicationAsSinkConnections = numberOfActivePullReplicationAsSinkConnections;
 
-            var numberOfActiveHubToSinkConfigs = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
-            if (numberOfActiveHubToSinkConfigs > 0)
+            var numberOfActiveHubToSinkConfigurations = database.ReplicationLoader.GetNumberOfPullReplicationsPreventingIdle();
+            if (statistics != null)
+                statistics.NumberOfActiveHubToSinkConfigurations = numberOfActiveHubToSinkConfigurations;
+
+            if (numberOfActiveHubToSinkConfigurations > 0)
             {
                 if (statistics == null)
                     return false;
 
-                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveHubToSinkConfigs}) Pull Replication Sink configurations with 'HubToSink' mode enabled. The database must remain active to poll the Hub.");
+                statistics.Explanations.Add($"Cannot unload database because there are ({numberOfActiveHubToSinkConfigurations}) Pull Replication Sink configurations with 'HubToSink' mode enabled. The database must remain active to poll the Hub.");
             }
 
             var hasActiveOperations = database.Operations.HasActive;

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -450,40 +450,69 @@ namespace Raven.Server.Utils
             }
         }
 
-        /// <param name="localEtags">DbId→etag map whose keys define "local" identity; the etag is used as an upper cap.</param>
-        /// <param name="alreadyReplicatedEtags">DbId→last-replicated-etag for non-local entries; may be null.</param>
-        /// <param name="localOriginEntries">Local-origin entries, each capped to the local etag.</param>
-        /// <param name="remoteOriginEntries">Non-local entries not yet fully replicated.</param>
-        internal static void ClassifyEntriesByOrigin(
-            List<ChangeVectorEntry> entries,
-            Dictionary<string, long> localEtags,
-            Dictionary<string, long> alreadyReplicatedEtags,
-            out List<ChangeVectorEntry> localOriginEntries,
-            out List<ChangeVectorEntry> remoteOriginEntries)
+        /// <summary>
+        /// Classifies incoming Sink CV entries: Hub-known, Sink-origin, or TRXN. No capping (write path).
+        /// Callers apply SINK/TRXN tags to respective buckets and register sinkOriginEntries' DbIds
+        /// in DbIdsToIgnore to preserve Hub's global CV invariant (see <see cref="CleanHubGlobalCv"/>).
+        /// </summary>
+        /// <param name="incomingEntries">Parsed entries from the Sink's incoming change vector.</param>
+        /// <param name="hubKnownDbIds">Hub's authoritative DbIds (Base64-22).
+        /// Write path: all entries from Hub's cleaned global CV are safe — <see cref="CleanHubGlobalCv"/> guarantees no Sink DbIds.
+        /// Idle path: topology ID + DbBase64Id only — using the full CV risks Identity Crisis
+        /// (Sink DbIds in Hub's CV would be misclassified as Hub-origin). See <see cref="DatabaseIdleManager.FilterIrrelevantEntries"/>.</param>
+        /// <param name="clusterTransactionId">Hub's RAFT cluster DbId (Base64-22); null treats all non-Hub entries as Sink-origin.</param>
+        /// <param name="hubKnownEntries">Hub-origin — merge into Hub's global CV as-is.</param>
+        /// <param name="sinkOriginEntries">Sink-origin — caller must SINK-tag and add DbIds to DbIdsToIgnore.</param>
+        /// <param name="trxnEntries">Cluster-transaction — caller must apply TRXN tag.</param>
+        internal static void ClassifyHubIncomingEntries(
+            List<ChangeVectorEntry> incomingEntries,
+            HashSet<string> hubKnownDbIds,
+            string clusterTransactionId,
+            out List<ChangeVectorEntry> hubKnownEntries,
+            out List<ChangeVectorEntry> sinkOriginEntries,
+            out List<ChangeVectorEntry> trxnEntries)
         {
-            localOriginEntries = new List<ChangeVectorEntry>();
-            remoteOriginEntries = new List<ChangeVectorEntry>();
+            hubKnownEntries = []; sinkOriginEntries = []; trxnEntries = [];
 
-            foreach (var entry in entries)
+            if (incomingEntries == null || incomingEntries.Count == 0)
+                return;
+
+            foreach (var entry in incomingEntries)
             {
-                bool isLocal = localEtags.TryGetValue(entry.DbId, out long localEtag);
-
-                if (isLocal == false && TryBase64ToGuid(entry.DbId, out var asGuid))
-                    isLocal = localEtags.TryGetValue(asGuid, out localEtag);
-
-                if (isLocal)
+                if (hubKnownDbIds?.Contains(entry.DbId) == true)
                 {
-                    localOriginEntries.Add(new ChangeVectorEntry { DbId = entry.DbId, Etag = Math.Min(entry.Etag, localEtag), NodeTag = entry.NodeTag });
-                    continue;
+                    hubKnownEntries.Add(entry);
                 }
-
-                if (alreadyReplicatedEtags == null ||
-                    alreadyReplicatedEtags.TryGetValue(entry.DbId, out long lastReplicated) == false ||
-                    entry.Etag > lastReplicated)
+                else if (clusterTransactionId != null && entry.DbId == clusterTransactionId)
                 {
-                    remoteOriginEntries.Add(entry);
+                    trxnEntries.Add(entry);
+                }
+                else
+                {
+                    sinkOriginEntries.Add(entry);
                 }
             }
+        }
+
+        /// <summary>
+        /// Enforces Hub's global CV invariant: strips SINK/TRXN tags and removes Sink DbIds (dbIdsToIgnore).
+        /// Without this, Sink DbIds would leak into hubKnownDbIds on the next write cycle,
+        /// silently misclassifying incoming Sink entries as Hub-origin.
+        /// </summary>
+        /// <param name="dbIdsToIgnore">Sink DbIds accumulated this transaction (from sinkOriginEntries); null/empty is safe.</param>
+        public static ChangeVector CleanHubGlobalCv(
+            ChangeVector rawCv,
+            IChangeVectorOperationContext context,
+            HashSet<string> dbIdsToIgnore = null)
+        {
+            var value = rawCv.StripSinkTags(context);
+            value = value.StripTrxnTags(context);
+
+            if (dbIdsToIgnore == null || dbIdsToIgnore.Count == 0 || value.IsNullOrEmpty)
+                return value;
+
+            value.TryRemoveIds(dbIdsToIgnore, context, out value);
+            return value;
         }
     }
 }

--- a/src/Raven.Server/Utils/ChangeVectorUtils.cs
+++ b/src/Raven.Server/Utils/ChangeVectorUtils.cs
@@ -429,5 +429,61 @@ namespace Raven.Server.Utils
             }
             return stringBuilder.ToString();
         }
+
+        internal static bool TryBase64ToGuid(string base64, out string guidString)
+        {
+            guidString = null;
+            if (string.IsNullOrEmpty(base64) || base64.Length > 24)
+                return false;
+            try
+            {
+                var padded = base64.Length % 4 == 0 ? base64 : base64.PadRight(base64.Length + (4 - base64.Length % 4), '=');
+                var bytes = Convert.FromBase64String(padded);
+                if (bytes.Length != 16)
+                    return false;
+                guidString = new Guid(bytes).ToString();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <param name="localEtags">DbId→etag map whose keys define "local" identity; the etag is used as an upper cap.</param>
+        /// <param name="alreadyReplicatedEtags">DbId→last-replicated-etag for non-local entries; may be null.</param>
+        /// <param name="localOriginEntries">Local-origin entries, each capped to the local etag.</param>
+        /// <param name="remoteOriginEntries">Non-local entries not yet fully replicated.</param>
+        internal static void ClassifyEntriesByOrigin(
+            List<ChangeVectorEntry> entries,
+            Dictionary<string, long> localEtags,
+            Dictionary<string, long> alreadyReplicatedEtags,
+            out List<ChangeVectorEntry> localOriginEntries,
+            out List<ChangeVectorEntry> remoteOriginEntries)
+        {
+            localOriginEntries = new List<ChangeVectorEntry>();
+            remoteOriginEntries = new List<ChangeVectorEntry>();
+
+            foreach (var entry in entries)
+            {
+                bool isLocal = localEtags.TryGetValue(entry.DbId, out long localEtag);
+
+                if (isLocal == false && TryBase64ToGuid(entry.DbId, out var asGuid))
+                    isLocal = localEtags.TryGetValue(asGuid, out localEtag);
+
+                if (isLocal)
+                {
+                    localOriginEntries.Add(new ChangeVectorEntry { DbId = entry.DbId, Etag = Math.Min(entry.Etag, localEtag), NodeTag = entry.NodeTag });
+                    continue;
+                }
+
+                if (alreadyReplicatedEtags == null ||
+                    alreadyReplicatedEtags.TryGetValue(entry.DbId, out long lastReplicated) == false ||
+                    entry.Etag > lastReplicated)
+                {
+                    remoteOriginEntries.Add(entry);
+                }
+            }
+        }
     }
 }

--- a/src/Raven.Server/Web/RequestHandler.cs
+++ b/src/Raven.Server/Web/RequestHandler.cs
@@ -408,6 +408,25 @@ namespace Raven.Server.Web
             return value[0];
         }
 
+        internal bool TryGetChangeVectorHeadersString(out string changeVector)
+        {
+            const string key = "change-vector";
+            if (HttpContext.Request.Headers.TryGetValue(key, out var headerChangeVector))
+            {
+                changeVector = headerChangeVector.ToString();
+                return true;
+            }
+
+            if (HttpContext.Request.Query.ContainsKey(key))
+            {
+                changeVector = GetStringQueryString(key, required: false) ?? string.Empty;
+                return true;
+            }
+
+            changeVector = null;
+            return false;
+        }
+
         [DoesNotReturn]
         private static void ThrowSingleCharacterRequired(string name, string value)
         {

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -26,7 +26,7 @@ namespace Raven.Server.Web.System
                     Name = databaseKvp.Key.ToString()
                 };
 
-                statistics.CanCleanup = ServerStore.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics, out _);
+                statistics.CanCleanup = ServerStore.DatabasesLandlord.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics, out _);
 
                 results.Add(statistics.ToJson());
             }

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -79,6 +79,8 @@ namespace Raven.Server.Web.System
 
             public int NumberOfActivePullReplicationAsSinkConnections { get; set; }
 
+            public int NumberOfActiveHubToSinkConfigurations { get; set; }
+
             public bool HasActiveOperations { get; set; }
 
             public List<string> Explanations { get; set; }

--- a/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
+++ b/src/Raven.Server/Web/System/DatabasesDebugHandler.cs
@@ -79,7 +79,7 @@ namespace Raven.Server.Web.System
 
             public int NumberOfActivePullReplicationAsSinkConnections { get; set; }
 
-            public int NumberOfActiveHubToSinkConfigurations { get; set; }
+            public int NumberOfActiveSinkPullReplicationConfigurations { get; set; }
 
             public bool HasActiveOperations { get; set; }
 
@@ -100,6 +100,7 @@ namespace Raven.Server.Web.System
                     [nameof(NumberOfChangesApiConnections)] = NumberOfChangesApiConnections,
                     [nameof(NumberOfSubscriptionConnections)] = NumberOfSubscriptionConnections,
                     [nameof(NumberOfActivePullReplicationAsSinkConnections)] = NumberOfActivePullReplicationAsSinkConnections,
+                    [nameof(NumberOfActiveSinkPullReplicationConfigurations)] = NumberOfActiveSinkPullReplicationConfigurations,
                     [nameof(HasActiveOperations)] = HasActiveOperations,
                     [nameof(Explanations)] = Explanations,
                 };

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -4,25 +4,25 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
-using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide;
 using Raven.Server.Documents;
-using Raven.Server.Documents.Replication;
 using Raven.Server.Extensions;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
+using Sparrow.Logging;
 
 namespace Raven.Server.Web.System
 {
     public sealed class TcpConnectionInfoHandler : ServerRequestHandler
     {
+        private static readonly Logger Logger = LoggingSource.Instance.GetLogger<TcpConnectionInfoHandler>("Server");
+
         [RavenAction("/info/tcp", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Get()
         {
@@ -52,8 +52,8 @@ namespace Raven.Server.Web.System
                 if (pullReplication.Disabled)
                     throw new InvalidOperationException($"The pull replication '{remoteTask}' is disabled.");
 
-                if (TryGetChangeVectorFromQuery(out string sinkChangeVector))
-                    ThrowIfIdleAndUpToDate(database, sinkChangeVector, pullReplication);
+                if (TryGetChangeVectorHeadersString(out string sinkChangeVector))
+                    ServerStore.DatabaseIdleManager.ThrowIfIdleAndUpToDate(database, sinkChangeVector, pullReplication, context);
 
                 var topology = ServerStore.Cluster.ReadDatabaseTopology(context, database);
                 nodes = GetResponsibleNodes(topology, databaseGroupId, pullReplication.MentorNode, pullReplication.PinToMentorNode);
@@ -85,14 +85,14 @@ namespace Raven.Server.Web.System
             if (ServerStore.IsPassive())
                 throw new NodeIsPassiveException($"Can't fetch Tcp info from a passive node in url {this.HttpContext.Request.GetFullUrl()}");
 
-            if (TryGetChangeVectorFromQuery(out string sinkChangeVector))
+            if (TryGetChangeVectorHeadersString(out string sinkChangeVector))
             {
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 using (context.OpenReadTransaction())
                 {
                     var pullReplication = ServerStore.Cluster.ReadPullReplicationDefinition(database, remoteTask, context);
                     if (pullReplication.Disabled == false)
-                        ThrowIfIdleAndUpToDate(database, sinkChangeVector, pullReplication);
+                        ServerStore.DatabaseIdleManager.ThrowIfIdleAndUpToDate(database, sinkChangeVector, pullReplication, context);
                 }
             }
 
@@ -121,62 +121,6 @@ namespace Raven.Server.Web.System
                 var output = Server.ServerStore.GetTcpInfoAndCertificates(HttpContext.Request.GetClientRequestedNodeUrl(), forExternalUse: true);
                 context.Write(writer, output);
             }
-        }
-
-        private void ThrowIfIdleAndUpToDate(string database, string sinkChangeVector, PullReplicationDefinition pullReplication)
-        {
-            if (ServerStore.IdleDatabases.TryGetValue(database, out _) == false)
-                return;
-
-            if (ServerStore.IdleDatabasesChangeVectors.TryGetValue(database, out var hubChangeVector) == false)
-                return;
-
-            // 1. HubToSink (Pull): Hub MUST wake up if it has strictly more data than Sink.
-            if ((pullReplication.Mode & PullReplicationMode.HubToSink) != 0)
-            {
-                // Status of SINK relative to HUB
-                var sinkStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: hubChangeVector, localAsString: sinkChangeVector);
-                if (sinkStatus == ConflictStatus.AlreadyMerged)
-                {
-                    // Sink <= Hub.
-                    var hubStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: sinkChangeVector, localAsString: hubChangeVector);
-                    if (hubStatus is not ConflictStatus.AlreadyMerged)
-                        return; // Hub > Sink (Strictly) -> Wake up.
-
-                    // Else: Already merged.
-                }
-                else
-                {
-                    // Sink > Hub or Diverged -> Wake up.
-                    return;
-                }
-            }
-
-            // 2. SinkToHub (Push): Hub MUST wake up if Sink sends new data.
-            if ((pullReplication.Mode & PullReplicationMode.SinkToHub) != 0)
-            {
-                var hubStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: sinkChangeVector, localAsString: hubChangeVector);
-                if (hubStatus is not ConflictStatus.AlreadyMerged)
-                    return; // Sink > Hub or Diverged -> Wake up.
-            }
-
-            // No condition forces us to wake up.
-            throw new DatabaseIdleException($"The database '{database}' is currently idle. " +
-                                            $"The request was rejected to avoid waking up the database unnecessarily, " +
-                                            $"as there are no new changes to replicate for the change vector '{sinkChangeVector}'.");
-        }
-
-        private bool TryGetChangeVectorFromQuery(out string changeVector)
-        {
-            const string key = "change-vector";
-            if (HttpContext.Request.Query.ContainsKey(key))
-            {
-                changeVector = GetStringQueryString(key, required: false) ?? string.Empty;
-                return true;
-            }
-
-            changeVector = null;
-            return false;
         }
 
         public static async ValueTask<bool> AuthenticateAsync(HttpContext httpContext, ServerStore serverStore, string database, string remoteTask)

--- a/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
+++ b/src/Raven.Server/Web/System/TcpConnectionInfoHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.Exceptions.Cluster;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.ServerWide;
@@ -13,6 +14,7 @@ using Raven.Server.Extensions;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -38,15 +40,9 @@ namespace Raven.Server.Web.System
             var database = GetStringQueryString("database");
             var databaseGroupId = GetStringQueryString("groupId");
             var remoteTask = GetStringQueryString("remote-task");
-            var tag = GetStringQueryString("tag", false);
 
             if (await AuthenticateAsync(HttpContext, ServerStore, database, remoteTask) == false)
                 return;
-
-            if (ServerStore.IdleDatabases.TryGetValue(database, out _) && (tag == ReplicationLoader.PullReplicationAsSinkTag || string.IsNullOrEmpty(tag)))
-            {
-                throw new DatabaseIdleException($"Cannot GetRemoteTaskTopology for PullReplicationAsSink connection because database '{database}' currently is idle.");
-            }
 
             List<string> nodes;
             using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
@@ -55,6 +51,9 @@ namespace Raven.Server.Web.System
                 var pullReplication = ServerStore.Cluster.ReadPullReplicationDefinition(database, remoteTask, context);
                 if (pullReplication.Disabled)
                     throw new InvalidOperationException($"The pull replication '{remoteTask}' is disabled.");
+
+                if (TryGetChangeVectorFromQuery(out string sinkChangeVector))
+                    ThrowIfIdleAndUpToDate(database, sinkChangeVector, pullReplication);
 
                 var topology = ServerStore.Cluster.ReadDatabaseTopology(context, database);
                 nodes = GetResponsibleNodes(topology, databaseGroupId, pullReplication.MentorNode, pullReplication.PinToMentorNode);
@@ -81,17 +80,20 @@ namespace Raven.Server.Web.System
         {
             var remoteTask = GetStringQueryString("remote-task");
             var database = GetStringQueryString("database");
-            var verifyDatabase = GetBoolValueQueryString("verify-database", false);
-            var tag = GetStringQueryString("tag", false);
+            var verifyDatabase = GetBoolValueQueryString("verify-database", required: false);
 
             if (ServerStore.IsPassive())
-            {
                 throw new NodeIsPassiveException($"Can't fetch Tcp info from a passive node in url {this.HttpContext.Request.GetFullUrl()}");
-            }
 
-            if (ServerStore.IdleDatabases.TryGetValue(database, out _) && tag == ReplicationLoader.PullReplicationAsSinkTag)
+            if (TryGetChangeVectorFromQuery(out string sinkChangeVector))
             {
-                throw new DatabaseIdleException($"Cannot GetRemoteTaskTcp for PullReplicationAsSink connection because database '{database}' currently is idle.");
+                using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var pullReplication = ServerStore.Cluster.ReadPullReplicationDefinition(database, remoteTask, context);
+                    if (pullReplication.Disabled == false)
+                        ThrowIfIdleAndUpToDate(database, sinkChangeVector, pullReplication);
+                }
             }
 
             if (verifyDatabase.HasValue && verifyDatabase.Value)
@@ -119,6 +121,62 @@ namespace Raven.Server.Web.System
                 var output = Server.ServerStore.GetTcpInfoAndCertificates(HttpContext.Request.GetClientRequestedNodeUrl(), forExternalUse: true);
                 context.Write(writer, output);
             }
+        }
+
+        private void ThrowIfIdleAndUpToDate(string database, string sinkChangeVector, PullReplicationDefinition pullReplication)
+        {
+            if (ServerStore.IdleDatabases.TryGetValue(database, out _) == false)
+                return;
+
+            if (ServerStore.IdleDatabasesChangeVectors.TryGetValue(database, out var hubChangeVector) == false)
+                return;
+
+            // 1. HubToSink (Pull): Hub MUST wake up if it has strictly more data than Sink.
+            if ((pullReplication.Mode & PullReplicationMode.HubToSink) != 0)
+            {
+                // Status of SINK relative to HUB
+                var sinkStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: hubChangeVector, localAsString: sinkChangeVector);
+                if (sinkStatus == ConflictStatus.AlreadyMerged)
+                {
+                    // Sink <= Hub.
+                    var hubStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: sinkChangeVector, localAsString: hubChangeVector);
+                    if (hubStatus is not ConflictStatus.AlreadyMerged)
+                        return; // Hub > Sink (Strictly) -> Wake up.
+
+                    // Else: Already merged.
+                }
+                else
+                {
+                    // Sink > Hub or Diverged -> Wake up.
+                    return;
+                }
+            }
+
+            // 2. SinkToHub (Push): Hub MUST wake up if Sink sends new data.
+            if ((pullReplication.Mode & PullReplicationMode.SinkToHub) != 0)
+            {
+                var hubStatus = ChangeVectorUtils.GetConflictStatus(remoteAsString: sinkChangeVector, localAsString: hubChangeVector);
+                if (hubStatus is not ConflictStatus.AlreadyMerged)
+                    return; // Sink > Hub or Diverged -> Wake up.
+            }
+
+            // No condition forces us to wake up.
+            throw new DatabaseIdleException($"The database '{database}' is currently idle. " +
+                                            $"The request was rejected to avoid waking up the database unnecessarily, " +
+                                            $"as there are no new changes to replicate for the change vector '{sinkChangeVector}'.");
+        }
+
+        private bool TryGetChangeVectorFromQuery(out string changeVector)
+        {
+            const string key = "change-vector";
+            if (HttpContext.Request.Query.ContainsKey(key))
+            {
+                changeVector = GetStringQueryString(key, required: false) ?? string.Empty;
+                return true;
+            }
+
+            changeVector = null;
+            return false;
         }
 
         public static async ValueTask<bool> AuthenticateAsync(HttpContext httpContext, ServerStore serverStore, string database, string remoteTask)

--- a/test/FastTests/Server/Basic/IdleOperations.cs
+++ b/test/FastTests/Server/Basic/IdleOperations.cs
@@ -99,7 +99,7 @@ namespace FastTests.Server.Basic
                 }
 
                 var stats = new Dictionary<StringSegment, DatabasesDebugHandler.IdleDatabaseStatistics>();
-                Server.ServerStore.IdleOperations(stats);
+                Server.ServerStore.DatabaseIdleManager.IdleOperations(stats);
 
                 var loadedCount = 0;
                 var unloadedCount = 0;

--- a/test/FastTests/Server/Cluster/TcpConnectionInfoHandlerTests.cs
+++ b/test/FastTests/Server/Cluster/TcpConnectionInfoHandlerTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.ServerWide;
-using Raven.Server.Web.System;
 using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
@@ -80,6 +78,25 @@ namespace FastTests.Server.Cluster
             Assert.Equal(string.Empty, forSinkToHub);
         }
 
+        [RavenFact(RavenTestCategory.Replication)]
+        public void HubToSink_WithVoronDbId_SinkEchoesVoronEntry_IsCappedToLocalEtag()
+        {
+            // Hub has NO topology ID, only a Voron DbBase64Id (e.g. after fallback identity construction).
+            // Sink echoes back Hub's Voron-originated entry with a higher etag (backup/restore scenario).
+            var voronId = "VoronBase64IdForXXXXXA"; // 22-char Base64
+
+            var localCv = FormatCv(voronId, 10);
+            var sinkCv  = FormatCv(voronId, 20); // Sink reports Hub's Voron entry at etag 20
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv, voronId); // DbBase64Id = voronId
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubDbId: null, out var forHubToSink, out var forSinkToHub);
+
+            // Voron entry classified as Hub-known → capped to Hub's local etag 10
+            Assert.Equal(FormatCv(voronId, 10), forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
         #endregion
 
         #region SinkToHub Tests
@@ -137,6 +154,24 @@ namespace FastTests.Server.Cluster
             Assert.Equal(string.Empty, forSinkToHub);
         }
 
+        [RavenFact(RavenTestCategory.Replication)]
+        public void SinkToHub_RemoteCvHasPartiallyReplicatedEntry_IncludesHigherEtag()
+        {
+            // Hub has replicated this DbId up to etag 5 (ReplicationInfo).
+            // Sink now reports etag 10 for the same DbId → new data → must be included.
+            // This is the "> lastReplicated" branch; existing test only covers the "==" case.
+            var sinkId = "wOG7DpOFCEaNIRJrwjAzBg";
+
+            var replicationInfo = new Dictionary<string, long> { { sinkId, 5 } };
+            var sinkCv = FormatCv(sinkId, 10); // 10 > 5 → new data not yet replicated
+            var idleInfo = new IdleDatabaseInfo(replicationInfo, string.Empty);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubDbId: null, out var forHubToSink, out var forSinkToHub);
+
+            Assert.Equal(string.Empty, forHubToSink);
+            Assert.Equal(FormatCv(sinkId, 10), forSinkToHub);
+        }
+
         #endregion
 
         #region TwoWay Tests
@@ -192,6 +227,27 @@ namespace FastTests.Server.Cluster
         }
 
         [RavenFact(RavenTestCategory.Replication)]
+        public void TwoWay_RemoteCvHasMultipleSinkIds_OnlyReplicatedExcluded_NewIncluded()
+        {
+            // Sink sends two of its own DbIds. Hub has already replicated sink1Id fully (etag == max),
+            // but sink2Id is new. Only sink2Id should appear in SinkToHub.
+            var hubId   = "AAAAAAAAAAAAAAAAAAAAAQ";
+            var sink1Id = "wOG7DpOFCEaNIRJrwjAzBg";
+            var sink2Id = "dgkaYTbY1kis2xFGE2jUmQ";
+
+            var localCv = FormatCv(hubId, 5);
+            var sinkCv  = FormatCv((hubId, 5), (sink1Id, 5), (sink2Id, 3));
+
+            var replicationInfo = new Dictionary<string, long> { { sink1Id, 5 } }; // sink1 fully replicated
+            var idleInfo = new IdleDatabaseInfo(replicationInfo, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            Assert.Equal(FormatCv(hubId, 5), forHubToSink);   // Hub entry, min(5,5)=5
+            Assert.Equal(FormatCv(sink2Id, 3), forSinkToHub); // sink1 excluded (5==5), sink2 included
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
         public void TwoWay_LocalCvMixed_RemoteCvHasUpdatedSinkData_AvoidsIdentityCrisis_AndProcessesSinkDataCorrectly()
         {
             var hubId = "1xxID9Byu0yy2dtdfzIlWg";
@@ -221,28 +277,27 @@ namespace FastTests.Server.Cluster
             Assert.Equal(FormatCv(sinkId, 10), forSinkToHub);
         }
 
+        #endregion
+
+        #region EdgeCase Tests
+
         [RavenFact(RavenTestCategory.Replication)]
-        public void TwoWay_LocalCvHubOnly_RemoteCvHasAlreadyReplicatedSinkDataWithGuidKey_MatchesGuidToBase64_AndIgnoresReplicatedData()
+        public void FilterIrrelevantEntries_BothHubIdsNull_AllEntriesTreatedAsSinkOrigin()
         {
-            // In production, SetLastReplicatedEtagFrom stores SourceDatabaseId (GUID string) as the key,
-            // while the CV DbId is Base64. This test verifies the format mismatch is handled correctly.
-            var hubId = "1xxID9Byu0yy2dtdfzIlWg";
-            var sinkIdBase64 = "wOG7DpOFCEaNIRJrwjAzBg";
-            // GUID equivalent of sinkIdBase64 (what SetLastReplicatedEtagFrom actually stores)
-            var sinkIdGuid = new System.Guid(System.Convert.FromBase64String(sinkIdBase64 + "==")).ToString();
+            // When Hub has no known IDs (no topology ID, no Voron DbBase64Id),
+            // hubKnownDbIds is null → ClassifyHubIncomingEntries puts everything in sinkOriginEntries.
+            // All entries pass ReplicationInfo filter (null) → all go to SinkToHub.
+            // Note: SerializeVector() outputs entries sorted alphabetically by DbId.
+            var sink1Id = "dgkaYTbY1kis2xFGE2jUmQ"; // 'd' < 'w' → first in sorted output
+            var sink2Id = "wOG7DpOFCEaNIRJrwjAzBg";
+            var sinkCv = FormatCv((sink1Id, 3), (sink2Id, 5));
 
-            var localCv = FormatCv(hubId, 5);
-            var sinkCv = FormatCv((hubId, 5), (sinkIdBase64, 3));
+            var idleInfo = new IdleDatabaseInfo(null, string.Empty); // DbBase64Id = null by default
 
-            // ReplicationInfo uses the GUID key (as stored by SetLastReplicatedEtagFrom)
-            var replicationInfo = new Dictionary<string, long> { { sinkIdGuid, 3 } };
-            var idleInfo = new IdleDatabaseInfo(replicationInfo, localCv);
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubDbId: null, out var forHubToSink, out var forSinkToHub);
 
-            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
-
-            // Hub entry → HubToSink; Sink entry already replicated (GUID key matched Base64 CV entry) → excluded from SinkToHub
-            Assert.Equal(FormatCv(hubId, 5), forHubToSink);
-            Assert.Equal(string.Empty, forSinkToHub);
+            Assert.Equal(string.Empty, forHubToSink);
+            Assert.Equal(sinkCv, forSinkToHub); // all entries pass through, alphabetical order preserved
         }
 
         #endregion
@@ -272,7 +327,7 @@ namespace FastTests.Server.Cluster
         {
             var hugeChangeVector = new string('A', 50_000); 
             var cmd = new Raven.Client.Documents.Commands.GetRemoteTaskTopologyCommand("dummy-db", "dummy-group", "dummy-task", hugeChangeVector);
-            using (var ctx = global::Sparrow.Json.JsonOperationContext.ShortTermSingleUse())
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
             {
                 var node = new Raven.Client.Http.ServerNode { Url = "http://localhost:8080" };
                 var request = cmd.CreateRequest(ctx, node, out string url);

--- a/test/FastTests/Server/Cluster/TcpConnectionInfoHandlerTests.cs
+++ b/test/FastTests/Server/Cluster/TcpConnectionInfoHandlerTests.cs
@@ -1,0 +1,300 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Server.ServerWide;
+using Raven.Server.Web.System;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Cluster
+{
+    public class TcpConnectionInfoHandlerTests : NoDisposalNeeded
+    {
+        public TcpConnectionInfoHandlerTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        #region HubToSink Tests
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void HubToSink_LocalCvEmpty_RemoteCvHasHubEntry_CapsRemoteEntryToZero()
+        {
+            var hubId = "AKxkHxxn4UyISdHVARwq4w";
+            var localCv = string.Empty; // New/empty Hub DB
+            var sinkCv = FormatCv(hubId, 1);
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Fallback ID treated as etag 0; Sink(1) > Local(0) → capped to 0
+            Assert.Equal(FormatCv(hubId, 0), forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void HubToSink_LocalCvHubOnly_RemoteCvHasHigherHubEntry_CapsRemoteEntryToLocalEtag()
+        {
+            var hubId = "AAAAAAAAAAAAAAAAAAAAAQ";
+            var localCv = FormatCv(hubId, 10);
+            var sinkCv = FormatCv(hubId, 20); // Sink reports Hub etag higher than Hub's own
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Hub-origin entry is capped to Hub's local etag; no non-Hub entries exist
+            Assert.Equal(FormatCv(hubId, 10), forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void HubToSink_LocalCvHubOnly_RemoteCvHasLowerHubEntry_ReturnsLowerHubEntry()
+        {
+            var hubId = "AAAAAAAAAAAAAAAAAAAAAQ";
+            var localCv = FormatCv(hubId, 20);
+            var sinkCv = FormatCv(hubId, 5); // Sink is behind
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Hub-origin entry retains Sink's reported etag because it is lower than local (no capping needed)
+            Assert.Equal(FormatCv(hubId, 5), forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void HubToSink_LocalCvHubOnly_RemoteCvEmpty_ReturnsEmpty()
+        {
+            var hubId = "AAAAAAAAAAAAAAAAAAAAAQ";
+            var localCv = FormatCv(hubId, 20);
+            var sinkCv = string.Empty; // Sink has nothing yet
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            Assert.Equal(string.Empty, forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        #endregion
+
+        #region SinkToHub Tests
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void SinkToHub_LocalCvEmpty_RemoteCvHasNewSinkData_IncludesNewSinkData()
+        {
+            var hubId = "C1bp3tyVlE2HnVTeIClzmg";
+            var sinkId = "wOG7DpOFCEaNIRJrwjAzBg";
+
+            var localCv = string.Empty; 
+            var sinkCv = FormatCv(sinkId, 5);
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            Assert.Equal(string.Empty, forHubToSink);
+            Assert.Equal(FormatCv(sinkId, 5), forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void SinkToHub_LocalCvHubOnly_RemoteCvHasHubEchoAndNewSinkData_IgnoresEcho_AndIncludesNewSinkData()
+        {
+            var hubId = "C1bp3tyVlE2HnVTeIClzmg";
+            var sinkId = "wOG7DpOFCEaNIRJrwjAzBg";
+
+            var localCv = FormatCv(hubId, 10);
+            // Sink sends back Hub's echo (10) + its own data (5)
+            var sinkCv = FormatCv((hubId, 10), (sinkId, 5));
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Hub-origin entry goes to HubToSink vector (which is ignored by SinkToHub mode, but populated correctly)
+            // Sink's own entry goes to SinkToHub vector
+            Assert.Equal(FormatCv(hubId, 10), forHubToSink);
+            Assert.Equal(FormatCv(sinkId, 5), forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void SinkToHub_LocalCvHubOnly_RemoteCvHasAlreadyReplicatedSinkData_IgnoresReplicatedData()
+        {
+            var sinkId = "dgkaYTbY1kis2xFGE2jUmQ";
+
+            var replicationInfo = new Dictionary<string, long> { { sinkId, 100 } };
+            var sinkCv = FormatCv(sinkId, 100);
+            var idleInfo = new IdleDatabaseInfo(replicationInfo, string.Empty);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubDbId: null, out var forHubToSink, out var forSinkToHub);
+
+            // Already replicated → excluded from SinkToHub
+            Assert.Equal(string.Empty, forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        #endregion
+
+        #region TwoWay Tests
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void TwoWay_LocalCvHubOnly_RemoteCvEmpty_ReturnsBothEmpty()
+        {
+            var hubId = "AAAAAAAAAAAAAAAAAAAAAQ";
+            var idleInfo = new IdleDatabaseInfo(null, FormatCv(hubId, 5));
+
+            DatabaseIdleManager.FilterIrrelevantEntries(string.Empty, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            Assert.Equal(string.Empty, forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void TwoWay_LocalCvHubOnly_RemoteCvHasHubEchoAndNewSinkData_SplitsEchoToHubToSink_AndNewDataToSinkToHub()
+        {
+            var hubId = "1xxID9Byu0yy2dtdfzIlWg";
+            var sinkId = "wOG7DpOFCEaNIRJrwjAzBg";
+
+            var localCv = FormatCv(hubId, 5);
+            var sinkCv = FormatCv((hubId, 5), (sinkId, 3));
+
+            var idleInfo = new IdleDatabaseInfo(null, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Hub entry → HubToSink only; Sink entry → SinkToHub only
+            Assert.Equal(FormatCv(hubId, 5), forHubToSink);
+            Assert.Equal(FormatCv(sinkId, 3), forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void TwoWay_LocalCvHubOnly_RemoteCvHasHubEchoAndAlreadyReplicatedSinkData_SplitsEchoToHubToSink_AndIgnoresReplicatedData()
+        {
+            var hubId = "1xxID9Byu0yy2dtdfzIlWg";
+            var sinkId = "wOG7DpOFCEaNIRJrwjAzBg";
+
+            var localCv = FormatCv(hubId, 5);
+            var sinkCv = FormatCv((hubId, 5), (sinkId, 3));
+
+            // Hub has already replicated sinkId up to etag 3
+            var replicationInfo = new Dictionary<string, long> { { sinkId, 3 } };
+            var idleInfo = new IdleDatabaseInfo(replicationInfo, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Hub entry → HubToSink; Sink entry already replicated → excluded from SinkToHub
+            Assert.Equal(FormatCv(hubId, 5), forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void TwoWay_LocalCvMixed_RemoteCvHasUpdatedSinkData_AvoidsIdentityCrisis_AndProcessesSinkDataCorrectly()
+        {
+            var hubId = "1xxID9Byu0yy2dtdfzIlWg";
+            var sinkId = "wOG7DpOFCEaNIRJrwjAzBg";
+
+            // Local CV has entries from BOTH nodes
+            var localCv = FormatCv((hubId, 5), (sinkId, 3));
+            
+            // Sink CV comes in with an UPDATE to its OWN data (from 3 to 10)
+            // It also echoes back the Hub's data (5)
+            var sinkCv = FormatCv((hubId, 5), (sinkId, 10));
+
+            // Replication info reflects the old state (up to 3)
+            var replicationInfo = new Dictionary<string, long> { { sinkId, 3 } };
+            var idleInfo = new IdleDatabaseInfo(replicationInfo, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // The Hub's own entry belongs in HubToSink (capped to 5).
+            // The Sink's new data (from 3 to 10) MUST be recognized as new Sink data,
+            // going into SinkToHub.
+            // Under the "Identity Crisis" bug, the Hub would look at localCv,
+            // assume *both* hubId and sinkId are its own "local Hub IDs",
+            // and therefore filter out the Sink's new data (etag 10) as a "Hub echo" instead of genuine remote data!
+            
+            Assert.Equal(FormatCv(hubId, 5), forHubToSink);
+            Assert.Equal(FormatCv(sinkId, 10), forSinkToHub);
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void TwoWay_LocalCvHubOnly_RemoteCvHasAlreadyReplicatedSinkDataWithGuidKey_MatchesGuidToBase64_AndIgnoresReplicatedData()
+        {
+            // In production, SetLastReplicatedEtagFrom stores SourceDatabaseId (GUID string) as the key,
+            // while the CV DbId is Base64. This test verifies the format mismatch is handled correctly.
+            var hubId = "1xxID9Byu0yy2dtdfzIlWg";
+            var sinkIdBase64 = "wOG7DpOFCEaNIRJrwjAzBg";
+            // GUID equivalent of sinkIdBase64 (what SetLastReplicatedEtagFrom actually stores)
+            var sinkIdGuid = new System.Guid(System.Convert.FromBase64String(sinkIdBase64 + "==")).ToString();
+
+            var localCv = FormatCv(hubId, 5);
+            var sinkCv = FormatCv((hubId, 5), (sinkIdBase64, 3));
+
+            // ReplicationInfo uses the GUID key (as stored by SetLastReplicatedEtagFrom)
+            var replicationInfo = new Dictionary<string, long> { { sinkIdGuid, 3 } };
+            var idleInfo = new IdleDatabaseInfo(replicationInfo, localCv);
+
+            DatabaseIdleManager.FilterIrrelevantEntries(sinkCv, idleInfo, hubId, out var forHubToSink, out var forSinkToHub);
+
+            // Hub entry → HubToSink; Sink entry already replicated (GUID key matched Base64 CV entry) → excluded from SinkToHub
+            Assert.Equal(FormatCv(hubId, 5), forHubToSink);
+            Assert.Equal(string.Empty, forSinkToHub);
+        }
+
+        #endregion
+
+        #region Command HttpRequestMessage Tests
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.ClientApi)]
+        public void GetTcpInfoForRemoteTaskCommand_WithHugeChangeVector_ShouldPutItInHeader_AndNotInUrl()
+        {
+            var hugeChangeVector = new string('A', 50_000); 
+            var cmd = new Raven.Client.Documents.Commands.GetTcpInfoForRemoteTaskCommand("dummy-db", "dummy-task", hugeChangeVector);
+            using (var ctx = JsonOperationContext.ShortTermSingleUse())
+            {
+                var node = new Raven.Client.Http.ServerNode { Url = "http://localhost:8080" };
+                var request = cmd.CreateRequest(ctx, node, out string url);
+                
+                Assert.True(url.Length < 1000, "URL should not be massively long");
+                Assert.DoesNotContain("change-vector=", url);
+                
+                Assert.True(request.Headers.TryGetValues("change-vector", out var values));
+                Assert.Contains(hugeChangeVector, values);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.ClientApi)]
+        public void GetRemoteTaskTopologyCommand_WithHugeChangeVector_ShouldPutItInHeader_AndNotInUrl()
+        {
+            var hugeChangeVector = new string('A', 50_000); 
+            var cmd = new Raven.Client.Documents.Commands.GetRemoteTaskTopologyCommand("dummy-db", "dummy-group", "dummy-task", hugeChangeVector);
+            using (var ctx = global::Sparrow.Json.JsonOperationContext.ShortTermSingleUse())
+            {
+                var node = new Raven.Client.Http.ServerNode { Url = "http://localhost:8080" };
+                var request = cmd.CreateRequest(ctx, node, out string url);
+                
+                Assert.True(url.Length < 1000, "URL should not be massively long");
+                Assert.DoesNotContain("change-vector=", url);
+                
+                Assert.True(request.Headers.TryGetValues("change-vector", out var values));
+                Assert.Contains(hugeChangeVector, values);
+            }
+        }
+
+        #endregion
+
+        private static string FormatCv(string dbId, long etag) => $"A:{etag}-{dbId}";
+
+        private static string FormatCv(params (string dbId, long etag)[] entries)
+        {
+            var list = new List<string>();
+            foreach (var (dbId, etag) in entries)
+                list.Add($"A:{etag}-{dbId}");
+            return string.Join(", ", list);
+        }
+    }
+}

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1418,8 +1418,8 @@ namespace SlowTests.Client.Subscriptions
             });
 
             using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
-            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false);
-            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+            using var dispose = new DisposableAction(() => server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false);
+            server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             var db = await GetDatabase(server, store.Database);
             var subsId = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions { Query = "from Users", Name = Guid.NewGuid().ToString() });

--- a/test/SlowTests/Issues/RavenDB-18442.cs
+++ b/test/SlowTests/Issues/RavenDB-18442.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Issues
             using var dispose = new DisposableAction(() =>
             {
                 foreach (var node in nodes)
-                    node.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                    node.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
             });
 
             var firstServer = nodes[0]; // leader
@@ -131,7 +131,7 @@ namespace SlowTests.Issues
 
             foreach (var node in nodes)
             {
-                node.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+                node.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
             }
 
             return nodes;

--- a/test/SlowTests/Issues/RavenDB-19379.cs
+++ b/test/SlowTests/Issues/RavenDB-19379.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Conventions;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
 using Xunit;
@@ -55,10 +56,11 @@ namespace SlowTests.Issues
                         dbIdEtagDictionary[kvp.Key] = kvp.Value;
                 }
 
-                Assert.True(server.ServerStore.DatabasesLandlord.UnloadDirectly(database.Name, database.PeriodicBackupRunner.GetNextIdleDatabaseActivity(database.Name)),
-                    $"didn't unload on node {server.ServerStore.NodeTag}");
-                server.ServerStore.IdleDatabases[database.Name] = dbIdEtagDictionary;
+                var nextIdleActivity = database.PeriodicBackupRunner.GetNextIdleDatabaseActivity(database.Name);
+                var idleDatabaseInfo = new IdleDatabaseInfo(dbIdEtagDictionary, ChangeVector: null);
 
+                Assert.True(server.ServerStore.DatabaseIdleManager.TryEnterIdleState(database.Name, idleDatabaseInfo, nextIdleActivity),
+                    $"Could not mark database '{database.Name}' as idle on node '{server.ServerStore.NodeTag}'");
             }
 
             var cs = new Dictionary<string, string>(DefaultClusterSettings);

--- a/test/SlowTests/Issues/RavenDB_10991.cs
+++ b/test/SlowTests/Issues/RavenDB_10991.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.ServerWide;
@@ -46,11 +46,11 @@ namespace SlowTests.Issues
                     database.LastAccessTime = DateTime.MinValue;
 
                     using (database.PreventFromUnloadingByIdleOperations()) // should prevent from unloading
-                        Server.ServerStore.IdleOperations(null);
+                        Server.ServerStore.DatabaseIdleManager.IdleOperations(null);
 
                     Assert.True(landlord.LastRecentlyUsed.TryGetValue(name, out _));
 
-                    Server.ServerStore.IdleOperations(null); // should unload
+                    Server.ServerStore.DatabaseIdleManager.IdleOperations(null); // should unload
 
                     Assert.False(landlord.LastRecentlyUsed.TryGetValue(name, out _));
                 }

--- a/test/SlowTests/Issues/RavenDB_20084.cs
+++ b/test/SlowTests/Issues/RavenDB_20084.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Extensions;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
@@ -65,21 +66,21 @@ public class RavenDB_20084 : ClusterTestBase
             var expectedTime = onGoingTaskBackup.NextBackup.DateTime;
 
             leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
-            leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+            leaderServer.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             using (leaderServer.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext serverStoreContext))
             using (serverStoreContext.OpenReadTransaction())
             {
                 // Ensuring the database is in an idle state
-                WaitForValue(() => leaderServer.ServerStore.IdleDatabases.Count,
-                    expectedVal: 1,
+                var state = WaitForValue(() => leaderServer.ServerStore.DatabaseIdleManager.GetActivityState(leaderStore.Database),
+                    expectedVal: DatabaseIdleManager.DatabaseActivityState.Idle,
                     timeout: Convert.ToInt32(TimeSpan.FromMinutes(5).TotalMilliseconds),
                     interval: Convert.ToInt32(TimeSpan.FromSeconds(1).TotalMilliseconds));
-                Assert.Equal(1, leaderServer.ServerStore.IdleDatabases.Count);
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Idle, state);
 
                 // No longer forcing the idle state for the database
                 leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
-                leaderServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                leaderServer.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
 
                 // Awaiting the next backup event to verify that the '/database' endpoint provides an updated value for the last incremental backup timestamp
                 using var client = new HttpClient().WithConventions(leaderStore.Conventions);

--- a/test/SlowTests/Issues/RavenDB_8544.cs
+++ b/test/SlowTests/Issues/RavenDB_8544.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.ServerWide;
@@ -47,7 +47,7 @@ namespace SlowTests.Issues
 
                     await database.TombstoneCleaner.ExecuteCleanup();
 
-                    Server.ServerStore.IdleOperations(null);
+                    Server.ServerStore.DatabaseIdleManager.IdleOperations(null);
 
                     Assert.False(landlord.LastRecentlyUsed.TryGetValue(name, out _));
                 }

--- a/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
+++ b/test/SlowTests/Server/Documents/QueueSink/Issues/RavenDB_22105.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RabbitMQ.Client;
+using Raven.Server.ServerWide;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -57,7 +58,7 @@ public class RavenDB_22105 : RabbitMqQueueSinkTestBase
 
         // Try to idle a database
 
-        landlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+        Server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
         var database = await GetDatabase(store.Database);
         database.ResetIdleTime();
@@ -69,9 +70,9 @@ public class RavenDB_22105 : RabbitMqQueueSinkTestBase
 
         database.LastAccessTime = DateTime.MinValue;
 
-        Server.ServerStore.IdleOperations(null);
+        Server.ServerStore.DatabaseIdleManager.IdleOperations(null);
 
-        Assert.Equal(0, Server.ServerStore.IdleDatabases.Count); // active queue sink process must prevent from unloading a database
+        Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Active, Server.ServerStore.DatabaseIdleManager.GetActivityState(database.Name)); // active queue sink process must prevent from unloading a database
         
         Assert.False(producer.IsClosed);
 

--- a/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
@@ -35,8 +35,8 @@ namespace SlowTests.Server.Replication
             var sinkWakeupEvent = new ManualResetEventSlim(initialState: false);
             context.SinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = sinkWakeupEvent;
 
-            // Wait > MaxIdleTime (5s) to see if it tries to sleep or flip states.
-            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(8));
+            // Wait > MaxIdleTime (3s) to see if it tries to sleep or flip states.
+            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(5));
             Assert.False(isSinkWokeUp, "Sink database triggered 'AfterDatabaseRemovedFromIdle', meaning it went to idle and woke up. It should have stayed awake.");
             Assert.False(context.SinkServer.ServerStore.IdleDatabases.ContainsKey(context.SinkDbName), "Sink DB is found in IdleDatabases. It should be awake.");
 
@@ -136,8 +136,8 @@ namespace SlowTests.Server.Replication
             var sinkWakeupEvent = new ManualResetEventSlim(initialState: false);
             context.SinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = sinkWakeupEvent;
 
-            // Wait > MaxIdleTime (5s)
-            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(8));
+            // Wait > MaxIdleTime (3s)
+            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(5));
             Assert.False(isSinkWokeUp, "Sink database triggered 'AfterDatabaseRemovedFromIdle' in TwoWay mode. It should have stayed awake.");
             Assert.False(context.SinkServer.ServerStore.IdleDatabases.ContainsKey(context.SinkDbName), "Sink DB found in IdleDatabases in TwoWay mode.");
 
@@ -191,7 +191,7 @@ namespace SlowTests.Server.Replication
             public async Task Initialize(PullReplicationMode pullReplicationMode, Dictionary<string, string> customSettings = null, [CallerMemberName] string caller = null)
             {
                 var settings = customSettings ?? new Dictionary<string, string>();
-                settings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "5";
+                settings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "3";
                 settings[RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1";
                 settings[RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false";
 
@@ -288,16 +288,16 @@ namespace SlowTests.Server.Replication
             {
                 var value = WaitForValue(() => server.ServerStore.IdleDatabases.ContainsKey(dbName),
                     expectedVal: true,
-                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    timeout: (int)TimeSpan.FromSeconds(60).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromMilliseconds(330).TotalMilliseconds);
 
                 Assert.True(value, $"Database '{dbName}' should be idle, but was not found in IdleDatabases.");
             }
 
             public static async Task AssertDatabaseIsNotIdle(RavenServer server, string dbName)
             {
-                // Wait > MaxIdleTime (5s)
-                await Task.Delay(8000);
+                // Wait > MaxIdleTime (3s)
+                await Task.Delay(5000);
                 Assert.False(server.ServerStore.IdleDatabases.ContainsKey(dbName), $"Database '{dbName}' is found in IdleDatabases collection.");
             }
 
@@ -336,7 +336,7 @@ namespace SlowTests.Server.Replication
             {
                 [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverDisposeResult.Url,
                 [RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certs.ServerCertificatePath,
-                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "5",
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "3",
                 [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1",
                 [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
             };

--- a/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
@@ -150,25 +150,25 @@ namespace SlowTests.Server.Replication
         }
 
         [NightlyBuildFact]
-        public async Task SinkToHub_LocalCvEmpty_OnConnect_BothStayIdle_AndWakeUpOnlyOnSinkChanges()
+        public async Task SinkToHub_LocalCvEmpty_OnConnect_SinkStaysAwake_HubStaysIdle_AndHubWakesUpOnSinkChanges()
         {
             using var context = new PullReplicationTestContext(this);
             await context.Initialize(PullReplicationMode.SinkToHub);
 
             // 1. Initial State:
-            // Sink (Push) -> Can sleep (wakes up on local write).
+            // Sink -> Must stay awake: any Sink Pull Replication configuration prevents idle,
+            //         because the Hub may come back online while Sink is asleep and nobody would wake it.
             // Hub (Passive) -> Can sleep.
             await using (var monitor = PullReplicationTestContext.Monitor())
             {
-                monitor.ExpectIdle(context.SinkServer, context.SinkDbName);
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
                 monitor.ExpectIdle(context.HubServer, context.HubDbName);
             }
 
             // 2. Action: Write to Sink
-            // Expectation: Sink wakes up (local write). Hub wakes up (incoming replication).
+            // Expectation: Hub wakes up to receive incoming replication from Sink.
             await using (var monitor = PullReplicationTestContext.Monitor())
             {
-                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
                 monitor.ExpectWakeup(context.HubServer, context.HubDbName);
 
                 using (var session = context.SinkStore.OpenSession())
@@ -179,7 +179,7 @@ namespace SlowTests.Server.Replication
             }
 
             Assert.True(WaitForDocument(context.HubStore, "users/1", timeout: 15_000),
-                "Document failed to replicate from Sink to Hub after waking up.");
+                "Document failed to replicate from Sink to Hub.");
         }
 
         [NightlyBuildFact]
@@ -313,6 +313,102 @@ namespace SlowTests.Server.Replication
                 "Hub failed to replicate document from Sink after correctly handling identity crisis.");
         }
 
+        [NightlyBuildFact]
+        public async Task SinkToHub_HubOffline_SinkWritesWhileHubDown_HubReceivesDataOnReturn()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.SinkToHub);
+
+            // 1. Initial state: Sink is awake (config prevents idle), Hub is idle
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+            }
+
+            // 2. Kill the Hub
+            var hubDisposeResult = await DisposeServerAndWaitForFinishOfDisposalAsync(context.HubServer);
+
+            // 3. Write to Sink while Hub is offline
+            using (var session = context.SinkStore.OpenSession())
+            {
+                session.Store(new User { Name = "BufferedWhileHubDown" }, "users/buffered");
+                session.SaveChanges();
+            }
+
+            // 4. Sink MUST stay awake despite Hub being unreachable.
+            // The anti-flicker check waits MaxIdleTime+3s to confirm Sink never goes idle.
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+            }
+
+            // 5. Resurrect Hub
+            using (var resurrectedHub = ResurrectServer(hubDisposeResult, context.Certificates))
+            using (var newHubStore = OpenStoreForResurrectedServer(resurrectedHub, context.HubDbName, context.Certificates))
+            {
+                // 6. Sink was awake → reconnects → data flows to Hub
+                Assert.True(WaitForDocument(newHubStore, "users/buffered", timeout: 30_000),
+                    "Buffered Sink data was not replicated to Hub after it came back online. " +
+                    "Sink may have gone idle while Hub was down and failed to wake up on Hub's return.");
+            }
+        }
+
+        [NightlyBuildFact]
+        public async Task TwoWay_HubOffline_SinkWritesWhileHubDown_HubReceivesDataOnReturn()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub);
+
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+            }
+
+            var hubDisposeResult = await DisposeServerAndWaitForFinishOfDisposalAsync(context.HubServer);
+
+            using (var session = context.SinkStore.OpenSession())
+            {
+                session.Store(new User { Name = "BufferedTwoWay" }, "users/buffered-twoway");
+                session.SaveChanges();
+            }
+
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+            }
+
+            using (var resurrectedHub = ResurrectServer(hubDisposeResult, context.Certificates))
+            using (var newHubStore = OpenStoreForResurrectedServer(resurrectedHub, context.HubDbName, context.Certificates))
+            {
+                Assert.True(WaitForDocument(newHubStore, "users/buffered-twoway", timeout: 30_000),
+                    "TwoWay: Buffered Sink data was not replicated to Hub after it came back online.");
+            }
+        }
+
+        [NightlyBuildFact]
+        public async Task SinkToHub_DisabledConfiguration_SinkCanGoIdle()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.SinkToHub);
+
+            // 1. Initially Sink stays awake (active config prevents idle)
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+
+            // 2. Disable the pull replication task
+            await context.SinkStore.Maintenance.SendAsync(
+                new Raven.Client.Documents.Operations.OngoingTasks.ToggleOngoingTaskStateOperation(
+                    context.SinkTaskId,
+                    Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskType.PullReplicationAsSink,
+                    disable: true));
+
+            // 3. Sink is now free to go idle (no active replication config)
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectIdle(context.SinkServer, context.SinkDbName);
+        }
+
         #region Helpers
 
         private class PullReplicationTestContext : IDisposable
@@ -328,6 +424,7 @@ namespace SlowTests.Server.Replication
 
             public string HubDbName => HubStore.Database;
             public string SinkDbName => SinkStore.Database;
+            public long SinkTaskId { get; private set; }
 
             public PullReplicationTestContext(PullReplicationIdleTests testBase)
             {
@@ -423,13 +520,14 @@ namespace SlowTests.Server.Replication
                 }));
 
                 // 4. Define Sink Task
-                await SinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                var sinkResult = await SinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
                 {
                     ConnectionStringName = connectionStringName,
                     HubName = pullName,
                     Mode = mode,
                     CertificateWithPrivateKey = Convert.ToBase64String(Certificates.ClientCertificate2.Value.Export(X509ContentType.Pfx))
                 }));
+                SinkTaskId = sinkResult.TaskId;
             }
 
             /// <summary>

--- a/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
@@ -1,0 +1,372 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.ServerWide.Operations.Certificates;
+using Raven.Server;
+using Raven.Server.Config;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Replication
+{
+    public class PullReplicationIdleTests : ReplicationTestBase
+    {
+        public PullReplicationIdleTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task HubToSink_SinkShouldStayAwake_HubShouldGoIdle_AndWakeUpOnChanges()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.HubToSink);
+
+            // 1. Verify Sink behavior (Initiator) -> Should NOT sleep
+            var sinkWakeupEvent = new ManualResetEventSlim(initialState: false);
+            context.SinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = sinkWakeupEvent;
+
+            // Wait > MaxIdleTime (5s) to see if it tries to sleep or flip states.
+            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(8));
+            Assert.False(isSinkWokeUp, "Sink database triggered 'AfterDatabaseRemovedFromIdle', meaning it went to idle and woke up. It should have stayed awake.");
+            Assert.False(context.SinkServer.ServerStore.IdleDatabases.ContainsKey(context.SinkDbName), "Sink DB is found in IdleDatabases. It should be awake.");
+
+            // 2. Verify Hub behavior (Target) -> CAN sleep
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+
+            // 3. Trigger change on Hub
+            using (var s = context.HubStore.OpenSession())
+            {
+                s.Store(new User { Name = "HubAwake" }, "users/1");
+                s.SaveChanges();
+            }
+
+            // 4. Verify Hub wakes up and replicates
+            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+
+            Assert.True(WaitForDocument(context.SinkStore, "users/1", timeout: (int)TimeSpan.FromSeconds(10).TotalMilliseconds),
+                "Document failed to replicate from Hub to Sink after Hub wakeup.");
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task SinkToHub_BothShouldGoIdle_AndWakeUpOnSinkChanges()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.SinkToHub);
+
+            // 1. Verify Sink behavior (Initiator, but Push mode) -> CAN sleep
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.SinkServer, context.SinkDbName);
+
+            // 2. Verify Hub behavior (Target) -> CAN sleep
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+
+            // 3. Trigger change on Sink
+            // This starts the chain reaction: Sink Wakes -> Establishes Connection -> Hub Wakes
+            using (var s = context.SinkStore.OpenSession())
+            {
+                s.Store(new User { Name = "SinkAwake" }, "users/1");
+                s.SaveChanges();
+            }
+
+            // 4. Verify Sink wakes up
+            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.SinkServer, context.SinkDbName);
+
+            // 5. Verify Hub wakes up (triggered by incoming replication batch)
+            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+
+            Assert.True(WaitForDocument(context.HubStore, "users/1", timeout: (int)TimeSpan.FromSeconds(10).TotalMilliseconds),
+                "Document failed to replicate from Sink to Hub after waking up.");
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task HubToSink_WhenSinkRestarts_AndHubHasChanges_HubWakesUp()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.HubToSink);
+
+            // 1. Initial State: Hub is Idle
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+
+            // 2. Kill the Sink
+            var serverDisposeResult = await DisposeServerAndWaitForFinishOfDisposalAsync(context.SinkServer);
+
+            // 3. Generate changes on Hub while Sink is offline
+            // This will wake the Hub, but it should go back to sleep because no one is pulling.
+            using (var s = context.HubStore.OpenSession())
+            {
+                s.Store(new User { Name = "PendingChange" }, "users/waiting");
+                s.SaveChanges();
+            }
+
+            // 4. Wait for Hub to go Idle again (it has changes, but no active replication connection)
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+
+            // 5. Resurrect Sink
+            using (var resurrectedSink = ResurrectServer(serverDisposeResult, context.Certificates))
+            using (var newSinkStore = OpenStoreForResurrectedServer(resurrectedSink, context.SinkDbName, context.Certificates))
+            {
+                // 6. Verify Hub Wakes Up
+                // Now that Sink is back, it detects pending changes on Hub (or connects), forcing Hub to wake up.
+                PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+
+                // 7. Verify Data Arrived
+                Assert.True(WaitForDocument(newSinkStore, "users/waiting", timeout: 30_000),
+                    "Replication did not resume or Hub did not serve the pending document after Sink resurrection.");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task TwoWay_SinkShouldStayAwake_HubShouldGoIdle_AndWakeUpOnChanges()
+        {
+            using var context = new PullReplicationTestContext(this);
+            // Initialize with TwoWay mode (HubToSink | SinkToHub)
+            await context.Initialize(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub);
+
+            // 1. Verify Sink behavior (Acts as Initiator) -> Should NOT sleep
+            // Even though it pushes changes (SinkToHub), it also pulls (HubToSink), so it must maintain the connection/state.
+            var sinkWakeupEvent = new ManualResetEventSlim(initialState: false);
+            context.SinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = sinkWakeupEvent;
+
+            // Wait > MaxIdleTime (5s)
+            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(8));
+            Assert.False(isSinkWokeUp, "Sink database triggered 'AfterDatabaseRemovedFromIdle' in TwoWay mode. It should have stayed awake.");
+            Assert.False(context.SinkServer.ServerStore.IdleDatabases.ContainsKey(context.SinkDbName), "Sink DB found in IdleDatabases in TwoWay mode.");
+
+            // 2. Verify Hub behavior (Target) -> CAN sleep
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+
+            // 3. Scenario A: Write to Hub (HubToSink flow) -> Hub should wake up
+            using (var s = context.HubStore.OpenSession())
+            {
+                s.Store(new User { Name = "HubChange" }, "users/1");
+                s.SaveChanges();
+            }
+
+            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+            Assert.True(WaitForDocument(context.SinkStore, "users/1", timeout: 15_000), "HubToSink replication failed in TwoWay mode.");
+
+            // 4. Wait for Hub to go back to sleep (to verify independence of operations)
+            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+
+            // 5. Scenario B: Write to Sink (SinkToHub flow) -> Hub should wake up to receive data
+            using (var s = context.SinkStore.OpenSession())
+            {
+                s.Store(new User { Name = "SinkChange" }, "users/2");
+                s.SaveChanges();
+            }
+
+            // Hub wakes up to process incoming replication from Sink
+            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+            Assert.True(WaitForDocument(context.HubStore, "users/2", timeout: 15_000), "SinkToHub replication failed in TwoWay mode.");
+        }
+
+        #region Helpers
+
+        private class PullReplicationTestContext : IDisposable
+        {
+            private readonly PullReplicationIdleTests _testBase;
+            public RavenServer HubServer { get; private set; }
+            public RavenServer SinkServer { get; private set; }
+            public DocumentStore HubStore { get; private set; }
+            public DocumentStore SinkStore { get; private set; }
+            public TestCertificatesHolder Certificates { get; private set; }
+
+            public string HubDbName => HubStore.Database;
+            public string SinkDbName => SinkStore.Database;
+
+            public PullReplicationTestContext(PullReplicationIdleTests testBase)
+            {
+                _testBase = testBase;
+            }
+
+            public async Task Initialize(PullReplicationMode pullReplicationMode, Dictionary<string, string> customSettings = null, [CallerMemberName] string caller = null)
+            {
+                var settings = customSettings ?? new Dictionary<string, string>();
+                settings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "5";
+                settings[RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1";
+                settings[RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false";
+
+                Certificates = _testBase.Certificates.SetupServerAuthentication(customSettings: settings);
+
+                HubServer = _testBase.GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = settings,
+                    RegisterForDisposal = false,
+                    NodeTag = "Hub"
+                });
+
+                _testBase.Certificates.RegisterClientCertificate(
+                    Certificates.ServerCertificate.Value,
+                    Certificates.ClientCertificate1.Value,
+                    new Dictionary<string, DatabaseAccess>(),
+                    SecurityClearance.ClusterAdmin,
+                    server: HubServer);
+
+                HubStore = _testBase.GetDocumentStore(new Options
+                {
+                    Server = HubServer,
+                    ModifyDatabaseName = s => $"HubDB_{s}",
+                    ClientCertificate = Certificates.ServerCertificate.Value,
+                    AdminCertificate = Certificates.ClientCertificate1.Value,
+                    RunInMemory = false
+                });
+
+                SinkServer = _testBase.GetNewServer(new ServerCreationOptions
+                {
+                    CustomSettings = settings,
+                    RegisterForDisposal = false,
+                    NodeTag = "Sink"
+                });
+
+                _testBase.Certificates.RegisterClientCertificate(
+                    Certificates.ServerCertificate.Value,
+                    Certificates.ClientCertificate1.Value,
+                    new Dictionary<string, DatabaseAccess>(),
+                    SecurityClearance.ClusterAdmin,
+                    server: SinkServer);
+
+                SinkStore = _testBase.GetDocumentStore(new Options
+                {
+                    Server = SinkServer,
+                    CreateDatabase =  true,
+                    ModifyDatabaseName = s => $"SinkDB_{s}",
+                    ClientCertificate = Certificates.ServerCertificate.Value,
+                    AdminCertificate = Certificates.ClientCertificate1.Value,
+                    RunInMemory = false
+                });
+
+                EnableIdleForTesting(HubServer);
+                EnableIdleForTesting(SinkServer);
+
+                await SetupPullReplicationAsync($"{caller}-pull-replication-task", pullReplicationMode);
+            }
+
+            public async Task SetupPullReplicationAsync(string pullName, PullReplicationMode mode)
+            {
+                // 1. Define Hub
+                await HubStore.Maintenance.ForDatabase(HubStore.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition(pullName)
+                {
+                    Mode = mode
+                }));
+
+                // 2. Register Access
+                await HubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation(pullName, new ReplicationHubAccess
+                {
+                    Name = "SinkUser",
+                    CertificateBase64 = Convert.ToBase64String(Certificates.ClientCertificate2.Value.Export(X509ContentType.Cert))
+                }));
+
+                // 3. Define Connection String on Sink
+                const string connectionStringName = "ConnectToHub";
+                await SinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                {
+                    Name = connectionStringName,
+                    Database = HubStore.Database,
+                    TopologyDiscoveryUrls = HubStore.Urls
+                }));
+
+                // 4. Define Sink Task
+                await SinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                {
+                    ConnectionStringName = connectionStringName,
+                    HubName = pullName,
+                    Mode = mode,
+                    CertificateWithPrivateKey = Convert.ToBase64String(Certificates.ClientCertificate2.Value.Export(X509ContentType.Pfx))
+                }));
+            }
+
+            public static void WaitAndAssertDatabaseIsIdle(RavenServer server, string dbName)
+            {
+                var value = WaitForValue(() => server.ServerStore.IdleDatabases.ContainsKey(dbName),
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
+                Assert.True(value, $"Database '{dbName}' should be idle, but was not found in IdleDatabases.");
+            }
+
+            public static async Task AssertDatabaseIsNotIdle(RavenServer server, string dbName)
+            {
+                // Wait > MaxIdleTime (5s)
+                await Task.Delay(8000);
+                Assert.False(server.ServerStore.IdleDatabases.ContainsKey(dbName), $"Database '{dbName}' is found in IdleDatabases collection.");
+            }
+
+            public static void WaitAndAssertDatabaseIsWakeUp(RavenServer server, string dbName)
+            {
+                var value = WaitForValue(() => server.ServerStore.IdleDatabases.ContainsKey(dbName),
+                    expectedVal: false,
+                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+
+                Assert.False(value, $"Database '{dbName}' should be wake-up, but still was found in IdleDatabases");
+            }
+
+            public void Dispose()
+            {
+                HubStore?.Dispose();
+                SinkStore?.Dispose();
+
+                if (HubServer is { Disposed: false })
+                    DisposeServer(HubServer);
+
+                if (SinkServer is { Disposed: false })
+                    DisposeServer(SinkServer);
+            }
+        }
+
+        private static void EnableIdleForTesting(RavenServer server)
+        {
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
+            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+        }
+
+        private RavenServer ResurrectServer((string DataDirectory, string Url, string NodeTag) serverDisposeResult, TestCertificatesHolder certs)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                [RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverDisposeResult.Url,
+                [RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certs.ServerCertificatePath,
+                [RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "5",
+                [RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1",
+                [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
+            };
+
+            var server = GetNewServer(new ServerCreationOptions
+            {
+                DeletePrevious = false,
+                DataDirectory = serverDisposeResult.DataDirectory,
+                CustomSettings = settings,
+                RegisterForDisposal = false,
+                NodeTag = serverDisposeResult.NodeTag
+            });
+
+            EnableIdleForTesting(server);
+
+            return server;
+        }
+
+        private DocumentStore OpenStoreForResurrectedServer(RavenServer server, string dbName, TestCertificatesHolder certs)
+        {
+            return GetDocumentStore(new Options
+            {
+                Server = server,
+                CreateDatabase = false, // DB exists on disk
+                ModifyDatabaseName = _ => dbName,
+                ClientCertificate = certs.ServerCertificate.Value,
+                AdminCertificate = certs.ClientCertificate1.Value,
+            });
+        }
+
+        #endregion
+    }
+}

--- a/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationIdleTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -12,6 +14,7 @@ using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -25,148 +28,289 @@ namespace SlowTests.Server.Replication
         {
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
-        public async Task HubToSink_SinkShouldStayAwake_HubShouldGoIdle_AndWakeUpOnChanges()
+        [NightlyBuildFact]
+        public async Task HubToSink_LocalCvEmpty_OnConnect_HubStaysIdle_AndWakesUpOnlyOnLocalChanges()
         {
             using var context = new PullReplicationTestContext(this);
             await context.Initialize(PullReplicationMode.HubToSink);
 
-            // 1. Verify Sink behavior (Initiator) -> Should NOT sleep
-            var sinkWakeupEvent = new ManualResetEventSlim(initialState: false);
-            context.SinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = sinkWakeupEvent;
-
-            // Wait > MaxIdleTime (3s) to see if it tries to sleep or flip states.
-            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(5));
-            Assert.False(isSinkWokeUp, "Sink database triggered 'AfterDatabaseRemovedFromIdle', meaning it went to idle and woke up. It should have stayed awake.");
-            Assert.False(context.SinkServer.ServerStore.IdleDatabases.ContainsKey(context.SinkDbName), "Sink DB is found in IdleDatabases. It should be awake.");
-
-            // 2. Verify Hub behavior (Target) -> CAN sleep
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
-
-            // 3. Trigger change on Hub
-            using (var s = context.HubStore.OpenSession())
+            // 1. Initial State:
+            // Sink (Initiator) -> Must stay awake to poll.
+            // Hub (Passive) -> Can sleep if no changes.
+            await using (var monitor = PullReplicationTestContext.Monitor())
             {
-                s.Store(new User { Name = "HubAwake" }, "users/1");
-                s.SaveChanges();
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
             }
 
-            // 4. Verify Hub wakes up and replicates
-            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+            // 2. Action: Write to Hub
+            // Expectation: Hub wakes up to serve the request. Sink continues polling and gets the doc.
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.HubServer, context.HubDbName);
 
-            Assert.True(WaitForDocument(context.SinkStore, "users/1", timeout: (int)TimeSpan.FromSeconds(10).TotalMilliseconds),
+                // Sink is already awake, but we assert it remains stable (no flickering/sleeping)
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+
+                using (var session = context.HubStore.OpenSession())
+                {
+                    session.Store(new User { Name = "HubAwake" }, "users/1");
+                    session.SaveChanges();
+                }
+            }
+
+            Assert.True(WaitForDocument(context.SinkStore, "users/1", timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds),
                 "Document failed to replicate from Hub to Sink after Hub wakeup.");
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
-        public async Task SinkToHub_BothShouldGoIdle_AndWakeUpOnSinkChanges()
+        [NightlyBuildFact]
+        public async Task HubToSink_LocalCvPopulated_OnConnectWithSinkAhead_HubCapsVector_AndStaysIdle()
         {
+            // Validates "Capping" logic:
+            // In HubToSink mode, if Sink reports having [Hub:100] but Hub only has [Hub:10],
+            // Hub must CAP the Sink's vector to [Hub:10] before comparison.
+            // Result: "AlreadyMerged" (Idle).
+            // Without capping, logic sees Sink > Hub (Conflict/Update) -> WakeUp.
+
             using var context = new PullReplicationTestContext(this);
-            await context.Initialize(PullReplicationMode.SinkToHub);
+            await context.Initialize(PullReplicationMode.HubToSink);
 
-            // 1. Verify Sink behavior (Initiator, but Push mode) -> CAN sleep
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.SinkServer, context.SinkDbName);
+            // 1. Establish initial state with some data (Hub:1)
+            using (var s = context.HubStore.OpenSession())
+            {
+                s.Store(new User(), "marker");
+                s.SaveChanges();
+            }
+            Assert.True(WaitForDocument(context.SinkStore, "marker"));
 
-            // 2. Verify Hub behavior (Target) -> CAN sleep
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+            // 2. Wait for Hub to become Idle
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
 
-            // 3. Trigger change on Sink
-            // This starts the chain reaction: Sink Wakes -> Establishes Connection -> Hub Wakes
+            // 3. Artificially advance Sink's vector (Simulating split-brain or Hub restore)
+            // Sink now has [Hub:1, Sink:1]. Hub has [Hub:1].
+            // Strict comparison says Sink > Hub.
+            // Correct HubToSink logic says: "I don't care what extra data you have, I have nothing NEW for you."
             using (var s = context.SinkStore.OpenSession())
             {
-                s.Store(new User { Name = "SinkAwake" }, "users/1");
+                s.Store(new User(), "sink-only-doc");
                 s.SaveChanges();
             }
 
-            // 4. Verify Sink wakes up
-            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.SinkServer, context.SinkDbName);
-
-            // 5. Verify Hub wakes up (triggered by incoming replication batch)
-            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
-
-            Assert.True(WaitForDocument(context.HubStore, "users/1", timeout: (int)TimeSpan.FromSeconds(10).TotalMilliseconds),
-                "Document failed to replicate from Sink to Hub after waking up.");
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                // Hub should remain IDLE.
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+            }
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
-        public async Task HubToSink_WhenSinkRestarts_AndHubHasChanges_HubWakesUp()
+        [NightlyBuildFact]
+        public async Task HubToSink_LocalCvPopulated_OnSinkRestart_HubWakesUp_ToSendNewLocalChanges()
         {
             using var context = new PullReplicationTestContext(this);
             await context.Initialize(PullReplicationMode.HubToSink);
 
             // 1. Initial State: Hub is Idle
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
 
             // 2. Kill the Sink
             var serverDisposeResult = await DisposeServerAndWaitForFinishOfDisposalAsync(context.SinkServer);
 
             // 3. Generate changes on Hub while Sink is offline
-            // This will wake the Hub, but it should go back to sleep because no one is pulling.
-            using (var s = context.HubStore.OpenSession())
+            // We expect Hub to wake up for write, but then go back to IDLE because Sink is dead (no one is pulling).
+            await using (var monitor = PullReplicationTestContext.Monitor())
             {
-                s.Store(new User { Name = "PendingChange" }, "users/waiting");
-                s.SaveChanges();
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+
+                using (var session = context.HubStore.OpenSession())
+                {
+                    session.Store(new User { Name = "PendingChange" }, "users/waiting");
+                    session.SaveChanges();
+                }
             }
 
-            // 4. Wait for Hub to go Idle again (it has changes, but no active replication connection)
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
-
-            // 5. Resurrect Sink
+            // 4. Resurrect Sink
+            // Expectation: As soon as Sink comes online, it connects to Hub. Hub must wake up.
             using (var resurrectedSink = ResurrectServer(serverDisposeResult, context.Certificates))
             using (var newSinkStore = OpenStoreForResurrectedServer(resurrectedSink, context.SinkDbName, context.Certificates))
             {
-                // 6. Verify Hub Wakes Up
-                // Now that Sink is back, it detects pending changes on Hub (or connects), forcing Hub to wake up.
-                PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+                await using (var monitor = PullReplicationTestContext.Monitor())
+                {
+                    monitor.ExpectWakeup(context.HubServer, context.HubDbName);
 
-                // 7. Verify Data Arrived
+                    // Just ensure Sink is up and running, triggering the connection
+                    WaitForDocument(newSinkStore, "users/waiting", timeout: 5_000);
+                }
+
+                // 5. Final Verification
                 Assert.True(WaitForDocument(newSinkStore, "users/waiting", timeout: 30_000),
                     "Replication did not resume or Hub did not serve the pending document after Sink resurrection.");
             }
         }
 
-        [RavenFact(RavenTestCategory.Replication)]
-        public async Task TwoWay_SinkShouldStayAwake_HubShouldGoIdle_AndWakeUpOnChanges()
+        [NightlyBuildFact]
+        public async Task SinkToHub_LocalCvEmpty_OnConnect_BothStayIdle_AndWakeUpOnlyOnSinkChanges()
+        {
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.SinkToHub);
+
+            // 1. Initial State:
+            // Sink (Push) -> Can sleep (wakes up on local write).
+            // Hub (Passive) -> Can sleep.
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectIdle(context.SinkServer, context.SinkDbName);
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+            }
+
+            // 2. Action: Write to Sink
+            // Expectation: Sink wakes up (local write). Hub wakes up (incoming replication).
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+                monitor.ExpectWakeup(context.HubServer, context.HubDbName);
+
+                using (var session = context.SinkStore.OpenSession())
+                {
+                    session.Store(new User { Name = "SinkAwake" }, "users/1");
+                    session.SaveChanges();
+                }
+            }
+
+            Assert.True(WaitForDocument(context.HubStore, "users/1", timeout: 15_000),
+                "Document failed to replicate from Sink to Hub after waking up.");
+        }
+
+        [NightlyBuildFact]
+        public async Task TwoWay_LocalCvEmpty_OnConnect_HubStaysIdle_WhileSinkStaysAwake_AndHubWakesUpOnlyOnSinkChanges()
         {
             using var context = new PullReplicationTestContext(this);
             // Initialize with TwoWay mode (HubToSink | SinkToHub)
             await context.Initialize(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub);
 
-            // 1. Verify Sink behavior (Acts as Initiator) -> Should NOT sleep
-            // Even though it pushes changes (SinkToHub), it also pulls (HubToSink), so it must maintain the connection/state.
-            var sinkWakeupEvent = new ManualResetEventSlim(initialState: false);
-            context.SinkServer.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = sinkWakeupEvent;
-
-            // Wait > MaxIdleTime (3s)
-            var isSinkWokeUp = sinkWakeupEvent.Wait(TimeSpan.FromSeconds(5));
-            Assert.False(isSinkWokeUp, "Sink database triggered 'AfterDatabaseRemovedFromIdle' in TwoWay mode. It should have stayed awake.");
-            Assert.False(context.SinkServer.ServerStore.IdleDatabases.ContainsKey(context.SinkDbName), "Sink DB found in IdleDatabases in TwoWay mode.");
-
-            // 2. Verify Hub behavior (Target) -> CAN sleep
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
-
-            // 3. Scenario A: Write to Hub (HubToSink flow) -> Hub should wake up
-            using (var s = context.HubStore.OpenSession())
+            // 1. Initial State:
+            // Sink (Active Pull) -> Must stay awake.
+            // Hub (Passive) -> Can sleep.
+            await using (var monitor = PullReplicationTestContext.Monitor())
             {
-                s.Store(new User { Name = "HubChange" }, "users/1");
-                s.SaveChanges();
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
             }
 
-            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
+            // 2. Scenario A: Write to Hub (HubToSink flow) -> Hub should wake up
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+                monitor.ExpectWakeup(context.HubServer, context.HubDbName);
+
+                using (var s = context.HubStore.OpenSession())
+                {
+                    s.Store(new User { Name = "HubChange" }, "users/1");
+                    s.SaveChanges();
+                }
+            }
+
             Assert.True(WaitForDocument(context.SinkStore, "users/1", timeout: 15_000), "HubToSink replication failed in TwoWay mode.");
 
-            // 4. Wait for Hub to go back to sleep (to verify independence of operations)
-            PullReplicationTestContext.WaitAndAssertDatabaseIsIdle(context.HubServer, context.HubDbName);
+            // 3. Wait for Hub to go back to sleep (to verify independence of operations)
+            // We need Hub to be Idle to properly test the next wake-up trigger
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
 
-            // 5. Scenario B: Write to Sink (SinkToHub flow) -> Hub should wake up to receive data
-            using (var s = context.SinkStore.OpenSession())
+            // 4. Scenario B: Write to Sink (SinkToHub flow) -> Hub should wake up to receive data
+            await using (var monitor = PullReplicationTestContext.Monitor())
             {
-                s.Store(new User { Name = "SinkChange" }, "users/2");
+                monitor.ExpectWakeup(context.HubServer, context.HubDbName);
+
+                using (var s = context.SinkStore.OpenSession())
+                {
+                    s.Store(new User { Name = "SinkChange" }, "users/2");
+                    s.SaveChanges();
+                }
+            }
+
+            Assert.True(WaitForDocument(context.HubStore, "users/2", timeout: 15_000), "SinkToHub replication failed in TwoWay mode.");
+        }
+
+        [NightlyBuildFact]
+        public async Task TwoWay_LocalCvPopulated_AfterHubWritesNewData_HubGoesIdleAgain_WithoutFlickering()
+        {
+            // After Hub writes and Sink receives the data, Sink's CV contains Hub's entries.
+            // Hub must stay idle when Sink re-polls — Sink's Hub-origin entries must not trigger a wakeup.
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub);
+
+            // 1. Write to Hub and wait for Sink to receive it
+            using (var s = context.HubStore.OpenSession())
+            {
+                s.Store(new User { Name = "HubChange" }, "users/hub/1");
                 s.SaveChanges();
             }
 
-            // Hub wakes up to process incoming replication from Sink
-            PullReplicationTestContext.WaitAndAssertDatabaseIsWakeUp(context.HubServer, context.HubDbName);
-            Assert.True(WaitForDocument(context.HubStore, "users/2", timeout: 15_000), "SinkToHub replication failed in TwoWay mode.");
+            Assert.True(WaitForDocument(context.SinkStore, "users/hub/1", timeout: 15_000),
+                "Document failed to replicate from Hub to Sink.");
+
+            // 2. Hub must go idle and STAY idle — Sink's CV now contains [HubID:1] which must not cause a wakeup
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+        }
+
+        [NightlyBuildFact]
+        public async Task TwoWay_LocalCvPopulated_AfterSinkSendsNewData_HubGoesIdleAgain_WithoutFlickering()
+        {
+            // After Hub receives Sink's data and goes idle, Sink re-polls with the same CV.
+            // Hub must stay idle — the already-replicated entry must be excluded from the SinkToHub check.
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub);
+
+            // 1. Write to Sink and wait for Hub to receive it
+            using (var s = context.SinkStore.OpenSession())
+            {
+                s.Store(new User { Name = "SinkChange" }, "users/sink/1");
+                s.SaveChanges();
+            }
+
+            Assert.True(WaitForDocument(context.HubStore, "users/sink/1", timeout: 15_000),
+                "Document failed to replicate from Sink to Hub.");
+
+            // 2. Hub must go idle and STAY idle — Sink's CV [SinkID:1] is now in Hub's ReplicationInfo
+            await using (var monitor = PullReplicationTestContext.Monitor())
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+        }
+
+        [NightlyBuildFact]
+        public async Task TwoWay_LocalCvEmpty_OnConnect_HubConstructsFallbackIdentity_StaysIdle_AndWakesUpOnlyOnSinkChanges()
+        {
+            // Validates "Identity Crisis" fix:
+            // 1. Hub identifies itself via Topology ID (ignoring echoes).
+            // 2. But verifies it NOT blind to actual new data from Sink.
+
+            using var context = new PullReplicationTestContext(this);
+            await context.Initialize(PullReplicationMode.HubToSink | PullReplicationMode.SinkToHub);
+
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                // 1. Verify Silence first (Identity Crisis Handled)
+                monitor.ExpectIdle(context.HubServer, context.HubDbName);
+                monitor.ExpectWakeup(context.SinkServer, context.SinkDbName);
+            }
+
+            // 2. Action: Write to SINK (generating strictly new remote data)
+            await using (var monitor = PullReplicationTestContext.Monitor())
+            {
+                // Hub MUST wake up now because Sink has [Sink:1], which is NOT filtered out by ID check
+                monitor.ExpectWakeup(context.HubServer, context.HubDbName);
+
+                using (var s = context.SinkStore.OpenSession())
+                {
+                    s.Store(new User { Name = "SinkChange" }, "users/sink/1");
+                    s.SaveChanges();
+                }
+            }
+
+            Assert.True(WaitForDocument(context.HubStore, "users/sink/1", timeout: 15_000),
+                "Hub failed to replicate document from Sink after correctly handling identity crisis.");
         }
 
         #region Helpers
@@ -174,6 +318,8 @@ namespace SlowTests.Server.Replication
         private class PullReplicationTestContext : IDisposable
         {
             private readonly PullReplicationIdleTests _testBase;
+            private static readonly TimeSpan MaxIdleTime = TimeSpan.FromSeconds(10);
+
             public RavenServer HubServer { get; private set; }
             public RavenServer SinkServer { get; private set; }
             public DocumentStore HubStore { get; private set; }
@@ -191,7 +337,7 @@ namespace SlowTests.Server.Replication
             public async Task Initialize(PullReplicationMode pullReplicationMode, Dictionary<string, string> customSettings = null, [CallerMemberName] string caller = null)
             {
                 var settings = customSettings ?? new Dictionary<string, string>();
-                settings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = "3";
+                settings[RavenConfiguration.GetKey(x => x.Databases.MaxIdleTime)] = MaxIdleTime.TotalSeconds.ToString(CultureInfo.InvariantCulture);
                 settings[RavenConfiguration.GetKey(x => x.Databases.FrequencyToCheckForIdle)] = "1";
                 settings[RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false";
 
@@ -203,6 +349,8 @@ namespace SlowTests.Server.Replication
                     RegisterForDisposal = false,
                     NodeTag = "Hub"
                 });
+
+
 
                 _testBase.Certificates.RegisterClientCertificate(
                     Certificates.ServerCertificate.Value,
@@ -237,7 +385,7 @@ namespace SlowTests.Server.Replication
                 SinkStore = _testBase.GetDocumentStore(new Options
                 {
                     Server = SinkServer,
-                    CreateDatabase =  true,
+                    CreateDatabase = true,
                     ModifyDatabaseName = s => $"SinkDB_{s}",
                     ClientCertificate = Certificates.ServerCertificate.Value,
                     AdminCertificate = Certificates.ClientCertificate1.Value,
@@ -284,31 +432,106 @@ namespace SlowTests.Server.Replication
                 }));
             }
 
-            public static void WaitAndAssertDatabaseIsIdle(RavenServer server, string dbName)
+            /// <summary>
+            /// Creates a monitor to assert database states in parallel.
+            /// Usage: await using (var monitor = context.Monitor()) { monitor.Expect...; Action(); }
+            /// </summary>
+            public static ReplicationActivityMonitor Monitor() => new();
+
+            public class ReplicationActivityMonitor : IAsyncDisposable
             {
-                var value = WaitForValue(() => server.ServerStore.IdleDatabases.ContainsKey(dbName),
-                    expectedVal: true,
-                    timeout: (int)TimeSpan.FromSeconds(60).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromMilliseconds(330).TotalMilliseconds);
+                private readonly List<Func<Task>> _verifications = [];
+                private readonly List<Action> _cleanups = [];
 
-                Assert.True(value, $"Database '{dbName}' should be idle, but was not found in IdleDatabases.");
-            }
+                public void ExpectWakeup(RavenServer server, string dbName)
+                {
+                    var wakeupEvent = new ManualResetEventSlim(false);
 
-            public static async Task AssertDatabaseIsNotIdle(RavenServer server, string dbName)
-            {
-                // Wait > MaxIdleTime (3s)
-                await Task.Delay(5000);
-                Assert.False(server.ServerStore.IdleDatabases.ContainsKey(dbName), $"Database '{dbName}' is found in IdleDatabases collection.");
-            }
+                    // Subscribe to the global action, but filter specifically for our database
+                    Action<string> onWakeup = name =>
+                    {
+                        if (string.Equals(name, dbName, StringComparison.OrdinalIgnoreCase))
+                            wakeupEvent.Set();
+                    };
 
-            public static void WaitAndAssertDatabaseIsWakeUp(RavenServer server, string dbName)
-            {
-                var value = WaitForValue(() => server.ServerStore.IdleDatabases.ContainsKey(dbName),
-                    expectedVal: false,
-                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
-                    interval: (int)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle += onWakeup;
+                    _cleanups.Add(() => server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle -= onWakeup);
 
-                Assert.False(value, $"Database '{dbName}' should be wake-up, but still was found in IdleDatabases");
+                    _verifications.Add(async () =>
+                    {
+                        // 1. Ensure it reaches Active state
+                        var state = WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(dbName),
+                            expectedVal: DatabaseIdleManager.DatabaseActivityState.Active,
+                            timeout: (int)TimeSpan.FromSeconds(30).TotalMilliseconds,
+                            interval: 500);
+
+                        Assert.True(state == DatabaseIdleManager.DatabaseActivityState.Active,
+                            $"Database `{dbName}` is expected to be 'Active' but was '{state}' after timeout.");
+
+                        // 1.5 Workaround test framework race: Wait for the AfterDatabaseRemovedFromIdle
+                        // event to be fired by the task continuation if it just became Active
+                        await Task.Delay(2000);
+
+                        // 2. Anti-Flicker check: Ensure it STAYS active (doesn't trigger wakeup again)
+                        // If AfterDatabaseRemovedFromIdle fires again, it means it went to sleep and woke up.
+                        wakeupEvent.Reset();
+
+                        // We wait slightly longer than MaxIdleTime to prove stability
+                        var waitTime = MaxIdleTime.Add(TimeSpan.FromSeconds(3));
+                        var wasFlickered = wakeupEvent.Wait(waitTime);
+
+                        Assert.False(wasFlickered,
+                            $"Database `{dbName}` flickered! It went back to sleep and woke up again immediately.");
+                    });
+                }
+
+                public void ExpectIdle(RavenServer server, string dbName)
+                {
+                    var wakeupEvent = new ManualResetEventSlim(false);
+                    Action<string> onWakeup = name =>
+                    {
+                        if (string.Equals(name, dbName, StringComparison.OrdinalIgnoreCase))
+                            wakeupEvent.Set();
+                    };
+
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle += onWakeup;
+                    _cleanups.Add(() => server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle -= onWakeup);
+
+                    _verifications.Add(() => Task.Run(() =>
+                    {
+                        // 1. Ensure it reaches Idle state
+                        var state = WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(dbName),
+                            expectedVal: DatabaseIdleManager.DatabaseActivityState.Idle,
+                            timeout: (int)TimeSpan.FromSeconds(60).TotalMilliseconds,
+                            interval: 500);
+
+                        Assert.True(state == DatabaseIdleManager.DatabaseActivityState.Idle,
+                             $"Database `{dbName}` is expected to be 'Idle' but was '{state}' after timeout.");
+
+                        // 2. Ensure it STAYS idle (doesn't trigger wakeup)
+                        wakeupEvent.Reset();
+
+                        var waitTime = MaxIdleTime.Add(TimeSpan.FromSeconds(3));
+                        var wasWokenUp = wakeupEvent.Wait(waitTime);
+
+                        Assert.False(wasWokenUp,
+                            $"Database `{dbName}` woke up unexpectedly immediately after going idle.");
+                    }));
+                }
+
+                public async ValueTask DisposeAsync()
+                {
+                    try
+                    {
+                        // Execute all verifications in parallel
+                        await Task.WhenAll(_verifications.Select(func => func()));
+                    }
+                    finally
+                    {
+                        foreach (var cleanup in _cleanups)
+                            cleanup();
+                    }
+                }
             }
 
             public void Dispose()
@@ -327,7 +550,7 @@ namespace SlowTests.Server.Replication
         private static void EnableIdleForTesting(RavenServer server)
         {
             server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
-            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+            server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
         }
 
         private RavenServer ResurrectServer((string DataDirectory, string Url, string NodeTag) serverDisposeResult, TestCertificatesHolder certs)

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -940,7 +940,7 @@ namespace SlowTests.Server.Replication
                         return false;
 
                     // Verify the specific reason from ServerStore.cs logic
-                    return statistics.Explanations.Any(x => x.Contains("Pull Replication Hub or Sink configurations with 'HubToSink' mode enabled"));
+                    return statistics.Explanations.Any(x => x.Contains("active Sink Pull Replication configuration"));
 
                 }, true, 75_000, 1000));
 
@@ -952,7 +952,7 @@ namespace SlowTests.Server.Replication
                     server.ServerStore.DatabasesLandlord.CanUnloadDatabase(hubDbKvp.Key, hubDbKvp.Value, hubStats, out _);
 
                     // The Hub should NOT have the configuration-based blocking message
-                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("Pull Replication Hub or Sink configurations with 'HubToSink' mode enabled"));
+                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("active Sink Pull Replication configuration"));
                 }
 
                 using (var s2 = hub.OpenSession())

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -917,48 +917,44 @@ namespace SlowTests.Server.Replication
 
                 server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
 
-                var dic = new Dictionary<IdleDatabaseStatistics, int>();
-                Assert.True(WaitForValue( () =>
+                // Wait for the Sink to be marked as "Cannot Unload" due to configuration intent.
+                // The Hub is allowed to sleep in this scenario, so we only verify the Sink's state.
+                Assert.True(WaitForValue(() =>
                 {
-                    dic = new Dictionary<IdleDatabaseStatistics, int>();
-                    foreach (var databaseKvp in server.ServerStore.DatabasesLandlord.LastRecentlyUsed.ForceEnumerateInThreadSafeManner())
-                    {
-                        var statistics = new IdleDatabaseStatistics
-                        {
-                            Name = databaseKvp.Key.ToString()
-                        };
+                    var sinkDbKvp = server.ServerStore.DatabasesLandlord.LastRecentlyUsed.FirstOrDefault(x => x.Key.Equals(sink.Database, StringComparison.OrdinalIgnoreCase));
 
-                        server.ServerStore.CanUnloadDatabase(databaseKvp.Key, databaseKvp.Value, statistics, out _);
-
-                        if (statistics.CanUnload == false)
-                            continue;
-
-                        if (statistics.Explanations.Count > 1)
-                        {
-                            continue;
-                        }
-
-                        if (statistics.NumberOfActivePullReplicationAsSinkConnections == 0)
-                            continue;
-
-                        dic.Add(statistics, statistics.NumberOfActivePullReplicationAsSinkConnections);
-                    }
-
-                    if (dic.Count != 2)
+                    // If Sink is not even in LRU, we can't check it. Wait until it is.
+                    if (sinkDbKvp.Key == null)
                         return false;
 
-                    return dic.All(x => x.Value == 1);
-                }, true, 75_000, 1000), string.Join(Environment.NewLine, dic.Keys.Select(x =>
-                {
-                    using (var context = JsonOperationContext.ShortTermSingleUse())
+                    var statistics = new IdleDatabaseStatistics
                     {
-                        return context.ReadObject(x.ToJson(), "json").ToString();
-                    }
-                })));
+                        Name = sinkDbKvp.Key.ToString()
+                    };
 
-                // the hub & sink should be online  
-                Assert.Equal(0, server.ServerStore.IdleDatabases.Count);
-                Assert.All(dic.Keys, x => Assert.Contains($"Cannot unload database because number of active PullReplication as Sink Connections (1) is greater than 0", x.Explanations));
+                    // Calculate the actual decision based on all factors
+                    bool serverSaysCanUnload = server.ServerStore.CanUnloadDatabase(sinkDbKvp.Key, sinkDbKvp.Value, statistics, out _);
+
+                    // If the server says it CAN unload, then our blocker hasn't kicked in yet.
+                    if (serverSaysCanUnload)
+                        return false;
+
+                    // Verify the specific reason from ServerStore.cs logic
+                    return statistics.Explanations.Any(x => x.Contains("Pull Replication Sink configurations with 'HubToSink' mode enabled"));
+
+                }, true, 75_000, 1000));
+
+                // Verify Hub is NOT blocked by replication connections (it might be blocked by time, but not by replication).
+                var hubDbKvp = server.ServerStore.DatabasesLandlord.LastRecentlyUsed.FirstOrDefault(x => x.Key.Equals(hub.Database, StringComparison.OrdinalIgnoreCase));
+                if (hubDbKvp.Key != null)
+                {
+                    var hubStats = new IdleDatabaseStatistics { Name = hubDbKvp.Key.ToString() };
+                    server.ServerStore.CanUnloadDatabase(hubDbKvp.Key, hubDbKvp.Value, hubStats, out _);
+
+                    // The Hub should NOT have the configuration-based blocking message, nor the old connection-based one.
+                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("Pull Replication Sink configurations with 'HubToSink' mode enabled"));
+                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("active PullReplication as Sink Connections"));
+                }
 
                 using (var s2 = hub.OpenSession())
                 {

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -15,6 +15,7 @@ using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
@@ -786,17 +787,17 @@ namespace SlowTests.Server.Replication
                     Name = hub.Database.ToString()
                 };
 
-                while (now < nextNow && hubServer.ServerStore.IdleDatabases.Count < 1)
+                while (now < nextNow && hubServer.ServerStore.DatabaseIdleManager.GetActivityState(hub.Database) is DatabaseIdleManager.DatabaseActivityState.Active)
                 {
                     await Task.Delay(1000);
                     var hubDb = hubServer.ServerStore.DatabasesLandlord.LastRecentlyUsed.FirstOrDefault();
-                    hubServer.ServerStore.CanUnloadDatabase(hubDb.Key, hubDb.Value, statistics, out _);
+                    hubServer.ServerStore.DatabasesLandlord.CanUnloadDatabase(hubDb.Key, hubDb.Value, statistics, out _);
 
                     now = DateTime.Now;
                 }
 
-                Assert.True(1 == hubServer.ServerStore.IdleDatabases.Count, string.Join(Environment.NewLine, statistics.Explanations));
-                Assert.Equal(0, sinkServer.ServerStore.IdleDatabases.Count);
+                Assert.True(hubServer.ServerStore.DatabaseIdleManager.GetActivityState(hub.Database) is DatabaseIdleManager.DatabaseActivityState.Idle, string.Join(Environment.NewLine, statistics.Explanations));
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Active, sinkServer.ServerStore.DatabaseIdleManager.GetActivityState(sink.Database));
 
                 var sinkDb = await GetDatabase(sinkServer, sink.Database);
 
@@ -816,8 +817,7 @@ namespace SlowTests.Server.Replication
                         {
                             if (error is not DatabaseIdleException idleException)
                                 continue;
-
-                            if (idleException.Message.Contains($"Raven.Client.Exceptions.Database.DatabaseIdleException: Cannot GetRemoteTaskTopology for PullReplicationAsSink connection because database '{hub.Database}' currently is idle."))
+                            if (idleException.Message.Contains($"Raven.Client.Exceptions.Database.DatabaseIdleException: The database '{hub.Database}' is currently idle. The request was rejected to avoid waking up the database unnecessarily"))
                                 return true;
                         }
                     }
@@ -831,7 +831,7 @@ namespace SlowTests.Server.Replication
                     s2.SaveChanges();
                 }
 
-                Assert.Equal(0, WaitForValue(() => sinkServer.ServerStore.IdleDatabases.Count, 0, 60_000, 333));
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Active, WaitForValue(() => sinkServer.ServerStore.DatabaseIdleManager.GetActivityState(sink.Database), DatabaseIdleManager.DatabaseActivityState.Active, 60_000, 333));
                 Assert.True(WaitForDocument(sink, "foo/bar/322", timeout * 5), sink.Identifier);
             }
         }
@@ -933,14 +933,14 @@ namespace SlowTests.Server.Replication
                     };
 
                     // Calculate the actual decision based on all factors
-                    bool serverSaysCanUnload = server.ServerStore.CanUnloadDatabase(sinkDbKvp.Key, sinkDbKvp.Value, statistics, out _);
+                    bool serverSaysCanUnload = server.ServerStore.DatabasesLandlord.CanUnloadDatabase(sinkDbKvp.Key, sinkDbKvp.Value, statistics, out _);
 
                     // If the server says it CAN unload, then our blocker hasn't kicked in yet.
                     if (serverSaysCanUnload)
                         return false;
 
                     // Verify the specific reason from ServerStore.cs logic
-                    return statistics.Explanations.Any(x => x.Contains("Pull Replication Sink configurations with 'HubToSink' mode enabled"));
+                    return statistics.Explanations.Any(x => x.Contains("Pull Replication Hub or Sink configurations with 'HubToSink' mode enabled"));
 
                 }, true, 75_000, 1000));
 
@@ -949,11 +949,10 @@ namespace SlowTests.Server.Replication
                 if (hubDbKvp.Key != null)
                 {
                     var hubStats = new IdleDatabaseStatistics { Name = hubDbKvp.Key.ToString() };
-                    server.ServerStore.CanUnloadDatabase(hubDbKvp.Key, hubDbKvp.Value, hubStats, out _);
+                    server.ServerStore.DatabasesLandlord.CanUnloadDatabase(hubDbKvp.Key, hubDbKvp.Value, hubStats, out _);
 
-                    // The Hub should NOT have the configuration-based blocking message, nor the old connection-based one.
-                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("Pull Replication Sink configurations with 'HubToSink' mode enabled"));
-                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("active PullReplication as Sink Connections"));
+                    // The Hub should NOT have the configuration-based blocking message
+                    Assert.DoesNotContain(hubStats.Explanations, x => x.Contains("Pull Replication Hub or Sink configurations with 'HubToSink' mode enabled"));
                 }
 
                 using (var s2 = hub.OpenSession())

--- a/test/StressTests/Issues/RavenDB-13987.cs
+++ b/test/StressTests/Issues/RavenDB-13987.cs
@@ -12,6 +12,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Voron.Util;
@@ -48,7 +49,7 @@ namespace StressTests.Issues
             {
                 foreach (var server in nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
                     server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
                     documentStores[server.ServerStore.NodeTag].Dispose();
                 }
@@ -56,7 +57,7 @@ namespace StressTests.Issues
 
             foreach (var server in nodes)
             {
-                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+                server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
                 server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
             }
 
@@ -122,7 +123,7 @@ namespace StressTests.Issues
             Assert.Equal(2, IdleCount());
 
             return;
-            int IdleCount() => nodes.Sum(server => server.ServerStore.IdleDatabases.Count);
+            int IdleCount() => nodes.Count(server => server.ServerStore.DatabaseIdleManager.GetActivityState(documentStores[server.ServerStore.NodeTag].Database) is DatabaseIdleManager.DatabaseActivityState.Idle);
             string CollectDiagnostics()
             {
                 var sb = new StringBuilder();
@@ -154,11 +155,11 @@ namespace StressTests.Issues
             using var dispose = new DisposableAction(() =>
             {
                 server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = false;
-                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
             });
 
             server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipIncreasingLastWorkTimeBasedOnDatabaseSize = true;
-            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+            server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             using var store = GetDocumentStore(new Options { Server = server, RunInMemory = false });
             while (DateTime.Now.Second > 10)
@@ -185,17 +186,15 @@ namespace StressTests.Issues
                 await session.SaveChangesAsync();
             }
 
-            WaitForUserToContinueTheTest(store);
-
             var getPeriodicBackupStatusOperation = new GetPeriodicBackupStatusOperation(backupTaskId);
             Assert.True(1 <= await WaitForGreaterThanAsync(async () =>
             {
-                Assert.Equal(0, server.ServerStore.IdleDatabases.Count);
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Active, server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database));
                 var status = await store.Maintenance.SendAsync(getPeriodicBackupStatusOperation);
                 return status?.Status?.LastEtag ?? 0;
             }, val: 1, timeout: 75000, interval: 300));
 
-            Assert.Equal(1, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60_000, interval: 3_000));
+            Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Idle, WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database), DatabaseIdleManager.DatabaseActivityState.Idle , timeout: 60_000, interval: 3_000));
         }
 
         internal static int WaitForCount(TimeSpan seconds, int excepted, Func<int> func)
@@ -212,9 +211,5 @@ namespace StressTests.Issues
 
             return count;
         }
-
-
-
-
     }
 }

--- a/test/StressTests/Issues/RavenDB_14292.cs
+++ b/test/StressTests/Issues/RavenDB_14292.cs
@@ -13,6 +13,7 @@ using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Voron.Util;
@@ -44,8 +45,8 @@ namespace StressTests.Issues
                     [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false"
                 }
             });
-            using var dispose = new DisposableAction(() => server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false);
-            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+            using var dispose = new DisposableAction(() => server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false);
+            server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
 
             var dbName = GetDatabaseName();
             var controlgroupDbName = GetDatabaseName() + "controlgroup";
@@ -80,10 +81,8 @@ namespace StressTests.Issues
             for (int i = 0; i < rounds; i++)
             {
                 // let db get idle
-                await WaitForValueAsync(() => Task.FromResult(server.ServerStore.IdleDatabases.Count > 0), true, 180 * 1000, 3000);
-
-                Assert.True(1 == server.ServerStore.IdleDatabases.Count, $"IdleDatabasesCount({server.ServerStore.IdleDatabases.Count}), Round({i})");
-                Assert.True(server.ServerStore.IdleDatabases.ContainsKey(store.Database), $"Round({i})");
+                var state = WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(dbName), DatabaseIdleManager.DatabaseActivityState.Idle, 180 * 1000, 3000);
+                Assert.True(DatabaseIdleManager.DatabaseActivityState.Idle == state, $"server.ServerStore.DatabaseIdleManager.GetActivityState(dbName) = '{state})', Round({i})");
 
                 DateTime lastBackup;
                 if (first)

--- a/test/StressTests/Issues/RavenDB_14744.cs
+++ b/test/StressTests/Issues/RavenDB_14744.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Operations;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,7 +41,7 @@ namespace StressTests.Issues
             {
                 foreach (var server in nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
                 }
 
                 using (var store = GetDocumentStore(new Options
@@ -59,16 +60,15 @@ namespace StressTests.Issues
                         server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().HoldDocumentDatabaseCreation = 3000;
                     }
 
-                    var count = RavenDB_13987.WaitForCount(TimeSpan.FromSeconds(300), clusterSize, () => GetIdleCount(nodes));
+                    var count = RavenDB_13987.WaitForCount(TimeSpan.FromSeconds(300), clusterSize, () => GetIdleCount(nodes, databaseName));
                     Assert.Equal(clusterSize, count);
 
                     foreach (var server in nodes)
                     {
-                        Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-                        Assert.True(server.ServerStore.IdleDatabases.TryGetValue(databaseName, out var dictionary));
+                        Assert.True(server.ServerStore.DatabaseIdleManager.TryGetIdleInfo(store.Database, out var idleDatabaseInfo));
 
                         // new incoming replications not saved in IdleDatabases
-                        Assert.Equal(0, dictionary.Count);
+                        Assert.Equal(0, idleDatabaseInfo.ReplicationInfo.Count);
                     }
 
                     using (var store2 = new DocumentStore { Urls = new[] { nodes[index].WebUrl }, Conventions = { DisableTopologyUpdates = true }, Database = databaseName }.Initialize())
@@ -78,7 +78,7 @@ namespace StressTests.Issues
                         Assert.True(await WaitForValueAsync(() => nodes.Any(x => x.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().PreventedRehabOfIdleDatabase), true),
                             "await WaitForValueAsync(() => _nodes.Any(x => x.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().PreventedRehabOfIdleDatabase), true)");
 
-                        Assert.Equal(2, GetIdleCount(nodes));
+                        Assert.Equal(2, GetIdleCount(nodes, databaseName));
                     }
                 }
             }
@@ -86,14 +86,12 @@ namespace StressTests.Issues
             {
                 foreach (var server in nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
                 }
             }
         }
 
-        private static int GetIdleCount(IEnumerable<RavenServer> nodes)
-        {
-            return nodes.Sum(server => server.ServerStore.IdleDatabases.Count);
-        }
+        private static int GetIdleCount(IEnumerable<RavenServer> nodes, string databaseName) =>
+            nodes.Count(server => server.ServerStore.DatabaseIdleManager.GetActivityState(databaseName) is DatabaseIdleManager.DatabaseActivityState.Idle);
     }
 }

--- a/test/StressTests/Issues/RavenDB_18420.cs
+++ b/test/StressTests/Issues/RavenDB_18420.cs
@@ -6,6 +6,7 @@ using FastTests;
 using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -31,13 +32,14 @@ public class RavenDB_18420 : RavenTestBase
                 [RavenConfiguration.GetKey(x => x.Core.RunInMemory)] = "false",
             }
         });
-        server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+        server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+        Action<string> onWakeup = null;
         try
         {
             var backupPath = NewDataPath(forceCreateDir: true);
             using (var store = GetDocumentStore(new Options { Server = server, RunInMemory = false }))
             {
-                Assert.Equal(1, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000));
+                Assert.True(WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database) is DatabaseIdleManager.DatabaseActivityState.Idle, true, timeout: 60000, interval: 1000));
                 var putConfiguration = new ServerWideBackupConfiguration
                 {
                     FullBackupFrequency = "*/1 * * * *",
@@ -63,10 +65,16 @@ public class RavenDB_18420 : RavenTestBase
 
                 // we wait here for UpdateResponsibleNodeForTasksCommand, it won't wake up the database since the db task is faulted with DatabaseConcurrentLoadTimeoutException
                 Backup.WaitForResponsibleNodeUpdate(server.ServerStore, store.Database, putConfiguration.TaskId);
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Idle, server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database));
 
                 var idleRemovedSignal = new ManualResetEventSlim(false);
-                server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle = idleRemovedSignal;
+                onWakeup = name =>
+                {
+                    if (string.Equals(name, store.Database, StringComparison.OrdinalIgnoreCase))
+                        idleRemovedSignal.Set();
+                };
+
+                server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle += onWakeup;
 
                 // enable backup and this will set wakeup timer
                 await store.Maintenance.Server.SendAsync(new PutServerWideBackupConfigurationOperation(putConfiguration));
@@ -78,7 +86,7 @@ public class RavenDB_18420 : RavenTestBase
 
                 Assert.True(idleRemovedSignal.Wait(TimeSpan.FromSeconds(65)));
                 // db should wake up after dueTimeOnRetry is hit
-                Assert.Equal(0, WaitForValue(() => server.ServerStore.IdleDatabases.Count, 0, interval: 333));
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Active, WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database), DatabaseIdleManager.DatabaseActivityState.Active, interval: 333));
 
                 PeriodicBackupStatus status = null;
                 var val = await WaitForValueAsync(async () =>
@@ -94,7 +102,9 @@ public class RavenDB_18420 : RavenTestBase
         }
         finally
         {
-            server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+            server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+            if (onWakeup != null)
+                server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().AfterDatabaseRemovedFromIdle -= onWakeup;
         }
     }
 }

--- a/test/StressTests/Server/Documents/PeriodicBackup/ServerWideBackupStress.cs
+++ b/test/StressTests/Server/Documents/PeriodicBackup/ServerWideBackupStress.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Commands;
 using StressTests.Issues;
 using Tests.Infrastructure;
@@ -56,7 +57,7 @@ namespace StressTests.Server.Documents.PeriodicBackup
             using (var store = GetDocumentStore(new RavenTestBase.Options { Server = server, RunInMemory = false }))
             using (var excludedStore = GetDocumentStore(new RavenTestBase.Options { Server = server, RunInMemory = false }))
             {
-                await AssertWaitForGreaterAsync(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000);
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Idle, WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database), DatabaseIdleManager.DatabaseActivityState.Idle, timeout: 60000, interval: 1000));
 
                 var fullFreq = "0 2 1 1 *";
                 var incFreq = "0 2 * * 0";
@@ -75,7 +76,7 @@ namespace StressTests.Server.Documents.PeriodicBackup
 
                 await BackupNow(store, serverWideConfiguration.Name);
 
-                await AssertWaitForGreaterAsync(() => server.ServerStore.IdleDatabases.Count, 1, timeout: 60000, interval: 1000);
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Idle, WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database), DatabaseIdleManager.DatabaseActivityState.Idle, timeout: 60000, interval: 1000));
 
                 // update the backup configuration
                 putConfiguration.Name = serverWideConfiguration.Name;
@@ -110,7 +111,8 @@ namespace StressTests.Server.Documents.PeriodicBackup
                 {
                     await BackupNow(createdAfter, serverWideConfiguration.Name);
 
-                    await AssertWaitForGreaterAsync(() => server.ServerStore.IdleDatabases.Count, 2, timeout: 60000, interval: 1000);
+                    Assert.True(WaitForValue(() => server.ServerStore.DatabaseIdleManager.GetActivityState(store.Database) is DatabaseIdleManager.DatabaseActivityState.Idle &&
+                                                   server.ServerStore.DatabaseIdleManager.GetActivityState(createdAfter.Database) is DatabaseIdleManager.DatabaseActivityState.Idle, true, timeout: 60000, interval: 1000));
 
                     putConfiguration.TaskId = result.RaftCommandIndex;
                     putConfiguration.RetentionPolicy = new RetentionPolicy { MinimumBackupAgeToKeep = TimeSpan.FromDays(10) };

--- a/test/StressTests/Server/Replication/ExternalReplicationStressTests.cs
+++ b/test/StressTests/Server/Replication/ExternalReplicationStressTests.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Server;
 using Raven.Server.Config;
+using Raven.Server.ServerWide;
 using Raven.Tests.Core.Utils.Entities;
 using StressTests.Issues;
 using Tests.Infrastructure;
@@ -59,65 +60,66 @@ namespace StressTests.Server.Replication
                 Assert.True(server.ServerStore.DatabasesLandlord.LastRecentlyUsed.TryGetValue(store1.Database, out _));
                 Assert.True(server.ServerStore.DatabasesLandlord.LastRecentlyUsed.TryGetValue(store2.Database, out _));
 
-                var now = DateTime.Now;
-                var nextNow = now + TimeSpan.FromSeconds(60);
-                while (now < nextNow && server.ServerStore.IdleDatabases.Count < 2)
-                {
-                    await Task.Delay(3000);
-                    now = DateTime.Now;
-                }
-                Assert.Equal(2, server.ServerStore.IdleDatabases.Count);
+                Assert.True(WaitForValue(() =>
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Idle &&
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle,
+                    expectedVal: true,
+                    timeout: (int) TimeSpan.FromSeconds(60).TotalMilliseconds,
+                    interval: (int) TimeSpan.FromSeconds(3).TotalMilliseconds));
 
                 await store1.Maintenance.SendAsync(new CreateSampleDataOperation());
                 Indexes.WaitForIndexing(store1);
 
-                var count = 0;
                 var docs = store1.Maintenance.Send(new GetStatisticsOperation()).CountOfDocuments;
-                var replicatedDocs = store2.Maintenance.Send(new GetStatisticsOperation()).CountOfDocuments;
-                while (docs != replicatedDocs && count < 20)
-                {
-                    await Task.Delay(3000);
-                    replicatedDocs = store2.Maintenance.Send(new GetStatisticsOperation()).CountOfDocuments;
-                    count++;
-                }
-                Assert.Equal(docs, replicatedDocs);
 
-                count = 0;
-                nextNow = DateTime.Now + TimeSpan.FromMinutes(5);
-                while (server.ServerStore.IdleDatabases.Count == 0 && now < nextNow)
-                {
-                    await Task.Delay(500);
-                    if (count % 10 == 0)
+                Assert.True(WaitForValue(() =>
+                    {
+                        var replicatedDocs = store2.Maintenance.Send(new GetStatisticsOperation()).CountOfDocuments;
+                        return docs == replicatedDocs;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromSeconds(60).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(3).TotalMilliseconds));
+
+                var count = 0;
+                Assert.True(WaitForValue(() =>
+                    {
+                        if (count % 10 == 0)
+                            store1.Maintenance.Send(new GetStatisticsOperation());
+
+                        count++;
+
+                        return server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Active &&
+                               server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                    interval: 500));
+
+                Assert.True(WaitForValue(() =>
+                    {
                         store1.Maintenance.Send(new GetStatisticsOperation());
+                        Assert.True(server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle);
 
-                    now = DateTime.Now;
-                    count++;
-                }
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
+                        return server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Active;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(2).TotalMilliseconds));
 
-                nextNow = DateTime.Now + TimeSpan.FromSeconds(15);
-                while (now < nextNow)
-                {
-                    await Task.Delay(2000);
-                    store1.Maintenance.Send(new GetStatisticsOperation());
-                    Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-                    now = DateTime.Now;
-                }
-
-                nextNow = DateTime.Now + TimeSpan.FromMinutes(10);
-                while (now < nextNow && server.ServerStore.IdleDatabases.Count < 2)
-                {
-                    await Task.Delay(3000);
-                    now = DateTime.Now;
-                }
-                Assert.Equal(2, server.ServerStore.IdleDatabases.Count);
+                Assert.True(WaitForValue(() =>
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Idle &&
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle,
+                    expectedVal: true,
+                    timeout: (int) TimeSpan.FromMinutes(10).TotalMilliseconds,
+                    interval: (int) TimeSpan.FromSeconds(3).TotalMilliseconds));
 
                 using (var s = store2.OpenSession())
                 {
                     s.Advanced.RawQuery<dynamic>("from @all_docs")
                         .ToList();
                 }
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
+                Assert.Equal(DatabaseIdleManager.DatabaseActivityState.Active, server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database));
 
                 var operation = await store2
                     .Operations
@@ -126,34 +128,38 @@ namespace StressTests.Server.Replication
 
                 await operation.WaitForCompletionAsync(TimeSpan.FromMinutes(5));
 
-                nextNow = DateTime.Now + TimeSpan.FromMinutes(2);
-                while (now < nextNow && server.ServerStore.IdleDatabases.Count > 0)
-                {
-                    await Task.Delay(5000);
-                    now = DateTime.Now;
-                }
-                Assert.Equal(0, server.ServerStore.IdleDatabases.Count);
+                Assert.True(WaitForValue(() =>
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Active &&
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Active,
+                    expectedVal: true,
+                    timeout: (int) TimeSpan.FromMinutes(2).TotalMilliseconds,
+                    interval: (int) TimeSpan.FromSeconds(5).TotalMilliseconds));
 
-                nextNow = DateTime.Now + TimeSpan.FromMinutes(10);
-                while (server.ServerStore.IdleDatabases.Count == 0 && now < nextNow)
-                {
-                    await Task.Delay(500);
-                    if (count % 10 == 0)
+                count = 0;
+                Assert.True(WaitForValue(() =>
+                    {
+                        if (count % 10 == 0)
+                            store2.Maintenance.Send(new GetStatisticsOperation());
+
+                        count++;
+
+                        return server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Idle &&
+                               server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Active;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(10).TotalMilliseconds,
+                    interval: 500));
+
+                Assert.True(WaitForValue(() =>
+                    {
                         store2.Maintenance.Send(new GetStatisticsOperation());
+                        Assert.True(server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Idle);
 
-                    now = DateTime.Now;
-                    count++;
-                }
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-
-                nextNow = DateTime.Now + TimeSpan.FromSeconds(15);
-                while (now < nextNow)
-                {
-                    await Task.Delay(2000);
-                    store2.Maintenance.Send(new GetStatisticsOperation());
-                    Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-                    now = DateTime.Now;
-                }
+                        return server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Active;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(2).TotalMilliseconds));
             }
         }
 
@@ -192,15 +198,12 @@ namespace StressTests.Server.Replication
                 Assert.True(server.ServerStore.DatabasesLandlord.LastRecentlyUsed.TryGetValue(store1.Database, out _));
                 Assert.True(server.ServerStore.DatabasesLandlord.LastRecentlyUsed.TryGetValue(store2.Database, out _));
 
-                var now = DateTime.Now;
-                var nextNow = now + TimeSpan.FromSeconds(60);
-                while (now < nextNow && server.ServerStore.IdleDatabases.Count < 2)
-                {
-                    await Task.Delay(3000);
-                    now = DateTime.Now;
-                }
-
-                Assert.Equal(2, server.ServerStore.IdleDatabases.Count);
+                Assert.True(WaitForValue(() =>
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Idle &&
+                        server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle,
+                    expectedVal: true,
+                    timeout: (int) TimeSpan.FromSeconds(60).TotalMilliseconds,
+                    interval: (int) TimeSpan.FromSeconds(3).TotalMilliseconds));
 
                 await store1.Maintenance.SendAsync(new CreateSampleDataOperation());
                 Indexes.WaitForIndexing(store1);
@@ -217,26 +220,30 @@ namespace StressTests.Server.Replication
                 Assert.Equal(docs, replicatedDocs);
 
                 count = 0;
-                nextNow = DateTime.Now + TimeSpan.FromMinutes(5);
-                while (server.ServerStore.IdleDatabases.Count == 0 && now < nextNow)
-                {
-                    await Task.Delay(500);
-                    if (count % 10 == 0)
+                Assert.True(WaitForValue(() =>
+                    {
+                        if (count % 10 == 0)
+                            store1.Maintenance.Send(new GetStatisticsOperation());
+
+                        count++;
+
+                        return server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Active &&
+                               server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromMinutes(5).TotalMilliseconds,
+                    interval: 500));
+
+                Assert.True(WaitForValue(() =>
+                    {
                         store1.Maintenance.Send(new GetStatisticsOperation());
+                        Assert.True(server.ServerStore.DatabaseIdleManager.GetActivityState(store2.Database) is DatabaseIdleManager.DatabaseActivityState.Idle);
 
-                    now = DateTime.Now;
-                    count++;
-                }
-                Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-
-                nextNow = DateTime.Now + TimeSpan.FromSeconds(15);
-                while (now < nextNow)
-                {
-                    await Task.Delay(2000);
-                    store1.Maintenance.Send(new GetStatisticsOperation());
-                    Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-                    now = DateTime.Now;
-                }
+                        return server.ServerStore.DatabaseIdleManager.GetActivityState(store1.Database) is DatabaseIdleManager.DatabaseActivityState.Active;
+                    },
+                    expectedVal: true,
+                    timeout: (int)TimeSpan.FromSeconds(15).TotalMilliseconds,
+                    interval: (int)TimeSpan.FromSeconds(2).TotalMilliseconds));
             }
         }
 
@@ -265,7 +272,7 @@ namespace StressTests.Server.Replication
                 foreach (var server in _nodes)
                 {
                     wakeUpReasons.Add(server.ServerStore.NodeTag, new List<string>());
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = true;
                     server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().AfterDatabaseCreation = tuple =>
                     {
                         var list = wakeUpReasons[tuple.Database.ServerStore.NodeTag];
@@ -282,16 +289,15 @@ namespace StressTests.Server.Replication
                     RunInMemory = false
                 }))
                 {
-                    var count = RavenDB_13987.WaitForCount(TimeSpan.FromSeconds(300), clusterSize, GetIdleCount);
+                    var count = RavenDB_13987.WaitForCount(TimeSpan.FromSeconds(300), clusterSize, () => GetIdleCount(store.Database));
                     Assert.True(clusterSize == count, string.Join(Environment.NewLine, wakeUpReasons.Select(x => string.Join(": ", x.Key, string.Join(", ", x.Value)))));
 
                     foreach (var server in _nodes)
                     {
-                        Assert.Equal(1, server.ServerStore.IdleDatabases.Count);
-                        Assert.True(server.ServerStore.IdleDatabases.TryGetValue(databaseName, out var dictionary));
+                        Assert.True(server.ServerStore.DatabaseIdleManager.TryGetIdleInfo(databaseName, out var idleDatabaseInfo));
 
                         // new incoming replications not saved in IdleDatabases
-                        Assert.Equal(0, dictionary.Count);
+                        Assert.Equal(0, idleDatabaseInfo.ReplicationInfo.Count);
                     }
 
                     var rnd = new Random();
@@ -300,7 +306,7 @@ namespace StressTests.Server.Replication
                     {
                         await store2.Maintenance.SendAsync(new GetStatisticsOperation());
 
-                        Assert.True(2 == GetIdleCount(), string.Join(Environment.NewLine, wakeUpReasons.Select(x => string.Join(": ", x.Key, string.Join(", ", x.Value)))));
+                        Assert.True(2 == GetIdleCount(store.Database), string.Join(Environment.NewLine, wakeUpReasons.Select(x => string.Join(": ", x.Key, string.Join(", ", x.Value)))));
                         using (var s = store2.OpenAsyncSession())
                         {
                             await s.StoreAsync(new User() { Name = "Egor" }, "foo/bar");
@@ -308,7 +314,7 @@ namespace StressTests.Server.Replication
                         }
                     }
 
-                    count = RavenDB_13987.WaitForCount(TimeSpan.FromSeconds(300), 0, GetIdleCount);
+                    count = RavenDB_13987.WaitForCount(TimeSpan.FromSeconds(300), 0, () => GetIdleCount(store.Database));
                     Assert.True(0 == count, string.Join(Environment.NewLine, wakeUpReasons.Select(x => string.Join(": ", x.Key, string.Join(", ", x.Value)))));
 
                     var timeout = 5000;
@@ -325,29 +331,26 @@ namespace StressTests.Server.Replication
                     var now = DateTime.Now;
                     using (var store2 = new DocumentStore { Urls = new[] { _nodes[index].WebUrl }, Conventions = { DisableTopologyUpdates = true }, Database = databaseName }.Initialize())
                     {
-                        while (now < nextNow && GetIdleCount() < 2)
+                        while (now < nextNow && GetIdleCount(store.Database) < 2)
                         {
                             await Task.Delay(2000);
                             await store2.Maintenance.SendAsync(new GetStatisticsOperation());
                             now = DateTime.Now;
                         }
                     }
-                    Assert.True(2 == GetIdleCount(), string.Join(Environment.NewLine, wakeUpReasons.Select(x => string.Join(": ", x.Key, string.Join(", ", x.Value)))));
+                    Assert.True(2 == GetIdleCount(store.Database), string.Join(Environment.NewLine, wakeUpReasons.Select(x => string.Join(": ", x.Key, string.Join(", ", x.Value)))));
                 }
             }
             finally
             {
                 foreach (var server in _nodes)
                 {
-                    server.ServerStore.DatabasesLandlord.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
+                    server.ServerStore.DatabaseIdleManager.ForTestingPurposesOnly().SkipShouldContinueDisposeCheck = false;
                     server.ServerStore.DatabasesLandlord.ForTestingPurposes = null;
                 }
             }
         }
 
-        private int GetIdleCount()
-        {
-            return _nodes.Sum(server => server.ServerStore.IdleDatabases.Count);
-        }
+        private int GetIdleCount(string databaseName) => _nodes.Count(server => server.ServerStore.DatabaseIdleManager.GetActivityState(databaseName) is DatabaseIdleManager.DatabaseActivityState.Idle);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25623

### Additional description
**Overview**
Refactored the database idle determination logic to rely on **Configuration-Based Intent** rather than the physical state of TCP connections. This ensures stability even in unstable network environments. Additionally, replaced the indiscriminate wake-up logic with a **Smart Wakeup** mechanism that prevents Hub databases from waking up unless actual changes need to be replicated.

**Key Changes**
*   **Configuration-Based Idle Check:** The database now determines if it can enter an idle state based on its defined replication role:
    *   **Sinks (Initiators):** Will strictly prevent idling if active Pull Replication tasks exist, ensuring they continue polling regardless of temporary connection drops.
    *   **Hubs (Targets):** Are allowed to enter idle state but remain responsive to polling.
*   **Smart Wakeup Mechanism:** Changed the Hub's wake-up behavior to smart (waking only when necessary). The Sink now transmits its current `change-vector` during the handshake. The Hub compares this with its own state and throws `DatabaseIdleException` if no new data exists, allowing it to remain asleep.
*   **Protocol Update:** Replaced the legacy `tag` parameter with `change-vector` in the replication handshake commands to enable the vector comparison logic.
*   **Backward Compatibility:** Requests from older nodes (missing the change vector) will now default to processing the request (waking the Hub). This prevents replication deadlocks in mixed clusters during rolling upgrades, prioritizing data consistency over resource saving in legacy scenarios.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured:
The protocol change involves replacing the `tag` parameter with `change-vector`. Compatibility is handled via a fallback mechanism:
*   **Old Sink -> New Hub:** The Old Sink will not send a change vector. The New Hub detects the absence of the vector and falls back to processing the request normally (waking up the database). This results in the database staying awake during the migration period but ensures data replication continues without interruption.
*   **New Sink -> Old Hub:** The New Sink sends the change vector (and omits the old tag). The Old Hub ignores the unknown vector parameter. Since the old tag is missing, the Old Hub treats it as a standard request and wakes up the database. 
In both mixed-version scenarios, the system prioritizes **data availability** (waking up the DB) over resource saving (idling), ensuring no replication deadlocks occur during rolling upgrades.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed