### PR TITLE
RavenDB-25424 Fixing race condition in applying sparse pages to data file

### DIFF
--- a/src/Voron/EnvironmentStateRecord.cs
+++ b/src/Voron/EnvironmentStateRecord.cs
@@ -18,12 +18,8 @@ public record EnvironmentStateRecord(
     // This represent the *current* journal state, which may involve
     // writes from _other_ envs due to shared journals
     (long Number, long Last4KWritePosition) Journal,
+    List<(long Start, long Count)> SparseRegions,
     object ClientState);
-
-public record SparseRegionsRecord(
-    long TransactionId,
-    List<(long Start, long Count)> Regions
-);
 
 internal sealed class EnvironmentStateRecordHolder
 {

--- a/src/Voron/Impl/ApplyTosToDataFileState.cs
+++ b/src/Voron/Impl/ApplyTosToDataFileState.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Voron.Impl.Scratch;
 
 namespace Voron.Impl;
 
 record ApplyLogsToDataFileState(
     List<PageFromScratchBuffer> Buffers,
+    List<(long Start, long Count)> SparseRegions,
     EnvironmentStateRecord Record)
 {
     public override string ToString()

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -792,17 +792,6 @@ namespace Voron.Impl.Journal
                     _waj._env.ActiveTransactions.ForceRecheckingOldestTransactionByFlusherThread();
                     long uptoTxIdExclusive = _waj._env.ActiveTransactions.OldestTransaction;
 
-                    var sparseRegionsToFlush = _waj._env.TryGetLatestSparseRegionsToFlush(uptoTxIdExclusive);
-                    if (sparseRegionsToFlush != Span<(long Start, long Count)>.Empty)
-                    {
-                        // This needs to happen _before_ we actually write to the disk
-                        // because we _first_ zero a range and then we may write data to that range (filling some of it up).
-                        // That is fine, and means that we don't need to track re-uses. 
-                        MarkSparseRegionsInDataFile(sparseRegionsToFlush);
-                    }
-
-                    _forTestingPurposes?.OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile?.Invoke();
-
                     if (_applyLogsToDataFileStateFromPreviousFailedAttempt != null)
                     {
                         // we have to keep this around since TryGetLatestEnvironmentStateToFlush will _consume_ the state
@@ -817,7 +806,18 @@ namespace Voron.Impl.Journal
                         if (_applyLogsToDataFileStateFromPreviousFailedAttempt == null)
                             return; // nothing to do
                     }
-                    
+
+                    if(_applyLogsToDataFileStateFromPreviousFailedAttempt.SparseRegions is {Count: > 0} sparseRegionsToFlush)
+                    {
+                        // This needs to happen _before_ we actually write to the disk
+                        // because we _first_ zero a range and then we may write data to that range (filling some of it up).
+                        // That is fine, and means that we don't need to track re-uses. 
+                        MarkSparseRegionsInDataFile(sparseRegionsToFlush);
+                    }
+
+                    _forTestingPurposes?.OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile?.Invoke();
+
+
                     Debug.Assert(_applyLogsToDataFileStateFromPreviousFailedAttempt is { Record: not null, Buffers: not null });
                     var currentTotalCommittedSinceLastFlushPages = TotalCommittedSinceLastFlushPages;
 
@@ -1484,7 +1484,7 @@ namespace Voron.Impl.Journal
                 return dataPagerState;
             }
 
-            private void MarkSparseRegionsInDataFile(Span<(long Start, long Count)> sparseRegions)
+            private void MarkSparseRegionsInDataFile(List<(long Start, long Count)> sparseRegions)
             {
                 var currentStateRecord = _waj._env.CurrentStateRecord;
                 var dataPagerState = currentStateRecord.DataPagerState;

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -801,6 +801,8 @@ namespace Voron.Impl.Journal
                         MarkSparseRegionsInDataFile(sparseRegionsToFlush);
                     }
 
+                    _forTestingPurposes?.OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile?.Invoke();
+
                     if (_applyLogsToDataFileStateFromPreviousFailedAttempt != null)
                     {
                         // we have to keep this around since TryGetLatestEnvironmentStateToFlush will _consume_ the state
@@ -816,8 +818,6 @@ namespace Voron.Impl.Journal
                             return; // nothing to do
                     }
                     
-                    _forTestingPurposes?.OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile?.Invoke();
-
                     Debug.Assert(_applyLogsToDataFileStateFromPreviousFailedAttempt is { Record: not null, Buffers: not null });
                     var currentTotalCommittedSinceLastFlushPages = TotalCommittedSinceLastFlushPages;
 

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -77,7 +77,6 @@ namespace Voron.Impl
         public Pager.PagerTransactionState PagerTransactionState;
         private readonly WriteAheadJournal _journal;
         public ImmutableDictionary<long, PageFromScratchBuffer> ModifiedPagesInTransaction;
-        private SparseRegionsRecord _sparseRangesInTransaction;
         private ImmutableDictionary<long, PageFromScratchBuffer> _scratchBuffersSnapshotToRollbackTo;
         internal sealed class WriteTransactionPool
         {
@@ -1224,21 +1223,24 @@ namespace Voron.Impl
 
             ref readonly var rootHeader = ref _root.ReadHeader();
             _txHeader.Root = rootHeader;
-            _envRecord = _envRecord with { Root = rootHeader };
-
             _txHeader.TxMarker |= TransactionMarker.Commit;
+
+            List<(long Start, long Count)> regions = null;
+            if (_sparsePageRanges != null && _sparsePageRanges.Count != 0)
+            {
+                regions = _freeSpaceHandling.GetSparseRegions(this, _sparsePageRanges);
+            }
+            _envRecord = _envRecord with
+            {
+                Root = rootHeader,
+                SparseRegions = regions
+            };
 
             LastChanceToReadFromWriteTransactionBeforeCommit?.Invoke(this);
 
             _env.Journal.Applicator.OnTransactionCommitted(this);
 
             ModifiedPagesInTransaction = _scratchPagesInUse.ToImmutable();
-
-            if (_sparsePageRanges != null && _sparsePageRanges.Count != 0)
-            {
-                var regions = _freeSpaceHandling.GetSparseRegions(this, _sparsePageRanges);
-                _sparseRangesInTransaction = new SparseRegionsRecord(Id, regions);
-            }
 
 
             if (_dirtyPages.Count > 0 || _hasFreePages)
@@ -1250,7 +1252,6 @@ namespace Voron.Impl
 
         }
 
-        public SparseRegionsRecord SparseRegionsRecord => _sparseRangesInTransaction;
 
         [DoesNotReturn]
         private static void ThrowNextPageNumberCannotBeSmallerOrEqualThanOne([CallerMemberName] string caller = null)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -120,12 +120,9 @@ namespace Voron
 
         internal TestingStuff _forTestingPurposes;
         private EnvironmentStateRecord _currentStateRecord;
-        private SparseRegionsRecord _currentSparseRegionsRecord;
         private readonly ConcurrentQueue<EnvironmentStateRecordHolder> _transactionsToFlush = new();
-        private readonly ConcurrentQueue<SparseRegionsRecord> _sparseRegionsToFlush = new();
 
         internal EnvironmentStateRecord CurrentStateRecord => _currentStateRecord;
-        internal SparseRegionsRecord CurrentSparseRegions => _currentSparseRegionsRecord;
 
         public DateTime LastWorkTime;
 
@@ -164,6 +161,7 @@ namespace Voron
                     default(TreeRootHeader), 
                     -1,
                     (-1, -1),
+                    null,
                     null);
                 
                 _lastValidPageAfterLoad = dataPagerState.NumberOfAllocatedPages;
@@ -1672,14 +1670,7 @@ namespace Voron
                 DataPagerState = tx.DataPagerState,
             };
 
-            var ranges = tx.SparseRegionsRecord;
-            if (ranges?.Regions.Count > 0)
-            {
-                _sparseRegionsToFlush.Enqueue(ranges);
-            }
-
             // we don't _have_ to make it using interlocked, but let's publish it immediately
-            Interlocked.Exchange(ref _currentSparseRegionsRecord, ranges);
             Interlocked.Exchange(ref _currentStateRecord, updatedState);
 
             // We only want to flush to data pager transactions that have been flushed to the journal.
@@ -1697,6 +1688,7 @@ namespace Voron
             if (uptoTxIdExclusive == 0)
                 uptoTxIdExclusive = long.MaxValue;
 
+            List<(long Start, long Count)> sparseRegions = null;
             var scratchBuffers = _cachedScratchBuffers;
             scratchBuffers.Clear();
             bool found = false;
@@ -1708,8 +1700,15 @@ namespace Voron
                 {
                     if (found == false)
                         return null;
+
                     Debug.Assert(record is not null);
-                    return new ApplyLogsToDataFileState(scratchBuffers,  record);
+
+                    if(sparseRegions is not null)
+                    {
+                        MergeSparseRegions(sparseRegions);
+                    }
+
+                    return new ApplyLogsToDataFileState(scratchBuffers, sparseRegions, record);
                 }
 
                 if (_transactionsToFlush.TryDequeue(out EnvironmentStateRecordHolder recordHolder) == false)
@@ -1723,6 +1722,12 @@ namespace Voron
                 recordHolder.EnvStateRecord = null; // this way we ensure that _transactionsToFlush won't hold reference in its internal slots preventing GC on EnvironmentStateRecord.ClientState object
 
 
+                if(record.SparseRegions is not null)
+                {
+                    sparseRegions ??= [];
+                    sparseRegions.AddRange(record.SparseRegions);
+                }
+
                 foreach (var (_, pageFromScratch) in record.ScratchPagesTable)
                 {
                     if (pageFromScratch.AllocatedInTransaction != record.TransactionId)
@@ -1734,52 +1739,14 @@ namespace Voron
             }
         }
 
-        private SparseRegionsRecord _lastPeek;
-        internal Span<(long Start, long Count)> TryGetLatestSparseRegionsToFlush(long uptoTxIdExclusive)
+        private static void MergeSparseRegions(List<(long Start, long Count)> sparseRegions)
         {
-            if (uptoTxIdExclusive == 0)
-                uptoTxIdExclusive = long.MaxValue;
-
-            bool found = false;
-            SparseRegionsRecord record = null;
-            var allRegions = new List<(long Start, long Count)>();
-            while (true)
-            {
-                if (_lastPeek is null)
-                {
-                    _sparseRegionsToFlush.TryPeek(out _lastPeek);
-                }
-
-                if (_lastPeek is null || _lastPeek.TransactionId >= uptoTxIdExclusive)
-                {
-                    if (found == false)
-                        return null;
-
-                    Debug.Assert(record is not null);
-                    break;
-                }
-
-                if (_sparseRegionsToFlush.TryDequeue(out record) == false)
-                    throw new InvalidOperationException("Failed to get transaction to flush after already peeked successfully");
-
-                // single thread is reading from this, so we can be sure that peek + take gets the same value
-                Debug.Assert(ReferenceEquals(record, _lastPeek));
-
-                _lastPeek = null;
-
-                allRegions.AddRange(record.Regions);
-
-                found = true;
-            }
-
-            Debug.Assert(allRegions.Count > 0, "allRegions.Count == 0");
-
-            // This sorts first by the start, then by the count, so 
-            allRegions.Sort();
+            // sorts first by the start, then by the count
+            sparseRegions.Sort();
             int used = 0;
-            var span = CollectionsMarshal.AsSpan(allRegions);
+            var span = CollectionsMarshal.AsSpan(sparseRegions);
             ref var prev = ref span[0];
-            for (int i = 1; i < allRegions.Count; i++)
+            for (int i = 1; i < sparseRegions.Count; i++)
             {
                 ref var inUsed = ref span[used];
                 ref var cur = ref span[i];
@@ -1798,9 +1765,7 @@ namespace Voron
                     span[used] = prev;
                 }
             }
-
-            return span.Slice(0, used + 1);
-
+            CollectionsMarshal.SetCount(sparseRegions, used + 1);
         }
 
         internal void UpdateJournal(long journalNumber, long last4KWrite)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1739,32 +1739,38 @@ namespace Voron
             }
         }
 
-        private static void MergeSparseRegions(List<(long Start, long Count)> sparseRegions)
+        public static void MergeSparseRegions(List<(long Start, long Count)> sparseRegions)
         {
-            // sorts first by the start, then by the count
+            if (sparseRegions.Count <= 1)
+                return;
+
+            // Sort Start, Count
+            // Equal Start will sort by smaller Count, we rely on that below
             sparseRegions.Sort();
+
             int used = 0;
             var span = CollectionsMarshal.AsSpan(sparseRegions);
-            ref var prev = ref span[0];
-            for (int i = 1; i < sparseRegions.Count; i++)
+
+            for (int i = 1; i < span.Length; i++)
             {
-                ref var inUsed = ref span[used];
-                ref var cur = ref span[i];
-                if (prev.Start == cur.Start)
+                ref var currentMerged = ref span[used];
+                var next = span[i];
+
+                // Check for overlap or adjacency:
+                if (next.Start <= currentMerged.Start + currentMerged.Count)
                 {
-                    inUsed.Count = cur.Count;
-                }
-                else if (prev.Start + prev.Count >= cur.Start)
-                {
-                    inUsed.Count = Math.Max(prev.Start + prev.Count, cur.Start + cur.Count) - prev.Start;
+                    long currentEnd = currentMerged.Start + currentMerged.Count;
+                    long nextEnd = next.Start + next.Count;
+
+                    currentMerged.Count = Math.Max(currentEnd, nextEnd) - currentMerged.Start;
                 }
                 else
                 {
                     used++;
-                    prev = ref cur;
-                    span[used] = prev;
+                    span[used] = next;
                 }
             }
+
             CollectionsMarshal.SetCount(sparseRegions, used + 1);
         }
 

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -46,7 +46,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         {
             // delete range of ~14MB - 40MB, expect to free: 16MB - 32MB
             for (int i = 7; i < 20; i++)
-            {
+            { 
                 for (int j = 0; j < 256; j++)
                 {
                     wtx.LowLevelTransaction.FreePage(pages[i] + j);
@@ -55,7 +55,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
 
             wtx.Commit();
         }
-        Assert.Equal([(2048, 2048), (4096, 1026)], Env.CurrentSparseRegions.Regions);
+        Assert.Equal([(2048, 2048), (4096, 1026)], Env.CurrentStateRecord.SparseRegions);
 
         using (var wtx = Env.WriteTransaction())
         {
@@ -71,7 +71,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
             wtx.Commit();
         }
         // proof that we can release regions released across multiple transactions
-        Assert.Equal([(4096, 2048), (6144, 514)], Env.CurrentSparseRegions.Regions);
+        Assert.Equal([(4096, 2048), (6144, 514)], Env.CurrentStateRecord.SparseRegions);
         (_, long beforePhysicalSize) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
 
         Env.FlushLogToDataFile();
@@ -125,6 +125,6 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
             wtx.Commit();
         }
         RestartDatabase();
-        Assert.Equal([(2, 2046), (2048, 2048), (4096, 2048), (6144, 2048)], Env.CurrentSparseRegions.Regions);
+        Assert.Equal([(2, 2046), (2048, 2048), (4096, 2048), (6144, 2048)], Env.CurrentStateRecord.SparseRegions);
     }
 }

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -127,4 +127,41 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
         RestartDatabase();
         Assert.Equal([(2, 2046), (2048, 2048), (4096, 2048), (6144, 2048)], Env.CurrentStateRecord.SparseRegions);
     }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void MergeSparseRegions_ShouldReturnMinimumConsolidatedRanges()
+    {
+        var inputSource = new List<(long Start, long Count)>
+        {
+            (4703, 1), (4487, 1), (4704, 1), (4707, 9), (4717, 7), (4703, 1), (4714, 3), (4735, 9),
+            (4718, 6), (4717, 1), (4738, 6), (4787, 7), (4718, 6), (4743, 1), (4787, 7), (4718, 6),
+            (4743, 1), (4787, 7), (4809, 6), (4718, 2), (4720, 4), (4743, 1), (4787, 7), (4809, 2),
+            (4813, 2), (4835, 2), (4722, 2), (4743, 1), (4787, 7), (4809, 2), (4813, 2), (4835, 2),
+            (4853, 2), (4722, 2), (4743, 1), (4787, 7), (4809, 2), (4813, 2), (4835, 2), (4853, 2),
+            (4857, 2), (4788, 6), (4809, 2), (4813, 2), (4835, 2), (4853, 2), (4857, 2), (4875, 2),
+            (4788, 2), (4790, 4), (4809, 2), (4813, 2), (4835, 2), (4853, 2), (4857, 2), (4875, 2),
+            (4879, 2), (4792, 2), (4809, 2), (4813, 2), (4835, 2), (4853, 2), (4857, 2), (4875, 2),
+            (4879, 2), (4897, 2)
+        };
+
+        var expectedResult = new List<(long Start, long Count)>
+        {
+            (4487, 1),
+            (4703, 2),
+            (4707, 17),
+            (4735, 9),
+            (4787, 7),
+            (4809, 6),
+            (4835, 2),
+            (4853, 2),
+            (4857, 2),
+            (4875, 2),
+            (4879, 2),
+            (4897, 2)
+        };
+
+        StorageEnvironment.MergeSparseRegions(inputSource);
+
+        Assert.Equal(expectedResult , inputSource);
+    }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB-25424.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25424.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25424(ITestOutputHelper output) : StorageTest(output)
+    {
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanHandleTransactionReleasingPagesWhileFlushing()
+        {
+            Options.ManualFlushing = true;
+
+            const int AllocationSize= 600;
+            const int OverflowSize = AllocationSize * Voron.Global.Constants.Storage.PageSize - Voron.PageHeader.SizeOf;
+
+            long pageNum;
+            using (var tx = Env.WriteTransaction())
+            {
+                var p = tx.LowLevelTransaction.AllocatePage(AllocationSize);
+                p.OverflowSize = OverflowSize;
+                p.Flags |= Voron.PageFlags.Overflow;
+                pageNum = p.PageNumber;
+                p.AsSpan(Voron.PageHeader.SizeOf, OverflowSize).Fill(1);
+                tx.Commit();
+            }
+
+            bool alreadyRun = false;
+            Env.Journal.Applicator.ForTestingPurposesOnly().OnApplyLogsToDataFile_AfterSparseRegionsSet_BeforeWritingToDataFile += () =>
+            {
+                if (alreadyRun)
+                    return;
+                alreadyRun = true;
+                // this will be ignored, because we _already_ process spare regions
+                using (var tx = Env.WriteTransaction())
+                {
+                    for (int i = 0; i < AllocationSize; i++)
+                    {
+                        tx.LowLevelTransaction.FreePage(pageNum+i);
+                    }
+                    tx.Commit();
+                }
+
+                // this will be flushed to disk, since we haven't gotten to it yet
+                using (var tx = Env.WriteTransaction())
+                {
+                    var p = tx.LowLevelTransaction.AllocatePage(AllocationSize);
+                    Assert.Equal(pageNum, p.PageNumber);
+                    p.OverflowSize = OverflowSize;
+                    p.Flags |= Voron.PageFlags.Overflow;
+                    p.AsSpan(Voron.PageHeader.SizeOf, OverflowSize).Fill(2);
+                    tx.Commit();
+                }
+            };
+
+            // first run, to create the "race" with the transactions
+            Env.FlushLogToDataFile();
+
+            // second run, forcing the sparse pages to be zeroed
+            Env.FlushLogToDataFile();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var p = tx.LowLevelTransaction.GetPage(pageNum);
+                pageNum = p.PageNumber;
+                Assert.Equal(OverflowSize, p.OverflowSize);
+                var span = p.AsSpan(Voron.PageHeader.SizeOf, OverflowSize);
+                Assert.False(span.ContainsAnyExcept((byte)2));
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
+++ b/test/SlowTests/Server/Documents/PeriodicBackup/PeriodicBackupSlowTests.cs
@@ -620,7 +620,9 @@ namespace SlowTests.Server.Documents.PeriodicBackup
                     {
                         var database = await GetDatabase(restoredDatabaseName);
                         var pathToIndexes = database.Configuration.Indexing.StoragePath;
-                        Assert.Equal(0, Directory.GetDirectories(pathToIndexes.FullPath).Length);
+                        var dirs = Directory.GetDirectories(pathToIndexes.FullPath);
+                        dirs = dirs.Where(d => new DirectoryInfo(d).Name != "@SharedJournals").ToArray();
+                        Assert.Equal(0, dirs.Length);
 
                         using (var session = store.OpenAsyncSession(restoredDatabaseName))
                         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25424

### Additional description

We used to have `_sparseRegionsToFlush` as well as `_transactionsToFlush`. 
The first used for finding the sparse regions to mark, and the second the pages to write to the disk.
Writing sparse region can take some time (requires I/O).
If _during_ that time, we would have additional transactions (including those that freed ranges), we would have a situation in which we read from `_sparseRegionsToFlush`, started working on it, then read from `_transactionsToFlush`.
However, while we were working on `_sparseRegionsToFlush`, a transaction added to _both_ `_sparseRegionsToFlush` and `_transactionsToFlush`.

Conceptually, this was meant to be:
* `_sparseRegionsToFlush = [Tx10, Tx11]`
*  `_transactionsToFlush = [Tx10, Tx11]` 

And you read first `_sparseRegionsToFlush`  and then from `_transactionsToFlush`.
Always processing the sparse regions first.

But, if you read through `_sparseRegionsToFlush`  and _then_ it was added to both queue, you'll process:

Flush: [Tx10, Tx111]

And in the _next_ run we'll have:

Sparse: [Tx10, Tx11]

That effectively wipe the already written data out.

The fix is to avoid having two such queues in the first place. We have a _single_ place that serve for this, the environment record.

Note that this is an 8.0 bug that only applies to it, not affecting older versions.


This PR also include some minor optimizations to sparse regions merging, which should reduce the number of syscalls we issue.

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Moderate 

### Backward compatibility

- [x] Non breaking change

### Is it platform specific issue?

- [x] No

### Documentation update

- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
