### PR TITLE
RavenDB-25918 Updated AssertNotificationReasonsIntegrity test

### DIFF
--- a/test/FastTests/Issues/RavenDB-25918.cs
+++ b/test/FastTests/Issues/RavenDB-25918.cs
@@ -21,8 +21,8 @@ public class RavenDB_25918 : RavenTestBase
         // Adding new values in between existing values will cause existing notifications to be read with incorrect reason.
         //
         // Make sure new value fulfills the above and update the assertion.
-        Assert.Equal(67, Enum.GetNames(typeof(AlertReason)).Length);
-        Assert.Equal(AlertReason.SqlConnectionString_DeprecatedFactoryReplaced, Enum.GetValues(typeof(AlertReason)).Cast<AlertReason>().Last());
+        Assert.Equal(71, Enum.GetNames(typeof(AlertReason)).Length);
+        Assert.Equal(AlertReason.SchemaValidationConfiguration_Error, Enum.GetValues(typeof(AlertReason)).Cast<AlertReason>().Last());
         
         Assert.Equal(10, Enum.GetNames(typeof(PerformanceHintReason)).Length);
         Assert.Equal(PerformanceHintReason.Indexing_References, Enum.GetValues(typeof(PerformanceHintReason)).Cast<PerformanceHintReason>().Last());


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25918/Add-tests-for-AlertReason-and-PerformanceHintReason-values

### Additional description

Updated test after v7.2 changes to AlertReason enum

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
