### PR TITLE
RavenDB-25927 - Support for `Regex.IsMatch` in Subscriptions

### DIFF
--- a/src/Raven.Client/Documents/Subscriptions/DocumentSubscriptions.cs
+++ b/src/Raven.Client/Documents/Subscriptions/DocumentSubscriptions.cs
@@ -140,6 +140,7 @@ namespace Raven.Client.Documents.Subscriptions
                         JavascriptConversionExtensions.NullCoalescingSupport.Instance,
                         JavascriptConversionExtensions.NestedConditionalSupport.Instance,
                         JavascriptConversionExtensions.StringSupport.Instance,
+                        JavascriptConversionExtensions.RegexSupport.Instance,
                         new JavascriptConversionExtensions.IdentityPropertySupport(conventions)
                     ));
 

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2765,8 +2765,16 @@ namespace Raven.Client.Util
                     return;
 
                 var method = mce.Method;
-                if (method.DeclaringType != typeof(Regex) || method.Name != nameof(Regex.IsMatch))
+                if (method.DeclaringType != typeof(Regex))
                     return;
+
+                if (method.Name != nameof(Regex.IsMatch))
+                {
+                    throw new NotSupportedException($"Only Regex.IsMatch is supported in query translation. Method '{method.Name}' is not supported.")
+                    {
+                        HelpLink = "DoNotWrap"
+                    };
+                }
 
                 // We currently support Regex.IsMatch(string input, string pattern)
                 // and Regex.IsMatch(string input, string pattern, RegexOptions options)

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2751,6 +2751,141 @@ namespace Raven.Client.Util
             public static JavascriptConversionExtension Instance = new EnumConversionExtension(EnumOptions.UseStrings);
         }
 
+        internal sealed class RegexSupport : JavascriptConversionExtension
+        {
+            public static readonly RegexSupport Instance = new RegexSupport();
+
+            private RegexSupport()
+            {
+            }
+
+            public override void ConvertToJavascript(JavascriptConversionContext context)
+            {
+                if (context.Node is not MethodCallExpression mce)
+                    return;
+
+                var method = mce.Method;
+                if (method.DeclaringType != typeof(Regex) || method.Name != nameof(Regex.IsMatch))
+                    return;
+
+                // We currently support Regex.IsMatch(string input, string pattern)
+                // and Regex.IsMatch(string input, string pattern, RegexOptions options)
+                if (mce.Arguments.Count > 3)
+                {
+                    throw new NotSupportedException("Regex.IsMatch with more than 3 arguments is not supported.")
+                    {
+                        HelpLink = "DoNotWrap"
+                    };
+                }
+
+                if (mce.Arguments.Count < 2)
+                {
+                    throw new NotSupportedException("Regex.IsMatch must be called with at least 2 arguments: input and pattern.")
+                    {
+                        HelpLink = "DoNotWrap"
+                    };
+                }
+
+                var inputExpr = mce.Arguments[0];
+                var patternExpr = mce.Arguments[1];
+
+                if (LinqPathProvider.GetValueFromExpressionWithoutConversion(patternExpr, out var patternObj) == false)
+                {
+                    throw new NotSupportedException("Regex.IsMatch pattern must be a constant expression.")
+                    {
+                        HelpLink = "DoNotWrap"
+                    };
+                }
+
+                if (patternObj is not string pattern)
+                {
+                    throw new NotSupportedException("Regex.IsMatch pattern must be a string constant.")
+                    {
+                        HelpLink = "DoNotWrap"
+                    };
+                }
+
+                // Extract RegexOptions when present
+                RegexOptions options = RegexOptions.None;
+                if (mce.Arguments.Count == 3)
+                {
+                    if (LinqPathProvider.GetValueFromExpressionWithoutConversion(mce.Arguments[2], out var optionsObj) == false || optionsObj is not RegexOptions ro)
+                        throw new NotSupportedException("Regex.IsMatch options must be a constant expression.")
+                        {
+                            HelpLink = "DoNotWrap"
+                        };
+
+                    options = ro;
+                }
+
+                var flags = GetJsFlags(options);
+
+                var writer = context.GetWriter();
+                context.PreventDefault();
+
+                using (writer.Operation(mce))
+                {
+                    writer.Write("new RegExp(");
+                    writer.Write("\"");
+                    writer.Write(EscapeForJsString(pattern));
+                    writer.Write("\"");
+
+                    if (flags.Length > 0)
+                    {
+                        writer.Write(", \"");
+                        writer.Write(flags);
+                        writer.Write("\"");
+                    }
+
+                    writer.Write(").test(");
+                    context.Visitor.Visit(inputExpr);
+                    writer.Write(")");
+                }
+            }
+
+            private static string GetJsFlags(RegexOptions options)
+            {
+                var flags = string.Empty;
+
+                if ((options & RegexOptions.IgnoreCase) == RegexOptions.IgnoreCase)
+                    flags += "i";
+
+                if ((options & RegexOptions.Multiline) == RegexOptions.Multiline)
+                    flags += "m";
+
+                // Singleline (RegexOptions.Singleline) => JS "." matches newlines flag "s"
+                if ((options & RegexOptions.Singleline) == RegexOptions.Singleline)
+                    flags += "s";
+
+                const RegexOptions supported = RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline;
+                var unsupported = options & ~supported;
+                if (unsupported != RegexOptions.None)
+                {
+                    throw new NotSupportedException($"RegexOptions '{unsupported}' are not supported in JavaScript regex translation.")
+                    {
+                        HelpLink = "DoNotWrap"
+                    };
+                }
+
+                return flags;
+            }
+
+            private static string EscapeForJsString(string pattern)
+            {
+                if (pattern == null)
+                    return string.Empty;
+
+                return pattern
+                    .Replace("\\", "\\\\")        // Must be first!
+                    .Replace("\"", "\\\"")        // Escape quotes
+                    .Replace("\r", "\\r")         // Escape CR
+                    .Replace("\n", "\\n")         // Escape LF
+                    .Replace("\u2028", "\\u2028") // CRITICAL: Escape Line Separator
+                    .Replace("\u2029", "\\u2029") // CRITICAL: Escape Paragraph Separator
+                    .Replace("\t", "\\t");        // Optional: nice for debugging readablity
+            }
+        }
+
         public static ParameterExpression GetParameter(MemberExpression expression)
         {
             return GetInnermostExpression(expression, out _, out _) as ParameterExpression;

--- a/test/SlowTests/Client/Subscriptions/RegexSubscriptionTests.cs
+++ b/test/SlowTests/Client/Subscriptions/RegexSubscriptionTests.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     var docs = new BlockingCollection<RegexMe>();
 
-                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+                    _ = worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
 
                     for (int i = 0; i < 4; i++)
                     {
@@ -101,7 +101,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     var docs = new BlockingCollection<RegexMe>();
 
-                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+                    _ = worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
 
                     for (int i = 0; i < 4; i++)
                     {
@@ -161,7 +161,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     var docs = new BlockingCollection<Message>();
 
-                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+                    _ = worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
 
                     for (int i = 0; i < 2; i++)
                     {
@@ -198,7 +198,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     var docs = new BlockingCollection<RegexMe>();
 
-                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+                    _ = worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
 
                     Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
                     Assert.True(Regex.IsMatch(doc.Text, pattern, RegexOptions.Singleline));
@@ -233,7 +233,7 @@ namespace SlowTests.Client.Subscriptions
                 {
                     var docs = new BlockingCollection<RegexMe>();
 
-                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+                    _ = worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
 
                     Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
                     Assert.True(Regex.IsMatch(doc.Text, pattern, RegexOptions.Multiline));

--- a/test/SlowTests/Client/Subscriptions/RegexSubscriptionTests.cs
+++ b/test/SlowTests/Client/Subscriptions/RegexSubscriptionTests.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Subscriptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Client.Subscriptions
+{
+    public class RegexSubscriptionTests : RavenTestBase
+    {
+        public RegexSubscriptionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private readonly TimeSpan _waitForDocTimeout = Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(15);
+
+        private static SubscriptionWorkerOptions CreateSubscriptionWorkerOptions(string subscriptionName)
+        {
+            return new SubscriptionWorkerOptions(subscriptionName)
+            {
+                MaxDocsPerBatch = 128,
+                MaxErroneousPeriod = TimeSpan.FromHours(1),
+                TimeToWaitBeforeConnectionRetry = TimeSpan.FromMinutes(10),
+                CloseWhenNoDocsLeft = true,
+                Strategy = SubscriptionOpeningStrategy.TakeOver,
+            };
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task SubscriptionWithRegexIsMatch_ShouldFilterCorrectly(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new RegexMe { Text = "i love dogs and cats" });
+                    session.Store(new RegexMe { Text = "i love cats" });
+                    session.Store(new RegexMe { Text = "i love dogs" });
+                    session.Store(new RegexMe { Text = "i love bats" });
+                    session.Store(new RegexMe { Text = "dogs love me" });
+                    session.Store(new RegexMe { Text = "cats love me" });
+                    session.SaveChanges();
+                }
+
+                const string pattern = "^[a-z ]{2,4}love";
+
+                var subscriptionName = await store.Subscriptions.CreateAsync<RegexMe>(
+                    x => Regex.IsMatch(x.Text, pattern));
+
+                var workerOptions = CreateSubscriptionWorkerOptions(subscriptionName);
+
+                using (var worker = store.Subscriptions.GetSubscriptionWorker<RegexMe>(workerOptions))
+                {
+                    var docs = new BlockingCollection<RegexMe>();
+
+                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
+                        Assert.True(Regex.IsMatch(doc.Text, pattern));
+                    }
+
+                    Assert.False(docs.TryTake(out _));
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task SubscriptionWithRegexIsMatch_AndIgnoreCase_ShouldFilterCorrectly(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new RegexMe { Text = "I LOVE DOGS AND CATS" });
+                    session.Store(new RegexMe { Text = "I LOVE CATS" });
+                    session.Store(new RegexMe { Text = "I LOVE DOGS" });
+                    session.Store(new RegexMe { Text = "I LOVE BATS" });
+                    session.Store(new RegexMe { Text = "DOGS LOVE ME" });
+                    session.Store(new RegexMe { Text = "CATS LOVE ME" });
+                    session.SaveChanges();
+                }
+
+                const string pattern = "^[a-z ]{2,4}love";
+
+                var subscriptionName = await store.Subscriptions.CreateAsync<RegexMe>(
+                    x => Regex.IsMatch(x.Text, pattern, RegexOptions.IgnoreCase));
+
+                var workerOptions = CreateSubscriptionWorkerOptions(subscriptionName);
+
+                using (var worker = store.Subscriptions.GetSubscriptionWorker<RegexMe>(workerOptions))
+                {
+                    var docs = new BlockingCollection<RegexMe>();
+
+                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+
+                    for (int i = 0; i < 4; i++)
+                    {
+                        Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
+                        Assert.True(Regex.IsMatch(doc.Text, pattern, RegexOptions.IgnoreCase));
+                    }
+
+                    Assert.False(docs.TryTake(out _));
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task SubscriptionWithWildcardRegexIsMatch_ShouldFilterCorrectly(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var pattern = "String or binary data would be truncated in table '*.dbo.SomeTable', column 'SomeColumn'. Truncated value: '*'. The statement has been terminated.";
+                var wildcardPattern = WildcardToRegex(pattern);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(
+                        new Message
+                        {
+                            Id = "240638ce-be95-4fbd-89ad-1f143f2a427a",
+                            UserMessage = "String or binary data would be truncated in table 'SpecificCustomerDatabase.dbo.SomeTable', column 'SomeColumn'. Truncated value: 'blablabla'. The statement has been terminated."
+                        }
+                    );
+
+                    await session.StoreAsync(
+                        new Message
+                        {
+                            Id = "250638ce-be95-4fbd-89ad-1f143f2a428a",
+                            UserMessage = "String or binary data would be truncated in table 'OtherCustomerDatabase.dbo.SomeTable', column 'SomeColumn'. Truncated value: 'zozozozo'. The statement has been terminated."
+                        }
+                    );
+
+                    await session.StoreAsync(
+                        new Message
+                        {
+                            Id = "340638ce-be95-4fbd-89ad-1f143f2a427b",
+                            UserMessage = "Other message."
+                        }
+                    );
+
+                    await session.SaveChangesAsync();
+                }
+
+                var subscriptionName = await store.Subscriptions.CreateAsync<Message>(
+                    x => Regex.IsMatch(x.UserMessage, wildcardPattern));
+
+                var workerOptions = CreateSubscriptionWorkerOptions(subscriptionName);
+
+                using (var worker = store.Subscriptions.GetSubscriptionWorker<Message>(workerOptions))
+                {
+                    var docs = new BlockingCollection<Message>();
+
+                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+
+                    for (int i = 0; i < 2; i++)
+                    {
+                        Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
+                        Assert.True(Regex.IsMatch(doc.UserMessage, wildcardPattern));
+                    }
+
+                    Assert.False(docs.TryTake(out _));
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task SubscriptionWithRegexIsMatch_AndSingleline_ShouldFilterCorrectly(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new RegexMe { Text = "first line\nsecond line" });
+                    session.Store(new RegexMe { Text = "no newline here" });
+                    session.SaveChanges();
+                }
+
+                const string pattern = "^first line.*second line$";
+
+                var subscriptionName = await store.Subscriptions.CreateAsync<RegexMe>(
+                    x => Regex.IsMatch(x.Text, pattern, RegexOptions.Singleline));
+
+                var workerOptions = CreateSubscriptionWorkerOptions(subscriptionName);
+
+                using (var worker = store.Subscriptions.GetSubscriptionWorker<RegexMe>(workerOptions))
+                {
+                    var docs = new BlockingCollection<RegexMe>();
+
+                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+
+                    Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
+                    Assert.True(Regex.IsMatch(doc.Text, pattern, RegexOptions.Singleline));
+                    Assert.False(Regex.IsMatch(doc.Text, pattern));
+
+                    Assert.False(docs.TryTake(out _));
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task SubscriptionWithRegexIsMatch_AndMultiline_ShouldFilterCorrectly(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new RegexMe { Text = "line1\nmatch here" });
+                    session.Store(new RegexMe { Text = "no match" });
+                    session.SaveChanges();
+                }
+
+                const string pattern = "^match";
+
+                var subscriptionName = await store.Subscriptions.CreateAsync<RegexMe>(
+                    x => Regex.IsMatch(x.Text, pattern, RegexOptions.Multiline));
+
+                var workerOptions = CreateSubscriptionWorkerOptions(subscriptionName);
+
+                using (var worker = store.Subscriptions.GetSubscriptionWorker<RegexMe>(workerOptions))
+                {
+                    var docs = new BlockingCollection<RegexMe>();
+
+                    worker.Run(batch => batch.Items.ForEach(i => docs.Add(i.Result)));
+
+                    Assert.True(docs.TryTake(out var doc, _waitForDocTimeout));
+                    Assert.True(Regex.IsMatch(doc.Text, pattern, RegexOptions.Multiline));
+                    Assert.False(Regex.IsMatch(doc.Text, pattern));
+
+                    Assert.False(docs.TryTake(out _));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]
+        public async Task SubscriptionWithRegexWithNotSupportedInput_ShouldFail()
+        {
+            using (var store = GetDocumentStore())
+            {
+                const string pattern = "^[a-z ]{2,4}love";
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.IgnoreCase, TimeSpan.FromSeconds(1)));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.ExplicitCapture));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.Compiled));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.Compiled));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.IgnorePatternWhitespace));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.RightToLeft));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.ECMAScript));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.CultureInvariant));
+                });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.NonBacktracking));
+                });
+            }
+        }
+
+        private static string WildcardToRegex([StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
+        {
+            var escaped = Regex.Escape(pattern);
+            var replaced = escaped.
+                Replace("\\*", ".*").
+                Replace("\\?", ".");
+
+            return "^" + replaced + "$";
+        }
+
+        private class RegexMe
+        {
+            public string Text { get; set; }
+        }
+
+        private class Message
+        {
+            public string Id { get; set; }
+
+            public string UserMessage { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Client/Subscriptions/RegexSubscriptionTests.cs
+++ b/test/SlowTests/Client/Subscriptions/RegexSubscriptionTests.cs
@@ -295,6 +295,11 @@ namespace SlowTests.Client.Subscriptions
                 {
                     await store.Subscriptions.CreateAsync<Message>(x => Regex.IsMatch(x.UserMessage, pattern, RegexOptions.NonBacktracking));
                 });
+
+                await Assert.ThrowsAsync<NotSupportedException>(async () =>
+                {
+                    await store.Subscriptions.CreateAsync<Message>(x => Regex.Match(x.UserMessage, pattern).Success);
+                });
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25927/Support-for-Regex-in-a-subscription

### Additional description

Added support for using `Regex.IsMatch` within Subscription LINQ filters. This allows users to filter documents using regular expressions directly on the server side.

The implementation converts supported C# `Regex.IsMatch` calls into their JavaScript equivalent (`new RegExp(...).test(...)`) during script generation. It includes strict validation to ensure only compatible overloads (Pattern, Options) and constant patterns are used, throwing a clear exception for unsupported `RegexOptions` or timeouts.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
