### PR TITLE
RavenDB-25328 - Add debug info

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -800,16 +800,6 @@ for(const comment of this.Comments)
 
         Assert.NotEmpty(stats2);
 
-        var resend = stats2.FirstOrDefault(s =>
-        {
-            var load = s.Details.Operations[^1];
-            var op = load.Operations.FirstOrDefault(x => x.Name == GenAiOperations.LoadToModel)
-                as GenAiPerformanceOperation;
-            return op is { TotalSentToModel: 1, NumberOfContextObjects: 1, TotalCachedContexts: 0 };
-        });
-
-        Assert.True(resend != null, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
-
         using (var session = store.OpenAsyncSession())
         {
             var doc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
@@ -821,6 +811,17 @@ for(const comment of this.Comments)
             var newHash = hashesArray.Last().ToString();
             Assert.NotEqual(originalHash, newHash);
         }
+
+        var resend = stats2.FirstOrDefault(s =>
+        {
+            var load = s.Details.Operations[^1];
+            var op = load.Operations.FirstOrDefault(x => x.Name == GenAiOperations.LoadToModel)
+                as GenAiPerformanceOperation;
+            return op is { TotalSentToModel: 1, NumberOfContextObjects: 1, TotalCachedContexts: 0 };
+        });
+
+        Assert.True(resend != null, $"baselineUtc: {baselineUtc}, etag: {etag} " + Environment.NewLine + await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+
     }
 
     [RavenTheory(RavenTestCategory.Ai)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25328/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenPromptChangesoptions-DatabaseMode-Single-configuration

### Additional description

Add debug info and put hash check before stats check on test

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
