### PR TITLE
[v7.1] RavenDB-25936 - Setup wizard Node Addresses URL value not updated correctly after editing (stale value in handleUrl)

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -289,9 +289,9 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
         }
     };
 
-    const handleNodeUrl = () => {
+    const handleNodeUrl = (formData: NodeEditFormData) => {
         if (securityOption === "letsEncrypt") {
-            return `${nodeData.nodeTag.toLowerCase()}.${domainStep.domain.toLocaleLowerCase()}.${domainStep.rootDomain}`;
+            return `${formData.nodeTag.toLowerCase()}.${domainStep.domain.toLocaleLowerCase()}.${domainStep.rootDomain}`;
         }
 
         if (securityOption === "ownCertificate") {
@@ -300,18 +300,18 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
             if (isWildcardCertificate) {
                 // For wildcard certificates, construct domain from CN and node tag
                 if (cns.length > 0 && cns[0].includes("*")) {
-                    nodeUrl = cns[0].replace("*", nodeData.nodeTag.toLowerCase());
+                    nodeUrl = cns[0].replace("*", formData.nodeTag.toLowerCase());
                 } else {
                     // Fallback to dnsName if available
-                    nodeUrl = nodeData.dnsName || "";
+                    nodeUrl = formData.dnsName || "";
                 }
             } else {
                 // For non-wildcard certificates, use the selected dnsName
-                nodeUrl = nodeData.dnsName || "";
+                nodeUrl = formData.dnsName || "";
             }
 
-            if (nodeData.httpPort !== 443 && nodeData.httpPort != null) {
-                nodeUrl += ":" + nodeData.httpPort;
+            if (formData.httpPort !== 443 && formData.httpPort != null) {
+                nodeUrl += ":" + formData.httpPort;
             }
             return nodeUrl;
         }
@@ -322,7 +322,7 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
     const handleSaveEdit = handleSubmit(async (formData: NodeEditFormData) => {
         setValue(`nodeAddressStep.nodes.${index}`, {
             ...formData,
-            nodeUrl: handleNodeUrl(),
+            nodeUrl: handleNodeUrl(formData),
             httpPort: formData.httpPort == null ? (securityOption === "none" ? 8080 : 443) : formData.httpPort,
             nodeTag: formData.isPassive ? undefined : formData.nodeTag,
             isEditing: false,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25936

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
