### PR TITLE
RavenDB-23644 - Improve remaining entry estimation logic to handle unbalanced trees and prevent overflow

### DIFF
--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1765,129 +1765,96 @@ namespace Voron.Data.Fixed
                 return (0, currentDepth);
             }
 
-            if (currentDepth + 1 == maxDepth)
+            var lastEntry = page.GetEntry(page.NumberOfEntries - 1);
+            var lastPage = GetReadOnlyPage(lastEntry->PageNumber);
+
+            long totalEstimate = 0;
+
+            if (lastPage.IsLeaf)
             {
-                // we are at the level just above leaves
-                var lastEntry = page.GetEntry(page.NumberOfEntries - 1);
-                var lastLeaf = GetPageHeader(lastEntry->PageNumber);
-                state.NonEstimatedAmount += lastLeaf.NumberOfEntries;
+                totalEstimate += lastPage.NumberOfEntries;
+                state.NonEstimatedAmount += lastPage.NumberOfEntries;
+                var reachedDepth = currentDepth;
 
-                if (lastLeaf.TreeFlags != FixedSizeTreePageFlags.Leaf)
-                    throw new InvalidOperationException($"Expected Leaf but got: {lastLeaf.TreeFlags}");
+                if (page.NumberOfEntries - page.LastSearchPosition <= 1)
+                    return (totalEstimate, currentDepth);
 
-                long totalEstimate = lastLeaf.NumberOfEntries;
-
-                if (page.NumberOfEntries - page.LastSearchPosition > 1)
+                var firstEntry = page.GetEntry(page.LastSearchPosition);
+                var firstPage = GetPageHeader(firstEntry->PageNumber);
+                if (firstPage.TreeFlags == FixedSizeTreePageFlags.Leaf)
                 {
-                    var steadyEntry = page.GetEntry(page.NumberOfEntries - 2);
-                    var steadyLeaf = GetPageHeader(steadyEntry->PageNumber);
-                    state.NonEstimatedAmount += steadyLeaf.NumberOfEntries;
-
-                    if (steadyLeaf.TreeFlags != FixedSizeTreePageFlags.Leaf)
-                        ThrowNonLeafPage(lastLeaf);
-
+                    // assuming that all entries are leafs
                     // apply this estimate to all previous leafs
-                    totalEstimate += (long)steadyLeaf.NumberOfEntries * (page.NumberOfEntries - page.LastSearchPosition - 1);
+                    totalEstimate += (long)firstPage.NumberOfEntries * (page.NumberOfEntries - page.LastSearchPosition - 1);
                 }
-
-                return (totalEstimate, currentDepth);
-            }
-            else
-            {
-                var lastEntry = page.GetEntry(page.NumberOfEntries - 1);
-                var lastPage = GetReadOnlyPage(lastEntry->PageNumber);
-
-                long totalEstimate = 0;
-
-                if (lastPage.IsLeaf)
+                else
                 {
-                    totalEstimate += lastPage.NumberOfEntries;
-                    state.NonEstimatedAmount += lastPage.NumberOfEntries;
-                    var reachedDepth = currentDepth;
+                    // mix of leafs and branches
+                    while (page.LastSearchPosition < page.NumberOfEntries - 1)
+                    {
+                        var entry = page.GetEntry(page.LastSearchPosition);
+                        var childPage = GetReadOnlyPage(entry->PageNumber);
 
-                    var firstEntry = page.GetEntry(page.LastSearchPosition);
-                    var firstPage = GetPageHeader(firstEntry->PageNumber);
-                    if (firstPage.TreeFlags == FixedSizeTreePageFlags.Leaf)
-                    {
-                        // all entries are leafs
-                        // apply this estimate to all previous leafs
-                        totalEstimate += (long)firstPage.NumberOfEntries * (page.NumberOfEntries - page.LastSearchPosition - 1);
-                    }
-                    else
-                    {
-                        // mix of leafs and branches
-                        while (page.LastSearchPosition < page.NumberOfEntries - 1)
+                        if (childPage.IsLeaf)
                         {
-                            var entry = page.GetEntry(page.LastSearchPosition);
-                            var childPage = GetReadOnlyPage(entry->PageNumber);
-
-                            if (childPage.IsLeaf)
-                            {
-                                totalEstimate += childPage.NumberOfEntries;
-                                state.NonEstimatedAmount += childPage.NumberOfEntries;
-                            }
-                            else
-                            {
-                                var branchEstimate = EstimateRemainingEntriesFor(childPage, currentDepth + 1, maxDepth, ref state);
-                                totalEstimate += branchEstimate.Count;
-                                reachedDepth = Math.Max(reachedDepth, branchEstimate.ReachedDepth);
-                            }
-
-                            page.LastSearchPosition++;
+                            totalEstimate += childPage.NumberOfEntries;
+                            state.NonEstimatedAmount += childPage.NumberOfEntries;
                         }
-                    }
+                        else
+                        {
+                            var branchEstimate = EstimateRemainingEntriesFor(childPage, currentDepth + 1, maxDepth, ref state);
+                            totalEstimate += branchEstimate.Count;
+                            reachedDepth = Math.Max(reachedDepth, branchEstimate.ReachedDepth);
+                        }
 
-                    return (totalEstimate, reachedDepth);
-                }
-
-                int index;
-
-                // iterate backwards from the last entry (right-to-left).
-                // in a less balanced tree, the right-most branches might be shallower or 
-                // contain fewer entries than the "steady" branches on the left.
-                var currentPage = lastPage;
-                for (index = page.NumberOfEntries - 1; index >= page.LastSearchPosition; index--)
-                {
-                    var estimate = EstimateRemainingEntriesFor(currentPage, currentDepth + 1, maxDepth, ref state);
-                    totalEstimate += estimate.Count;
-
-                    // check if this branch reaches the full expected depth (maxDepth - 1).
-                    // if it does, we assume we have reached the "steady state" of the tree.
-                    // instead of iterating through the remaining (left-side) pages individually,
-                    // we can break here and use this "full" branch to extrapolate the count 
-                    // for all preceding branches, significantly improving performance.
-                    if (estimate.ReachedDepth == maxDepth - 1)
-                    {
-                        index--;
-                        break;
-                    }
-
-                    if (index > page.LastSearchPosition)
-                    {
-                        var nextEntry = page.GetEntry(index - 1);
-                        currentPage = GetReadOnlyPage(nextEntry->PageNumber);
+                        page.LastSearchPosition++;
                     }
                 }
 
-                if (index - page.LastSearchPosition >= 0)
-                {
-                    var steadyEntry = page.GetEntry(page.LastSearchPosition);
-                    var steadyBranchPage = GetReadOnlyPage(steadyEntry->PageNumber);
-
-                    var steadyBranchEstimate = EstimateRemainingEntriesFor(steadyBranchPage, currentDepth + 1, maxDepth, ref state);
-
-                    // apply this estimate to all previous branches
-                    totalEstimate += steadyBranchEstimate.Count * (page.NumberOfEntries - page.LastSearchPosition - 1);
-                }
-
-                return (totalEstimate, currentDepth);
+                return (totalEstimate, reachedDepth);
             }
-        }
 
-        [DoesNotReturn]
-        private static void ThrowNonLeafPage(FixedSizeTreePageHeader lastLeaf)
-        {
-            throw new InvalidOperationException($"Expected Leaf but got: {lastLeaf.TreeFlags}");
+            int index;
+
+            // iterate backwards from the last entry (right-to-left).
+            // in a less balanced tree, the right-most branches might be shallower or 
+            // contain fewer entries than the "steady" branches on the left.
+            var currentPage = lastPage;
+            for (index = page.NumberOfEntries - 1; index >= page.LastSearchPosition; index--)
+            {
+                var estimate = EstimateRemainingEntriesFor(currentPage, currentDepth + 1, maxDepth, ref state);
+                totalEstimate += estimate.Count;
+
+                // check if this branch reaches the full expected depth (maxDepth - 1).
+                // if it does, we assume we have reached the "steady state" of the tree.
+                // instead of iterating through the remaining (left-side) pages individually,
+                // we can break here and use this "full" branch to extrapolate the count 
+                // for all preceding branches, significantly improving performance.
+                if (estimate.ReachedDepth == maxDepth - 1)
+                {
+                    index--;
+                    break;
+                }
+
+                if (index > page.LastSearchPosition)
+                {
+                    var nextEntry = page.GetEntry(index - 1);
+                    currentPage = GetReadOnlyPage(nextEntry->PageNumber);
+                }
+            }
+
+            if (index >= page.LastSearchPosition)
+            {
+                var steadyEntry = page.GetEntry(page.LastSearchPosition);
+                var steadyBranchPage = GetReadOnlyPage(steadyEntry->PageNumber);
+
+                var steadyBranchEstimate = EstimateRemainingEntriesFor(steadyBranchPage, currentDepth + 1, maxDepth, ref state);
+
+                // apply this estimate to all previous branches
+                totalEstimate += steadyBranchEstimate.Count * (page.NumberOfEntries - page.LastSearchPosition - 1);
+            }
+
+            return (totalEstimate, currentDepth);
         }
 
         internal void SetNewPageAllocator(NewPageAllocator newPageAllocator)

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1674,7 +1674,7 @@ namespace Voron.Data.Fixed
             return Name.ToString();
         }
 
-        public long GetNumberOfEntriesAfter(TVal value, out long totalCount, Stopwatch overallDuration)
+        public long GetNumberOfEntriesAfter(TVal value, out long totalCount, Stopwatch overallDuration, EstimationAccuracy accuracy)
         {
             totalCount = NumberOfEntries;
             if (totalCount == 0)
@@ -1698,7 +1698,7 @@ namespace Voron.Data.Fixed
             if (page.LastMatch >= 0)
                 page.LastSearchPosition++;
 
-            var state = new RemainingNumberOfEntriesState { Start = overallDuration };
+            var state = new RemainingNumberOfEntriesState { Start = overallDuration, EstimationAccuracy = accuracy };
             var maxDepth = _cursor.Count + 1;
             var count = GetRemainingNumberOfEntriesFor(page, maxDepth, maxDepth, ref state);
             while (_cursor.TryPop(out page))
@@ -1721,11 +1721,10 @@ namespace Voron.Data.Fixed
 
         private struct RemainingNumberOfEntriesState
         {
-            public long NumberOfEntriesInLeafPagesScanned;
-            public int NumberOfLeafPagesScanned;
             public bool EstimatedAmount;
             public long NonEstimatedAmount;
             public Stopwatch Start;
+            public EstimationAccuracy EstimationAccuracy;
         }
 
         private long GetRemainingNumberOfEntriesFor(FixedSizeTreePage<TVal> page, int depth, int maxDepth, ref RemainingNumberOfEntriesState state)
@@ -1733,8 +1732,6 @@ namespace Voron.Data.Fixed
             if (page.IsLeaf)
             {
                 int entries = page.NumberOfEntries - page.LastSearchPosition;
-                state.NumberOfLeafPagesScanned++;
-                state.NumberOfEntriesInLeafPagesScanned += page.NumberOfEntries;
                 state.NonEstimatedAmount += entries;
                 return entries;
             }
@@ -1742,10 +1739,11 @@ namespace Voron.Data.Fixed
             if (page.IsBranch == false) 
                 throw new InvalidOperationException("Should not happen!");
 
-            if (state.Start.Elapsed > TimeSpan.FromSeconds(1))
+            if ((state.EstimationAccuracy == EstimationAccuracy.EstimateIfLongRunning && state.Start.Elapsed > TimeSpan.FromSeconds(1)) 
+                || state.EstimationAccuracy == EstimationAccuracy.Estimated)
             {
                 state.EstimatedAmount = true;
-                return EstimateRemainingEntriesFor(page, depth, maxDepth, ref state);
+                return EstimateRemainingEntriesFor(page, depth, maxDepth, ref state).Count;
             }
 
             long count = 0;
@@ -1759,43 +1757,137 @@ namespace Voron.Data.Fixed
 
             return count;
         }
-        
-        private long EstimateRemainingEntriesFor(FixedSizeTreePage<TVal> page, int depth, int maxDepth, ref RemainingNumberOfEntriesState state)
+
+        private (long Count, int ReachedDepth) EstimateRemainingEntriesFor(FixedSizeTreePage<TVal> page, int currentDepth, int maxDepth, ref RemainingNumberOfEntriesState state)
         {
-            if (page.IsBranch == false)
-                throw new InvalidOperationException("This is only valid for branches!");
-
-            // here we can assume that we are working on a dense tree. We are only called if we already scanned > 1 million
-            // entries, and we care about the overall speed more than exact results. Dense tree assumption means that we can
-            // compute the total number of entries based on the projected size of the tree and its depth
-
-            var entriesPerLeafPage = state.NumberOfEntriesInLeafPagesScanned / (state.NumberOfLeafPagesScanned == 0 ? 1 : state.NumberOfLeafPagesScanned);
-
-            long sum = 1;
-            for (int i = depth; i < maxDepth; i++)
+            if (page.NumberOfEntries == page.LastSearchPosition)
             {
-                sum *= entriesPerLeafPage;
+                return (0, currentDepth);
             }
 
-            // our estimate for remaining descendants. 
-            long count = (page.NumberOfEntries - 1 - page.LastSearchPosition) * sum;
-            
-            // we'll still check the right most entry anyway...
-            var entry = page.GetEntry(page.NumberOfEntries - 1);
-            var childPage = GetReadOnlyPage(entry->PageNumber);
-            if (childPage.IsLeaf)
+            if (currentDepth + 1 == maxDepth)
             {
-                int entries = childPage.NumberOfEntries - childPage.LastSearchPosition;
-                count += entries;
-                state.NumberOfLeafPagesScanned++;
-                state.NumberOfEntriesInLeafPagesScanned += childPage.NumberOfEntries;
+                // we are at the level just above leaves
+                var lastEntry = page.GetEntry(page.NumberOfEntries - 1);
+                var lastLeaf = GetPageHeader(lastEntry->PageNumber);
+                state.NonEstimatedAmount += lastLeaf.NumberOfEntries;
+
+                if (lastLeaf.TreeFlags != FixedSizeTreePageFlags.Leaf)
+                    throw new InvalidOperationException($"Expected Leaf but got: {lastLeaf.TreeFlags}");
+
+                long totalEstimate = lastLeaf.NumberOfEntries;
+
+                if (page.NumberOfEntries - page.LastSearchPosition > 1)
+                {
+                    var steadyEntry = page.GetEntry(page.NumberOfEntries - 2);
+                    var steadyLeaf = GetPageHeader(steadyEntry->PageNumber);
+                    state.NonEstimatedAmount += steadyLeaf.NumberOfEntries;
+
+                    if (steadyLeaf.TreeFlags != FixedSizeTreePageFlags.Leaf)
+                        ThrowNonLeafPage(lastLeaf);
+
+                    // apply this estimate to all previous leafs
+                    totalEstimate += (long)steadyLeaf.NumberOfEntries * (page.NumberOfEntries - page.LastSearchPosition - 1);
+                }
+
+                return (totalEstimate, currentDepth);
             }
             else
             {
-                count += EstimateRemainingEntriesFor(childPage, depth + 1, maxDepth, ref state);
-            }
+                var lastEntry = page.GetEntry(page.NumberOfEntries - 1);
+                var lastPage = GetReadOnlyPage(lastEntry->PageNumber);
 
-            return count;
+                long totalEstimate = 0;
+
+                if (lastPage.IsLeaf)
+                {
+                    totalEstimate += lastPage.NumberOfEntries;
+                    state.NonEstimatedAmount += lastPage.NumberOfEntries;
+                    var reachedDepth = currentDepth;
+
+                    var firstEntry = page.GetEntry(page.LastSearchPosition);
+                    var firstPage = GetPageHeader(firstEntry->PageNumber);
+                    if (firstPage.TreeFlags == FixedSizeTreePageFlags.Leaf)
+                    {
+                        // all entries are leafs
+                        // apply this estimate to all previous leafs
+                        totalEstimate += (long)firstPage.NumberOfEntries * (page.NumberOfEntries - page.LastSearchPosition - 1);
+                    }
+                    else
+                    {
+                        // mix of leafs and branches
+                        while (page.LastSearchPosition < page.NumberOfEntries - 1)
+                        {
+                            var entry = page.GetEntry(page.LastSearchPosition);
+                            var childPage = GetReadOnlyPage(entry->PageNumber);
+
+                            if (childPage.IsLeaf)
+                            {
+                                totalEstimate += childPage.NumberOfEntries;
+                                state.NonEstimatedAmount += childPage.NumberOfEntries;
+                            }
+                            else
+                            {
+                                var branchEstimate = EstimateRemainingEntriesFor(childPage, currentDepth + 1, maxDepth, ref state);
+                                totalEstimate += branchEstimate.Count;
+                                reachedDepth = Math.Max(reachedDepth, branchEstimate.ReachedDepth);
+                            }
+
+                            page.LastSearchPosition++;
+                        }
+                    }
+
+                    return (totalEstimate, reachedDepth);
+                }
+
+                int index;
+
+                // iterate backwards from the last entry (right-to-left).
+                // in a less balanced tree, the right-most branches might be shallower or 
+                // contain fewer entries than the "steady" branches on the left.
+                var currentPage = lastPage;
+                for (index = page.NumberOfEntries - 1; index >= page.LastSearchPosition; index--)
+                {
+                    var estimate = EstimateRemainingEntriesFor(currentPage, currentDepth + 1, maxDepth, ref state);
+                    totalEstimate += estimate.Count;
+
+                    // check if this branch reaches the full expected depth (maxDepth - 1).
+                    // if it does, we assume we have reached the "steady state" of the tree.
+                    // instead of iterating through the remaining (left-side) pages individually,
+                    // we can break here and use this "full" branch to extrapolate the count 
+                    // for all preceding branches, significantly improving performance.
+                    if (estimate.ReachedDepth == maxDepth - 1)
+                    {
+                        index--;
+                        break;
+                    }
+
+                    if (index > page.LastSearchPosition)
+                    {
+                        var nextEntry = page.GetEntry(index - 1);
+                        currentPage = GetReadOnlyPage(nextEntry->PageNumber);
+                    }
+                }
+
+                if (index - page.LastSearchPosition >= 0)
+                {
+                    var steadyEntry = page.GetEntry(page.LastSearchPosition);
+                    var steadyBranchPage = GetReadOnlyPage(steadyEntry->PageNumber);
+
+                    var steadyBranchEstimate = EstimateRemainingEntriesFor(steadyBranchPage, currentDepth + 1, maxDepth, ref state);
+
+                    // apply this estimate to all previous branches
+                    totalEstimate += steadyBranchEstimate.Count * (page.NumberOfEntries - page.LastSearchPosition - 1);
+                }
+
+                return (totalEstimate, currentDepth);
+            }
+        }
+
+        [DoesNotReturn]
+        private static void ThrowNonLeafPage(FixedSizeTreePageHeader lastLeaf)
+        {
+            throw new InvalidOperationException($"Expected Leaf but got: {lastLeaf.TreeFlags}");
         }
 
         internal void SetNewPageAllocator(NewPageAllocator newPageAllocator)
@@ -1804,5 +1896,12 @@ namespace Voron.Data.Fixed
 
             _newPageAllocator = newPageAllocator;
         }
+    }
+
+    public enum EstimationAccuracy
+    {
+        EstimateIfLongRunning,
+        Exact,
+        Estimated
     }
 }

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1760,11 +1760,6 @@ namespace Voron.Data.Fixed
 
         private (long Count, int ReachedDepth) EstimateRemainingEntriesFor(FixedSizeTreePage<TVal> page, int currentDepth, int maxDepth, ref RemainingNumberOfEntriesState state)
         {
-            if (page.NumberOfEntries == page.LastSearchPosition)
-            {
-                return (0, currentDepth);
-            }
-
             var lastEntry = page.GetEntry(page.NumberOfEntries - 1);
             var lastPage = GetReadOnlyPage(lastEntry->PageNumber);
 
@@ -1776,7 +1771,7 @@ namespace Voron.Data.Fixed
                 state.NonEstimatedAmount += lastPage.NumberOfEntries;
                 var reachedDepth = currentDepth;
 
-                if (page.NumberOfEntries - page.LastSearchPosition <= 1)
+                if (page.LastSearchPosition >= page.NumberOfEntries - 1)
                     return (totalEstimate, currentDepth);
 
                 var firstEntry = page.GetEntry(page.LastSearchPosition);
@@ -1832,7 +1827,20 @@ namespace Voron.Data.Fixed
                 // for all preceding branches, significantly improving performance.
                 if (estimate.ReachedDepth == maxDepth - 1)
                 {
+                    // move to the left neighbor to use as sample
                     index--;
+
+                    if (index >= page.LastSearchPosition)
+                    {
+                        var steadyEntry = page.GetEntry(index);
+                        var steadyBranchPage = GetReadOnlyPage(steadyEntry->PageNumber);
+
+                        var steadyBranchEstimate = EstimateRemainingEntriesFor(steadyBranchPage, currentDepth + 1, maxDepth, ref state);
+
+                        // apply this estimate to itself and all previous branches
+                        long remainingEntries = index - page.LastSearchPosition + 1;
+                        totalEstimate += steadyBranchEstimate.Count * remainingEntries;
+                    }
                     break;
                 }
 
@@ -1841,17 +1849,6 @@ namespace Voron.Data.Fixed
                     var nextEntry = page.GetEntry(index - 1);
                     currentPage = GetReadOnlyPage(nextEntry->PageNumber);
                 }
-            }
-
-            if (index >= page.LastSearchPosition)
-            {
-                var steadyEntry = page.GetEntry(page.LastSearchPosition);
-                var steadyBranchPage = GetReadOnlyPage(steadyEntry->PageNumber);
-
-                var steadyBranchEstimate = EstimateRemainingEntriesFor(steadyBranchPage, currentDepth + 1, maxDepth, ref state);
-
-                // apply this estimate to all previous branches
-                totalEstimate += steadyBranchEstimate.Count * (page.NumberOfEntries - page.LastSearchPosition - 1);
             }
 
             return (totalEstimate, currentDepth);

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1705,6 +1705,10 @@ namespace Voron.Data.Fixed
             {
                 System.Diagnostics.Debug.Assert(page.IsBranch);
                 page.LastSearchPosition++;
+
+                if (page.LastSearchPosition == page.NumberOfEntries)
+                    continue;
+
                 var depth = _cursor.Count + 1;
                 long recursivePageCount = GetRemainingNumberOfEntriesFor(page, depth, maxDepth, ref state);
                 count += recursivePageCount;

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1341,7 +1341,7 @@ namespace Voron.Data.Tables
         {
             var fst = GetFixedSizeTree(index);
 
-            return fst.GetNumberOfEntriesAfter(afterValue, out totalCount, overallDuration);
+            return fst.GetNumberOfEntriesAfter(afterValue, out totalCount, overallDuration, EstimationAccuracy.EstimateIfLongRunning);
         }
 
         public long GetNumberOfEntriesFor(TableSchema.FixedSizeKeyIndexDef index)

--- a/test/SlowTests/Issues/RavenDB_7281.cs
+++ b/test/SlowTests/Issues/RavenDB_7281.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Issues
 
                 for (var i = 0; i < total; i++)
                 {
-                    var count = tree.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew());
+                    var count = tree.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew(), EstimationAccuracy.EstimateIfLongRunning);
                     var expectedCount = Calculate(tree, i, out long expectedTotalCount);
 
                     Assert.Equal(inserted, expectedTotalCount);

--- a/test/SlowTests/Voron/LargeFixedSizeTrees.cs
+++ b/test/SlowTests/Voron/LargeFixedSizeTrees.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections;
+using System.Diagnostics;
 using FastTests.Voron;
 using SlowTests.Utils;
+using Sparrow.Server;
 using Tests.Infrastructure;
 using Voron;
+using Voron.Data.Fixed;
 using Voron.Util.Conversion;
 using Xunit;
 using Xunit.Abstractions;
@@ -521,5 +524,326 @@ namespace SlowTests.Voron
                 }
             }
         }
+
+        #region GetNumberOfEntriesAfter Tests
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(10, EstimationAccuracy.Exact)]
+        [InlineData(10, EstimationAccuracy.Estimated)]
+        [InlineData(100, EstimationAccuracy.Exact)]
+        [InlineData(100, EstimationAccuracy.Estimated)]
+        [InlineData(1000, EstimationAccuracy.Exact)]
+        [InlineData(1000, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_SmallTree_WithAndWithoutEstimate(int count, EstimationAccuracy accuracy)
+        {
+            Slice treeId;
+            Slice.From(Allocator, "test", out treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                for (int i = 0; i < count; i++)
+                {
+                    fst.Add(i, new byte[sizeof(long)]);
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                for (int i = 0; i < count; i++)
+                {
+                    var actualCount = fst.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew(), accuracy);
+                    var expectedCount = CalculateExpectedEntriesAfter(fst, i, out long expectedTotalCount);
+
+                    Assert.Equal(count, expectedTotalCount);
+                    Assert.Equal(expectedTotalCount, totalCount);
+                    Assert.Equal(expectedCount, actualCount);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(10000, EstimationAccuracy.Exact)]
+        [InlineData(10000, EstimationAccuracy.Estimated)]
+        [InlineData(50000, EstimationAccuracy.Exact)]
+        [InlineData(50000, EstimationAccuracy.Estimated)]
+        [InlineData(100000, EstimationAccuracy.Exact)]
+        [InlineData(100000, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_LargeTree_WithAndWithoutEstimate(int count, EstimationAccuracy accuracy)
+        {
+            Slice treeId;
+            Slice.From(Allocator, "test", out treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                for (int i = 0; i < count; i++)
+                {
+                    fst.Add(i, new byte[sizeof(long)]);
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                // Test at specific positions to reduce test time for large trees
+                int[] testPositions = { 0, count / 4, count / 2, 3 * count / 4, count - 1, count };
+
+                foreach (var position in testPositions)
+                {
+                    var actualCount = fst.GetNumberOfEntriesAfter(position, out long totalCount, Stopwatch.StartNew(), accuracy);
+                    var expectedCount = CalculateExpectedEntriesAfter(fst, position, out long expectedTotalCount);
+
+                    Assert.Equal(count, expectedTotalCount);
+                    Assert.Equal(expectedTotalCount, totalCount);
+                    Assert.Equal(expectedCount, actualCount);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(13, 2, EstimationAccuracy.Exact)]
+        [InlineData(13, 2, EstimationAccuracy.Estimated)]
+        [InlineData(5111, 2, EstimationAccuracy.Exact)]
+        [InlineData(5111, 2, EstimationAccuracy.Estimated)]
+        [InlineData(5111, 5, EstimationAccuracy.Exact)]
+        [InlineData(5111, 5, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_WithGaps_WithAndWithoutEstimate(int total, int mod, EstimationAccuracy accuracy)
+        {
+            // Insert entries with gaps (only entries where i % mod == 0)
+            DoWorkWithGaps(total, mod, modZero: true, accuracy);
+            // Insert entries with gaps (only entries where i % mod != 0)
+            DoWorkWithGaps(total, mod, modZero: false, accuracy);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed]
+        public void GetNumberOfEntriesAfter_Random_WithoutEstimate(int seed)
+        {
+            var random = new Random(seed);
+            var total = random.Next(10, 10_000);
+            var mod = random.Next(2, 100);
+
+            DoWorkWithGaps(total, mod, modZero: true, EstimationAccuracy.Exact);
+            DoWorkWithGaps(total, mod, modZero: false, EstimationAccuracy.Exact);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineDataWithRandomSeed]
+        public void GetNumberOfEntriesAfter_Random_WithEstimate(int seed)
+        {
+            var random = new Random(seed);
+            var total = random.Next(10, 10_000);
+            var mod = random.Next(2, 100);
+
+            DoWorkWithGaps(total, mod, modZero: true, EstimationAccuracy.Estimated);
+            DoWorkWithGaps(total, mod, modZero: false, EstimationAccuracy.Estimated);
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(0, EstimationAccuracy.Exact)]
+        [InlineData(0, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_EmptyTree_ReturnsZero(int count, EstimationAccuracy accuracy)
+        {
+            Slice treeId;
+            Slice.From(Allocator, "test", out treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+                // Don't add any entries
+
+                var actualCount = fst.GetNumberOfEntriesAfter(0, out long totalCount, Stopwatch.StartNew(), accuracy);
+
+                Assert.Equal(0, totalCount);
+                Assert.Equal(0, actualCount);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(1, EstimationAccuracy.Exact)]
+        [InlineData(1, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_SingleEntry_WithAndWithoutEstimate(int count, EstimationAccuracy accuracy)
+        {
+            Slice treeId;
+            Slice.From(Allocator, "test", out treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+                fst.Add(100, new byte[sizeof(long)]);
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                // Query before the entry
+                var beforeCount = fst.GetNumberOfEntriesAfter(50, out long totalCount1, Stopwatch.StartNew(), accuracy);
+                Assert.Equal(1, totalCount1);
+                Assert.Equal(1, beforeCount);
+
+                // Query at the entry
+                var atCount = fst.GetNumberOfEntriesAfter(100, out long totalCount2, Stopwatch.StartNew(), accuracy);
+                Assert.Equal(1, totalCount2);
+                Assert.Equal(0, atCount);
+
+                // Query after the entry
+                var afterCount = fst.GetNumberOfEntriesAfter(150, out long totalCount3, Stopwatch.StartNew(), accuracy);
+                Assert.Equal(1, totalCount3);
+                Assert.Equal(0, afterCount);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(1000, EstimationAccuracy.Exact)]
+        [InlineData(1000, EstimationAccuracy.Estimated)]
+        [InlineData(10000, EstimationAccuracy.Exact)]
+        [InlineData(10000, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_QueryBeyondLastEntry_ReturnsZero(int count, EstimationAccuracy accuracy)
+        {
+            Slice treeId;
+            Slice.From(Allocator, "test", out treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                for (int i = 0; i < count; i++)
+                {
+                    fst.Add(i, new byte[sizeof(long)]);
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                // Query way beyond the last entry
+                var actualCount = fst.GetNumberOfEntriesAfter(count + 1000, out long totalCount, Stopwatch.StartNew(), accuracy);
+
+                Assert.Equal(count, totalCount);
+                Assert.Equal(0, actualCount);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(1000, EstimationAccuracy.Exact)]
+        [InlineData(1000, EstimationAccuracy.Estimated)]
+        [InlineData(10000, EstimationAccuracy.Exact)]
+        [InlineData(10000, EstimationAccuracy.Estimated)]
+        public void GetNumberOfEntriesAfter_QueryBeforeFirstEntry_ReturnsAll(int count, EstimationAccuracy accuracy)
+        {
+            Slice treeId;
+            Slice.From(Allocator, "test", out treeId);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                // Start entries from 100 so we can query before them
+                for (int i = 0; i < count; i++)
+                {
+                    fst.Add(i + 100, new byte[sizeof(long)]);
+                }
+
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
+
+                // Query before all entries
+                var actualCount = fst.GetNumberOfEntriesAfter(0, out long totalCount, Stopwatch.StartNew(), accuracy);
+
+                Assert.Equal(count, totalCount);
+                Assert.Equal(count, actualCount);
+            }
+        }
+
+        private void DoWorkWithGaps(int total, int mod, bool modZero, EstimationAccuracy accuracy)
+        {
+            var inserted = 0;
+            var treeName = Guid.NewGuid().ToString("N");
+
+            using (var txw = Env.WriteTransaction())
+            {
+                Slice treeNameSlice;
+                Slice.From(Allocator, treeName, ByteStringType.Immutable, out treeNameSlice);
+
+                var tree = txw.GetGlobalFixedSizeTree(treeNameSlice, sizeof(long));
+
+                for (var i = 0; i < total; i++)
+                {
+                    var modResult = i % mod;
+
+                    if (modZero && modResult == 0)
+                        continue;
+
+                    if (modZero == false && modResult != 0)
+                        continue;
+
+                    tree.Add(i, new byte[sizeof(long)]);
+                    inserted++;
+                }
+
+                txw.Commit();
+            }
+
+            using (var txr = Env.ReadTransaction())
+            {
+                var tree = txr.FixedTreeFor(treeName, sizeof(long));
+
+                for (var i = 0; i < total; i++)
+                {
+                    var count = tree.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew(), accuracy);
+                    var expectedCount = CalculateExpectedEntriesAfter(tree, i, out long expectedTotalCount);
+
+                    Assert.Equal(inserted, expectedTotalCount);
+                    Assert.Equal(expectedTotalCount, totalCount);
+                    Assert.Equal(expectedCount, count);
+                }
+            }
+        }
+
+        private static long CalculateExpectedEntriesAfter(FixedSizeTree fst, long afterValue, out long totalCount)
+        {
+            totalCount = fst.NumberOfEntries;
+            if (totalCount == 0)
+                return 0;
+
+            long count = 0;
+            using (var it = fst.Iterate())
+            {
+                if (it.Seek(afterValue) == false)
+                    return 0;
+
+                do
+                {
+                    if (it.CurrentKey == afterValue)
+                        continue;
+
+                    count++;
+                } while (it.MoveNext());
+            }
+
+            return count;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23644/Indexing-progress-over-100

### Additional description

## Summary
This PR refactors `EstimateRemainingEntriesFor` to replace the previous "dense tree assumption" algorithm. The previous logic performed a simple power-law calculation which assumed that the tree was perfectly balanced and dense.

While this worked for shallow, balanced trees, it failed on deep or unbalanced trees (e.g., depth 26), resulting in integer overflows or estimation errors by orders of magnitude. The new implementation traverses the right-most branches to find a "steady state" (a branch reaching full depth) and extrapolates the remaining entries based on that actual data, rather than a global average.

## The Overflow Issue
In the previous implementation, we calculated the remaining count using a simple loop:

```csharp
long sum = 1;
for (int i = depth; i < maxDepth; i++)
{
    sum *= entriesPerLeafPage;
}
```

This logic is mathematically dangerous for trees with significant depth. In our specific use case, `entriesPerLeafPage` is typically around **500**.
The maximum value of a `long` (Int64) is roughly $9 \times 10^{18}$.
With 500 entries per page, $500^8$ already exceeds `long.MaxValue`.

For a tree with depth 26 (like Index C in the results below), we were attempting to calculate $500^{26}$. This is astronomically larger than what a 64-bit integer can hold, guaranteeing an immediate overflow and negative/garbage results.

## The Strategy
- If we are at the Leaf Level (Bottom): We assume the leaves are "dense" (full). Instead of reading every single leaf page, we check the first leaf, multiply its entry count by the number of unread pages, and just add the specific count of the last leaf.

- If we are at the Branch Level (Middle): We scan the tree backwards (Right-to-Left). We recursively estimate the right-most branches because they are often incomplete or "ragged." As soon as we find a "steady" branch (one that reaches full depth), we stop scanning. We assume all remaining branches to the left are identical to the first one and extrapolate their count using multiplication.

## The Fix: Right-to-Left Steady Branch Scan
Instead of blindly exponentiating based on a global average:
1. We iterate backwards (right-to-left) through the children of the current page.
2. We recursively descend to check the actual density of these right-most branches.
3. Once we find a branch that reaches the expected `maxDepth - 1`, we consider this the **"steady state"**.
4. We assume the remaining unvisited branches (to the left) share the characteristics of this steady branch and extrapolate the count.

This avoids exponential math entirely and bases the estimate on the actual structure of the specific sub-tree being scanned.

## Performance & Accuracy Results
The new algorithm maintains milliseconds-level performance for estimations while providing drastically improved accuracy.

| Index | Documents | Tree Depth | Actual Remaining | Estimated Remaining | Diff | Accuracy |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **A** | 180M | 3 | 179,940,709 | 179,940,709 | 0 | **100%** |
| **B** | 1.45B | 4 | 1,362,995,616 | 1,365,092,977 | +2,097,361 | **99.85%** |
| **C** | 1.05B | 26 | 897,959,808 | 864,474,480 | -33,485,328 | **96.27%** |

* **Index A:** Perfect match.
* **Index B:** Estimate is within **0.15%** of the actual count.
* **Index C:** Previously overflowed/failed. Now provides a usable estimate within **3.7%** of the truth.

### Timing
The estimation overhead remains negligible compared to the full scan. The improvement is most critical during "First Runs" (cold cache), where the accurate scan can take nearly a minute, while the estimate remains sub-second.

| Index | Scenario | Accurate Scan Time | Estimate Scan Time |
| :--- | :--- | :--- | :--- |
| **A** | First Run (Cold) | ~1.9 s | **~10 ms** |
| | Consecutive (Warm) | ~10 ms | **~4 ms** |
| **B** | First Run (Cold) | ~43 s | **~110 ms** |
| | Consecutive (Warm) | ~1.2 s | **~6 ms** |
| **C** | First Run (Cold) | ~18 s | **~170 ms** |
| | Consecutive (Warm) | ~200 ms | **~15 ms** |

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
