### PR TITLE
RavenDB-22224: flaky test adjustments 

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
@@ -8,6 +9,7 @@ using Raven.Client.Documents.Operations.Backups;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server;
 using Raven.Server.ServerWide.Context;
 using Tests.Infrastructure;
 using Xunit;
@@ -107,7 +109,7 @@ loadTo(""Orders"", partitionBy(key),
                     }
                 }, expectedVal: true, timeout: 30_000);
 
-                Assert.True(itemDeleted);
+                Assert.True(itemDeleted, AddDebugInfo(Server));
             }
         }
 
@@ -145,6 +147,17 @@ loadTo(""Orders"", partitionBy(key),
 
                 await session.SaveChangesAsync();
             }
+        }
+
+        private static string AddDebugInfo(RavenServer server)
+        {
+            var sb = new StringBuilder("ETL process state was not deleted from storage")
+                .AppendLine()
+                .AppendLine("Server debug logs:")
+                .AppendLine();
+
+            ClusterTestBase.GetDebugLogsForNode(server, sb);
+            return sb.ToString();
         }
     }
 

--- a/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
+++ b/test/SlowTests/Server/Documents/ETL/Olap/RavenDB_18465.cs
@@ -93,19 +93,21 @@ loadTo(""Orders"", partitionBy(key),
                 }
 
                 // delete task
-                var deleteTaskResult = store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
+                store.Maintenance.Send(new DeleteOngoingTaskOperation(result.TaskId, OngoingTaskType.OlapEtl));
                 var ongoingTask = store.Maintenance.Send(new GetOngoingTaskInfoOperation(result.TaskId, OngoingTaskType.OlapEtl));
                 Assert.Null(ongoingTask);
 
-                // wait for RemoveEtlProcessStateCommand to complete (executed after DeleteOngoingTaskCommand)
-                await Server.ServerStore.Cluster.WaitForIndexNotification(deleteTaskResult.RaftCommandIndex + 1);
-
-                using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
-                using (context.OpenReadTransaction())
+                // wait for etl process state to be deleted
+                var itemDeleted = WaitForValue(() =>
                 {
-                    var item = Server.ServerStore.Engine.StateMachine.GetItem(context, key);
-                    Assert.Null(item);
-                }
+                    using (Server.ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
+                    using (context.OpenReadTransaction())
+                    {
+                        return Server.ServerStore.Engine.StateMachine.GetItem(context, key) == null;
+                    }
+                }, expectedVal: true, timeout: 30_000);
+
+                Assert.True(itemDeleted);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22224/SlowTests.Server.Documents.ETL.Olap.RavenDB18465.EtlProcessStateShouldBeDeletedAfterTaskRemovaloptions-DatabaseMode-Sharded


### Additional description

- Wait for the ETL process state to be removed after OLAP task deletion
- Add debug info if process state is not deleted

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
