### PR TITLE
RavenDB-25839 NativeList should not be accessed after dispose.

### DIFF
--- a/src/Voron/Data/PostingLists/PostingListLeafPage.cs
+++ b/src/Voron/Data/PostingLists/PostingListLeafPage.cs
@@ -293,10 +293,10 @@ public readonly unsafe struct PostingListLeafPage
             
             encoder.Write(tmpPtr + PageHeader.SizeOf, Constants.Storage.PageSize - PageHeader.SizeOf);
         }
-        mergedList.Dispose();
 
         newHeader->SizeUsed = (ushort)reqSize;
         newHeader->NumberOfEntries =  mergedList.Count;
+        mergedList.Dispose();
 
         Memory.Set((byte*)dest + PageHeader.SizeOf + dest->SizeUsed, 0,
             Constants.Storage.PageSize - (PageHeader.SizeOf + dest->SizeUsed));

--- a/src/Voron/Util/NativeList.cs
+++ b/src/Voron/Util/NativeList.cs
@@ -27,10 +27,29 @@ public unsafe struct NativeList<T>
     public T* RawItems => Capacity > 0 ? (T*)_storage.Ptr : null;
 
     public int Capacity = 0;
+    
+#if DEBUG
+    private bool _disposed = false;
+    private int _count = 0;
+    public int Count
+    {
+        readonly get
+        {
+            Debug.Assert(_count <= Capacity, "NativeList count is greater than capacity.");
+            Debug.Assert(_disposed == false, "NativeList has been disposed.");
+            return _count;
+        }
+        set
+        {
+            _count = value;
+        }
+    }
+#else
     public int Count;
+#endif
 
     public readonly Span<T> ToSpan() => Count == 0 ? Span<T>.Empty : new Span<T>(_storage.Ptr, Count);
-    
+
     public bool IsValid => RawItems != null;
 
     public NativeList()
@@ -219,6 +238,11 @@ public unsafe struct NativeList<T>
         if(_storage.HasValue)
             ctx.Release(ref _storage);
         Capacity = 0;
+        Count = 0;
+        
+#if DEBUG
+        _disposed = true;
+#endif
     }
 
     public void Clear()

--- a/test/SlowTests/Voron/Issues/RavenDB-25839.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB-25839.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Corax;
+using Corax.Indexing;
+using Corax.Utils;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Containers;
+using Voron.Data.PostingLists;
+using Voron.Util;
+using Voron.Util.PFor;
+using Xunit;
+using Xunit.Abstractions;
+namespace SlowTests.Voron.Issues;
+
+public unsafe class RavenDB_25839(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Corax)]
+    public void CanProperlyUpdateNumberOfEntriesWhenMergingLeaves()
+    {
+        ContainerId postingListContainerId;
+        long setId;
+        var currentId = 1;
+        List<long> currentElements = new();
+        using (var wTx = Env.WriteTransaction())
+        {
+            using var pForEncoder = new FastPForEncoder(wTx.Allocator);
+            using var pForDecoderDisposal = new FastPForDecoder(wTx.Allocator);
+            postingListContainerId = wTx.OpenContainer(Constants.IndexWriter.PostingListsSlice);
+
+            setId = (long)Container.Allocate(wTx.LowLevelTransaction, postingListContainerId, sizeof(PostingListState), out var setSpace);
+            ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
+
+
+            var currentMax = currentId + 2 * 80_000;
+            var toInsert = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+            for (; currentId < currentMax; currentId++)
+            {
+                var id = EntryIdEncodings.Encode(currentId, 1, TermIdMask.Single);
+                toInsert.Add(id);
+                currentElements.Add(id);
+            }
+
+            toInsert.Sort();
+            pForEncoder.Encode(toInsert.RawItems, toInsert.Count);
+            PostingList.Create(wTx.LowLevelTransaction, ref postingListState, pForEncoder);
+
+            wTx.Commit();
+        }
+
+        var toRemoveLimitFirst = EntryIdEncodings.DecodeAndDiscardFrequency(62391300);
+        var toRemoveSecond = EntryIdEncodings.DecodeAndDiscardFrequency(124781572);
+
+        using (var wTx = Env.WriteTransaction())
+        {
+            using var pForEncoder = new FastPForEncoder(wTx.Allocator);
+            using var pForDecoderDisposal = new FastPForDecoder(wTx.Allocator);
+            Container.GetMutable(wTx.LowLevelTransaction, new ContainerEntryId(setId), out var setSpace);
+            ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace.ToSpan());
+
+            var pForDecoder = pForDecoderDisposal;
+            var tmpBuffer = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+            var removalList = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+            for (var i = 1; i < (long)toRemoveLimitFirst / 2; i++)
+            {
+                var id = EntryIdEncodings.Encode(i, 1, TermIdMask.Single);
+                currentElements.Remove(id);
+                removalList.Add(id | 1); //removal mask
+            }
+
+            var skipIt = 0;
+            for (var i = (long)toRemoveLimitFirst; i < (long)toRemoveSecond; i++)
+            {
+                if (skipIt++ < 100) continue;
+
+                var id = EntryIdEncodings.Encode(i, 1, TermIdMask.Single);
+                currentElements.Remove(id);
+                removalList.Add(id | 1); //removal mask
+            }
+
+            removalList.Sort();
+
+            PostingList.Update(wTx.LowLevelTransaction, ref postingListState, null, 0, removalList.RawItems, removalList.Count, pForEncoder, ref tmpBuffer, ref pForDecoder);
+
+            wTx.Commit();
+        }
+
+
+        using (var wTx = Env.WriteTransaction())
+        {
+            using var pForEncoder = new FastPForEncoder(wTx.Allocator);
+            using var pForDecoderDisposal = new FastPForDecoder(wTx.Allocator);
+            var pForDecoder = pForDecoderDisposal;
+            Container.GetMutable(wTx.LowLevelTransaction, new ContainerEntryId(setId), out var setSpace);
+            ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace.ToSpan());
+            var postingList = new PostingList(wTx.LowLevelTransaction, Slices.Empty, postingListState);
+            postingList.Render();
+            var iterate = postingList.Iterate();
+            iterate.Seek(0);
+            var buff = new long[1024];
+            var dataFromIterator = new List<long>();
+            while (iterate.Fill(buff, out var read))
+            {
+                dataFromIterator.AddRange(buff[0..read]);
+            }
+
+            Assert.Equal(currentElements, dataFromIterator);
+
+            var tmpBuffer = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+            var removalList = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+            removalList.Add(currentElements[0] | 1);
+            currentElements.RemoveAt(0);
+            PostingList.Update(wTx.LowLevelTransaction, ref postingListState, null, 0, removalList.RawItems, removalList.Count, pForEncoder, ref tmpBuffer, ref pForDecoder);
+            wTx.Commit();
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25839

### Additional description

- NativeList should not be accessed after the Dispose call.
- The PostingList leaf should retrieve the Count from NativeList before disposal.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
