### PR TITLE
RavenDB-25922 Move RemoteAttachmentsConfigurationNotValid to end of enum to prevent breaking change

### DIFF
--- a/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertReason.cs
@@ -58,7 +58,6 @@ namespace Raven.Server.NotificationCenter.Notifications
 
         RevisionsConfigurationNotValid,
         ArchivalConfigurationNotValid,
-        RemoteAttachmentsConfigurationNotValid,
 
         ReplicationMissingAttachments,
 
@@ -101,8 +100,10 @@ namespace Raven.Server.NotificationCenter.Notifications
         ConflictRevisionsExceeded,
         
         SqlConnectionString_DeprecatedFactoryReplaced,
+        
         Attachments_RemoteAttachmentWithoutIdentifier,
         Attachments_RemoteAttachmentErroredIdentifier,
+        RemoteAttachmentsConfigurationNotValid,
         
         SchemaValidationConfiguration_Error,
     }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25922

### Additional description

The new values of `AlretReason` enum need to have greater values since they are persisted (since https://github.com/ravendb/ravendb/pull/21531). This is hotfix to `release/v7.2` branch but we already have https://github.com/ravendb/ravendb/pull/22212 open which ensure it won't happen in the future.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
