### PR TITLE
RavenDB-25918 Added test for AlertReason and PerformanceHintReason integrity

### DIFF
--- a/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
@@ -3,102 +3,102 @@ namespace Raven.Server.NotificationCenter.Notifications
 {
     public enum AlertReason
     {
-        Etl_Error,
-        Etl_Warning,
-        Etl_TransformationError,
-        Etl_LoadError,
+        Etl_Error = 0,
+        Etl_Warning = 1,
+        Etl_TransformationError = 2,
+        Etl_LoadError = 3,
         
-        QueueSink_Error,
-        QueueSink_Warning,
-        QueueSink_ScriptError,
-        QueueSink_ConsumeError,
-        QueueSink_ConsumerCreationError,
+        QueueSink_Error = 4,
+        QueueSink_Warning = 5,
+        QueueSink_ScriptError = 6,
+        QueueSink_ConsumeError = 7,
+        QueueSink_ConsumerCreationError = 8,
 
-        AiAgent_ExceededTokenThreshold,
+        AiAgent_ExceededTokenThreshold = 9,
 
-        SqlEtl_ConnectionError,
-        SqlEtl_ProviderError,
+        SqlEtl_ConnectionError = 10,
+        SqlEtl_ProviderError = 11,
         
-        SnowflakeEtl_ConnectionError,
+        SnowflakeEtl_ConnectionError = 12,
 
-        Etl_InvalidScript,
+        Etl_InvalidScript = 13,
 
-        PeriodicBackup,
-        Replication,
-        Server_NewVersionAvailable,
+        PeriodicBackup = 14,
+        Replication = 15,
+        Server_NewVersionAvailable = 16,
 
-        LicenseManager_InitializationError,
-        LicenseManager_LeaseLicenseSuccess,
-        LicenseManager_LeaseLicenseError,
-        LicenseManager_LicenseUpdateMessage,
-        LicenseManager_HighlyAvailableTasks,
-        LicenseManager_LicenseLimit,
-        LicenseManager_AGPL3,
+        LicenseManager_InitializationError = 17,
+        LicenseManager_LeaseLicenseSuccess = 18,
+        LicenseManager_LeaseLicenseError = 19,
+        LicenseManager_LicenseUpdateMessage = 20,
+        LicenseManager_HighlyAvailableTasks = 21,
+        LicenseManager_LicenseLimit = 22,
+        LicenseManager_AGPL3 = 23,
 
-        Certificates_Expiration,
-        Certificates_DeveloperLetsEncryptRenewal,
-        Certificates_EntireClusterReplaceSuccess,
-        Certificates_ReplaceSuccess,
-        Certificates_ReplaceError,
-        Certificates_ReplacePending,
+        Certificates_Expiration = 24,
+        Certificates_DeveloperLetsEncryptRenewal = 25,
+        Certificates_EntireClusterReplaceSuccess = 26,
+        Certificates_ReplaceSuccess = 27,
+        Certificates_ReplaceError = 28,
+        Certificates_ReplacePending = 29,
 
-        IndexStore_IndexCouldNotBeOpened,
-        WarnIndexOutputsPerDocument,
-        ErrorSavingReduceOutputDocuments,
-        CatastrophicDatabaseFailure,
-        RecoverableVoronFailure,
-        NonDurableFileSystem,
-        RecoveryError,
-        RestoreError,
-        DeletionError,
+        IndexStore_IndexCouldNotBeOpened = 30,
+        WarnIndexOutputsPerDocument = 31,
+        ErrorSavingReduceOutputDocuments = 32,
+        CatastrophicDatabaseFailure = 33,
+        RecoverableVoronFailure = 34,
+        NonDurableFileSystem = 35,
+        RecoveryError = 36,
+        RestoreError = 37,
+        DeletionError = 38,
 
-        ClusterTopologyWarning,
-        DatabaseTopologyWarning,
-        SwappingHddInsteadOfSsd,
+        ClusterTopologyWarning = 39,
+        DatabaseTopologyWarning = 40,
+        SwappingHddInsteadOfSsd = 41,
 
-        RevisionsConfigurationNotValid,
-        ArchivalConfigurationNotValid,
+        RevisionsConfigurationNotValid = 42,
+        ArchivalConfigurationNotValid = 43,
 
-        ReplicationMissingAttachments,
+        ReplicationMissingAttachments = 44,
 
-        ClusterTransactionFailure,
+        ClusterTransactionFailure = 45,
 
-        OutOfMemoryException,
+        OutOfMemoryException = 46,
 
-        LowDiskSpace,
+        LowDiskSpace = 47,
 
         // Required for backward compatibility
-        UnexpectedIndexingThreadError,
+        UnexpectedIndexingThreadError = 48,
 
-        Indexing_UnexpectedIndexingThreadError,
-        Indexing_CouldNotGetStats,
-        Indexing_CoraxComplexItem,
+        Indexing_UnexpectedIndexingThreadError = 49,
+        Indexing_CouldNotGetStats = 50,
+        Indexing_CoraxComplexItem = 51,
 
-        CpuUsageExtensionPointError,
-        TcpListenerError,
+        CpuUsageExtensionPointError = 52,
+        TcpListenerError = 53,
 
-        Throttling_CpuCreditsBalance,
+        Throttling_CpuCreditsBalance = 54,
 
-        IntegrityErrorOfAlreadySyncedData,
+        IntegrityErrorOfAlreadySyncedData = 55,
 
-        ConcurrentDatabaseLoadTimeout,
+        ConcurrentDatabaseLoadTimeout = 56,
 
-        HighClientCreationRate,
-        RollupExceedNumberOfValues,
+        HighClientCreationRate = 57,
+        RollupExceedNumberOfValues = 58,
 
-        LowSwapSize,
+        LowSwapSize = 59,
 
-        UnrecoverableClusterError,
+        UnrecoverableClusterError = 60,
         
-        MicrosoftLogsConfigurationLoadError,
+        MicrosoftLogsConfigurationLoadError = 61,
         
-        MismatchedReferenceLoad,
+        MismatchedReferenceLoad = 62,
 
-        BlockingTombstones,
-        ServerLimits,
+        BlockingTombstones = 63,
+        ServerLimits = 64,
 
-        ConflictRevisionsExceeded,
+        ConflictRevisionsExceeded = 65,
         
-        SqlConnectionString_DeprecatedFactoryReplaced,
+        SqlConnectionString_DeprecatedFactoryReplaced = 66,
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/PerformanceHintReason.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/PerformanceHintReason.cs
@@ -2,15 +2,15 @@
 {
     public enum PerformanceHintReason
     {
-        None,
-        Indexing,
-        Replication,
-        Paging,
-        RequestLatency,
-        UnusedCapacity,
-        SlowIO,
-        SqlEtl_SlowSql,
-        HugeDocuments,
-        Indexing_References
+        None = 0,
+        Indexing = 1,
+        Replication = 2,
+        Paging = 3,
+        RequestLatency = 4,
+        UnusedCapacity = 5,
+        SlowIO = 6,
+        SqlEtl_SlowSql = 7,
+        HugeDocuments = 8,
+        Indexing_References = 9
     }
 }

--- a/test/FastTests/Issues/RavenDB-25918.cs
+++ b/test/FastTests/Issues/RavenDB-25918.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Raven.Server.NotificationCenter.Notifications;
 using Tests.Infrastructure;
 using Xunit;
@@ -21,6 +22,9 @@ public class RavenDB_25918 : RavenTestBase
         //
         // Make sure new value fulfills the above and update the assertion.
         Assert.Equal(67, Enum.GetNames(typeof(AlertReason)).Length);
+        Assert.Equal(AlertReason.SqlConnectionString_DeprecatedFactoryReplaced, Enum.GetValues(typeof(AlertReason)).Cast<AlertReason>().Last());
+        
         Assert.Equal(10, Enum.GetNames(typeof(PerformanceHintReason)).Length);
+        Assert.Equal(PerformanceHintReason.Indexing_References, Enum.GetValues(typeof(PerformanceHintReason)).Cast<PerformanceHintReason>().Last());
     }
 }

--- a/test/FastTests/Issues/RavenDB-25918.cs
+++ b/test/FastTests/Issues/RavenDB-25918.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Raven.Server.NotificationCenter.Notifications;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_25918 : RavenTestBase
+{
+    public RavenDB_25918(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Codebase)]
+    public void AssertNotificationReasonsIntegrity()
+    {
+        // We want to make sure new enum values of AlertReason and PerformanceHintReason are added after existing ones.
+        // After RavenDB-24424 changes we store these values in storage in form of integers, not strings.
+        // Adding new values in between existing values will cause existing notifications to be read with incorrect reason.
+        //
+        // Make sure new value fulfills the above and update the assertion.
+        Assert.Equal(67, Enum.GetNames(typeof(AlertReason)).Length);
+        Assert.Equal(10, Enum.GetNames(typeof(PerformanceHintReason)).Length);
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25918/Add-tests-for-AlertReason-and-PerformanceHintReason-values

### Additional description

We want to make sure new enum values are added after existing ones. After [RavenDB-24424](https://github.com/ravendb/ravendb/pull/21531) changes we store these values in storage in form of integers, not strings. Adding new values in between existing values will cause existing notifications to be read with incorrect reason.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
