### PR TITLE
RavenDB-25825 : Add debug info to flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24973.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24973.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
@@ -188,57 +189,13 @@ if($output.Blocked)
                 {
                     Assert.True(item.ModelOutput.Output.TryGet("Blocked", out bool _));
                     Assert.True(item.ModelOutput.Output.TryGet("Reason", out string _));
-                }
 
-                // assert conversation documents were created
-                foreach (var item in result.Results)
-                {
+                    // assert conversation documents were created
                     var doc = item.ModelOutput.ConversationDocument;
                     Assert.NotNull(doc);
 
-                    Assert.True(doc.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages));
-                    Assert.Equal(4, messages.Length);
-
-                    // prompt message
-                    var msgAsObj = messages[0] as BlittableJsonReaderObject;
-                    Assert.NotNull(msgAsObj);
-                    Assert.True(msgAsObj.TryGet("content", out string content));
-                    Assert.Equal(config.Prompt, content);
-
-                    Assert.True(msgAsObj.TryGet("role", out string role));
-                    Assert.Equal("system", role);
-
-                    // agent parameters message
-                    msgAsObj = messages[1] as BlittableJsonReaderObject;
-                    Assert.NotNull(msgAsObj);
-                    Assert.True(msgAsObj.TryGet("content", out content));
-                    Assert.Contains("AI Agent Parameters", content);
-
-                    Assert.True(msgAsObj.TryGet("role", out role));
-                    Assert.Equal("user", role);
-
-                    // context object message
-                    msgAsObj = messages[2] as BlittableJsonReaderObject;
-                    Assert.NotNull(msgAsObj);
-                    Assert.True(msgAsObj.TryGet("content", out content));
-                    Assert.True(comments.Any(c => content.Contains($"\"Text\":\"{c.Text}\",\"Author\":\"{c.Author}\",\"Id\":\"{c.Id}\"")));
-
-                    Assert.True(msgAsObj.TryGet("role", out role));
-                    Assert.Equal("user", role);
-
-                    // model response message
-                    msgAsObj = messages[3] as BlittableJsonReaderObject;
-                    Assert.NotNull(msgAsObj);
-                    Assert.True(msgAsObj.TryGet("content", out BlittableJsonReaderObject contentObj));
-                   
-                    Assert.True(contentObj.TryGet("Blocked", out bool _));
-                    Assert.True(contentObj.TryGet("Reason", out string _));
-
-                    Assert.True(msgAsObj.TryGet("role", out role));
-                    Assert.Equal("assistant", role);
-
+                    AssertDocument(doc, config, comments);
                 }
-
             }
         }
     }
@@ -255,5 +212,64 @@ if($output.Blocked)
 
         [JsonProperty("content")]
         public JToken Content { get; set; }
+    }
+
+    private static void AssertDocument(BlittableJsonReaderObject document, GenAiConfiguration configuration, List<GenAiBasics.Comment> comments)
+    {
+        try
+        {
+            Assert.True(document.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages));
+            Assert.Equal(4, messages.Length);
+
+            // prompt message
+            var msgAsObj = messages[0] as BlittableJsonReaderObject;
+            Assert.NotNull(msgAsObj);
+            Assert.True(msgAsObj.TryGet("content", out string content));
+            Assert.Equal(configuration.Prompt, content);
+
+            Assert.True(msgAsObj.TryGet("role", out string role));
+            Assert.Equal("system", role);
+
+            // agent parameters message
+            msgAsObj = messages[1] as BlittableJsonReaderObject;
+            Assert.NotNull(msgAsObj);
+            Assert.True(msgAsObj.TryGet("content", out content));
+            Assert.Contains("AI Agent Parameters", content);
+
+            Assert.True(msgAsObj.TryGet("role", out role));
+            Assert.Equal("user", role);
+
+            // context object message
+            msgAsObj = messages[2] as BlittableJsonReaderObject;
+            Assert.NotNull(msgAsObj);
+            Assert.True(msgAsObj.TryGet("content", out content));
+            Assert.True(comments.Any(c => content.Contains($"\"Text\":\"{c.Text}\",\"Author\":\"{c.Author}\",\"Id\":\"{c.Id}\"")));
+
+            Assert.True(msgAsObj.TryGet("role", out role));
+            Assert.Equal("user", role);
+
+            // model response message
+            msgAsObj = messages[3] as BlittableJsonReaderObject;
+            Assert.NotNull(msgAsObj);
+            Assert.True(msgAsObj.TryGet("content", out BlittableJsonReaderObject contentObj));
+
+            Assert.True(contentObj.TryGet("Blocked", out bool _));
+            Assert.True(contentObj.TryGet("Reason", out string _));
+
+            Assert.True(msgAsObj.TryGet("role", out role));
+            Assert.Equal("assistant", role);
+        }
+        catch (Exception e)
+        {
+            var sb = new StringBuilder()
+                .AppendLine("Conversation document assertion failed: unexpected structure or missing/invalid fields.")
+                .AppendLine()
+                .AppendLine("Document:")
+                .AppendLine(document.ToString())
+                .AppendLine("Failure:")
+                .AppendLine(e.Message);
+            
+            Assert.Fail(sb.ToString());
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25825/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24973.TestGenAiShouldReturnConversationDocumentoptions-DatabaseMode-Single

### Additional description

 add debug info to flaky test (print conversation doc)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
