### PR TITLE
RavenDB-25307 & RavenDB-25892 : Fix AI Agent Handle async overload and enforce single action response per tool

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -21,7 +21,7 @@ internal class AiConversation : IAiConversationOperations
 
     private string _conversationId;
     private List<AiAgentActionRequest> _actionRequests;
-    private readonly List<AiAgentActionResponse> _actionResponses = [];
+    private readonly Dictionary<string, AiAgentActionResponse> _actionResponses = [];
     private readonly List<AiAgentArtificialActionResponse> _artificialActions = [];
     private readonly List<ContentPart> _promptParts = [];
     private string _changeVector;
@@ -117,11 +117,15 @@ internal class AiConversation : IAiConversationOperations
         ValidationMethods.AssertNotNullOrEmpty(toolId, nameof(toolId));
         ValidationMethods.AssertNotNullOrEmpty(actionResponse, nameof(actionResponse));
 
-        _actionResponses.Add(new AiAgentActionResponse
+        if (_actionResponses.ContainsKey(toolId))
+            throw new InvalidOperationException($"An action response for tool-id '{toolId}' was already added. Each tool call must have exactly one response. " +
+                                                $"If you're using {nameof(Handle)}, return the value from the handler (don't call {nameof(AddActionResponse)} manually).");
+
+        _actionResponses[toolId] = new AiAgentActionResponse
         {
             ToolId = toolId,
             Content = actionResponse
-        });
+        };
     }
 
     public void SetUserPrompt(string userPrompt)
@@ -275,7 +279,7 @@ internal class AiConversation : IAiConversationOperations
             };
         }
 
-        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, _actionResponses, _artificialActions, _options, _changeVector, streamPropertyPath, streamedChunksCallback);
+        var op = new RunConversationOperation<TAnswer>(_agentId, _conversationId, _promptParts, [.. _actionResponses.Values], _artificialActions, _options, _changeVector, streamPropertyPath, streamedChunksCallback);
 
         try
         {

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -140,9 +140,11 @@ internal class AiConversation : IAiConversationOperations
         }
     }
 
-    public void Handle<TArgs>(string actionName, Func<TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError) where TArgs : class
+    public void Handle<TArgs, TResult>(string actionName, Func<TArgs, Task<TResult>> action, AiHandleErrorStrategy aiHandleError) 
+        where TArgs : class 
+        where TResult : class
     {
-        Handle<TArgs>(actionName, (_, token) => action(token), aiHandleError);
+        Handle<TArgs, TResult>(actionName, (_, token) => action(token), aiHandleError);
     }
 
     public void Handle<TArgs>(string actionName, Func<TArgs, object> action, AiHandleErrorStrategy aiHandleError) where TArgs : class
@@ -150,15 +152,14 @@ internal class AiConversation : IAiConversationOperations
         Handle<TArgs>(actionName, (_, token) => action(token), aiHandleError);
     }
 
-    public void Handle<TArgs>(string actionName, Func<AiAgentActionRequest, TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError)
+    public void Handle<TArgs, TResult>(string actionName, Func<AiAgentActionRequest, TArgs, Task<TResult>> action, AiHandleErrorStrategy aiHandleError)
         where TArgs : class
+        where TResult : class
     {
-        Receive<TArgs>(actionName, (request, args) =>
+        Receive<TArgs>(actionName, async (request, args) =>
         {
-            return action(request, args).ContinueWith(t =>
-            {
-                AddActionResponse(request.ToolId, t.Result);
-            }, TaskContinuationOptions.OnlyOnRanToCompletion);
+            var result = await action(request, args).ConfigureAwait(false);
+            AddActionResponse(request.ToolId, result);
         }, aiHandleError);
     }
 

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -13,11 +13,13 @@ public interface IAiConversationOperations
     /// Registers an asynchronous handler for an action tool.
     /// </summary>
     /// <typeparam name="TArgs">The type of the argument passed to the handler.</typeparam>
+    /// <typeparam name="TResult">The type of the result returned by the handler.</typeparam>
     /// <param name="actionName">The name of the action tool to handle.</param>
     /// <param name="action">A function that processes the arguments and returns a <see cref="Task{Object}"/> representing the response.</param>
     /// <param name="aiHandleError">An optional strategy for handling errors during execution.</param>
-    void Handle<TArgs>(string actionName, Func<TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError = AiHandleErrorStrategy.SendErrorsToModel)
-        where TArgs : class;
+    void Handle<TArgs, TResult>(string actionName, Func<TArgs, Task<TResult>> action, AiHandleErrorStrategy aiHandleError = AiHandleErrorStrategy.SendErrorsToModel)
+        where TArgs : class
+        where TResult : class;
 
     /// <summary>
     /// Registers a synchronous handler for an action tool.
@@ -32,11 +34,13 @@ public interface IAiConversationOperations
     /// Registers an asynchronous handler for an action tool.
     /// </summary>
     /// <typeparam name="TArgs">The type of the argument passed to the handler.</typeparam>
+    /// <typeparam name="TResult">The type of the result returned by the handler.</typeparam>
     /// <param name="actionName">The name of the action tool to handle.</param>
     /// <param name="action">A function that processes the arguments and returns a <see cref="Task{Object}"/> representing the response.</param>
     /// <param name="aiHandleError">An optional strategy for handling errors during execution.</param>
-    void Handle<TArgs>(string actionName, Func<AiAgentActionRequest, TArgs, Task<object>> action, AiHandleErrorStrategy aiHandleError = AiHandleErrorStrategy.SendErrorsToModel)
-        where TArgs : class;
+    void Handle<TArgs, TResult>(string actionName, Func<AiAgentActionRequest, TArgs, Task<TResult>> action, AiHandleErrorStrategy aiHandleError = AiHandleErrorStrategy.SendErrorsToModel)
+        where TArgs : class
+        where TResult : class;
 
     /// <summary>
     /// Registers a synchronous handler for an action tool.

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25307.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25307.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+public class RavenDB_25307 : RavenTestBase
+{
+    public RavenDB_25307(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task CallingAddActionResponseFromHandle_ShouldThrow(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agentConfig = new AiAgentConfiguration("alert-tester", config.ConnectionStringName, "You are a test agent. Your only purpose is to call the 'log-user-query' tool, no matter what the user says.")
+        {
+            Actions =
+            [
+                new AiAgentToolAction { Name = "log-user-query", Description = "A tool that logs a query", ParametersSampleObject = "{}" }
+            ],
+            SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+        };
+        var agent = await store.AI.CreateAgentAsync(agentConfig);
+
+        var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+
+        conversation.Handle("log-user-query", (AiAgentActionRequest request, dynamic data) =>
+        {
+            // calling AddActionResponse inside Handle is now blocked --> this should throw 
+            conversation.AddActionResponse(request.ToolId, "logged");
+            return "ok";
+        });
+
+        conversation.SetUserPrompt("Please run the tool.");
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await conversation.RunAsync<object>());
+        Assert.Contains("Each tool call must have exactly one response", ex.Message);
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task Handle_TaskOfTResult_DoesNotBindToObjectOverload(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agentConfig = new AiAgentConfiguration("tester", config.ConnectionStringName, "You are a test agent. Your only purpose is to call the 'RecentOrder' tool, no matter what the user says.")
+        {
+            Actions =
+            [
+                new AiAgentToolAction
+                {
+                    Name = "RecentOrder", 
+                    Description = "test tool", 
+                    ParametersSampleObject = "{}"
+                }
+            ],
+            SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
+        };
+
+        var agent = await store.AI.CreateAgentAsync(agentConfig);
+        var chat = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
+        var recentOrderCalled = false;
+
+        // should be resolved to the async overload of Handle
+        chat.Handle("RecentOrder", (object query) =>
+        {
+            recentOrderCalled = true;
+            return Task.FromResult("done");
+        }, AiHandleErrorStrategy.RaiseImmediately);
+
+        chat.SetUserPrompt("Please run the tool.");
+
+        // should not throw
+        await chat.RunAsync<object>();
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25307.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25307.cs
@@ -74,12 +74,10 @@ public class RavenDB_25307 : RavenTestBase
 
         var agent = await store.AI.CreateAgentAsync(agentConfig);
         var chat = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
-        var recentOrderCalled = false;
 
         // should be resolved to the async overload of Handle
         chat.Handle("RecentOrder", (object query) =>
         {
-            recentOrderCalled = true;
             return Task.FromResult("done");
         }, AiHandleErrorStrategy.RaiseImmediately);
 


### PR DESCRIPTION
### Issue link

- https://issues.hibernatingrhinos.com/issue/RavenDB-25307/Block-AddActionResponse-inside-Handle-Recieve
- https://issues.hibernatingrhinos.com/issue/RavenDB-25892/Fix-AI-Agent-Handle-overload-that-accept-Task

### Additional description

- `RavenDB-25307`: Store action responses by toolId (dictionary) and throw on duplicates to enforce one response per tool invocation (prevents accidental `AddActionResponse` inside `Handle`/ double replies).

- `RavenDB-25892`: Fix `Handle` overload selection for async handlers by changing the existing `Handle` Task overload to accept `Task<TResult>` instead of `Task<object>`. This is a **breaking change**, but the previous API was effectively wrong (it caused `Task<T>` handlers to bind to the object overload and treat the Task itself as the response).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
