### PR TITLE
RavenDB-25766 - Add manual multi-get requests to traffic watch

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -10,17 +10,14 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Newtonsoft.Json;
-using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands.MultiGet;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions;
-using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Handlers.Processors.MultiGet;
-using Raven.Server.Integrations.PostgreSQL.Exceptions;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -432,7 +429,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             memoryStream.Position = 0;
 
             if (TrafficWatchManager.HasRegisteredClients)
-                RavenServerStartup.LogTrafficWatch(multiGetHandler.HttpContext, 0, database.Name);
+                RavenServerStartup.LogTrafficWatch(multiGetHandler.HttpContext, elapsedMilliseconds: 0, database.Name);
 
             using var resp = context.Sync.ReadForMemory(memoryStream, "query/response");
             if (resp.TryGet("Results", out BlittableJsonReaderArray results) is false)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -10,17 +10,21 @@ using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Newtonsoft.Json;
+using Raven.Client.Documents.Changes;
 using Raven.Client.Documents.Commands.MultiGet;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Exceptions;
+using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.Documents.Handlers.Processors.MultiGet;
+using Raven.Server.Integrations.PostgreSQL.Exceptions;
 using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.TrafficWatch;
 using Raven.Server.Web;
 using Sparrow;
 using Sparrow.Json;
@@ -426,6 +430,10 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
         {
             await handler.ExecuteMultiGetAsync(context, reqsBlittable, memoryStream);
             memoryStream.Position = 0;
+
+            if (TrafficWatchManager.HasRegisteredClients)
+                RavenServerStartup.LogTrafficWatch(multiGetHandler.HttpContext, 0, database.Name);
+
             using var resp = context.Sync.ReadForMemory(memoryStream, "query/response");
             if (resp.TryGet("Results", out BlittableJsonReaderArray results) is false)
                 throw new InvalidOperationException("Missing Results from multi-get reply");

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -48,7 +48,7 @@ namespace Raven.Server
     {
         private RequestRouter _router;
         private RavenServer _server;
-        private long _requestId;
+        private static long _requestId;
         private readonly RavenLogger _logger = RavenLogManager.Instance.GetLoggerForServer<RavenServerStartup>();
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
@@ -314,7 +314,7 @@ namespace Raven.Server
         /// <param name="context"></param>
         /// <param name="elapsedMilliseconds"></param>
         /// <param name="database"></param>
-        private void LogTrafficWatch(HttpContext context, long elapsedMilliseconds, string database)
+        internal static void LogTrafficWatch(HttpContext context, long elapsedMilliseconds, string database)
         {
             var requestId = Interlocked.Increment(ref _requestId);
             var contextItem = context.Items["TrafficWatch"];


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25766/Add-manual-multi-get-requests-to-traffic-watch

### Additional description

Whenever the agent is calling a query tool, we use the multi-get handler.
Need to register those calls to the traffic watch

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
