### PR TITLE
RavenDB 25909 - added info to flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24645.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -91,7 +93,7 @@ ai.genContext({})
             Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(Debugger.IsAttached ? 1200 : 30)));
         
             var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            Assert.False(ValidateErrorNotification(db, string.Empty));
+            Assert.False(ValidateErrorNotification(db, string.Empty), PrintNotificationErrors(db));
             using (var session = store.OpenAsyncSession())
             {
                 var item1 = await session.LoadAsync<Item>(FirstItemId);
@@ -199,6 +201,22 @@ ai.genContext({})
                                                 "Check Build Action = Embedded Resource and the path/casing.");
 
             return stream;
+        }
+
+        public static string PrintNotificationErrors(DocumentDatabase db)
+        {
+            using (db.NotificationCenter.GetStored(out var actions))
+            {
+                var jsonAlerts = actions.ToList();
+                if (jsonAlerts.Count == 0)
+                    return null;
+
+                var fullNotificationsJson = string.Join(
+                    Environment.NewLine,
+                    jsonAlerts.Select(a => a.Json?.ToString() ?? string.Empty));
+
+                return fullNotificationsJson;
+            }
         }
 
         private static byte[] GetEmbeddedImgBytes(string format)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25909/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24645.CanUseImageWithTheWrongFormatoptions-DatabaseMode-Single-config

https://issues.hibernatingrhinos.com/issue/RavenDB-25910/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB24645.CanUseImageWithTheWrongFormatoptions-DatabaseMode-Single-config

### Additional description

added info to flaky test

### Type of change

- [x] Test Fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
