### PR TITLE
RavenDB-25455 : Fix counters include cache + align session counters with tracked-entity semantics

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1620,7 +1620,15 @@ more responsive application.
             }
             else
             {
-                RegisterCountersInternal(resultCounters, countersToInclude: null, fromQueryResult: false, gotAll: gotAll);
+                Dictionary<string, string[]> includeMap = null;
+                if (countersToInclude != null)
+                {
+                    includeMap = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var id in ids)
+                        includeMap[id] = countersToInclude;
+                }
+
+                RegisterCountersInternal(resultCounters, countersToInclude: includeMap, fromQueryResult: false, gotAll: gotAll);
             }
 
             RegisterMissingCounters(ids, countersToInclude);
@@ -1684,16 +1692,28 @@ more responsive application.
 
         private void RegisterCountersForDocument(string id, bool gotAll, BlittableJsonReaderArray counters, Dictionary<string, string[]> countersToInclude)
         {
-            if (CountersByDocId.TryGetValue(id, out var cache) == false)
+            if (CountersByDocId.TryGetValue(id, out var cache) == false || cache.Values == null)
             {
                 cache.Values = new Dictionary<string, long?>(StringComparer.OrdinalIgnoreCase);
             }
 
-            var deletedCounters = cache.Values.Count == 0
-                ? new HashSet<string>()
-                : countersToInclude[id].Length == 0 // IncludeAllCounters
-                    ? new HashSet<string>(cache.Values.Keys)
-                    : new HashSet<string>(countersToInclude[id]);
+            HashSet<string> deletedCounters;
+            if (cache.Values.Count == 0 || countersToInclude == null)
+            {
+                deletedCounters = new HashSet<string>();
+            }
+            else if (countersToInclude.TryGetValue(id, out var included) == false)
+            {
+                deletedCounters = new HashSet<string>();
+            }
+            else if (included.Length == 0) // IncludeAllCounters
+            {
+                deletedCounters = new HashSet<string>(cache.Values.Keys);
+            }
+            else
+            {
+                deletedCounters = new HashSet<string>(included);
+            }
 
             foreach (BlittableJsonReaderObject counterBlittable in counters)
             {
@@ -1702,7 +1722,20 @@ more responsive application.
                     counterBlittable.TryGet(nameof(CounterDetail.TotalValue), out long value) == false)
                     continue;
 
-                cache.Values[name] = value;
+                var merged = value;
+                if (TryGetDeferredCounterDelta(id, name, out var delta, out var deleted))
+                {
+                    if (deleted)
+                    {
+                        cache.Values.Remove(name);
+                        deletedCounters.Remove(name);
+                        continue;
+                    }
+
+                    merged += delta;
+                }
+
+                cache.Values[name] = merged;
                 deletedCounters.Remove(name);
             }
 
@@ -1710,12 +1743,43 @@ more responsive application.
             {
                 foreach (var name in deletedCounters)
                 {
+                    if (TryGetDeferredCounterDelta(id, name, out _, out var deleted) && deleted == false)
+                        continue; // there is a deferred operation for this counter, so we don't remove it
+
                     cache.Values.Remove(name);
                 }
             }
 
             cache.GotAll = gotAll;
             CountersByDocId[id] = cache;
+        }
+
+        private bool TryGetDeferredCounterDelta(string docId, string counter, out long delta, out bool deleted)
+        {
+            delta = 0;
+            deleted = false;
+
+            if (DeferredCommandsDictionary.TryGetValue((docId, CommandType.Counters, null), out var cmd) == false)
+                return false;
+
+            var batch = (CountersBatchCommandData)cmd;
+
+            foreach (var op in batch.Counters.Operations)
+            {
+                if (string.Equals(op.CounterName, counter, StringComparison.OrdinalIgnoreCase) == false)
+                    continue;
+
+                if (op.Type == CounterOperationType.Delete)
+                {
+                    deleted = true;
+                    return true;
+                }
+
+                if (op.Type == CounterOperationType.Increment)
+                    delta += op.Delta;
+            }
+
+            return delta != 0 || deleted;
         }
 
         private void SetGotAllInCacheIfNeeded(Dictionary<string, string[]> countersToInclude)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1700,19 +1700,19 @@ more responsive application.
             HashSet<string> deletedCounters;
             if (cache.Values.Count == 0 || countersToInclude == null)
             {
-                deletedCounters = new HashSet<string>();
+                deletedCounters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
             else if (countersToInclude.TryGetValue(id, out var included) == false)
             {
-                deletedCounters = new HashSet<string>();
+                deletedCounters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             }
             else if (included.Length == 0) // IncludeAllCounters
             {
-                deletedCounters = new HashSet<string>(cache.Values.Keys);
+                deletedCounters = new HashSet<string>(cache.Values.Keys, StringComparer.OrdinalIgnoreCase);
             }
             else
             {
-                deletedCounters = new HashSet<string>(included);
+                deletedCounters = new HashSet<string>(included, StringComparer.OrdinalIgnoreCase);
             }
 
             foreach (BlittableJsonReaderObject counterBlittable in counters)

--- a/src/Raven.Client/Documents/Session/SessionCountersBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionCountersBase.cs
@@ -141,3 +141,4 @@ namespace Raven.Client.Documents.Session
 
     }
 }
+

--- a/src/Raven.Client/Documents/Session/SessionCountersBase.cs
+++ b/src/Raven.Client/Documents/Session/SessionCountersBase.cs
@@ -64,6 +64,14 @@ namespace Raven.Client.Documents.Session
             {
                 Session.Defer(new CountersBatchCommandData(DocId, counterOp));
             }
+
+            if (Session.CountersByDocId.TryGetValue(DocId, out var cache) &&
+                cache.Values != null &&
+                cache.Values.TryGetValue(counter, out var val))
+            {
+                cache.Values[counter] = (val ?? 0) + delta;
+                Session.CountersByDocId[DocId] = cache;
+            }
         }
 
         /// <inheritdoc cref="ISessionDocumentCountersBase.Delete(string)"/> 
@@ -100,9 +108,10 @@ namespace Raven.Client.Documents.Session
                 Session.Defer(new CountersBatchCommandData(DocId, counterOp));
             }
 
-            if (Session.CountersByDocId.TryGetValue(DocId, out var cache))
+            if (Session.CountersByDocId.TryGetValue(DocId, out var cache) && cache.Values != null)
             {
-                cache.Values.Remove(counter);
+                cache.Values[counter] = null;
+                Session.CountersByDocId[DocId] = cache;
             }
 
         }

--- a/test/SlowTests/Client/Counters/SessionCounters.cs
+++ b/test/SlowTests/Client/Counters/SessionCounters.cs
@@ -970,9 +970,9 @@ namespace SlowTests.Client.Counters
                     Assert.Equal(100, val);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
 
-                    session.CountersFor("users/1-A").Increment("likes", 50); // should not increment the counter value in cache
+                    session.CountersFor("users/1-A").Increment("likes", 50); // should increment the counter value in cache
                     val = session.CountersFor("users/1-A").Get("likes");
-                    Assert.Equal(100, val);
+                    Assert.Equal(150, val);
                     Assert.Equal(1, session.Advanced.NumberOfRequests);
 
                     session.CountersFor("users/1-A").Increment("dislikes", 200); // should not add the counter to cache
@@ -983,8 +983,6 @@ namespace SlowTests.Client.Counters
                     session.CountersFor("users/1-A").Increment("score", 1000); // should not add the counter to cache
                     Assert.Equal(2, session.Advanced.NumberOfRequests);
 
-                    // SaveChanges should updated counters values in cache
-                    // according to increment result
                     session.SaveChanges();
                     Assert.Equal(3, session.Advanced.NumberOfRequests);
 
@@ -1005,7 +1003,7 @@ namespace SlowTests.Client.Counters
         }
 
         [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Counters)]
-        public void SessionShouldRemoveCounterFromCacheAfterCounterDeletion()
+        public void SessionShouldSetCounterAsKnownMissingInCacheAfterCounterDeletion()
         {
             using (var store = GetDocumentStore())
             {
@@ -1027,9 +1025,10 @@ namespace SlowTests.Client.Counters
                     session.SaveChanges();
                     Assert.Equal(2, session.Advanced.NumberOfRequests);
 
+                    // should not go to server again
                     val = session.CountersFor("users/1-A").Get("likes");
                     Assert.Null(val);
-                    Assert.Equal(3, session.Advanced.NumberOfRequests);
+                    Assert.Equal(2, session.Advanced.NumberOfRequests);
 
                 }
             }

--- a/test/SlowTests/Issues/RavenDB_25455.cs
+++ b/test/SlowTests/Issues/RavenDB_25455.cs
@@ -52,10 +52,8 @@ public class RavenDB_25455 : ReplicationTestBase
         var bookId1 = "books/1";
         var bookId2 = "books/2";
 
-
         const string counter1 = "Book1";
         const string counter2 = "Book2";
-
 
         using (var session = store.OpenAsyncSession())
         {
@@ -132,7 +130,6 @@ public class RavenDB_25455 : ReplicationTestBase
             Assert.Null(await session.CountersFor(bookId1).GetAsync(counter));
         }
     }
-
 
     private class Book
     {

--- a/test/SlowTests/Issues/RavenDB_25455.cs
+++ b/test/SlowTests/Issues/RavenDB_25455.cs
@@ -1,0 +1,142 @@
+﻿using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25455 : ReplicationTestBase
+{
+    public RavenDB_25455(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task CounterIsNotOverridenWhenLoadedOnceAgain()
+    {
+        using var store = GetDocumentStore();
+        var bookId1 = "books/1";
+        var bookId2 = "books/2";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Book { Id = bookId1, Title = "Book1" }, bookId1);
+            await session.StoreAsync(new Book { Id = bookId2, Title = "Book2" }, bookId2);
+            await session.SaveChangesAsync();
+
+            session.CountersFor(bookId1).Increment(nameof(Book), 1);
+            session.CountersFor(bookId2).Increment(nameof(Book), 2);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var loadDocs = await session.LoadAsync<Book>([bookId1], b => b.IncludeCounter(nameof(Book)));
+            loadDocs[bookId1].Title = "CurrentSessionObject";
+            session.CountersFor(bookId1).Increment(nameof(Book), 24);
+
+            Assert.Equal(25, await session.CountersFor(bookId1).GetAsync(nameof(Book)));
+            Assert.Equal("CurrentSessionObject", (await session.LoadAsync<Book>(bookId1)).Title);
+
+            var loadedMore = await session.LoadAsync<Book>([bookId1, bookId2], b => b.IncludeCounter(nameof(Book)));
+            Assert.Equal("CurrentSessionObject", loadedMore[bookId1].Title);
+            Assert.Equal(25, await session.CountersFor(bookId1).GetAsync(nameof(Book)));
+            Assert.Equal(2, await session.CountersFor(bookId2).GetAsync(nameof(Book)));
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task CanIncludeCountersOfSameDocumentInSeparateLoads()
+    {
+        using var store = GetDocumentStore();
+        var bookId1 = "books/1";
+        var bookId2 = "books/2";
+
+
+        const string counter1 = "Book1";
+        const string counter2 = "Book2";
+
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Book(), bookId1);
+            await session.StoreAsync(new Book(), bookId2);
+
+            session.CountersFor(bookId1).Increment(counter1, 10);
+            session.CountersFor(bookId1).Increment(counter2, 20);
+
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var doc = await session.LoadAsync<Book>(bookId1, b => b.IncludeCounter(counter1));
+            Assert.NotNull(doc);
+
+            var counter1Value = await session.CountersFor(bookId1).GetAsync(counter1);
+            Assert.Equal(10, counter1Value);
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // document books/1 already has counters tracked in the session
+            // including more counters of this document should not throw NRE
+
+            var moreDocs = await session.LoadAsync<Book>([bookId1, bookId2], b => b.IncludeCounter(counter2));
+            Assert.Equal(2, moreDocs.Count);
+
+            Assert.Equal(20, await session.CountersFor(bookId1).GetAsync(counter2));
+            Assert.Equal(null, await session.CountersFor(bookId2).GetAsync(counter2));
+
+            Assert.Equal(2, session.Advanced.NumberOfRequests);
+
+        }
+    }
+
+    [RavenFact(RavenTestCategory.ClientApi)]
+    public async Task DeletingTrackedCounterShouldReturnNullImmediately()
+    {
+        using var store = GetDocumentStore();
+        var bookId1 = "books/1";
+
+        const string counter = "Likes";
+
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new Book(), bookId1);
+            session.CountersFor(bookId1).Increment(counter, 10);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // track the counter in session (include -> no server request on Get)
+            var doc = await session.LoadAsync<Book>(bookId1, b => b.IncludeCounter(counter));
+            Assert.NotNull(doc);
+
+            Assert.Equal(10, await session.CountersFor(bookId1).GetAsync(counter));
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // delete should update in-session cache
+            session.CountersFor(bookId1).Delete(counter);
+
+            // should return null immediately, without going to server
+            Assert.Null(await session.CountersFor(bookId1).GetAsync(counter));
+            Assert.Equal(1, session.Advanced.NumberOfRequests);
+
+            // persist deletion
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            // verify deletion persisted
+            Assert.Null(await session.CountersFor(bookId1).GetAsync(counter));
+        }
+    }
+
+
+    private class Book
+    {
+        public string Id { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_25455.cs
+++ b/test/SlowTests/Issues/RavenDB_25455.cs
@@ -11,7 +11,7 @@ public class RavenDB_25455 : ReplicationTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.ClientApi)]
+    [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Counters)]
     public async Task CounterIsNotOverridenWhenLoadedOnceAgain()
     {
         using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25455/Counter-is-overridden-in-Load-operation.

### Additional description

Fixes three issues in session counters handling:

- Fix `NRE` when including counters for a document that already has tracked counters (use per-id include map + null-safe registration).

- Prevent included counter results from overwriting newer in-session counter values by merging server results with deferred counter ops.

- Align counters with tracked-entity “read-your-writes” semantics.

**Behavior change (intentional / breaking):**
Previously, counter Increment operations didn’t affect the session counter cache until `SaveChanges()`, and Delete didn’t always mark the counter as known missing (null) in cache, which could trigger an extra server request on a subsequent Get.
This PR changes that: in-session counter Increment/Delete now immediately updates the session cache (and deletions mark the counter as known missing) so reads reflect in-session changes consistently—matching how tracked entities behave.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
