### PR TITLE
RavenDB-25590 Overwrite sign byte for serial number to be positive

### DIFF
--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -404,12 +404,14 @@ namespace Raven.Server.Utils
                 rng.GetBytes(serialNumberBytes);
             }
 
+            serialNumberBytes[0] &= 0x7F; // Force positive number, preventing the '00' padding
+
+            log?.AppendLine($"serialNumber bytes generated.");
+
             if (issuerCertBytes is { Length: > 0 })
             {
                 request.CertificateExtensions.Add(new X509Extension(new Oid(Constants.Certificates.ServerCertExtensionOid), issuerCertBytes, false));
             }
-
-            log?.AppendLine($"serialNumber bytes generated.");
 
             // Create the signature generator.
             // This is the correct way to pass the private key for signing in older .NET versions.

--- a/test/SlowTests/Issues/RavenDB-25590.cs
+++ b/test/SlowTests/Issues/RavenDB-25590.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using FastTests;
+using Raven.Client.Util;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25590 : RavenTestBase
+{
+    public RavenDB_25590(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Certificates)]
+    public void SerialNumberIsNotLongerThan20Bytes()
+    {
+        for (int i = 0; i < 10; i++)
+        {
+            var guid = Guid.NewGuid().ToString().Split('-')[0];
+            var certBytes = CertificateUtils.CreateSelfSignedTestCertificate($"RavenDB_25590-{guid}", $"RavenDB_25590_CA-{guid}");
+            
+            using (var cert = CertificateLoaderUtil.CreateCertificate(certBytes))
+            {
+                var serialNumber = cert.GetSerialNumber();
+                
+                Assert.True(serialNumber.Length <= 20, 
+                    $"Serial number length is {serialNumber.Length} bytes, which exceeds the 20-byte limit. Serial: {cert.SerialNumber}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25590

### Additional description

When generated serial number is negative, it get's padded with additional byte. Then the length in bytes is over the limit by one.
https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
