### PR TITLE
RavenDB-25826 : flaky test adjusments

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-25435.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-25435.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Operations.AI;
@@ -118,7 +118,7 @@ for(const comment of this.Comments)
             public string Role { get; set; }
 
             [JsonProperty("content")]
-            public object Content { get; set; }
+            public JToken Content { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25826/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB25435.CanCreateGenAiTaskoptions-DatabaseMode-Single-config

### Additional description

Updates GenAI conversation test POCOs to deserialize Messages[].content as JToken, so it can handle both string and structured object content without flaky JSON deserialization errors.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
