### PR TITLE
RavenDB-25513 : Fix time-series replication after deletion conflicts

### DIFF
--- a/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
+++ b/src/Raven.Client/ServerWide/Tcp/TcpConnectionHeader.cs
@@ -80,6 +80,7 @@ namespace Raven.Client.ServerWide.Tcp
         public static readonly int ReplicationWithDeduplicatedAttachments = 53_001;
         public static readonly int ReplicationWithRevisionTombstones = 60_000;
         public static readonly int ReplicationWithRemoteAttachments = 72_000;
+        public static readonly int ReplicationWithTimeSeriesDocumentChangeVector = 72_001;
 
         public static readonly int TcpConnectionsWithCompression = 53_000;
         public static readonly int SubscriptionBaseLine = 40;
@@ -90,7 +91,7 @@ namespace Raven.Client.ServerWide.Tcp
 
         public static readonly int ClusterTcpVersion = ClusterWithTcpCompression;
         public static readonly int HeartbeatsTcpVersion = HeartbeatsWithTcpCompression;
-        public static readonly int ReplicationTcpVersion = ReplicationWithRemoteAttachments;
+        public static readonly int ReplicationTcpVersion = ReplicationWithTimeSeriesDocumentChangeVector;
         public static readonly int SubscriptionTcpVersion = TcpConnectionsWithCompression; 
         public static readonly int TestConnectionTcpVersion = TestConnectionBaseLine;
 
@@ -266,6 +267,7 @@ namespace Raven.Client.ServerWide.Tcp
                 public bool DeduplicatedAttachments;
                 public bool RevisionTombstonesWithId;
                 public bool RemoteAttachments;
+                public bool TimeSeriesWithDocumentChangeVector;
             }
         }
 
@@ -294,6 +296,7 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Replication] = new List<int>
                 {
+                    ReplicationWithTimeSeriesDocumentChangeVector,
                     ReplicationWithRemoteAttachments,
                     ReplicationWithRevisionTombstones,
                     ReplicationWithDeduplicatedAttachments,
@@ -390,6 +393,24 @@ namespace Raven.Client.ServerWide.Tcp
                 },
                 [OperationTypes.Replication] = new Dictionary<int, SupportedFeatures>
                 {
+                    [ReplicationWithTimeSeriesDocumentChangeVector] = new SupportedFeatures(ReplicationWithTimeSeriesDocumentChangeVector)
+                    {
+                        DataCompression = true,
+                        Replication = new SupportedFeatures.ReplicationFeatures
+                        {
+                            TimeSeriesWithDocumentChangeVector = true,
+                            RemoteAttachments = true,
+                            RevisionTombstonesWithId = true,
+                            DeduplicatedAttachments = true,
+                            MissingAttachments = true,
+                            CountersBatch = true,
+                            PullReplication = true,
+                            TimeSeries = true,
+                            CaseInsensitiveCounters = true,
+                            ClusterTransaction = true,
+                            IncrementalTimeSeries = true
+                        }
+                    },
                     [ReplicationWithRemoteAttachments] = new SupportedFeatures(ReplicationWithRemoteAttachments)
                     {
                         DataCompression = true,

--- a/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/ReplicationHandler.cs
@@ -9,6 +9,7 @@ using CsvHelper;
 using CsvHelper.Configuration;
 using Raven.Client;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Processors.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
@@ -126,14 +127,9 @@ namespace Raven.Server.Documents.Handlers
                     TimeSeriesRead = new OutgoingReplicationStatsScope(runStats),
                 };
 
-                var supportedFeatures = new ReplicationDocumentSenderBase.ReplicationSupportedFeatures
-                {
-                    CaseInsensitiveCounters = true,
-                    RevisionTombstonesWithId = true,
-                    RemoteAttachments = true
-                };
+                var tcpSupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Replication, TcpConnectionHeaderMessage.ReplicationTcpVersion);
 
-                var items = ReplicationDocumentSenderBase.GetReplicationItems(Database, context, etag: etag == 0 ? 0 : etag - 1, stats, supportedFeatures);
+                var items = ReplicationDocumentSenderBase.GetReplicationItems(Database, context, etag: etag == 0 ? 0 : etag - 1, stats, tcpSupportedFeatures.Replication);
                 if (types.Count > 0)
                     items = items.Where(x => types.Contains(x.Type));
                 items = items.Take(pageSize);

--- a/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Replication/Incoming/AbstractIncomingReplicationHandler.cs
@@ -435,7 +435,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             {
                 stats.RecordInputAttempt();
 
-                var item = ReplicationBatchItem.ReadTypeAndInstantiate(reader, SupportedFeatures.Replication.RemoteAttachments);
+                var item = ReplicationBatchItem.ReadTypeAndInstantiate(reader, SupportedFeatures.Replication);
                 item.ReadChangeVectorAndMarker();
                 item.Read(context, allocator, stats);
 
@@ -451,7 +451,7 @@ namespace Raven.Server.Documents.Replication.Incoming
             var replicatedAttachmentStreams = new Dictionary<Slice, AttachmentReplicationItem>(SliceComparer.Instance);
             for (var i = 0; i < attachmentStreamCount; i++)
             {
-                var attachment = (AttachmentReplicationItem)ReplicationBatchItem.ReadTypeAndInstantiate(reader, SupportedFeatures.Replication.RemoteAttachments);
+                var attachment = (AttachmentReplicationItem)ReplicationBatchItem.ReadTypeAndInstantiate(reader, SupportedFeatures.Replication);
                 Debug.Assert(attachment.Type == ReplicationBatchItem.ReplicationItemType.AttachmentStream);
 
                 using (stats.For(ReplicationOperation.Incoming.AttachmentRead))

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/AttachmentReplicationItem.cs
@@ -2,7 +2,6 @@
 using System.Globalization;
 using System.IO;
 using Raven.Client.Documents.Attachments;
-using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.ServerWide.Context;

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -63,7 +63,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             return item;
         }
 
-        public static unsafe ReplicationBatchItem ReadTypeAndInstantiate(Reader reader, bool replicationRemoteAttachments)
+        public static unsafe ReplicationBatchItem ReadTypeAndInstantiate(Reader reader, TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures replicationSupportedFeatures)
         {
             var type = *(ReplicationItemType*)reader.ReadExactly(sizeof(byte));
 
@@ -74,7 +74,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                     return new DocumentReplicationItem { Type = type, Reader = reader };
                 case ReplicationItemType.Attachment:
                 case ReplicationItemType.AttachmentStream:
-                    return new AttachmentReplicationItem { Type = type, Reader = reader, RemoteAttachments = replicationRemoteAttachments };
+                    return new AttachmentReplicationItem { Type = type, Reader = reader, RemoteAttachments = replicationSupportedFeatures.RemoteAttachments };
                 case ReplicationItemType.AttachmentTombstone:
                     return new AttachmentTombstoneReplicationItem { Type = type, Reader = reader };
                 case ReplicationItemType.RevisionTombstone:
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 case ReplicationItemType.CounterGroup:
                     return new CounterReplicationItem { Type = type, Reader = reader };
                 case ReplicationItemType.TimeSeriesSegment:
-                    return new TimeSeriesReplicationItem { Type = type, Reader = reader };
+                    return new TimeSeriesReplicationItem { Type = type, Reader = reader, IncludeDocumentChangeVector = replicationSupportedFeatures.TimeSeriesWithDocumentChangeVector };
                 case ReplicationItemType.DeletedTimeSeriesRange:
                     return new TimeSeriesDeletedRangeItem { Type = type, Reader = reader };
                 default:

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -110,6 +110,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Name; // original casing
         public LazyStringValue Collection;
         public TimeSeriesValuesSegment Segment;
+        public LazyStringValue ParentDocChangeVector;
 
         public override long Size => base.Size + // common
 
@@ -123,7 +124,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                                      Collection.Size + // doc collection
 
                                      sizeof(int) + // size of name
-                                     Name.Size; // name;
+                                     Name.Size + // name
+
+                                     sizeof(int) + // size of parent cv
+                                     (ParentDocChangeVector?.Size ?? 0); // parent doc cv
+
 
         public override DynamicJsonValue ToDebugJson()
         {
@@ -131,6 +136,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             djv[nameof(Collection)] = Collection?.ToString(CultureInfo.InvariantCulture) ?? Constants.Documents.Collections.EmptyCollection;
             djv[nameof(Name)] = Name.ToString(CultureInfo.InvariantCulture);
             djv[nameof(Key)] = CompoundKeyHelper.ExtractDocumentId(Key);
+            djv[nameof(ParentDocChangeVector)] = ParentDocChangeVector?.ToString(CultureInfo.InvariantCulture);
+
             return djv;
         }
 
@@ -164,6 +171,15 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 tempBufferPos += sizeof(int);
                 Memory.Copy(pTemp + tempBufferPos, Name.Buffer, Name.Size);
                 tempBufferPos += Name.Size;
+                
+                *(int*)(pTemp + tempBufferPos) = ParentDocChangeVector?.Size ?? 0;
+                tempBufferPos += sizeof(int);
+
+                if (ParentDocChangeVector != null)
+                {
+                    Memory.Copy(pTemp + tempBufferPos, ParentDocChangeVector.Buffer, ParentDocChangeVector.Size);
+                    tempBufferPos += ParentDocChangeVector.Size;
+                }
 
                 stream.Write(tempBuffer, 0, tempBufferPos);
                 stats.RecordTimeSeriesOutput(Size);
@@ -189,16 +205,20 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 SetLazyStringValueFromString(context, out Name);
                 Debug.Assert(Name != null);
 
+                SetLazyStringValueFromString(context, out ParentDocChangeVector);
+                Debug.Assert(ParentDocChangeVector != null);
+
                 stats.RecordTimeSeriesRead(Size);
             }
         }
-
 
         protected override ReplicationBatchItem CloneInternal(JsonOperationContext context, ByteStringContext allocator)
         {
             var item = new TimeSeriesReplicationItem
             {
-                Collection = Collection.Clone(context)
+                Collection = Collection.Clone(context),
+                Name = Name.Clone(context),
+                ParentDocChangeVector = ParentDocChangeVector?.Clone(context)
             };
 
             var mem = Segment.Clone(context, out item.Segment);
@@ -216,6 +236,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         protected override void InnerDispose()
         {
             Collection?.Dispose();
+            Name?.Dispose();
+            ParentDocChangeVector?.Dispose();
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/TimeSeriesReplicationItem.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using Raven.Client;
-using Raven.Client.ServerWide.Tcp;
 using Raven.Client.Util;
 using Raven.Server.Documents.Replication.Stats;
 using Raven.Server.Documents.TimeSeries;
@@ -111,6 +110,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
         public LazyStringValue Collection;
         public TimeSeriesValuesSegment Segment;
         public LazyStringValue ParentDocChangeVector;
+        public bool IncludeDocumentChangeVector;
 
         public override long Size => base.Size + // common
 
@@ -126,8 +126,10 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                                      sizeof(int) + // size of name
                                      Name.Size + // name
 
-                                     sizeof(int) + // size of parent cv
-                                     (ParentDocChangeVector?.Size ?? 0); // parent doc cv
+                                     (IncludeDocumentChangeVector 
+                                        ? sizeof(int) + // size of doc cv
+                                          (ParentDocChangeVector?.Size ?? 0)  // parent doc cv
+                                        : 0);
 
 
         public override DynamicJsonValue ToDebugJson()
@@ -171,14 +173,17 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 tempBufferPos += sizeof(int);
                 Memory.Copy(pTemp + tempBufferPos, Name.Buffer, Name.Size);
                 tempBufferPos += Name.Size;
-                
-                *(int*)(pTemp + tempBufferPos) = ParentDocChangeVector?.Size ?? 0;
-                tempBufferPos += sizeof(int);
 
-                if (ParentDocChangeVector != null)
+                if (IncludeDocumentChangeVector)
                 {
-                    Memory.Copy(pTemp + tempBufferPos, ParentDocChangeVector.Buffer, ParentDocChangeVector.Size);
-                    tempBufferPos += ParentDocChangeVector.Size;
+                    *(int*)(pTemp + tempBufferPos) = ParentDocChangeVector?.Size ?? 0;
+                    tempBufferPos += sizeof(int);
+
+                    if (ParentDocChangeVector != null)
+                    {
+                        Memory.Copy(pTemp + tempBufferPos, ParentDocChangeVector.Buffer, ParentDocChangeVector.Size);
+                        tempBufferPos += ParentDocChangeVector.Size;
+                    }
                 }
 
                 stream.Write(tempBuffer, 0, tempBufferPos);
@@ -205,8 +210,11 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
                 SetLazyStringValueFromString(context, out Name);
                 Debug.Assert(Name != null);
 
-                SetLazyStringValueFromString(context, out ParentDocChangeVector);
-                Debug.Assert(ParentDocChangeVector != null);
+                if (IncludeDocumentChangeVector)
+                {
+                    SetLazyStringValueFromString(context, out ParentDocChangeVector);
+                    Debug.Assert(ParentDocChangeVector != null);
+                }
 
                 stats.RecordTimeSeriesRead(Size);
             }

--- a/src/Raven.Server/Documents/Replication/Senders/MigrationReplicationDocumentSender.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/MigrationReplicationDocumentSender.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Documents.Replication.Outgoing;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Replication.Stats;
@@ -24,7 +25,7 @@ namespace Raven.Server.Documents.Replication.Senders
         }
 
         protected override IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentsOperationContext ctx, long etag, ReplicationStats stats,
-            ReplicationSupportedFeatures replicationSupportedFeatures)
+            TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures replicationSupportedFeatures)
         {
             var database = ShardedDocumentDatabase.CastToShardedDocumentDatabase(ctx.DocumentDatabase);
             var documentsStorage = database.ShardedDocumentsStorage;
@@ -38,7 +39,7 @@ namespace Raven.Server.Documents.Replication.Senders
             }
         }
 
-        internal static IEnumerable<ReplicationBatchItem> ReplicationBatchItemsForBucket(ShardedDocumentsStorage documentsStorage, DocumentsOperationContext ctx, long etag, ReplicationStats stats, int bucket, ReplicationSupportedFeatures replicationSupportedFeatures)
+        internal static IEnumerable<ReplicationBatchItem> ReplicationBatchItemsForBucket(ShardedDocumentsStorage documentsStorage, DocumentsOperationContext ctx, long etag, ReplicationStats stats, int bucket, TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures replicationSupportedFeatures)
         {
             var docs = documentsStorage.GetDocumentsByBucketFrom(ctx, bucket, etag + 1).Select(x => DocumentReplicationItem.From(x, ctx));
             var tombs = documentsStorage.GetTombstonesByBucketFrom(ctx, bucket, etag + 1);
@@ -47,7 +48,7 @@ namespace Raven.Server.Documents.Replication.Senders
             var revisions = revisionsStorage.GetRevisionsByBucketFrom(ctx, bucket, etag + 1).Select(x => DocumentReplicationItem.From(x, ctx));
             var attachments = documentsStorage.AttachmentsStorage.GetAttachmentsByBucketFrom(ctx, bucket, etag + 1, replicationSupportedFeatures.RemoteAttachments);
             var counters = documentsStorage.CountersStorage.GetCountersByBucketFrom(ctx, bucket, etag + 1);
-            var timeSeries = documentsStorage.TimeSeriesStorage.GetSegmentsByBucketFrom(ctx, bucket, etag + 1);
+            var timeSeries = documentsStorage.TimeSeriesStorage.GetSegmentsByBucketFrom(ctx, bucket, etag + 1, replicationSupportedFeatures.TimeSeriesWithDocumentChangeVector);
             var deletedTimeSeriesRanges = documentsStorage.TimeSeriesStorage.GetDeletedRangesByBucketFrom(ctx, bucket, etag + 1);
 
             using (var docsIt = docs.GetEnumerator())

--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Replication.Messages;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server.Config;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.Outgoing;
@@ -57,12 +58,12 @@ namespace Raven.Server.Documents.Replication.Senders
         }
 
         protected virtual IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentsOperationContext ctx, long etag, ReplicationStats stats,
-            ReplicationSupportedFeatures replicationSupportedFeatures)
+            TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures replicationSupportedFeatures)
         {
             return GetReplicationItems(_parent._database, ctx, etag, stats, replicationSupportedFeatures);
         }
 
-        protected internal static IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentDatabase database, DocumentsOperationContext ctx, long etag, ReplicationStats stats, ReplicationSupportedFeatures replicationSupportedFeatures)
+        protected internal static IEnumerable<ReplicationBatchItem> GetReplicationItems(DocumentDatabase database, DocumentsOperationContext ctx, long etag, ReplicationStats stats, TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures replicationSupportedFeatures)
         {
             var docs = database.DocumentsStorage.GetDocumentsFrom(ctx, etag + 1, fields: DocumentFields.Id | DocumentFields.ChangeVector | DocumentFields.Data);
             var tombs = database.DocumentsStorage.GetTombstonesFrom(ctx, etag + 1, replicationSupportedFeatures.RevisionTombstonesWithId);
@@ -71,7 +72,7 @@ namespace Raven.Server.Documents.Replication.Senders
             var revisions = revisionsStorage.GetRevisionsFrom(ctx, etag + 1, long.MaxValue, fields: DocumentFields.Id | DocumentFields.ChangeVector | DocumentFields.Data).Select(x => DocumentReplicationItem.From(x, ctx));
             var attachments = database.DocumentsStorage.AttachmentsStorage.GetAttachmentsFrom(ctx, etag + 1, replicationSupportedFeatures.RemoteAttachments);
             var counters = database.DocumentsStorage.CountersStorage.GetCountersFrom(ctx, etag + 1, replicationSupportedFeatures.CaseInsensitiveCounters);
-            var timeSeries = database.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(ctx, etag + 1);
+            var timeSeries = database.DocumentsStorage.TimeSeriesStorage.GetSegmentsFrom(ctx, etag + 1, replicationSupportedFeatures.TimeSeriesWithDocumentChangeVector);
             var deletedTimeSeriesRanges = database.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(ctx, etag + 1);
 
             using (var docsIt = docs.GetEnumerator())
@@ -137,17 +138,10 @@ namespace Raven.Server.Documents.Replication.Senders
                         CurrentNextReplicateTicks = currentNextReplicateTicks
                     };
 
-                    var replicationSupportedFeatures = new ReplicationSupportedFeatures
-                    {
-                        CaseInsensitiveCounters = _parent.SupportedFeatures.Replication.CaseInsensitiveCounters,
-                        RevisionTombstonesWithId = _parent.SupportedFeatures.Replication.RevisionTombstonesWithId,
-                        RemoteAttachments = _parent.SupportedFeatures.Replication.RemoteAttachments
-                    };
-
                     using (_stats.Storage.Start())
                     {
                         using var enumerator = new PulsedTransactionEnumerator<ReplicationBatchItem, ReplicationBatchState>(documentsContext, _ =>
-                            GetReplicationItems(documentsContext, _lastEtag, _stats, replicationSupportedFeatures), state);
+                            GetReplicationItems(documentsContext, _lastEtag, _stats, _parent.SupportedFeatures.Replication), state);
 
                         while (enumerator.MoveNext())
                         {
@@ -852,13 +846,6 @@ namespace Raven.Server.Documents.Replication.Senders
 
                 return false;
             }
-        }
-
-        protected internal sealed class ReplicationSupportedFeatures
-        {
-            public bool CaseInsensitiveCounters;
-            public bool RevisionTombstonesWithId;
-            public bool RemoteAttachments;
         }
 
         public virtual void Dispose()

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.Sharding.cs
@@ -13,13 +13,13 @@ namespace Raven.Server.Documents.TimeSeries
 {
     public partial class TimeSeriesStorage
     {
-        public IEnumerable<TimeSeriesReplicationItem> GetSegmentsByBucketFrom(DocumentsOperationContext context, int bucket, long etag)
+        public IEnumerable<TimeSeriesReplicationItem> GetSegmentsByBucketFrom(DocumentsOperationContext context, int bucket, long etag, bool includeDocumentChangeVector = true)
         {
             var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
 
             foreach (var result in ShardedDocumentsStorage.GetItemsByBucket(context.Allocator, table, TimeSeriesSchema.DynamicKeyIndexes[TimeSeriesBucketAndEtagSlice], bucket, etag))
             {
-                yield return CreateTimeSeriesSegmentItem(context, ref result.Result.Reader);
+                yield return CreateTimeSeriesSegmentItem(context, ref result.Result.Reader, includeDocumentChangeVector);
             }
         }
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2348,18 +2348,18 @@ namespace Raven.Server.Documents.TimeSeries
             return name;
         }
 
-        public IEnumerable<TimeSeriesReplicationItem> GetSegmentsFrom(DocumentsOperationContext context, long etag)
+        public IEnumerable<TimeSeriesReplicationItem> GetSegmentsFrom(DocumentsOperationContext context, long etag, bool includeDocumentChangeVector = true)
         {
             var table = new Table(TimeSeriesSchema, context.Transaction.InnerTransaction);
 
             // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var result in table.SeekForwardFrom(TimeSeriesSchema.FixedSizeIndexes[AllTimeSeriesEtagSlice], etag, 0))
             {
-                yield return CreateTimeSeriesSegmentItem(context, ref result.Reader);
+                yield return CreateTimeSeriesSegmentItem(context, ref result.Reader, includeDocumentChangeVector);
             }
         }
 
-        internal TimeSeriesReplicationItem CreateTimeSeriesSegmentItem(DocumentsOperationContext context, ref TableValueReader reader)
+        internal TimeSeriesReplicationItem CreateTimeSeriesSegmentItem(DocumentsOperationContext context, ref TableValueReader reader, bool includeDocumentChangeVector)
         {
             var etag = *(long*)reader.Read((int)TimeSeriesTable.Etag, out _);
             var changeVectorPtr = reader.Read((int)TimeSeriesTable.ChangeVector, out int changeVectorSize);
@@ -2389,8 +2389,13 @@ namespace Raven.Server.Documents.TimeSeries
                 item.Name ??= name;
             }
 
-            var doc = context.DocumentDatabase.DocumentsStorage.Get(context, docId, DocumentFields.ChangeVector);
-            item.ParentDocChangeVector = context.GetLazyString(doc?.ChangeVector);
+            item.IncludeDocumentChangeVector = includeDocumentChangeVector;
+
+            if (includeDocumentChangeVector)
+            {
+                var doc = context.DocumentDatabase.DocumentsStorage.Get(context, docId, DocumentFields.ChangeVector);
+                item.ParentDocChangeVector = context.GetLazyString(doc?.ChangeVector);
+            }
 
             return item;
         }

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -858,6 +858,9 @@ namespace Raven.Server.Documents.TimeSeries
                     if (ChangeVectorUtils.GetConflictStatus(changeVector, item.ChangeVector) == ConflictStatus.AlreadyMerged)
                         return true;
 
+                    // Segment CV may advance while replication is broken, so delete-range CV isn't always newer than the segment CV.
+                    // As a fallback, compare the delete-range CV to the segment's parent document CV.
+                    // If the delete-range already covers that doc CV, the segment belongs to a document version that was already deleted.
                     if (parentDocCv != null && ChangeVectorUtils.GetConflictStatus(parentDocCv, item.ChangeVector) == ConflictStatus.AlreadyMerged)
                         return true;
                 }
@@ -2378,15 +2381,18 @@ namespace Raven.Server.Documents.TimeSeries
             var keyPtr = reader.Read((int)TimeSeriesTable.TimeSeriesKey, out int keySize);
             item.ToDispose(Slice.From(context.Allocator, keyPtr, keySize, ByteStringType.Immutable, out item.Key));
 
-            LazyStringValue docId;
+            LazyStringValue docId = null;
             using (TimeSeriesStats.ExtractStatsKeyFromStorageKey(context, item.Key, out var statsKey))
             {
                 item.Name = Stats.GetTimeSeriesNameOriginalCasing(context, statsKey);
 
-                TimeSeriesValuesSegment.ParseTimeSeriesKey(item.Key, context, out docId, out var name);
+                if (includeDocumentChangeVector || item.Name == null)
+                {
+                    TimeSeriesValuesSegment.ParseTimeSeriesKey(item.Key, context, out docId, out var nameFromKey);
 
-                // RavenDB-18381 - replace Null in lower-case name to recover from an existing state of broken replication
-                item.Name ??= name;
+                    // RavenDB-18381 - replace null in lower-case name to recover from an existing state of broken replication
+                    item.Name ??= nameFromKey;
+                }
             }
 
             item.IncludeDocumentChangeVector = includeDocumentChangeVector;

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -15,7 +15,6 @@ using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Workers.Cleanup;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Logging;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Smuggler.Documents;
@@ -25,7 +24,6 @@ using Sparrow.Binary;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
-using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Logging;
 using Sparrow.Server.Utils;
@@ -35,6 +33,7 @@ using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.Schemas.DeletedRanges;
 using static Raven.Server.Documents.Schemas.TimeSeries;
+using Slices = Voron.Slices;
 
 namespace Raven.Server.Documents.TimeSeries
 {
@@ -621,18 +620,18 @@ namespace Raven.Server.Documents.TimeSeries
         public bool TryAppendEntireSegment(DocumentsOperationContext context, TimeSeriesReplicationItem item, string docId, LazyStringValue name, ChangeVector changeVector, DateTime baseline)
         {
             var collectionName = _documentsStorage.ExtractCollectionName(context, item.Collection);
-            return TryAppendEntireSegment(context, item.Key, docId, name, collectionName, changeVector, item.Segment, baseline);
+            return TryAppendEntireSegment(context, item.Key, docId, name, collectionName, changeVector, item.Segment, baseline, item.ParentDocChangeVector);
         }
 
-        private bool TryAppendEntireSegment(
-            DocumentsOperationContext context,
+        private bool TryAppendEntireSegment(DocumentsOperationContext context,
             Slice key,
             string documentId,
             string name,
             CollectionName collectionName,
             ChangeVector changeVector,
             TimeSeriesValuesSegment segment,
-            DateTime baseline)
+            DateTime baseline, 
+            LazyStringValue parentDocCv)
         {
             var table = GetOrCreateTimeSeriesTable(context.Transaction.InnerTransaction, collectionName);
 
@@ -654,7 +653,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
 
             if (Stats.GetStats(context, documentId, name) == default &&
-                SegmentAlreadyDeleted(context, documentId, name, changeVector, collectionName, segment, baseline))
+                SegmentAlreadyDeleted(context, documentId, name, changeVector, collectionName, segment, baseline, parentDocCv))
             {
                 // if we reach this point, it means the entire time series was deleted,
                 // and the deletion has a newer change vector than this segment.
@@ -839,8 +838,8 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        private bool SegmentAlreadyDeleted(DocumentsOperationContext context, string documentId, string name, string changeVector, 
-            CollectionName collectionName, TimeSeriesValuesSegment segment, DateTime baseline)
+        private bool SegmentAlreadyDeleted(DocumentsOperationContext context, string documentId, string name, string changeVector,
+            CollectionName collectionName, TimeSeriesValuesSegment segment, DateTime baseline, LazyStringValue parentDocCv)
         {
             var hash = (long)Hashing.XXHash64.Calculate(changeVector, Encoding.UTF8);
             using (var sliceHolder = new TimeSeriesSliceHolder(context, documentId, name, collectionName.Name).WithChangeVectorHash(hash))
@@ -857,6 +856,9 @@ namespace Raven.Server.Documents.TimeSeries
                         continue;
 
                     if (ChangeVectorUtils.GetConflictStatus(changeVector, item.ChangeVector) == ConflictStatus.AlreadyMerged)
+                        return true;
+
+                    if (parentDocCv != null && ChangeVectorUtils.GetConflictStatus(parentDocCv, item.ChangeVector) == ConflictStatus.AlreadyMerged)
                         return true;
                 }
 
@@ -2376,16 +2378,19 @@ namespace Raven.Server.Documents.TimeSeries
             var keyPtr = reader.Read((int)TimeSeriesTable.TimeSeriesKey, out int keySize);
             item.ToDispose(Slice.From(context.Allocator, keyPtr, keySize, ByteStringType.Immutable, out item.Key));
 
+            LazyStringValue docId;
             using (TimeSeriesStats.ExtractStatsKeyFromStorageKey(context, item.Key, out var statsKey))
             {
                 item.Name = Stats.GetTimeSeriesNameOriginalCasing(context, statsKey);
 
-                if (item.Name == null)
-                {
-                    // RavenDB-18381 - replace Null in lower-case name to recover from an existing state of broken replication
-                    TimeSeriesValuesSegment.ParseTimeSeriesKey(item.Key, context, out _, out item.Name);
-                }
+                TimeSeriesValuesSegment.ParseTimeSeriesKey(item.Key, context, out docId, out var name);
+
+                // RavenDB-18381 - replace Null in lower-case name to recover from an existing state of broken replication
+                item.Name ??= name;
             }
+
+            var doc = context.DocumentDatabase.DocumentsStorage.Get(context, docId, DocumentFields.ChangeVector);
+            item.ParentDocChangeVector = context.GetLazyString(doc?.ChangeVector);
 
             return item;
         }

--- a/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBucket.cs
+++ b/src/Raven.Server/Web/Studio/Processors/BucketsHandlerProcessorForGetBucket.cs
@@ -24,17 +24,11 @@ namespace Raven.Server.Web.Studio.Processors
                 var shardedDocumentDatabase = ShardedDocumentDatabase.CastToShardedDocumentDatabase(RequestHandler.Database);
                 var stats = new ReplicationDocumentSenderBase.ReplicationStats();
                 var tcpSupportedFeatures = TcpConnectionHeaderMessage.GetSupportedFeaturesFor(TcpConnectionHeaderMessage.OperationTypes.Replication, TcpConnectionHeaderMessage.ReplicationTcpVersion);
-                var supportedFeatures = new ReplicationDocumentSenderBase.ReplicationSupportedFeatures()
-                {
-                    RemoteAttachments = tcpSupportedFeatures.Replication.RemoteAttachments,
-                    CaseInsensitiveCounters = tcpSupportedFeatures.Replication.CaseInsensitiveCounters,
-                    RevisionTombstonesWithId = tcpSupportedFeatures.Replication.RevisionTombstonesWithId
-                };
 
                 using var helper = new DocumentInfoHelper(context);
 
                 var items = new List<string>();
-                foreach (var item in MigrationReplicationDocumentSender.ReplicationBatchItemsForBucket(shardedDocumentDatabase.ShardedDocumentsStorage, context, 0, stats, bucket, supportedFeatures))
+                foreach (var item in MigrationReplicationDocumentSender.ReplicationBatchItemsForBucket(shardedDocumentDatabase.ShardedDocumentsStorage, context, 0, stats, bucket, tcpSupportedFeatures.Replication))
                 {
                     var info = helper.GetItemInformation(item); 
                     items.Add(info);

--- a/test/SlowTests.Issues/Issues/RavenDB-25513.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25513.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Operations;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25513(ITestOutputHelper output) : ReplicationTestBase(output)
+{
+    [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+    public async Task MergeTimeSeriesOnConflict()
+    {
+        using (var storeA = GetDocumentStore())
+        using (var storeB = GetDocumentStore())
+        {
+            using (var session = storeA.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Karmel" }, "users/1");
+                session.TimeSeriesFor("users/1", "heartbeat").Append(DateTime.Now, new List<double> { 1, 2, 3 }, "herz");
+                await session.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(storeA, storeB);
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            using var r = await GetReplicationManagerAsync(storeA, storeA.Database, RavenDatabaseMode.Single);
+            r.Break();
+
+            using (var session = storeB.OpenAsyncSession())
+            {
+                session.Delete("users/1");
+                await session.SaveChangesAsync();
+            }
+
+            string cv;
+            using (var session = storeA.OpenAsyncSession())
+            {
+                session.TimeSeriesFor("users/1", "heartbeat").Append(DateTime.Now.AddDays(35), new List<double> { 1, 2, 3 }, "herz");
+                await session.SaveChangesAsync();
+
+                var doc = await session.LoadAsync<User>("users/1");
+                cv = session.Advanced.GetChangeVectorFor(doc);
+            }
+            r.Mend();
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            await SetupReplicationAsync(storeB, storeA);
+            await EnsureReplicatingAsync(storeB, storeA);
+
+            var statsA = await storeA.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.Equal(0, statsA.CountOfTimeSeriesSegments);
+
+            var statsB = await storeB.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.Equal(0, statsB.CountOfTimeSeriesSegments);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+    public async Task RecreatedDocumentTimeSeries_ShouldReplicateAfterPreviousDeletion()
+    {
+        using (var storeA = GetDocumentStore())
+        using (var storeB = GetDocumentStore())
+        {
+            var baseline = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            using (var session = storeA.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Karmel" }, "users/1");
+                session.TimeSeriesFor("users/1", "heartbeat")
+                    .Append(baseline, new List<double> { 1, 2, 3 }, "herz");
+                await session.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(storeA, storeB);
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            var preStatsB = await storeB.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.True(preStatsB.CountOfTimeSeriesSegments > 0);
+
+            using var r = await GetReplicationManagerAsync(storeA, storeA.Database, RavenDatabaseMode.Single);
+            r.Break();
+
+            using (var session = storeB.OpenAsyncSession())
+            {
+                session.Delete("users/1");
+                await session.SaveChangesAsync();
+            }
+
+            r.Mend();
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            await SetupReplicationAsync(storeB, storeA);
+            await EnsureReplicatingAsync(storeB, storeA);
+
+            using (var session = storeA.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<User>("users/1");
+                Assert.Null(doc);
+            }
+
+            // A: recreate doc + append new TS
+            using (var session = storeA.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Recreated" }, "users/1");
+                session.TimeSeriesFor("users/1", "heartbeat")
+                    .Append(baseline.AddDays(1), new List<double> { 10, 20, 30 }, "herz");
+                await session.SaveChangesAsync();
+            }
+
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            // verify that B has the recreated doc + the new TS entry
+            using (var session = storeB.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<User>("users/1");
+                Assert.NotNull(doc);
+                Assert.Equal("Recreated", doc.Name);
+
+                var entries = await session.TimeSeriesFor("users/1", "heartbeat")
+                    .GetAsync(baseline.AddDays(1), baseline.AddDays(1));
+
+                Assert.NotNull(entries);
+                Assert.Equal(1, entries.Length);
+                Assert.Equal(baseline.AddDays(1), entries[0].Timestamp);
+            }
+
+            var statsB = await storeB.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.True(statsB.CountOfTimeSeriesSegments > 0);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.TimeSeries | RavenTestCategory.Replication)]
+    public async Task DocDeletionShouldPreventReintroducingPreviouslyExistingSegments()
+    {
+        using (var storeA = GetDocumentStore())
+        using (var storeB = GetDocumentStore())
+        {
+            var baseline = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            using (var session = storeA.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Karmel" }, "users/1");
+                session.TimeSeriesFor("users/1", "heartbeat")
+                    .Append(baseline, new List<double> { 1, 2, 3 }, "herz");
+                await session.SaveChangesAsync();
+            }
+
+            await SetupReplicationAsync(storeA, storeB);
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            var preStatsB = await storeB.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.True(preStatsB.CountOfTimeSeriesSegments > 0);
+
+            using var r = await GetReplicationManagerAsync(storeA, storeA.Database, RavenDatabaseMode.Single);
+            r.Break();
+
+            // B: delete doc
+            using (var session = storeB.OpenAsyncSession())
+            {
+                session.Delete("users/1");
+                await session.SaveChangesAsync();
+            }
+
+            // A: modify the segment while replication is broken
+            using (var session = storeA.OpenAsyncSession())
+            {
+                session.TimeSeriesFor("users/1", "heartbeat")
+                    .Append(baseline.AddMinutes(10), new List<double> { 4, 5, 6 }, "herz");
+                await session.SaveChangesAsync();
+            }
+
+            r.Mend();
+            await EnsureReplicatingAsync(storeA, storeB);
+
+            // replicate deletion back to A
+            await SetupReplicationAsync(storeB, storeA);
+            await EnsureReplicatingAsync(storeB, storeA);
+
+            var statsA = await storeA.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.Equal(0, statsA.CountOfTimeSeriesSegments);
+
+            var statsB = await storeB.Maintenance.SendAsync(new GetEssentialStatisticsOperation());
+            Assert.Equal(0, statsB.CountOfTimeSeriesSegments);
+        }
+    }
+
+
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_15538.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_15538.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Revisions;
+using Raven.Client.ServerWide.Tcp;
 using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.Documents;
@@ -148,7 +149,7 @@ namespace SlowTests.Issues
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
-                            }, new ReplicationDocumentSenderBase.ReplicationSupportedFeatures()).Select(item => item.Clone(ctx, ctx.Allocator)));
+                            }, new TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures()).Select(item => item.Clone(ctx, ctx.Allocator)));
                             etag = firstReplicationOrder.Select(x => x.Etag).Max();
                         }
                         // Replication from source to firstDestination
@@ -175,7 +176,7 @@ namespace SlowTests.Issues
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
-                            }, new ReplicationDocumentSenderBase.ReplicationSupportedFeatures()).Select(item => item.Clone(ctx, ctx.Allocator)));
+                            }, new TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures()).Select(item => item.Clone(ctx, ctx.Allocator)));
                         }
 
                         var database2 = await GetDocumentDatabaseInstanceForAsync(firstDestination, options.DatabaseMode, id, server);
@@ -189,7 +190,7 @@ namespace SlowTests.Issues
                             {
                                 DocumentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats()),
                                 AttachmentRead = new OutgoingReplicationStatsScope(new OutgoingReplicationRunStats())
-                            }, new ReplicationDocumentSenderBase.ReplicationSupportedFeatures()).Select(item => item.Clone(ctx, ctx.Allocator)));
+                            }, new TcpConnectionHeaderMessage.SupportedFeatures.ReplicationFeatures()).Select(item => item.Clone(ctx, ctx.Allocator)));
                         }
 
                         // remove the 1st doc sent, because of its change in the middle of the 1st replication, so it was sent twice


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25513/Verify-correct-conflict-resolution-for-deleting-time-series

### Additional description

- Fixed a replication conflict case where time-series segments could survive after the owning document was deleted on another node.
- Added the parent document change vector to time-series replication items to resolve incoming segments against delete-ranges.
- Introduced a new replication protocol version so inter-version replication continues to work.
- Added regression tests + manually tested time-series replication in mixed-version setup (v7.1 + v7.2).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
