### PR TITLE
RavenDB-25944 - JSON Schema: Duplicate schema visible during creation

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/DocumentSchema.tsx
@@ -305,9 +305,9 @@ const CollectionSchemaRichPanel = ({
     const handleEditSchema = async (data: DocumentSchemaFormData) => {
         const updatedItem = documentSchemaUtils.mapToDocumentSchemaValidatorConfigDto(data);
         dispatch(documentSchemaActions.validatorEdited({ originalName: validator.Name, validator: updatedItem }));
+        toggleEditingSchema();
         const next = [...validatorsAll.filter((v) => v.Name !== validator.Name), updatedItem];
         await asyncSaveValidators(next);
-        toggleEditingSchema();
     };
 
     const handleBulkStatusToggle = async (disabled: boolean) => {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/useDocumentSchema.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentSchema/useDocumentSchema.tsx
@@ -67,9 +67,9 @@ export const useDocumentSchema = () => {
     const handleNewSchemaSubmit = (id: string, data: DocumentSchemaFormData) => {
         return tryHandleSubmit(async () => {
             const newItem = documentSchemaUtils.mapToDocumentSchemaValidatorConfigDto(data);
+            dispatch(documentSchemaActions.draftRemoved(id));
             dispatch(documentSchemaActions.validatorAdded(newItem));
             await asyncSaveValidators.execute([...validators.filter((v) => v.Name !== newItem.Name), newItem]);
-            dispatch(documentSchemaActions.draftRemoved(id));
         });
     };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25944

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
