### PR TITLE
RavenDB-25948 Fix tests using 1eku cert for communication

### DIFF
--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -418,9 +418,10 @@ namespace SlowTests.Authentication
                 Assert.Equal(serverCert.Thumbprint, nodes[0].Certificate.ServerCertificate.Thumbprint);
                 var databaseName = GetDatabaseName();
 
+                var certForCommunication = CertificateUtils.CreateClientCertificateFromServerCertificate(serverCert, out _);
                 var options = Sharding.GetOptionsForCluster(leader, clusterSize, shardReplicationFactor: 1, orchestratorReplicationFactor: 1);
-                options.ClientCertificate = serverCert;
-                options.AdminCertificate = serverCert;
+                options.ClientCertificate = certForCommunication;
+                options.AdminCertificate = certForCommunication;
                 options.ModifyDatabaseName = _ => databaseName;
                 options.RunInMemory = false;
                 options.DeleteDatabaseOnDispose = false;

--- a/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
+++ b/test/SlowTests/Tools/SetupSecuredClusterUsingRvn.cs
@@ -453,11 +453,12 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
         });
 
         var dbName = GetDatabaseName();
+        var certForCommunication = CertificateUtils.CreateClientCertificateFromServerCertificate(serverCert, out _);
 
         using (var store = new DocumentStore
         {
             Urls = new[] { url1 },
-            Certificate = serverCert,
+            Certificate = certForCommunication,
             Conventions =
             {
                 DisposeCertificate = false
@@ -638,11 +639,12 @@ public class SetupSecuredClusterUsingRvn : ClusterTestBase
         });
 
         var dbName = GetDatabaseName();
+        var certForCommunication = CertificateUtils.CreateClientCertificateFromServerCertificate(serverCert, out _);
 
         using (var store = new DocumentStore
         {
             Urls = new[] { url1 },
-            Certificate = serverCert,
+            Certificate = certForCommunication,
             Conventions =
             {
                 DisposeCertificate = false


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25948 
https://issues.hibernatingrhinos.com/issue/RavenDB-25949
https://issues.hibernatingrhinos.com/issue/RavenDB-25950 

### Additional description

Let's Encrypt changed default profile on staging to 1EKU certs. Tests were using server cert for sending requests.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
