### PR TITLE
RavenDB-25919 - Add uuid ClrFunction to RavenDB scripting

### DIFF
--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -362,6 +362,8 @@ namespace Raven.Server.Documents.Patch
                 ScriptEngine.SetClrFunc("Raven_Min", Raven_Min);
                 ScriptEngine.SetClrFunc("Raven_Max", Raven_Max);
 
+                ScriptEngine.SetClrFunc("uuid", GenerateUuid);
+
                 ScriptEngine.SetClrFunc("convertJsTimeToTimeSpanString", ConvertJsTimeToTimeSpanString);
                 ScriptEngine.SetClrFunc("convertToTimeSpanString", ConvertToTimeSpanString);
                 ScriptEngine.SetClrFunc("compareDates", CompareDates);
@@ -879,6 +881,19 @@ namespace Raven.Server.Documents.Patch
             {
                 GenericSortTwoElementArray(args);
                 return args[0];
+            }
+
+            private JsValue GenerateUuid(JsValue self, JsValue[] args)
+            {
+                // In the future, we might accept seed parameter(s) to provide stable identifier generation
+                // based on content, but for now we only support parameterless calls
+                if (args.Length != 0)
+                {
+                    throw new InvalidOperationException("uuid() must be called without arguments");
+                }
+
+                // Explicitly specify the format to ensure stability even if .ToString() default changes
+                return JsValue.FromObject(ScriptEngine, Guid.NewGuid().ToString("D"));
             }
 
             private JsValue ArchiveAt(JsValue self, JsValue[] args)
@@ -2149,6 +2164,14 @@ namespace Raven.Server.Documents.Patch
                     //ScriptRunnerResult is in charge of disposing of the disposable but it is not created (the clones did)
                     JavaScriptUtils.Clear();
                     throw CreateFullError(documentId, e);
+                }
+                catch (InvalidOperationException ioe)
+                {
+                    //When a CLR function called from JavaScript throws an InvalidOperationException, 
+                    //we need to convert it to a JavaScriptException so the client receives the proper exception type
+                    JavaScriptUtils.Clear();
+                    var msg = $"Script failed for document ID '{documentId}'. {ioe.Message}";
+                    throw new Client.Exceptions.Documents.Patching.JavaScriptException(msg, ioe);
                 }
                 catch (Exception)
                 {

--- a/test/SlowTests/Core/ScriptedPatching/ScriptedPatchTests.cs
+++ b/test/SlowTests/Core/ScriptedPatching/ScriptedPatchTests.cs
@@ -256,5 +256,97 @@ Update
         {
             public List<ProcessRules> ProcessRules { get; set; }
         }
+
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void CanUseUuidFunction(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var commands = store.Commands())
+            {
+                commands.Put("companies/1", null, new Company
+                {
+                    Name = "Test Company"
+                }, null);
+
+                // Test that uuid() generates a valid UUID
+                store.Operations.Send(new PatchOperation("companies/1", null,
+                    new PatchRequest
+                    {
+                        Script = @"this.Uuid = uuid();"
+                    }));
+
+                dynamic result = commands.Get("companies/1");
+                Assert.NotNull(result.Uuid);
+                
+                // Verify it's a valid GUID format (36 characters with dashes)
+                string uuid = result.Uuid.ToString();
+                Assert.True(Guid.TryParse(uuid, out _), $"uuid() should generate a valid UUID, but got: {uuid}");
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void UuidFunctionGeneratesUniqueValues(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var commands = store.Commands())
+            {
+                commands.Put("companies/1", null, new Company
+                {
+                    Name = "Test Company"
+                }, null);
+
+                // Generate multiple UUIDs and ensure they are unique
+                store.Operations.Send(new PatchOperation("companies/1", null,
+                    new PatchRequest
+                    {
+                        Script = @"this.Uuid1 = uuid(); this.Uuid2 = uuid(); this.Uuid3 = uuid();"
+                    }));
+
+                dynamic result = commands.Get("companies/1");
+                Assert.NotNull(result.Uuid1);
+                Assert.NotNull(result.Uuid2);
+                Assert.NotNull(result.Uuid3);
+                
+                string uuid1 = result.Uuid1.ToString();
+                string uuid2 = result.Uuid2.ToString();
+                string uuid3 = result.Uuid3.ToString();
+                
+                // Verify all three are different
+                Assert.NotEqual(uuid1, uuid2);
+                Assert.NotEqual(uuid2, uuid3);
+                Assert.NotEqual(uuid1, uuid3);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void UuidFunctionShouldThrowOnParameters(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var commands = store.Commands())
+            {
+                commands.Put("companies/1", null, new Company
+                {
+                    Name = "Test Company"
+                }, null);
+
+                // Test that uuid() throws when called with parameters
+                var exception = Assert.Throws<JavaScriptException>(() =>
+                {
+                    store.Operations.Send(new PatchOperation("companies/1", null,
+                        new PatchRequest
+                        {
+                            Script = @"this.Uuid = uuid('invalid');"
+                        }));
+                });
+
+                Assert.Contains("must be called without arguments", exception.Message);
+            }
+        }
     }
 }

--- a/test/SlowTests/Core/ScriptedPatching/ScriptedPatchTests.cs
+++ b/test/SlowTests/Core/ScriptedPatching/ScriptedPatchTests.cs
@@ -257,36 +257,7 @@ Update
             public List<ProcessRules> ProcessRules { get; set; }
         }
 
-        [RavenTheory(RavenTestCategory.Patching)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void CanUseUuidFunction(Options options)
-        {
-            using var store = GetDocumentStore(options);
-
-            using (var commands = store.Commands())
-            {
-                commands.Put("companies/1", null, new Company
-                {
-                    Name = "Test Company"
-                }, null);
-
-                // Test that uuid() generates a valid UUID
-                store.Operations.Send(new PatchOperation("companies/1", null,
-                    new PatchRequest
-                    {
-                        Script = @"this.Uuid = uuid();"
-                    }));
-
-                dynamic result = commands.Get("companies/1");
-                Assert.NotNull(result.Uuid);
-                
-                // Verify it's a valid GUID format (36 characters with dashes)
-                string uuid = result.Uuid.ToString();
-                Assert.True(Guid.TryParse(uuid, out _), $"uuid() should generate a valid UUID, but got: {uuid}");
-            }
-        }
-
-        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.JavaScript)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void UuidFunctionGeneratesUniqueValues(Options options)
         {
@@ -314,15 +285,17 @@ Update
                 string uuid1 = result.Uuid1.ToString();
                 string uuid2 = result.Uuid2.ToString();
                 string uuid3 = result.Uuid3.ToString();
-                
+
+                Assert.True(Guid.TryParse(uuid1, out _), $"uuid() should generate a valid UUID, but got: {uuid1}");
+                Assert.True(Guid.TryParse(uuid2, out _), $"uuid() should generate a valid UUID, but got: {uuid2}");
+                Assert.True(Guid.TryParse(uuid3, out _), $"uuid() should generate a valid UUID, but got: {uuid3}");
+
                 // Verify all three are different
-                Assert.NotEqual(uuid1, uuid2);
-                Assert.NotEqual(uuid2, uuid3);
-                Assert.NotEqual(uuid1, uuid3);
+                Assert.Equal(new HashSet<string>() { uuid1, uuid2, uuid3 }.Count, 3);
             }
         }
 
-        [RavenTheory(RavenTestCategory.Patching)]
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.JavaScript)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
         public void UuidFunctionShouldThrowOnParameters(Options options)
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25919/Add-a-script-function-to-generate-unique-identifiers-uuid

### Additional description

Introduces `uuid()` ClrFunction for generating UUIDs in JavaScript patching/querying contexts.

- `uuid()` returns `Guid.NewGuid().ToString("D")`
- validates zero parameters; throws `InvalidOperationException` with clear message
- exception handler converts `InvalidOperationException` → `JavaScriptException` for proper client-side error propagation

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed