### PR TITLE
RavenDB-25890 Updated notifications storing and reading logic for database notifications widget

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/DatabaseNotifications/DatabaseNotificationsSummaryNotificationSender.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/DatabaseNotifications/DatabaseNotificationsSummaryNotificationSender.cs
@@ -55,7 +55,7 @@ public class DatabaseNotificationsSummaryNotificationSender : AbstractClusterDas
                     var notificationSummaryItem = new NotificationSummaryItem
                     {
                         Reason = notificationReasonCount.Key,
-                        PrettifiedReason = NotificationSummaryItem.PrettifyReason(notificationReasonCount.Key),
+                        PrettifiedReason = NotificationSummaryItem.PrettifyReason(notificationType, notificationReasonCount.Key),
                         Count = notificationReasonCount.Value
                     };
 

--- a/src/Raven.Server/Dashboard/Cluster/Notifications/DatabaseNotifications/NotificationSummaryItem.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/DatabaseNotifications/NotificationSummaryItem.cs
@@ -20,46 +20,54 @@ public class NotificationSummaryItem
         };
     }
     
-    public static string PrettifyReason(string reason)
+    public static string PrettifyReason(NotificationType notificationType, string reason)
     {
-        return reason switch
+        return notificationType switch
         {
-            // Performance hints
-            nameof(PerformanceHintReason.Paging) => "Requests: Page size too big",
-            nameof(PerformanceHintReason.RequestLatency) => "Requests: Latency is too high",
-            
-            nameof(PerformanceHintReason.Indexing) => "Indexing: Definition issues",
-            nameof(PerformanceHintReason.Indexing_References) => "Indexing: High load reference rate",
-            
-            nameof(PerformanceHintReason.SlowIO) => "Storage: An extremely slow write to disk",
-            
-            nameof(PerformanceHintReason.UnusedCapacity) => "System: Not all cores are used",
-            
-            nameof(PerformanceHintReason.Replication) => "Replication: Disabled destination",
-            
-            nameof(PerformanceHintReason.SqlEtl_SlowSql) => "ETL: Slow SQL detected",
-            
-            nameof(PerformanceHintReason.HugeDocuments) => "Huge documents impacting performance",
-            
-            // Alerts
-            nameof(AlertReason.QueueSink_Error) => "Queue Sink: Invalid configuration",
-            nameof(AlertReason.QueueSink_ScriptError) => "Queue Sink: Could not parse script",
-            nameof(AlertReason.QueueSink_ConsumeError) => "Queue Sink: Messages consumption has failed",
-            nameof(AlertReason.QueueSink_ConsumerCreationError) => "Queue Sink: Failed to create consumer",
-            
-            nameof(AlertReason.OutOfMemoryException) => "System: Out of memory occurred",
-            nameof(AlertReason.ServerLimits) => "System: Server is running close to OS limits",
-            
-            nameof(AlertReason.LowDiskSpace) => "Storage: Low free disk space",
-            
-            nameof(AlertReason.MismatchedReferenceLoad) => "Indexing: Loading documents with mismatched collection",
-            
-            nameof(AlertReason.Etl_LoadError) => "ETL: Loading transformed data to the destination has failed",
-            
-            nameof(AlertReason.BlockingTombstones) => "Blockage in tombstone deletion",
-            nameof(AlertReason.PeriodicBackup) => "Failed to run backup",
-            nameof(AlertReason.ConflictRevisionsExceeded) => "Excess number of Conflict Revisions",
-            nameof(AlertReason.ReplicationMissingAttachments) => "Detected missing attachments for a document",
+            NotificationType.PerformanceHint => reason switch
+            {
+                nameof(PerformanceHintReason.Paging) => "Requests: Page size too big",
+                nameof(PerformanceHintReason.RequestLatency) => "Requests: Latency is too high",
+
+                nameof(PerformanceHintReason.Indexing) => "Indexing: Definition issues",
+                nameof(PerformanceHintReason.Indexing_References) => "Indexing: High load reference rate",
+
+                nameof(PerformanceHintReason.SlowIO) => "Storage: An extremely slow write to disk",
+
+                nameof(PerformanceHintReason.UnusedCapacity) => "System: Not all cores are used",
+
+                nameof(PerformanceHintReason.Replication) => "Replication: Disabled destination",
+
+                nameof(PerformanceHintReason.SqlEtl_SlowSql) => "ETL: Slow SQL detected",
+
+                nameof(PerformanceHintReason.HugeDocuments) => "Huge documents impacting performance",
+
+                _ => DefaultPrettify(reason)
+            },
+
+            NotificationType.AlertRaised => reason switch
+            {
+                nameof(AlertReason.QueueSink_Error) => "Queue Sink: Invalid configuration",
+                nameof(AlertReason.QueueSink_ScriptError) => "Queue Sink: Could not parse script",
+                nameof(AlertReason.QueueSink_ConsumeError) => "Queue Sink: Messages consumption has failed",
+                nameof(AlertReason.QueueSink_ConsumerCreationError) => "Queue Sink: Failed to create consumer",
+
+                nameof(AlertReason.OutOfMemoryException) => "System: Out of memory occurred",
+                nameof(AlertReason.ServerLimits) => "System: Server is running close to OS limits",
+
+                nameof(AlertReason.LowDiskSpace) => "Storage: Low free disk space",
+
+                nameof(AlertReason.MismatchedReferenceLoad) => "Indexing: Loading documents with mismatched collection",
+
+                nameof(AlertReason.Etl_LoadError) => "ETL: Loading transformed data to the destination has failed",
+
+                nameof(AlertReason.BlockingTombstones) => "Blockage in tombstone deletion",
+                nameof(AlertReason.PeriodicBackup) => "Failed to run backup",
+                nameof(AlertReason.ConflictRevisionsExceeded) => "Excess number of Conflict Revisions",
+                nameof(AlertReason.ReplicationMissingAttachments) => "Detected missing attachments for a document",
+
+                _ => DefaultPrettify(reason)
+            },
             
             _ => DefaultPrettify(reason)
         };

--- a/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
+++ b/src/Raven.Server/Dashboard/DatabasesInfoRetriever.cs
@@ -639,6 +639,7 @@ namespace Raven.Server.Dashboard
         private static NotificationCounts GetNotificationCounts(DocumentDatabase database)
         {
             var result = new NotificationCounts();
+            var now = SystemTime.UtcNow;
             
             var storage = database.NotificationCenter.Storage;
             
@@ -647,23 +648,29 @@ namespace Raven.Server.Dashboard
             {
                 foreach (var alert in storage.ReadActionsOfType(context, NotificationType.AlertRaised))
                 {
-                    var reason = Bits.SwapBytes(alert.Reason);
+                    if (alert.PostponedUntil == null || alert.PostponedUntil <= now)
+                    {
+                        var reason = Bits.SwapBytes(alert.Reason);
 
-                    var reasonName = ((AlertReason)reason).ToString();
+                        var reasonName = ((AlertReason)reason).ToString();
                     
-                    result.Increment(NotificationType.AlertRaised, reasonName);
+                        result.Increment(NotificationType.AlertRaised, reasonName);
+                    }
                     
                     alert.Dispose();
                 }
                 
                 foreach (var performanceHint in storage.ReadActionsOfType(context, NotificationType.PerformanceHint))
                 {
-                    var reason = Bits.SwapBytes(performanceHint.Reason);
+                    if (performanceHint.PostponedUntil == null || performanceHint.PostponedUntil <= now)
+                    {
+                        var reason = Bits.SwapBytes(performanceHint.Reason);
 
-                    var reasonName = ((PerformanceHintReason)reason).ToString();
-                    
-                    result.Increment(NotificationType.PerformanceHint, reasonName);
-                    
+                        var reasonName = ((PerformanceHintReason)reason).ToString();
+
+                        result.Increment(NotificationType.PerformanceHint, reasonName);
+                    }
+
                     performanceHint.Dispose();
                 }
             }

--- a/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
+++ b/src/Raven.Server/NotificationCenter/NotificationsStorage.cs
@@ -13,6 +13,7 @@ using Raven.Server.ServerWide.Context;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
 using Sparrow.Server.Utils;
@@ -120,9 +121,28 @@ namespace Raven.Server.NotificationCenter
             var postponedUntilTicks = postponedUntil != null
                 ? Bits.SwapBytes(postponedUntil.Value.Ticks)
                 : _postponeDateNotSpecified;
+            
+            action.Modifications = new DynamicJsonValue(action)
+            {
+                [nameof(Notification.Type)] = notificationType
+            };
 
+            switch ((NotificationType)notificationType)
+            {
+                case NotificationType.AlertRaised:
+                    action.Modifications[nameof(AlertRaised.Reason)] = notificationReason;
+                    break;
+                case NotificationType.PerformanceHint:
+                    action.Modifications[nameof(PerformanceHint.Reason)] = notificationReason;
+                    break;
+            }
+            
+            using (_ = action)
+            using (ContextPool.AllocateOperationContext(out JsonOperationContext context))
             using (table.Allocate(out TableValueBuilder tvb))
             {
+                action = context.ReadObject(action, null);
+                    
                 tvb.Add(id.Buffer, id.Size);
                 tvb.Add((byte*)&createdAtTicks, sizeof(long));
                 tvb.Add((byte*)&postponedUntilTicks, sizeof(long));
@@ -359,14 +379,52 @@ namespace Raven.Server.NotificationCenter
             var type = reader.ReadLong(Documents.Schemas.Notifications.NotificationsTable.TypeIndex);
             var reason = reader.ReadLong(Documents.Schemas.Notifications.NotificationsTable.ReasonIndex);
 
-            return new NotificationTableValue
+            var json = new BlittableJsonReaderObject(jsonPtr, jsonSize, context);
+
+            // If notification JSON has Type and Reason stored as strings, they can be extracted directly
+            // Maintains backward compatibility due to RavenDB-24424
+            if (json.TryGet(nameof(Notification.Type), out string _))
             {
-                CreatedAt = createdAt,
-                PostponedUntil = postponedUntil,
-                Json = new BlittableJsonReaderObject(jsonPtr, jsonSize, context),
-                Type = type,
-                Reason = reason
+                return new NotificationTableValue
+                {
+                    CreatedAt = createdAt,
+                    PostponedUntil = postponedUntil,
+                    Json = json,
+                    Type = type,
+                    Reason = reason
+                };
+            }
+
+            var typeEnumValue = (NotificationType)Bits.SwapBytes(type);
+            
+            json.Modifications = new DynamicJsonValue
+            {
+                [nameof(Notification.Type)] = typeEnumValue
             };
+
+            switch (typeEnumValue)
+            {
+                case NotificationType.AlertRaised:
+                    json.Modifications[nameof(AlertRaised.Reason)] = (AlertReason)Bits.SwapBytes(reason);
+                    break;
+                case NotificationType.PerformanceHint:
+                    json.Modifications[nameof(PerformanceHint.Reason)] = (PerformanceHintReason)Bits.SwapBytes(reason);
+                    break;
+            }
+
+            using (_ = json)
+            {
+                json = context.ReadObject(json, null);
+                
+                return new NotificationTableValue
+                {
+                    CreatedAt = createdAt,
+                    PostponedUntil = postponedUntil,
+                    Json = json,
+                    Type = type,
+                    Reason = reason
+                };
+            }
         }
 
         public string GetDatabaseFor(string id)

--- a/test/SlowTests/SlowTests/Issues/RavenDB-24424.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB-24424.cs
@@ -87,12 +87,12 @@ public class RavenDB_24424 : RavenTestBase
                     Assert.Equal(NotificationType.PerformanceHint, performanceHintType);
                     Assert.Equal(PerformanceHintReason.Paging, performanceHintReason);
                     
-                    Assert.True(alert.Json.TryGet("Reason", out int alertReasonFromJson));
-                    var alertReasonEnumValue = (AlertReason)alertReasonFromJson;
+                    Assert.True(alert.Json.TryGet("Reason", out string alertReasonFromJson));
+                    var alertReasonEnumValue = Enum.Parse<AlertReason>(alertReasonFromJson);
                     Assert.Equal(alertReasonEnumValue, AlertReason.Replication);
                     
-                    Assert.True(performanceHint.Json.TryGet("Reason", out int performanceHintReasonFromJson));
-                    var performanceHintReasonEnumValue = (PerformanceHintReason)performanceHintReasonFromJson;
+                    Assert.True(performanceHint.Json.TryGet("Reason", out string performanceHintReasonFromJson));
+                    var performanceHintReasonEnumValue = Enum.Parse<PerformanceHintReason>(performanceHintReasonFromJson);
                     Assert.Equal(performanceHintReasonEnumValue, PerformanceHintReason.Paging);
                 }
             }
@@ -170,12 +170,12 @@ public class RavenDB_24424 : RavenTestBase
                 Assert.Equal(NotificationType.PerformanceHint, performanceHintType);
                 Assert.Equal(PerformanceHintReason.Paging, performanceHintReason);
 
-                Assert.True(alert.Json.TryGet("Reason", out int alertReasonFromJson));
-                var alertReasonEnumValue = (AlertReason)alertReasonFromJson;
+                Assert.True(alert.Json.TryGet("Reason", out string alertReasonFromJson));
+                var alertReasonEnumValue = Enum.Parse<AlertReason>(alertReasonFromJson);
                 Assert.Equal(alertReasonEnumValue, AlertReason.Replication);
 
-                Assert.True(performanceHint.Json.TryGet("Reason", out int performanceHintReasonFromJson));
-                var performanceHintReasonEnumValue = (PerformanceHintReason)performanceHintReasonFromJson;
+                Assert.True(performanceHint.Json.TryGet("Reason", out string performanceHintReasonFromJson));
+                var performanceHintReasonEnumValue = Enum.Parse<PerformanceHintReason>(performanceHintReasonFromJson);
                 Assert.Equal(performanceHintReasonEnumValue, PerformanceHintReason.Paging);
             }
         }
@@ -226,6 +226,8 @@ public class RavenDB_24424 : RavenTestBase
             var database = GetDatabase(store.Database).Result;
             
             CreateNotifications(Server, database);
+            
+            WaitForUserToContinueTheTest(store);
             
             var serverUrl = Server.WebUrl;
 

--- a/test/SlowTests/SlowTests/Issues/RavenDB-24424.cs
+++ b/test/SlowTests/SlowTests/Issues/RavenDB-24424.cs
@@ -227,8 +227,6 @@ public class RavenDB_24424 : RavenTestBase
             
             CreateNotifications(Server, database);
             
-            WaitForUserToContinueTheTest(store);
-            
             var serverUrl = Server.WebUrl;
 
             using (var ws = new ClientWebSocket())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25890

### Additional description

This PR consists of three changes
1. Updated `PrettifyReason` logic of `DatabaseNotificationsSummaryNotificationSender` - prettified reason was incorrect for alerts that had the same reason as any of the performance hint reasons.
2. Added filtering of postponed notifications for database notifications widget - now the logic is consistent with other places where we extract notifications to be displayed in studio.
3. When storing `NotificationTableValue` json, we want to store `Reason` and `Type` as integers and convert them to string values when reading notification (if needed). For table values that already contain string values, we just extract them directly.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured.
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
