### PR TITLE
RavenDB-25642 - Remote attachments - when the remote server is down (Studio part)

### DIFF
--- a/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
+++ b/src/Raven.Studio/typescript/common/notifications/notificationCenter.ts
@@ -45,6 +45,7 @@ import pagingDetails = require("viewmodels/common/notificationCenter/detailViewe
 import hugeDocumentsDetails = require("viewmodels/common/notificationCenter/detailViewer/performanceHint/hugeDocumentsDetails");
 import newVersionAvailableDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/newVersionAvailableDetails");
 import etlTransformOrLoadErrorDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails");
+import remoteAttachmentErrorDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/remoteAttachmentErrorDetails");
 import genericAlertDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/genericAlertDetails");
 import recentErrorDetails = require("viewmodels/common/notificationCenter/detailViewer/recentErrorDetails");
 import notificationCenterSettings = require("common/notifications/notificationCenterSettings");
@@ -194,6 +195,7 @@ class notificationCenter {
             conflictExceededDetails,
             complexFieldsAlertDetails,
             aiAgentExceededTokenThreshold,
+            remoteAttachmentErrorDetails,
             genericAlertDetails  // leave it as last item on this list - this is fallback handler for all alert types
         );
 

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/remoteAttachmentErrorDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/remoteAttachmentErrorDetails.ts
@@ -1,0 +1,117 @@
+import app = require("durandal/app");
+import abstractNotification = require("common/notifications/models/abstractNotification");
+import notificationCenter = require("common/notifications/notificationCenter");
+import virtualGridController = require("widgets/virtualGrid/virtualGridController");
+import textColumn = require("widgets/virtualGrid/columns/textColumn");
+import alert = require("common/notifications/models/alert");
+import columnPreviewPlugin = require("widgets/virtualGrid/columnPreviewPlugin");
+import actionColumn = require("widgets/virtualGrid/columns/actionColumn");
+import abstractAlertDetails = require("viewmodels/common/notificationCenter/detailViewer/alerts/abstractAlertDetails");
+import copyToClipboard = require("common/copyToClipboard");
+import generalUtils = require("common/generalUtils");
+import moment = require("moment");
+
+interface RemoteAttachmentErrorInfo {
+    Date: string;
+    Error: string;
+    Identifier: string;
+    Hash: string;
+    Ids: string[];
+}
+
+interface RemoteAttachmentErrorsDetails {
+    Errors: RemoteAttachmentErrorInfo[];
+}
+
+class remoteAttachmentErrorDetails extends abstractAlertDetails {
+
+    view = require("views/common/notificationCenter/detailViewer/alerts/remoteAttachmentErrorDetails.html");
+
+    currentDetails = ko.observable<RemoteAttachmentErrorInfo>();
+
+    tableItems: RemoteAttachmentErrorInfo[] = [];
+    private gridController = ko.observable<virtualGridController<RemoteAttachmentErrorInfo>>();
+    private columnPreview = new columnPreviewPlugin<RemoteAttachmentErrorInfo>();
+
+    constructor(alert: alert, notificationCenter: notificationCenter) {
+        super(alert, notificationCenter);
+
+        this.tableItems = (this.alert.details() as RemoteAttachmentErrorsDetails).Errors;
+
+        // newest first
+        this.tableItems.reverse();
+    }
+
+    compositionComplete() {
+        super.compositionComplete();
+
+        const grid = this.gridController();
+        grid.headerVisible(true);
+
+        grid.init(() => this.fetcher(), () => {
+
+            const previewColumn = new actionColumn<RemoteAttachmentErrorInfo>(
+                grid, item => this.showDetails(item), "Preview", `<i class="icon-preview"></i>`, "70px",
+            {
+                title: () => 'Show item preview'
+            });
+            const dateColumn = new textColumn<RemoteAttachmentErrorInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.Date), "Date", "15%", {
+                sortable: x => x.Date
+            });
+            const idsColumn = new textColumn<RemoteAttachmentErrorInfo>(grid, x => x.Ids.join(', '), "Ids", "10%", {
+                sortable: x => x.Ids.join(', ')
+            });
+            const identifierColumn = new textColumn<RemoteAttachmentErrorInfo>(grid, x => x.Identifier, "Identifier", "15%", {
+                sortable: x => x.Identifier
+            });
+            const errorColumn = new textColumn<RemoteAttachmentErrorInfo>(grid, x => x.Error, "Error", "45%", {
+                sortable: x => x.Error
+            });
+
+            return [previewColumn, dateColumn, idsColumn, identifierColumn, errorColumn];
+        });
+
+        this.columnPreview.install(".remoteAttachmentErrorDetails", ".js-remote-attachment-error-details-tooltip",
+            (details: RemoteAttachmentErrorInfo,
+             column: textColumn<RemoteAttachmentErrorInfo>,
+             e: JQuery.TriggeredEvent, onValue: (context: any, valueToCopy?: string) => void) => {
+                if (!(column instanceof actionColumn)) {
+
+                    if (column.header === "Date") {
+                        onValue(moment.utc(details.Date), details.Date);
+                    } else {
+                        const value = column.getCellValue(details);
+                        if (value) {
+                            onValue(generalUtils.escapeHtml(value), value);
+                        }
+                    }
+                }
+            });
+    }
+
+    private showDetails(item: RemoteAttachmentErrorInfo) {
+        this.currentDetails(item);
+    }
+
+    copyToClipboard(item: RemoteAttachmentErrorInfo) {
+        copyToClipboard.copy(item.Error, "Error has been copied to clipboard", document.getElementById("js-remote-attachment-error-details"));
+    }
+
+    private fetcher(): JQueryPromise<pagedResult<RemoteAttachmentErrorInfo>> {
+        return $.Deferred<pagedResult<RemoteAttachmentErrorInfo>>()
+            .resolve({
+                items: this.tableItems,
+                totalResultCount: this.tableItems.length
+            });
+    }
+
+    static supportsDetailsFor(notification: abstractNotification) {
+        return (notification instanceof alert) && notification.alertReason() === "Attachments_RemoteAttachmentErroredIdentifier";
+    }
+
+    static showDetailsFor(alert: alert, center: notificationCenter) {
+        return app.showBootstrapDialog(new remoteAttachmentErrorDetails(alert, center));
+    }
+}
+
+export = remoteAttachmentErrorDetails;

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/remoteAttachmentErrorDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/remoteAttachmentErrorDetails.html
@@ -1,0 +1,87 @@
+<div class="modal-dialog modal-lg remoteAttachmentErrorDetails" id="js-remote-attachment-error-details" role="document">
+    <div class="modal-content force-text-wrap-word" tabindex="-1">
+        <div class="modal-header">
+            <button type="button" class="close" data-bind="click: close" aria-hidden="true">
+                <i class="icon-cancel"></i>
+            </button>
+            <div data-bind="with: alert">
+                <h3 class="modal-title" id="myModalLabel" data-bind="text: title, attr:{ class: 'modal-title ' + headerClass() }"></h3>
+                <div class="notification-time" data-bind="text: displayDate().format('LLL')"></div>
+            </div>
+        </div>
+        <div class="modal-body">
+            <h3 data-bind="html: alert.message"></h3>
+            <div class="margin-bottom" style="position: relative; height: 300px">
+                <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
+            </div>
+            <div data-bind="with: currentDetails">
+                <div class="flex-horizontal">
+                    <h3>Details:</h3>
+                    <div class="flex-separator"></div>
+                    <div>
+                        <button class="btn btn-default" data-bind="click: $root.copyToClipboard">
+                            <i class="icon-copy"></i>
+                            <span>Copy error to clipboard</span>
+                        </button>
+                    </div>
+                </div>
+                <div class="modal-details">
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Identifier:
+                            </div>
+                            <div class="col-sm-9 details-value">
+                                <span data-bind="text: Identifier"></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Hash:
+                            </div>
+                            <div class="col-sm-9 details-value">
+                                <span data-bind="text: Hash"></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Document IDs:
+                            </div>
+                            <div class="col-sm-9 details-value">
+                                <span data-bind="text: Ids ? Ids.join(', ') : ' - '"></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Date:
+                            </div>
+                            <div class="col-sm-9 details-value">
+                                <span data-bind="text: Date"></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="details-item">
+                        <div class="row">
+                            <div class="col-sm-3 text-right">
+                                Error:
+                            </div>
+                            <div class="col-sm-9">
+                                <pre style="max-height: 250px;" data-bind="text: Error"></pre>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="modal-footer" data-bind="compose: $root.footerPartialView">
+        </div>
+    </div>
+</div>
+<div class="tooltip json-preview js-remote-attachment-error-details-tooltip" style="opacity: 0">
+</div>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25642

### Additional description

<img width="925" height="1172" alt="image" src="https://github.com/user-attachments/assets/cacea86e-0e8a-4ecf-bced-79e02a02a19e" />

<img width="965" height="665" alt="image" src="https://github.com/user-attachments/assets/328396a8-ca65-4a5b-a605-345c85eb1a6a" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
