### PR TITLE
RavenDB-25920 Simplify queue for transactions to flush

### DIFF
--- a/src/Voron/EnvironmentStateRecord.cs
+++ b/src/Voron/EnvironmentStateRecord.cs
@@ -20,8 +20,3 @@ public record EnvironmentStateRecord(
     (long Number, long Last4KWritePosition) Journal,
     List<(long Start, long Count)> SparseRegions,
     object ClientState);
-
-internal sealed class EnvironmentStateRecordHolder
-{
-    public EnvironmentStateRecord EnvStateRecord;
-}

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1744,6 +1744,11 @@ namespace Voron.Impl.Journal
                 }
                 VoronUnrecoverableErrorException.Raise(env, message);
             }
+
+            public void AssertJournalLockIsHeld()
+            {
+                Debug.Assert(Monitor.IsEntered(_flushingLock));
+            }
         }
 
         private void CurrentFileIsDone()
@@ -2604,5 +2609,6 @@ namespace Voron.Impl.Journal
 
             return output - dst;
         }
+
     }
 }

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -120,7 +121,7 @@ namespace Voron
 
         internal TestingStuff _forTestingPurposes;
         private EnvironmentStateRecord _currentStateRecord;
-        private readonly ConcurrentQueue<EnvironmentStateRecordHolder> _transactionsToFlush = new();
+        private readonly ConcurrentQueue<EnvironmentStateRecord> _transactionsToFlush = new();
 
         internal EnvironmentStateRecord CurrentStateRecord => _currentStateRecord;
 
@@ -1350,19 +1351,16 @@ namespace Voron
                     WrittenToJournalNumber = envStateRecord.FlushedToJournal,
                     ClientStateType = envStateRecord.ClientState?.GetType().ToString()
                 },
-                TransactionsToFlush = _transactionsToFlush.ToList().Select(x =>
-                {
-                    var record = x.EnvStateRecord;
-
-                    return new InMemoryStorageState.EnvironmentStateRecordDetails
+                TransactionsToFlush = GetTransactionToFlushList()
+                    .Select(record => new InMemoryStorageState.EnvironmentStateRecordDetails
                     {
                         TransactionId = record.TransactionId,
                         ScratchPagesTable = GetScratchTableSummary(record.ScratchPagesTable),
                         NextPageNumber = record.NextPageNumber,
                         WrittenToJournalNumber = record.FlushedToJournal,
                         ClientStateType = record.ClientState?.GetType().ToString()
-                    };
-                }).ToList(),
+                    })
+                    .ToList(),
                 FlushState = new InMemoryStorageState.FlushStateDetails
                 {
                     LastFlushTime = Journal.Applicator.LastFlushTime,
@@ -1381,6 +1379,17 @@ namespace Voron
             };
 
             return state;
+
+            List<EnvironmentStateRecord> GetTransactionToFlushList()
+            {
+                var transactionToFlushList = _transactionsToFlush.ToList();
+                var peeked = _lastPeekedRecord;
+                if (peeked != null)
+                {
+                    transactionToFlushList.Add(peeked);
+                }
+                return transactionToFlushList;
+            }
         }
 
         private InMemoryStorageState.ScratchTableDetails GetScratchTableSummary(ImmutableDictionary<long, PageFromScratchBuffer> scratchTable)
@@ -1677,17 +1686,20 @@ namespace Voron
             // Transactions that _haven't_ been flushed are mostly book-keeping (updating scratch table, etc)
             if (tx.WrittenToJournalNumber >= 0)
             {
-                _transactionsToFlush.Enqueue(new EnvironmentStateRecordHolder { EnvStateRecord = updatedState });
+                _transactionsToFlush.Enqueue(updatedState);
             }
         }
 
         private readonly List<PageFromScratchBuffer> _cachedScratchBuffers = [];
+        private EnvironmentStateRecord _lastPeekedRecord = null;
 
         internal ApplyLogsToDataFileState TryGetLatestEnvironmentStateToFlush(long uptoTxIdExclusive)
         {
             if (uptoTxIdExclusive == 0)
                 uptoTxIdExclusive = long.MaxValue;
 
+            _journal.Applicator.AssertJournalLockIsHeld();
+            
             List<(long Start, long Count)> sparseRegions = null;
             var scratchBuffers = _cachedScratchBuffers;
             scratchBuffers.Clear();
@@ -1695,8 +1707,11 @@ namespace Voron
             EnvironmentStateRecord record = null;
             while (true)
             {
-                if (_transactionsToFlush.TryPeek(out var maybe) == false ||
-                    maybe.EnvStateRecord.TransactionId >= uptoTxIdExclusive)
+                if (
+                    // we retain peeked record and avoid using TryPeek because of: https://ayende.com/blog/201891-B/the-memory-leak-in-concurrentqueue
+                    _lastPeekedRecord != null ||
+                    _transactionsToFlush.TryDequeue(out _lastPeekedRecord) == false ||
+                    _lastPeekedRecord.TransactionId >= uptoTxIdExclusive)
                 {
                     if (found == false)
                         return null;
@@ -1710,17 +1725,12 @@ namespace Voron
 
                     return new ApplyLogsToDataFileState(scratchBuffers, sparseRegions, record);
                 }
-
-                if (_transactionsToFlush.TryDequeue(out EnvironmentStateRecordHolder recordHolder) == false)
-                    throw new InvalidOperationException("Failed to get transaction to flush after already peeked successfully");
-
-                record = recordHolder.EnvStateRecord;
-
-                // single thread is reading from this, so we can be sure that peek + take gets the same value
-                Debug.Assert(ReferenceEquals(record, maybe.EnvStateRecord));
-
-                recordHolder.EnvStateRecord = null; // this way we ensure that _transactionsToFlush won't hold reference in its internal slots preventing GC on EnvironmentStateRecord.ClientState object
-
+                Debug.Assert(_lastPeekedRecord is not null && _lastPeekedRecord.TransactionId < uptoTxIdExclusive);
+                
+                record = _lastPeekedRecord;
+                // we consumed the peeked record, so we set it to null, to allow the
+                // GC to collect it in the future
+                _lastPeekedRecord = null; 
 
                 if(record.SparseRegions is not null)
                 {

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1693,13 +1693,35 @@ namespace Voron
         private readonly List<PageFromScratchBuffer> _cachedScratchBuffers = [];
         private EnvironmentStateRecord _lastPeekedRecord = null;
 
+        private bool TryPeekNextRecordToFlush(long uptoTxIdExclusive, out EnvironmentStateRecord record)
+        {
+            _journal.Applicator.AssertJournalLockIsHeld();
+
+            // we retain peeked record and avoid using TryPeek because of: https://ayende.com/blog/201891-B/the-memory-leak-in-concurrentqueue
+            if (_lastPeekedRecord == null)
+            {
+                if(_transactionsToFlush.TryDequeue(out _lastPeekedRecord) == false)
+                {
+                    record = null;
+                    return false;
+                }
+            }
+            if(_lastPeekedRecord.TransactionId >= uptoTxIdExclusive)
+            {
+                record = null;
+                return false;
+            }
+            record = _lastPeekedRecord;
+            // we consumed the peeked record, so we set it to null, to allow the GC to collect it in the future
+            _lastPeekedRecord = null; 
+            return true;
+        }
+
         internal ApplyLogsToDataFileState TryGetLatestEnvironmentStateToFlush(long uptoTxIdExclusive)
         {
             if (uptoTxIdExclusive == 0)
                 uptoTxIdExclusive = long.MaxValue;
 
-            _journal.Applicator.AssertJournalLockIsHeld();
-            
             List<(long Start, long Count)> sparseRegions = null;
             var scratchBuffers = _cachedScratchBuffers;
             scratchBuffers.Clear();
@@ -1707,11 +1729,7 @@ namespace Voron
             EnvironmentStateRecord record = null;
             while (true)
             {
-                if (
-                    // we retain peeked record and avoid using TryPeek because of: https://ayende.com/blog/201891-B/the-memory-leak-in-concurrentqueue
-                    _lastPeekedRecord != null ||
-                    _transactionsToFlush.TryDequeue(out _lastPeekedRecord) == false ||
-                    _lastPeekedRecord.TransactionId >= uptoTxIdExclusive)
+                if (TryPeekNextRecordToFlush(uptoTxIdExclusive, out var mabye) is false)
                 {
                     if (found == false)
                         return null;
@@ -1725,12 +1743,9 @@ namespace Voron
 
                     return new ApplyLogsToDataFileState(scratchBuffers, sparseRegions, record);
                 }
-                Debug.Assert(_lastPeekedRecord is not null && _lastPeekedRecord.TransactionId < uptoTxIdExclusive);
+                Debug.Assert(mabye is not null && mabye.TransactionId < uptoTxIdExclusive);
                 
-                record = _lastPeekedRecord;
-                // we consumed the peeked record, so we set it to null, to allow the
-                // GC to collect it in the future
-                _lastPeekedRecord = null; 
+                record = mabye;
 
                 if(record.SparseRegions is not null)
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25920

### Additional description

Avoid NRE because we are looking at the `_transactionToFlush` and reading `null` because we reset the container.
Instead, keep track of the last seen value directly using `TryDequeue` - also simplify memory management for the queue itself.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
