### PR TITLE
RavenDB-25881 Server-Wide Backup Task NRE

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/editServerWideBackup.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/editServerWideBackup.ts
@@ -15,6 +15,9 @@ import activeDatabaseTracker = require("common/shell/activeDatabaseTracker");
 import clusterTopologyManager = require("common/shell/clusterTopologyManager");
 import licenseModel = require("models/auth/licenseModel");
 import EditServerWideBackupInfoHub = require("./EditServerWideBackupInfoHub");
+import accessManager = require("common/shell/accessManager");
+import store = require("components/store");
+import databaseSliceSelectors = require("components/common/shell/databaseSliceSelectors");
 
 class editServerWideBackup extends viewModelBase {
 
@@ -45,13 +48,27 @@ class editServerWideBackup extends viewModelBase {
     spinners = {
         save: ko.observable<boolean>(false)
     };
+
+    overrideViaExternalScriptDisableReason: KnockoutComputed<string>;
     
     constructor() {
         super();
         this.bindToCurrentInstance("testCredentials", "setState");
         this.infoHubView = ko.pureComputed(() => ({
             component: EditServerWideBackupInfoHub.EditServerWideBackupInfoHub
-        }))
+        }));
+
+        this.overrideViaExternalScriptDisableReason = ko.pureComputed(() => {
+            const isClusterAdminOrClusterNode = accessManager.default.isClusterAdminOrClusterNode();
+            const storeState = store.default.getState();
+            const isRestricted = databaseSliceSelectors.databaseSelectors.isRestrictExternalScriptUsageForNonClusterAdmin(storeState);
+
+            if (!isClusterAdminOrClusterNode && isRestricted) {
+                return tasksCommonContent.externalScriptNotAllowedForNonClusterAdmins;
+            }
+
+            return null;
+        });
     }
     
     activate(args: any) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25881/Server-Wide-Backup-Task-NRE

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
