### PR TITLE
RavenDB-25912 - ConcurrentSet iterating .Keys causes contention

### DIFF
--- a/src/Sparrow/Collections/ConcurrentSet.cs
+++ b/src/Sparrow/Collections/ConcurrentSet.cs
@@ -76,7 +76,8 @@ namespace Sparrow.Collections
 
         public IEnumerator<T> GetEnumerator()
         {
-            return _inner.Keys.GetEnumerator();
+            foreach (var item in _inner)
+                yield return item.Key;
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/test/FastTests/Issues/RavenDB-8097.cs
+++ b/test/FastTests/Issues/RavenDB-8097.cs
@@ -33,7 +33,7 @@ namespace FastTests.Issues
         [Fact]
         public void ServerUrlShouldOnlyAllowHttpOrHttps()
         {
-            GetConfiguration("http://test.com");
+            GetConfiguration("http://ravendb.net");
             GetConfiguration("https://192.152.23.3:345", certPath: "certPath.pem");
 
             foreach (var serverUrl in new string[]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25912/High-CPU-usage-when-starting-the-server

### Additional description

Iterating over keys in ConcurrentSet causes locks and therefore is susceptible to high contention and convoys.
Port from 6.2: https://github.com/ravendb/ravendb/pull/17220

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
