### PR TITLE
RavenDB-25907: IndexOutOfRangeException in Corax Indexing Due to Non-Atomic Dictionary+Storage Update

### DIFF
--- a/src/Corax/Constants.cs
+++ b/src/Corax/Constants.cs
@@ -95,6 +95,13 @@ namespace Corax
             
             public const int InvalidPageId = -1;
 
+            /// <summary>
+            /// Sentinel value used to mark dictionary entries as "in-progress" during atomic Dictionary+Storage updates.
+            /// If Storage.AddByRef throws, the dictionary entry remains at this value, allowing retry on next access.
+            /// See RavenDB-25907.
+            /// </summary>
+            public const int InvalidStorageIndex = -1;
+
             static IndexWriter()
             {
                 using (StorageEnvironment.GetStaticContext(out var ctx))

--- a/src/Corax/Indexing/IndexWriter.FieldBuffers.cs
+++ b/src/Corax/Indexing/IndexWriter.FieldBuffers.cs
@@ -58,6 +58,9 @@ public partial class IndexWriter
             {
                 foreach (var (k, v) in field.Textual)
                 {
+                    // RavenDB-25907: Skip incomplete entries (sentinel value from failed allocation)
+                    if (v == Constants.IndexWriter.InvalidStorageIndex)
+                        continue;
                     _sortedTerms[idx] = (TKey)(object)k;
                     _termIndexes[idx] = v;
                     idx++;
@@ -67,6 +70,9 @@ public partial class IndexWriter
             {
                 foreach (var (k, v) in field.Longs)
                 {
+                    // RavenDB-25907: Skip incomplete entries (sentinel value from failed allocation)
+                    if (v == Constants.IndexWriter.InvalidStorageIndex)
+                        continue;
                     _sortedTerms[idx] = (TKey)(object)k;
                     _termIndexes[idx] = v;
                     idx++;
@@ -76,14 +82,18 @@ public partial class IndexWriter
             {
                 foreach (var (k, v) in field.Doubles)
                 {
+                    // RavenDB-25907: Skip incomplete entries (sentinel value from failed allocation)
+                    if (v == Constants.IndexWriter.InvalidStorageIndex)
+                        continue;
                     _sortedTerms[idx] = (TKey)(object)k;
                     _termIndexes[idx] = v;
                     idx++;
                 }
             }
 
-            terms = new Span<TKey>(_sortedTerms, 0, termsCount);
-            indexes = new Span<int>(_termIndexes, 0, termsCount);
+            // Use idx (actual count) instead of termsCount to account for skipped sentinel entries
+            terms = new Span<TKey>(_sortedTerms, 0, idx);
+            indexes = new Span<int>(_termIndexes, 0, idx);
 
             if (typeof(TKey) == typeof(Slice))
                 (MemoryMarshal.Cast<TKey, Slice>(terms)).Sort(indexes, SliceComparer.Instance);

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -173,16 +173,15 @@ public partial class IndexWriter
 
             ByteStringContext<ByteStringMemoryCache>.InternalScope? scope = CreateNormalizedTerm(_parent._entriesAllocator, value, out var slice);
 
-            // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
-            // GetValueRefOrAddDefault would add a default entry (0) before we can set the correct index,
-            // which causes IndexOutOfRangeException if AddByRef throws.
-            int termLocation;
-            if (field.Textual.TryGetValue(slice, out termLocation) == false)
+            // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+            // If any allocation throws, termLocation remains InvalidStorageIndex, allowing retry on next access.
+            ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, slice, out var exists);
+            if (exists == false || termLocation == Constants.IndexWriter.InvalidStorageIndex)
             {
+                termLocation = Constants.IndexWriter.InvalidStorageIndex; // Mark as in-progress FIRST
                 var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(value.Length));
-                field.Textual[slice] = newIndex;
-                termLocation = newIndex;
+                termLocation = newIndex; // Commit only after ALL allocations succeed
 
                 scope = null; // We don't want the fieldname (slice) to be returned.
             }
@@ -241,24 +240,23 @@ public partial class IndexWriter
 
         void NumericInsert(IndexedField field, long lVal, double dVal)
         {
-            int doublesTermsLocation;
-            if (field.Doubles.TryGetValue(dVal, out doublesTermsLocation) == false)
+            // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+            ref var doublesTermsLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Doubles, dVal, out bool fieldDoublesExist);
+            if (fieldDoublesExist == false || doublesTermsLocation == Constants.IndexWriter.InvalidStorageIndex)
             {
-                // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                doublesTermsLocation = Constants.IndexWriter.InvalidStorageIndex;
                 var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(sizeof(double)));
-                // Only add to dictionary AFTER successful Storage.AddByRef
-                field.Doubles[dVal] = newIndex;
                 doublesTermsLocation = newIndex;
             }
-            
-            int longsTermsLocation;
-            if (field.Longs.TryGetValue(lVal, out longsTermsLocation) == false)
+
+            // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+            ref var longsTermsLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Longs, lVal, out bool fieldLongExist);
+            if (fieldLongExist == false || longsTermsLocation == Constants.IndexWriter.InvalidStorageIndex)
             {
-                // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                longsTermsLocation = Constants.IndexWriter.InvalidStorageIndex;
                 var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(sizeof(long)));
-                field.Longs[lVal] = newIndex;
                 longsTermsLocation = newIndex;
             }
 

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -170,16 +170,20 @@ public partial class IndexWriter
         ref EntriesModifications ExactInsert(IndexedField field, ReadOnlySpan<byte> value, InserterMode inserterMode)
         {
             Debug.Assert(field.FieldIndexingMode != FieldIndexingMode.No, "field.FieldIndexingMode != FieldIndexingMode.No");
-            
+
             ByteStringContext<ByteStringMemoryCache>.InternalScope? scope = CreateNormalizedTerm(_parent._entriesAllocator, value, out var slice);
 
-            // We are gonna try to get the reference if it exists, but we wont try to do the addition here, because to store in the
-            // dictionary we need to close the slice as we are disposing it afterwards. 
-            ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, slice, out var exists);
-            if (exists == false)
+            // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+            // GetValueRefOrAddDefault would add a default entry (0) before we can set the correct index,
+            // which causes IndexOutOfRangeException if AddByRef throws.
+            int termLocation;
+            if (field.Textual.TryGetValue(slice, out termLocation) == false)
             {
-                termLocation = field.Storage.Count;
+                var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(value.Length));
+                field.Textual[slice] = newIndex;
+                termLocation = newIndex;
+
                 scope = null; // We don't want the fieldname (slice) to be returned.
             }
 
@@ -237,20 +241,25 @@ public partial class IndexWriter
 
         void NumericInsert(IndexedField field, long lVal, double dVal)
         {
-            // We make sure we get a reference because we want the struct to be modified directly from the dictionary.
-            ref var doublesTermsLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Doubles, dVal, out bool fieldDoublesExist);
-            if (fieldDoublesExist == false)
+            int doublesTermsLocation;
+            if (field.Doubles.TryGetValue(dVal, out doublesTermsLocation) == false)
             {
-                doublesTermsLocation = field.Storage.Count;
+                // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(sizeof(double)));
+                // Only add to dictionary AFTER successful Storage.AddByRef
+                field.Doubles[dVal] = newIndex;
+                doublesTermsLocation = newIndex;
             }
-
-            // We make sure we get a reference because we want the struct to be modified directly from the dictionary.
-            ref var longsTermsLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Longs, lVal, out bool fieldLongExist);
-            if (fieldLongExist == false)
+            
+            int longsTermsLocation;
+            if (field.Longs.TryGetValue(lVal, out longsTermsLocation) == false)
             {
-                longsTermsLocation = field.Storage.Count;
+                // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(sizeof(long)));
+                field.Longs[lVal] = newIndex;
+                longsTermsLocation = newIndex;
             }
 
             ref var doublesTerm = ref field.Storage.GetAsRef(doublesTermsLocation);

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -614,11 +614,15 @@ namespace Corax.Indexing
                 if (field.HasSuggestions)
                     RemoveSuggestions(field, decodedKey);
 
-                ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, termSlice, out var exists);
-                if (exists == false)
+                int termLocation;
+                if (field.Textual.TryGetValue(termSlice, out termLocation) == false)
                 {
-                    termLocation = field.Storage.Count;
+                    // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                    var newIndex = field.Storage.Count;
                     field.Storage.AddByRef(new EntriesModifications(decodedKey.Length));
+                    field.Textual[termSlice] = newIndex;
+                    termLocation = newIndex;
+
                     scope = default; // We don't want to reclaim the term name
                 }
 
@@ -629,21 +633,27 @@ namespace Corax.Indexing
                 if (reader.HasNumeric == false)
                     continue;
 
-                termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Longs, reader.CurrentLong, out exists);
-                if (exists == false)
+                if (field.Longs.TryGetValue(reader.CurrentLong, out termLocation) == false)
                 {
-                    termLocation = field.Storage.Count;
+                    // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                    var newIndex = field.Storage.Count;
                     field.Storage.AddByRef(new EntriesModifications(sizeof(long)));
+                    field.Longs[reader.CurrentLong] = newIndex;
+
+                    termLocation = newIndex;
                 }
 
                 term = ref field.Storage.GetAsRef(termLocation);
                 term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
 
-                termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Doubles, reader.CurrentDouble, out exists);
-                if (exists == false)
+                if (field.Doubles.TryGetValue(reader.CurrentDouble, out termLocation) == false)
                 {
-                    termLocation = field.Storage.Count;
+                    // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                    var newIndex = field.Storage.Count;
                     field.Storage.AddByRef(new EntriesModifications(sizeof(long)));
+                    field.Doubles[reader.CurrentDouble] = newIndex;
+
+                    termLocation = newIndex;
                 }
 
                 term = ref field.Storage.GetAsRef(termLocation);
@@ -653,11 +663,15 @@ namespace Corax.Indexing
 
         private void RemoveMarkerTerm(IndexedField field, EntryTermsReader reader, Slice termSlice, DocumentEntryId entryToDelete, int termsPerEntryIndex)
         {
-            ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, termSlice, out var exists);
-            if (exists == false)
+            int termLocation;
+            if (field.Textual.TryGetValue(termSlice, out termLocation) == false)
             {
-                termLocation = field.Storage.Count;
+                // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(1));
+                field.Textual[termSlice] = newIndex;
+
+                termLocation = newIndex;
                 // We dont want to reclaim the term name
             }
 

--- a/src/Corax/Indexing/IndexWriter.cs
+++ b/src/Corax/Indexing/IndexWriter.cs
@@ -614,13 +614,13 @@ namespace Corax.Indexing
                 if (field.HasSuggestions)
                     RemoveSuggestions(field, decodedKey);
 
-                int termLocation;
-                if (field.Textual.TryGetValue(termSlice, out termLocation) == false)
+                // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+                ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, termSlice, out var exists);
+                if (exists == false || termLocation == Constants.IndexWriter.InvalidStorageIndex)
                 {
-                    // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                    termLocation = Constants.IndexWriter.InvalidStorageIndex;
                     var newIndex = field.Storage.Count;
                     field.Storage.AddByRef(new EntriesModifications(decodedKey.Length));
-                    field.Textual[termSlice] = newIndex;
                     termLocation = newIndex;
 
                     scope = default; // We don't want to reclaim the term name
@@ -633,44 +633,43 @@ namespace Corax.Indexing
                 if (reader.HasNumeric == false)
                     continue;
 
-                if (field.Longs.TryGetValue(reader.CurrentLong, out termLocation) == false)
+                // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+                ref var longTermLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Longs, reader.CurrentLong, out exists);
+                if (exists == false || longTermLocation == Constants.IndexWriter.InvalidStorageIndex)
                 {
-                    // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                    longTermLocation = Constants.IndexWriter.InvalidStorageIndex;
                     var newIndex = field.Storage.Count;
                     field.Storage.AddByRef(new EntriesModifications(sizeof(long)));
-                    field.Longs[reader.CurrentLong] = newIndex;
-
-                    termLocation = newIndex;
+                    longTermLocation = newIndex;
                 }
 
-                term = ref field.Storage.GetAsRef(termLocation);
+                term = ref field.Storage.GetAsRef(longTermLocation);
                 term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
 
-                if (field.Doubles.TryGetValue(reader.CurrentDouble, out termLocation) == false)
+                // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+                ref var doubleTermLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Doubles, reader.CurrentDouble, out exists);
+                if (exists == false || doubleTermLocation == Constants.IndexWriter.InvalidStorageIndex)
                 {
-                    // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                    doubleTermLocation = Constants.IndexWriter.InvalidStorageIndex;
                     var newIndex = field.Storage.Count;
-                    field.Storage.AddByRef(new EntriesModifications(sizeof(long)));
-                    field.Doubles[reader.CurrentDouble] = newIndex;
-
-                    termLocation = newIndex;
+                    field.Storage.AddByRef(new EntriesModifications(sizeof(double)));
+                    doubleTermLocation = newIndex;
                 }
 
-                term = ref field.Storage.GetAsRef(termLocation);
+                term = ref field.Storage.GetAsRef(doubleTermLocation);
                 term.Removal(_entriesAllocator, entryToDelete, termsPerEntryIndex, freq: 1, InserterMode.Numerical);
             }
         }
 
         private void RemoveMarkerTerm(IndexedField field, EntryTermsReader reader, Slice termSlice, DocumentEntryId entryToDelete, int termsPerEntryIndex)
         {
-            int termLocation;
-            if (field.Textual.TryGetValue(termSlice, out termLocation) == false)
+            // RavenDB-25907: Sentinel value pattern for atomic Dictionary+Storage update.
+            ref var termLocation = ref CollectionsMarshal.GetValueRefOrAddDefault(field.Textual, termSlice, out var exists);
+            if (exists == false || termLocation == Constants.IndexWriter.InvalidStorageIndex)
             {
-                // RavenDB-25907: Use TryGetValue pattern to ensure atomic Dictionary+Storage update.
+                termLocation = Constants.IndexWriter.InvalidStorageIndex;
                 var newIndex = field.Storage.Count;
                 field.Storage.AddByRef(new EntriesModifications(1));
-                field.Textual[termSlice] = newIndex;
-
                 termLocation = newIndex;
                 // We dont want to reclaim the term name
             }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25907

### Additional description

This PR is divided into 2 different commits. The first commit is the solution which would essentially revert an optimization. The problem happens because there are cases (specifically during batch operations) where failures could cause this issues. This has been verified using debug code by being able to inject failures in specific places. There is no way we can build a reproduction without adding the ability to run those hooks. After verifying the fix, I setup to build an alternative way to recover the optimization. Both commits should be reviews separately. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
