### PR TITLE
RavenDB-25887 Sink to hub should work with the cluster admin cert

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -83,6 +83,7 @@ using Voron;
 using DateTime = System.DateTime;
 using Raven.Server.Monitoring.OpenTelemetry;
 using Sparrow.Platform;
+using static Raven.Client.ServerWide.Tcp.TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod;
 using Constants = Sparrow.Global.Constants;
 using TelemetryConstants = Raven.Server.Monitoring.OpenTelemetry.Constants;
 using ClientConstants = Raven.Client.Constants;
@@ -3017,6 +3018,7 @@ namespace Raven.Server
             }
 
             var auth = AuthenticateConnectionCertificate(certificate, tcpClient);
+            var info = header.AuthorizeInfo;
 
             switch (auth.Status)
             {
@@ -3030,9 +3032,32 @@ namespace Raven.Server
 
                 case AuthenticationStatus.ClusterAdmin:
                 case AuthenticationStatus.Operator:
+                    if (info?.AuthorizeAs is PullReplication or PushReplication)
+                    {
+                        using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+                        using (ctx.OpenReadTransaction())
+                        {
+                            if (CheckPullReplicationMode(ctx, header, info, out msg) is false)
+                                return false;
+                        }
+                        // Create a ReplicationHubAccess that allows full access for admin
+                        header.ReplicationHubAccess = new DetailedReplicationHubAccess
+                        {
+                            Name = auth.Status.ToString(),
+                            Thumbprint = certificate.Thumbprint,
+                            Certificate = Convert.ToBase64String(certificate.Export(X509ContentType.Cert)),
+                            NotBefore = certificate.NotBefore,
+                            NotAfter = certificate.NotAfter,
+                            Subject = certificate.Subject,
+                            Issuer = certificate.Issuer,
+                            AllowedHubToSinkPaths = null, // null means all paths allowed
+                            AllowedSinkToHubPaths = null  // null means all paths allowed
+                        };
+                        return true;
+                    }
+
                     msg = "Admin can do it all";
                     return true;
-
                 case AuthenticationStatus.Allowed:
                     switch (header.Operation)
                     {
@@ -3049,7 +3074,15 @@ namespace Raven.Server
                                 msg = "Cannot allow access. Database name is empty.";
                                 return false;
                             }
-                            if (auth.CanAccess(header.DatabaseName, requireAdmin: false, requireWrite: header.Operation == TcpConnectionHeaderMessage.OperationTypes.Replication))
+
+                            bool isReplication = header.Operation == TcpConnectionHeaderMessage.OperationTypes.Replication;
+
+                            if (isReplication && info?.AuthorizeAs is PullReplication or PushReplication)
+                            {
+                                return CanProceedOnReplication(header, certificate, remoteAddress: tcpClient.Client.RemoteEndPoint?.ToString(), out msg);
+                            }
+
+                            if (auth.CanAccess(header.DatabaseName, requireAdmin: false, requireWrite: isReplication))
                                 return true;
                             msg = $"The certificate {certificate.FriendlyName} does not allow access to {header.DatabaseName}";
                             return false;
@@ -3064,50 +3097,76 @@ namespace Raven.Server
                     return false;
 
                 case AuthenticationStatus.UnfamiliarCertificate:
-                    var info = header.AuthorizeInfo;
-                    switch (info?.AuthorizeAs)
+                    if (info?.AuthorizeAs is PullReplication or PushReplication)
                     {
-                        case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication:
-                        case TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication:
-                            using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
-                            using (ctx.OpenReadTransaction())
-                            {
-                                if (ServerStore.Cluster.TryReadPullReplicationDefinition(header.DatabaseName, info.AuthorizationFor, ctx, out var pullReplication))
-                                {
-                                    var expectedMode = info.AuthorizeAs switch
-                                    {
-                                        TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PullReplication => PullReplicationMode.HubToSink,
-                                        TcpConnectionHeaderMessage.AuthorizationInfo.AuthorizeMethod.PushReplication => PullReplicationMode.SinkToHub,
-                                        _ => PullReplicationMode.None
-                                    };
-
-                                    if ((pullReplication.Mode & expectedMode) != expectedMode || expectedMode == PullReplicationMode.None)
-                                    {
-                                        msg = "The expected replication mode does not match the replication mode on the replication hub";
-                                        return false;
-                                    }
-
-                                    if (ServerStore.Cluster.IsReplicationCertificate(ctx, header.DatabaseName, info.AuthorizationFor, certificate, out header.ReplicationHubAccess))
-                                        return true;
-
-                                    if (ServerStore.Cluster.IsReplicationCertificateByPublicKeyPinningHash(ctx, header.DatabaseName, info.AuthorizationFor, certificate, configuration.Security, out header.ReplicationHubAccess))
-                                    {
-                                        RegisterNewReplicationCertificateWithSamePublicKeyPinningHash(tcpClient.Client.RemoteEndPoint.ToString(), header.DatabaseName, info.AuthorizationFor, header.ReplicationHubAccess, certificate);
-
-                                        return true;
-                                    }
-                                }
-
-                                msg = $"The certificate {certificate.FriendlyName} does not allow access to {header.DatabaseName} for {info.AuthorizationFor} ({info.AuthorizeAs})";
-                                return false;
-                            }
-                        default:
-                            throw new ArgumentOutOfRangeException("AuthorizeAs", "Unknown value for AuthorizeAs: " + info?.AuthorizeAs);
+                        return CanProceedOnReplication(header, certificate, remoteAddress: tcpClient.Client.RemoteEndPoint?.ToString(), out msg);
                     }
+
+                    throw new ArgumentOutOfRangeException(nameof(info.AuthorizeAs), "Unknown value for AuthorizeAs: " + info?.AuthorizeAs);
                 default:
                     msg = "Cannot allow access to a certificate with status: " + auth.Status;
                     return false;
             }
+        }
+
+        /// <summary>
+        /// Checks the <see cref="TcpConnectionHeaderMessage.AuthorizeInfo"/> and checks if it can proceed as replication.
+        /// </summary>
+        private bool CanProceedOnReplication(
+            TcpConnectionHeaderMessage header,
+            X509Certificate2 certificate,
+            string remoteAddress,
+            out string msg)
+        {
+            msg = null;
+            var info = header.AuthorizeInfo;
+
+            Debug.Assert(info?.AuthorizeAs is PullReplication or PushReplication, "It should be called only for replication.");
+            
+            using (ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext ctx))
+            using (ctx.OpenReadTransaction())
+            {
+                if (CheckPullReplicationMode(ctx, header, info, out msg) is false) 
+                    return false;
+
+                // For non-admin certificates, check if the certificate is registered
+                if (ServerStore.Cluster.IsReplicationCertificate(ctx, header.DatabaseName, info.AuthorizationFor, certificate, out header.ReplicationHubAccess))
+                    return true;
+
+                if (ServerStore.Cluster.IsReplicationCertificateByPublicKeyPinningHash(ctx, header.DatabaseName, info.AuthorizationFor, certificate, ServerStore.Configuration.Security, out header.ReplicationHubAccess))
+                {
+                    RegisterNewReplicationCertificateWithSamePublicKeyPinningHash(remoteAddress, header.DatabaseName, info.AuthorizationFor, header.ReplicationHubAccess, certificate);
+                    return true;
+                }
+
+                msg = $"The certificate {certificate.FriendlyName} does not allow access to {header.DatabaseName} for {info.AuthorizationFor} ({info.AuthorizeAs})";
+                return false;
+            }
+        }
+
+        private bool CheckPullReplicationMode(ClusterOperationContext ctx, TcpConnectionHeaderMessage header, TcpConnectionHeaderMessage.AuthorizationInfo info, out string msg)
+        {
+            if (ServerStore.Cluster.TryReadPullReplicationDefinition(header.DatabaseName, info.AuthorizationFor, ctx, out var pullReplication) == false)
+            {
+                msg = $"The pull replication hub '{info.AuthorizationFor}' does not exist in database '{header.DatabaseName}'";
+                return false;
+            }
+
+            var expectedMode = info.AuthorizeAs switch
+            {
+                PullReplication => PullReplicationMode.HubToSink,
+                PushReplication => PullReplicationMode.SinkToHub,
+                _ => PullReplicationMode.None
+            };
+
+            if ((pullReplication.Mode & expectedMode) != expectedMode || expectedMode == PullReplicationMode.None)
+            {
+                msg = "The expected replication mode does not match the replication mode on the replication hub";
+                return false;
+            }
+
+            msg = null;
+            return true;
         }
 
         private void RegisterNewReplicationCertificateWithSamePublicKeyPinningHash(

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -14,6 +14,7 @@ using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.ServerWide.Operations.Certificates;
 using Raven.Server.Config;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
@@ -978,6 +979,274 @@ namespace SlowTests.Server.Replication
             }
         }
 
+        [RavenTheory(RavenTestCategory.Replication)]
+        [InlineData(SecurityClearance.ClusterAdmin)]
+        [InlineData(SecurityClearance.Operator)]
+        [InlineData(SecurityClearance.ValidUser)]
+        public async Task SinkToHubWithThisClearanceShouldWork(SecurityClearance clearance)
+        {
+            var settings = new Dictionary<string, string>();
+            var certificates = Certificates.SetupServerAuthentication(settings);
+
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = settings }))
+            using (var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = settings }))
+            {
+                Certificates.RegisterClientCertificate(
+                    certificates.ServerCertificate.Value,
+                    certificates.ClientCertificate1.Value,
+                    new Dictionary<string, DatabaseAccess>(),
+                    SecurityClearance.ClusterAdmin,
+                    server: hubServer);
+
+                using (var hubStore = GetDocumentStore(new Options
+                {
+                    Server = hubServer,
+                    ModifyDatabaseName = s => $"HubDB_{s}",
+                    ClientCertificate = certificates.ServerCertificate.Value,
+                    AdminCertificate = certificates.ClientCertificate1.Value,
+                }))
+                {
+                    Certificates.RegisterClientCertificate(
+                        certificates.ServerCertificate.Value,
+                        certificates.ClientCertificate1.Value,
+                        new Dictionary<string, DatabaseAccess>(),
+                        SecurityClearance.ClusterAdmin,
+                        server: sinkServer);
+
+                    using (var sinkStore = GetDocumentStore(new Options
+                    {
+                        Server = sinkServer,
+                        CreateDatabase = true,
+                        ModifyDatabaseName = s => $"SinkDB_{s}",
+                        ClientCertificate = certificates.ServerCertificate.Value,
+                        AdminCertificate = certificates.ClientCertificate1.Value,
+                    }))
+                    {
+                        Dictionary<string, DatabaseAccess> permissions = clearance == SecurityClearance.ValidUser
+                            ? new()
+                            {
+                                [hubStore.Database] = DatabaseAccess.ReadWrite
+                            }
+                            : new();
+
+                        // Registering certificate with ClusterAdmin permissions
+                        Certificates.RegisterClientCertificate(
+                            certificates.ServerCertificate.Value, 
+                            certificates.ClientCertificate2.Value, 
+                            permissions: permissions,
+                            clearance,
+                            server: hubServer);
+
+                        await hubStore.Maintenance.ForDatabase(hubStore.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition("pull-replication-task")
+                        {
+                            Mode = PullReplicationMode.SinkToHub
+                        }));
+
+                        await hubStore.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("pull-replication-task", new ReplicationHubAccess
+                        {
+                            Name = "SinkUser",
+                            CertificateBase64 = Convert.ToBase64String(certificates.ClientCertificate2.Value.Export(X509ContentType.Cert))
+                        }));
+
+                        const string connectionStringName = "ConnectToHub";
+                        await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                        {
+                            Name = connectionStringName,
+                            Database = hubStore.Database,
+                            TopologyDiscoveryUrls = hubStore.Urls
+                        }));
+
+                        await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                        {
+                            ConnectionStringName = connectionStringName,
+                            HubName = "pull-replication-task",
+                            Mode = PullReplicationMode.SinkToHub,
+                            CertificateWithPrivateKey = Convert.ToBase64String(certificates.ClientCertificate2.Value.Export(X509ContentType.Pfx))
+                        }));
+
+                        // Add a document to sink and wait for it to replicate to hub
+                        using (var session = sinkStore.OpenSession())
+                        {
+                            session.Store(new User { Name = "Test User" }, "users/1");
+                            session.SaveChanges();
+                        }
+
+                        // Wait for the document to replicate to hub
+                        var timeout = 10000;
+                        Assert.True(WaitForDocument(hubStore, "users/1", timeout), hubStore.Identifier);
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ClusterAdminCertificateOnNonExistentHubShouldFail()
+        {
+            var settings = new Dictionary<string, string>();
+            var certificates = Certificates.SetupServerAuthentication(settings);
+
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = settings }))
+            using (var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = settings }))
+            {
+                Certificates.RegisterClientCertificate(
+                    certificates.ServerCertificate.Value,
+                    certificates.ClientCertificate1.Value,
+                    new Dictionary<string, DatabaseAccess>(),
+                    SecurityClearance.ClusterAdmin,
+                    server: hubServer);
+
+                using (var hubStore = GetDocumentStore(new Options
+                {
+                    Server = hubServer,
+                    ModifyDatabaseName = s => $"HubDB_{s}",
+                    ClientCertificate = certificates.ServerCertificate.Value,
+                    AdminCertificate = certificates.ClientCertificate1.Value,
+                }))
+                {
+                    Certificates.RegisterClientCertificate(
+                        certificates.ServerCertificate.Value,
+                        certificates.ClientCertificate1.Value,
+                        new Dictionary<string, DatabaseAccess>(),
+                        SecurityClearance.ClusterAdmin,
+                        server: sinkServer);
+
+                    using (var sinkStore = GetDocumentStore(new Options
+                    {
+                        Server = sinkServer,
+                        CreateDatabase = true,
+                        ModifyDatabaseName = s => $"SinkDB_{s}",
+                        ClientCertificate = certificates.ServerCertificate.Value,
+                        AdminCertificate = certificates.ClientCertificate1.Value,
+                    }))
+                    {
+                        // Register ClientCertificate2 as ClusterAdmin on the hub for replication
+                        Certificates.RegisterClientCertificate(
+                            certificates.ServerCertificate.Value,
+                            certificates.ClientCertificate2.Value,
+                            permissions: new Dictionary<string, DatabaseAccess>(),
+                            SecurityClearance.ClusterAdmin,
+                            server: hubServer);
+
+                        // Do NOT create any hub replication definition — point to a non-existent hub name
+                        const string connectionStringName = "ConnectToHub";
+                        await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                        {
+                            Name = connectionStringName,
+                            Database = hubStore.Database,
+                            TopologyDiscoveryUrls = hubStore.Urls
+                        }));
+
+                        await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                        {
+                            ConnectionStringName = connectionStringName,
+                            HubName = "non-existent-hub",
+                            Mode = PullReplicationMode.SinkToHub,
+                            CertificateWithPrivateKey = Convert.ToBase64String(certificates.ClientCertificate2.Value.Export(X509ContentType.Pfx))
+                        }));
+
+                        using (var session = sinkStore.OpenSession())
+                        {
+                            session.Store(new User { Name = "Test User" }, "users/1");
+                            session.SaveChanges();
+                        }
+
+                        Assert.False(WaitForDocument(hubStore, "users/1", 3000), "Replication to a non-existent hub should not succeed");
+
+                        // Await failure
+                        var sinkDb = await GetDatabase(sinkServer, sinkStore.Database);
+                        await AssertWaitForTrueAsync(() =>
+                        {
+                            var failures = sinkDb.ReplicationLoader.OutgoingFailureInfo;
+                            return Task.FromResult(failures.Count > 0 && failures.Values.Any(f => f.Errors.Count > 0));
+                        });
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public async Task ClusterAdminCertificateWithModeMismatchShouldFail()
+        {
+            var settings = new Dictionary<string, string>();
+            var certificates = Certificates.SetupServerAuthentication(settings);
+
+            using (var hubServer = GetNewServer(new ServerCreationOptions { CustomSettings = settings }))
+            using (var sinkServer = GetNewServer(new ServerCreationOptions { CustomSettings = settings }))
+            {
+                Certificates.RegisterClientCertificate(
+                    certificates.ServerCertificate.Value,
+                    certificates.ClientCertificate1.Value,
+                    new Dictionary<string, DatabaseAccess>(),
+                    SecurityClearance.ClusterAdmin,
+                    server: hubServer);
+
+                using (var hubStore = GetDocumentStore(new Options
+                {
+                    Server = hubServer,
+                    ModifyDatabaseName = s => $"HubDB_{s}",
+                    ClientCertificate = certificates.ServerCertificate.Value,
+                    AdminCertificate = certificates.ClientCertificate1.Value,
+                }))
+                {
+                    Certificates.RegisterClientCertificate(
+                        certificates.ServerCertificate.Value,
+                        certificates.ClientCertificate1.Value,
+                        new Dictionary<string, DatabaseAccess>(),
+                        SecurityClearance.ClusterAdmin,
+                        server: sinkServer);
+
+                    using (var sinkStore = GetDocumentStore(new Options
+                    {
+                        Server = sinkServer,
+                        CreateDatabase = true,
+                        ModifyDatabaseName = s => $"SinkDB_{s}",
+                        ClientCertificate = certificates.ServerCertificate.Value,
+                        AdminCertificate = certificates.ClientCertificate1.Value,
+                    }))
+                    {
+                        // Register ClientCertificate2 as ClusterAdmin on the hub for replication
+                        Certificates.RegisterClientCertificate(
+                            certificates.ServerCertificate.Value,
+                            certificates.ClientCertificate2.Value,
+                            permissions: new Dictionary<string, DatabaseAccess>(),
+                            SecurityClearance.ClusterAdmin,
+                            server: hubServer);
+
+                        // Create hub that only supports HubToSink (pull-only, no push allowed)
+                        await hubStore.Maintenance.ForDatabase(hubStore.Database).SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition("pull-replication-task")
+                        {
+                            Mode = PullReplicationMode.HubToSink
+                        }));
+
+                        const string connectionStringName = "ConnectToHub";
+                        await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+                        {
+                            Name = connectionStringName,
+                            Database = hubStore.Database,
+                            TopologyDiscoveryUrls = hubStore.Urls
+                        }));
+
+                        // Try to push to a pull-only hub using a cluster admin certificate
+                        await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+                        {
+                            ConnectionStringName = connectionStringName,
+                            HubName = "pull-replication-task",
+                            Mode = PullReplicationMode.SinkToHub,
+                            CertificateWithPrivateKey = Convert.ToBase64String(certificates.ClientCertificate2.Value.Export(X509ContentType.Pfx))
+                        }));
+
+                        using (var session = sinkStore.OpenSession())
+                        {
+                            session.Store(new User { Name = "Test User" }, "users/1");
+                            session.SaveChanges();
+                        }
+
+                        Assert.False(WaitForDocument(hubStore, "users/1", 3000), "Pushing to a pull-only hub should not succeed even for admin certs");
+                    }
+                }
+            }
+        }
+
         //TODO write test for deletion! - make sure replication is stopped after we delete hub!
 
         public static Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, params DocumentStore[] hub)
@@ -985,7 +1254,7 @@ namespace SlowTests.Server.Replication
             return SetupPullReplicationAsync(remoteName, sink, null, hub);
         }
 
-        public static async Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, X509Certificate2 certificate, params DocumentStore[] hub)
+        private static async Task<List<ModifyOngoingTaskResult>> SetupPullReplicationAsync(string remoteName, DocumentStore sink, X509Certificate2 certificate, params DocumentStore[] hub)
         {
             var tasks = new List<Task<ModifyOngoingTaskResult>>();
             var resList = new List<ModifyOngoingTaskResult>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25887/NullReferenceException-in-Pull-Replication-SinkToHub-when-using-ClusterAdmin-certificate

### Additional description

Previously, the admin cert handling did not properly handled replication angle. This PR, moves pieces a bit, ensuring that it properly handles replication setup.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
