### PR TITLE
RavenDB-25154 - Add the ability to send all tracked entities when SaveChanges is executed in Session

### DIFF
--- a/src/Raven.Client/DocumentationUrls.cs
+++ b/src/Raven.Client/DocumentationUrls.cs
@@ -143,7 +143,7 @@ internal static class DocumentationUrls
         internal static class Options
         {
             ///<remarks><seealso href="https://ravendb.net/docs/article-page/7.2/csharp/client-api/session/configuration/how-to-disable-tracking#disable-entity-tracking"/></remarks>
-            public const string NoTracking = nameof(NoTracking);
+            public const string TrackingMode = nameof(TrackingMode);
 
             ///<remarks><seealso href="https://ravendb.net/docs/article-page/7.2/csharp/client-api/session/configuration/how-to-disable-caching"/></remarks>
             public const string NoCaching = nameof(NoCaching);

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -34,38 +34,9 @@ namespace Raven.Client.Documents.Commands.Batches
         }
     }
 
-    internal class SingleNodeBatchWithTrackingCommand : SingleNodeBatchCommand
-    {
-        private readonly BatchTrackChangesCommandData _trackChangesCommand;
-
-        public SingleNodeBatchWithTrackingCommand(DocumentConventions conventions,  IList<ICommandData> commands, BatchTrackChangesCommandData trackChangesCommand, 
-            BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode) : base(conventions, commands, options, mode)
-        {
-            _trackChangesCommand = trackChangesCommand;
-        }
-
-        protected override IList<ICommandData> Initialize(IList<ICommandData> commands)
-        {
-            if (_trackChangesCommand == null) 
-                return base.Initialize(commands);
-
-            var cmds = new List<ICommandData>{ _trackChangesCommand };
-            foreach (var command in commands)
-            {
-                HandlePutAttachmentCommandData(command);
-                cmds.Add(command);
-            }
-
-            _commandsAsJson = new BlittableJsonReaderObject[cmds.Count];
-
-            return cmds;
-
-        }
-    }
-
     public class SingleNodeBatchCommand : RavenCommand<BatchCommandResult>, IDisposable
     {
-        protected BlittableJsonReaderObject[] _commandsAsJson;
+        private readonly BlittableJsonReaderObject[] _commandsAsJson;
         private bool? _supportsAtomicWrites;
         private HashSet<Stream> _uniqueAttachmentStreams;
         private readonly DocumentConventions _conventions;
@@ -85,21 +56,15 @@ namespace Raven.Client.Documents.Commands.Batches
             _options = options;
             _mode = mode;
 
-            Timeout = options?.RequestTimeout;
-        }
-
-        protected virtual IList<ICommandData> Initialize(IList<ICommandData> commands)
-        {
-            _commandsAsJson = new BlittableJsonReaderObject[commands.Count];
+            _commandsAsJson = new BlittableJsonReaderObject[_commands.Count];
             foreach (var command in commands)
             {
                 HandlePutAttachmentCommandData(command);
             }
-
-            return commands;
+            Timeout = options?.RequestTimeout;
         }
 
-        protected void HandlePutAttachmentCommandData(ICommandData command)
+        private void HandlePutAttachmentCommandData(ICommandData command)
         {
             if (command is not PutAttachmentCommandData putAttachmentCommandData) 
                 return;
@@ -116,16 +81,12 @@ namespace Raven.Client.Documents.Commands.Batches
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            //TODO: egor the best would be to combine the loop in Initialize with if (_supportsAtomicWrites == null)
-            var commands = Initialize(_commands);
-
             if (_supportsAtomicWrites == null)
             {
                 _supportsAtomicWrites = node.SupportsAtomicClusterWrites;
-
-                for (var i = 0; i < commands.Count; i++)
+                for (var i = 0; i < _commands.Count; i++)
                 {
-                    var command = commands[i];
+                    var command = _commands[i];
 
                     var json = command.ToJson(_conventions, ctx);
 

--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -34,9 +34,38 @@ namespace Raven.Client.Documents.Commands.Batches
         }
     }
 
+    internal class SingleNodeBatchWithTrackingCommand : SingleNodeBatchCommand
+    {
+        private readonly BatchTrackChangesCommandData _trackChangesCommand;
+
+        public SingleNodeBatchWithTrackingCommand(DocumentConventions conventions,  IList<ICommandData> commands, BatchTrackChangesCommandData trackChangesCommand, 
+            BatchOptions options = null, TransactionMode mode = TransactionMode.SingleNode) : base(conventions, commands, options, mode)
+        {
+            _trackChangesCommand = trackChangesCommand;
+        }
+
+        protected override IList<ICommandData> Initialize(IList<ICommandData> commands)
+        {
+            if (_trackChangesCommand == null) 
+                return base.Initialize(commands);
+
+            var cmds = new List<ICommandData>{ _trackChangesCommand };
+            foreach (var command in commands)
+            {
+                HandlePutAttachmentCommandData(command);
+                cmds.Add(command);
+            }
+
+            _commandsAsJson = new BlittableJsonReaderObject[cmds.Count];
+
+            return cmds;
+
+        }
+    }
+
     public class SingleNodeBatchCommand : RavenCommand<BatchCommandResult>, IDisposable
     {
-        private readonly BlittableJsonReaderObject[] _commandsAsJson;
+        protected BlittableJsonReaderObject[] _commandsAsJson;
         private bool? _supportsAtomicWrites;
         private HashSet<Stream> _uniqueAttachmentStreams;
         private readonly DocumentConventions _conventions;
@@ -56,15 +85,21 @@ namespace Raven.Client.Documents.Commands.Batches
             _options = options;
             _mode = mode;
 
-            _commandsAsJson = new BlittableJsonReaderObject[_commands.Count];
+            Timeout = options?.RequestTimeout;
+        }
+
+        protected virtual IList<ICommandData> Initialize(IList<ICommandData> commands)
+        {
+            _commandsAsJson = new BlittableJsonReaderObject[commands.Count];
             foreach (var command in commands)
             {
                 HandlePutAttachmentCommandData(command);
             }
-            Timeout = options?.RequestTimeout;
+
+            return commands;
         }
 
-        private void HandlePutAttachmentCommandData(ICommandData command)
+        protected void HandlePutAttachmentCommandData(ICommandData command)
         {
             if (command is not PutAttachmentCommandData putAttachmentCommandData) 
                 return;
@@ -81,12 +116,16 @@ namespace Raven.Client.Documents.Commands.Batches
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
+            //TODO: egor the best would be to combine the loop in Initialize with if (_supportsAtomicWrites == null)
+            var commands = Initialize(_commands);
+
             if (_supportsAtomicWrites == null)
             {
                 _supportsAtomicWrites = node.SupportsAtomicClusterWrites;
-                for (var i = 0; i < _commands.Count; i++)
+
+                for (var i = 0; i < commands.Count; i++)
                 {
-                    var command = _commands[i];
+                    var command = commands[i];
 
                     var json = command.ToJson(_conventions, ctx);
 

--- a/src/Raven.Client/Documents/Commands/Batches/BatchTrackChangesCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchTrackChangesCommandData.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Extensions;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Commands.Batches
+{
+    internal sealed class BatchTrackChangesCommandData : ICommandData
+    {
+        internal readonly Dictionary<string, string> TrackedEntities;
+        public string Id => throw new NotSupportedException();
+        public string Name { get; } = null;
+        public string ChangeVector => throw new NotSupportedException();
+
+        public CommandType Type { get; } = CommandType.BatchTrackChanges;
+
+        public BatchTrackChangesCommandData(Dictionary<string, string> trackedEntities)
+        {
+            TrackedEntities = trackedEntities;
+        }
+
+        public DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
+        {
+            var json = new DynamicJsonValue
+            {
+                [nameof(Type)] = Type.ToString(),
+                [nameof(TrackedEntities)] = TrackedEntities.ToJson(),
+            };
+            return json;
+        }
+
+        public void OnBeforeSaveChanges(InMemoryDocumentSessionOperations session)
+        {
+            // this command does not update session state after SaveChanges call!
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Commands/Batches/ICommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/ICommandData.cs
@@ -49,6 +49,8 @@ namespace Raven.Client.Documents.Commands.Batches
         JsonPatch,
         ClientAnyCommand,
         ClientModifyDocumentCommand,
-        HeartBeat
+        HeartBeat,
+
+        BatchTrackChanges
     }
 }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -193,7 +193,7 @@ namespace Raven.Client.Documents.Session
                     if (command == null)
                         return;
 
-                    if (NoTracking)
+                    if (TrackingMode == TrackingMode.NoTracking)
                         throw new InvalidOperationException($"Cannot execute '{nameof(SaveChangesAsync)}' when entity tracking is disabled in session.");
 
                     await RequestExecutor.ExecuteAsync(command, Context, _sessionInfo, token).ConfigureAwait(false);

--- a/src/Raven.Client/Documents/Session/AsyncSessionDocumentCounters.cs
+++ b/src/Raven.Client/Documents/Session/AsyncSessionDocumentCounters.cs
@@ -58,7 +58,7 @@ namespace Raven.Client.Documents.Session
 
                 cache.Values[counter] = value;
 
-                if (Session.NoTracking == false)
+                if (Session.TrackingMode != TrackingMode.NoTracking)
                     Session.CountersByDocId[DocId] = cache;
 
                 return value;
@@ -114,7 +114,7 @@ namespace Raven.Client.Documents.Session
                     break;
                 }
 
-                if (Session.NoTracking == false)
+                if (Session.TrackingMode != TrackingMode.NoTracking)
                     Session.CountersByDocId[DocId] = cache;
 
                 return result;
@@ -174,7 +174,7 @@ namespace Raven.Client.Documents.Session
 
                 cache.GotAll = true;
 
-                if (Session.NoTracking == false)
+                if (Session.TrackingMode != TrackingMode.NoTracking)
                     Session.CountersByDocId[DocId] = cache;
 
                 return cache.Values;

--- a/src/Raven.Client/Documents/Session/AsyncSessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/AsyncSessionDocumentTimeSeries.cs
@@ -115,7 +115,7 @@ namespace Raven.Client.Documents.Session
             if (rangeResult == null)
                 return null;
 
-            if (Session.NoTracking == false)
+            if (Session.TrackingMode != TrackingMode.NoTracking)
             {
                 HandleIncludes(rangeResult);
 
@@ -286,7 +286,7 @@ namespace Raven.Client.Documents.Session
             var mergedValues = MergeRangesWithResults(from, to, ranges, fromRangeIndex, toRangeIndex,
                 resultFromServer: details.Values[Name], out var resultToUser);
 
-            if (Session.NoTracking == false)
+            if (Session.TrackingMode != TrackingMode.NoTracking)
             {
                 from = details.Values[Name].Min(ts => ts.From);
                 to = details.Values[Name].Max(ts => ts.To);

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -225,7 +225,7 @@ namespace Raven.Client.Documents.Session
         internal CompareExchangeSessionValue RegisterMissingCompareExchangeValue(string key)
         {
             var value = new CompareExchangeSessionValue(key, -1, CompareExchangeSessionValue.CompareExchangeValueState.Missing);
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
                 return value;
 
             _state.Add(key, value);
@@ -234,7 +234,7 @@ namespace Raven.Client.Documents.Session
 
         internal void RegisterCompareExchangeIncludes(BlittableJsonReaderObject values, bool includingMissingAtomicGuards)
         {
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (values != null)
@@ -272,7 +272,7 @@ namespace Raven.Client.Documents.Session
 
             AssertNotAtomicGuard(value);
 
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
                 return new CompareExchangeSessionValue(value);
 
             _compareExchangeIncludes.Remove(value.Key);
@@ -291,7 +291,7 @@ namespace Raven.Client.Documents.Session
 
             AssertNotAtomicGuard(value);
 
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
                 return;
 
             _compareExchangeIncludes[value.Key] = value;
@@ -301,7 +301,7 @@ namespace Raven.Client.Documents.Session
         {
             AssertNotAtomicGuard(key);
 
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
                 return;
             
             _compareExchangeIncludes[key] = new CompareExchangeValue<BlittableJsonReaderObject>(key, -1, null);

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -93,7 +93,7 @@ namespace Raven.Client.Documents.Session
                 if (command == null)
                     return;
 
-                if (NoTracking)
+                if (TrackingMode == TrackingMode.NoTracking)
                     throw new InvalidOperationException($"Cannot execute '{nameof(SaveChanges)}' when entity tracking is disabled in session.");
 
                 RequestExecutor.Execute(command, Context, sessionInfo: _sessionInfo);

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
@@ -38,6 +39,7 @@ namespace Raven.Client.Documents.Session
     /// <summary>
     /// Abstract implementation for in memory session operations
     /// </summary>
+    [SuppressMessage("ReSharper", "CanSimplifyDictionaryLookupWithTryAdd")]
     public abstract partial class InMemoryDocumentSessionOperations : IDisposable
     {
         internal long _asyncTasksCounter;
@@ -209,6 +211,7 @@ namespace Raven.Client.Documents.Session
             new Dictionary<(string, CommandType, string), ICommandData>();
 
         public readonly bool NoTracking;
+        public readonly TrackingMode TrackingMode;
 
         internal Dictionary<string, ForceRevisionStrategy> IdsForCreatingForcedRevisions = new Dictionary<string, ForceRevisionStrategy>(StringComparer.OrdinalIgnoreCase);
 
@@ -235,7 +238,10 @@ namespace Raven.Client.Documents.Session
             _documentStore = documentStore;
             _requestExecutor = options.RequestExecutor ?? documentStore.GetRequestExecutor(DatabaseName);
             _releaseOperationContext = _requestExecutor.ContextPool.AllocateOperationContext(out _context);
-            NoTracking = options.NoTracking;
+
+            //TODO: egor drop this NoTracking
+            NoTracking = options.TrackingMode == TrackingMode.NoTracking;
+            TrackingMode = options.TrackingMode;
             UseOptimisticConcurrency = _requestExecutor.Conventions.UseOptimisticConcurrency;
             MaxNumberOfRequestsPerSession = _requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
             GenerateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, entity => _requestExecutor.Conventions.GenerateDocumentIdAsync(DatabaseName, entity));
@@ -650,6 +656,20 @@ more responsive application.
 
             _knownMissingIds.Add(id);
             changeVector = UseOptimisticConcurrency ? changeVector : null;
+
+            if (TrackingMode == TrackingMode.TrackAllEntities)
+            {
+                if (string.IsNullOrEmpty(documentInfo.ChangeVector) == false) // this is tracked in session
+                {
+                    _trackedEntities.Add(id, documentInfo.ChangeVector);
+                }
+                else
+                {
+                    // we are not checking it since this entity is not in session
+                    _trackedEntities.Add(id, null);
+                }
+            }
+
             _countersByDocId?.Remove(id);
             Defer(new DeleteCommandData(id, expectedChangeVector ?? changeVector, expectedChangeVector ?? documentInfo?.ChangeVector));
         }
@@ -858,6 +878,11 @@ more responsive application.
             foreach (var deferredCommand in result.DeferredCommands)
                 deferredCommand.OnBeforeSaveChanges(this);
 
+            if (TrackingMode == TrackingMode.TrackAllEntities)
+            {
+                PrepareForEntitiesTrack(result);
+            }
+
             return result;
         }
 
@@ -1027,6 +1052,8 @@ more responsive application.
                 result.OnSuccess.ClearDeletedEntities();
         }
 
+        private readonly Dictionary<string, string> _trackedEntities = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
         private void PrepareForEntitiesPuts(SaveChangesData result)
         {
             using (DocumentsByEntity.PrepareEntitiesPuts())
@@ -1041,6 +1068,11 @@ more responsive application.
                     {
                         if (shouldIgnoreEntityChanges(this, entity.Value.Entity, entity.Value.Id))
                             continue;
+                    }
+
+                    if (TrackingMode == TrackingMode.TrackAllEntities)
+                    {
+                        _trackedEntities.Add(entity.Value.Id, entity.Value.ChangeVector);
                     }
 
                     if (IsDeleted(entity.Value.Id))
@@ -1122,6 +1154,32 @@ more responsive application.
                     }
 
                     result.SessionCommands.Add(new PutCommandDataWithBlittableJson(entity.Value.Id, changeVector, entity.Value.ChangeVector, document, forceRevisionCreationStrategy));
+                }
+            }
+        }
+
+        private void PrepareForEntitiesTrack(SaveChangesData result)
+        {
+            if (result.SessionCommands.Count > 0 || result.DeferredCommands.Count > 0)
+            {
+                if (_trackedEntities.Any() || _knownMissingIds.Any())
+                {
+                    var batchTrackingEntities = new Dictionary<string, string>(_trackedEntities, StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var id in _knownMissingIds)
+                    {
+                        if (batchTrackingEntities.TryGetValue(id, out var cv) == false)
+                        {
+                            batchTrackingEntities.Add(id, string.Empty);
+                        }
+                        else if (cv == null)
+                        {
+                            // this is when we delete by id a document that is not tracked in session
+                            batchTrackingEntities.Remove(id);
+                        }
+                    }
+
+                    result.TrackChangesCommandData = new BatchTrackChangesCommandData(batchTrackingEntities);
                 }
             }
         }
@@ -2382,6 +2440,7 @@ more responsive application.
             public readonly List<ICommandData> DeferredCommands;
             public readonly Dictionary<(string, CommandType, string), ICommandData> DeferredCommandsDictionary;
             public readonly List<ICommandData> SessionCommands = new List<ICommandData>();
+            public BatchTrackChangesCommandData TrackChangesCommandData;
             public readonly List<object> Entities = new List<object>();
             public readonly BatchOptions Options;
             internal readonly ActionsToRunOnSuccess OnSuccess;
@@ -2466,7 +2525,8 @@ more responsive application.
 
         protected void UpdateSessionAfterSaveChanges(BatchCommandResult result)
         {
-            var returnedTransactionIndex = result.TransactionIndex;
+            _trackedEntities.Clear();
+             var returnedTransactionIndex = result.TransactionIndex;
             _documentStore.SetLastTransactionIndex(DatabaseName, returnedTransactionIndex);
             _sessionInfo.LastClusterTransactionIndex = returnedTransactionIndex;
         }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -90,6 +90,7 @@ namespace Raven.Client.Documents.Session
         /// Entities whose id we already know do not exists, because they are a missing include, or a missing load, etc.
         /// </summary>
         internal readonly KnownMissingIdsHolder _knownMissingIds;
+
         private Dictionary<string, object> _externalState;
 
         public IDictionary<string, object> ExternalState => _externalState ??= new Dictionary<string, object>();
@@ -130,8 +131,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         internal readonly DeletedEntitiesHolder DeletedEntities = new DeletedEntitiesHolder();
 
-        internal readonly TrackedEntitiesHolder TrackedEntities ;
-
+        internal readonly TrackedEntitiesHolder TrackedEntities;
 
         /// <summary>
         /// hold the data required to manage Counters tracking for RavenDB's Unit of Work
@@ -240,7 +240,6 @@ namespace Raven.Client.Documents.Session
             _requestExecutor = options.RequestExecutor ?? documentStore.GetRequestExecutor(DatabaseName);
             _releaseOperationContext = _requestExecutor.ContextPool.AllocateOperationContext(out _context);
 
-            //TODO: egor drop this NoTracking
             NoTracking = options.TrackingMode == TrackingMode.NoTracking;
             TrackingMode = options.TrackingMode;
 
@@ -2904,18 +2903,16 @@ more responsive application.
     {
         private readonly Dictionary<string, string> _trackedEntities = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly TrackingMode TrackingMode;
-
-        private bool ShouldTrack => TrackingMode == TrackingMode.TrackAllEntities;
+        private readonly bool _shouldTrack;
 
         public TrackedEntitiesHolder(TrackingMode trackingMode)
         {
-            TrackingMode = trackingMode;
+            _shouldTrack = trackingMode == TrackingMode.TrackAllEntities;
         }
 
         public bool Any()
         {
-            if (ShouldTrack)
+            if (_shouldTrack)
                 return _trackedEntities.Any();
 
             return false;
@@ -2923,13 +2920,13 @@ more responsive application.
 
         public void TryRemove(string id)
         {
-            if (ShouldTrack)
+            if (_shouldTrack)
                 _trackedEntities.Remove(id);
         }
 
         public void TryAdd(string entity, string cv)
         {
-            if (ShouldTrack && _trackedEntities.ContainsKey(entity) == false)
+            if (_shouldTrack && _trackedEntities.ContainsKey(entity) == false)
             {
                 _trackedEntities[entity] = cv;
             }
@@ -2937,7 +2934,7 @@ more responsive application.
 
         public void Clear()
         {
-            if (ShouldTrack)
+            if (_shouldTrack)
                 _trackedEntities.Clear();
         }
 
@@ -2945,7 +2942,7 @@ more responsive application.
         {
             cv = null;
 
-            if (ShouldTrack == false)
+            if (_shouldTrack == false)
                 return false;
 
             if (_trackedEntities.TryGetValue(id, out cv))
@@ -2969,7 +2966,7 @@ more responsive application.
         {
             set
             {
-                if (ShouldTrack)
+                if (_shouldTrack)
                     _trackedEntities[id] = value;
 
             }
@@ -2991,7 +2988,6 @@ more responsive application.
 
         private readonly TrackedEntitiesHolder _trackedEntities;
 
-
         public KnownMissingIdsHolder(TrackedEntitiesHolder trackedEntities)
         {
             _trackedEntities = trackedEntities;
@@ -3004,8 +3000,9 @@ more responsive application.
 
         public bool Any()
         {
-                return _knownMissingIds.Any();
+            return _knownMissingIds.Any();
         }
+
         public bool Contains(string id)
         {
             return _knownMissingIds.Contains(id);

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -132,6 +132,9 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         internal readonly DeletedEntitiesHolder DeletedEntities = new DeletedEntitiesHolder();
 
+        internal readonly TrackedEntitiesHolder TrackedEntities ;
+
+
         /// <summary>
         /// hold the data required to manage Counters tracking for RavenDB's Unit of Work
         /// </summary>
@@ -242,6 +245,7 @@ namespace Raven.Client.Documents.Session
             //TODO: egor drop this NoTracking
             NoTracking = options.TrackingMode == TrackingMode.NoTracking;
             TrackingMode = options.TrackingMode;
+            TrackedEntities = new TrackedEntitiesHolder(options.TrackingMode);
             UseOptimisticConcurrency = _requestExecutor.Conventions.UseOptimisticConcurrency;
             MaxNumberOfRequestsPerSession = _requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
             GenerateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, entity => _requestExecutor.Conventions.GenerateDocumentIdAsync(DatabaseName, entity));
@@ -508,6 +512,7 @@ more responsive application.
             DocumentsByEntity.Add(info.Entity, info);
             DocumentsById.Add(info);
             IncludedDocumentsById.Remove(info.Id);
+            TrackedEntities.TryAdd(info.Id, info.ChangeVector);
         }
 
         /// <summary>
@@ -539,6 +544,7 @@ more responsive application.
                 {
                     IncludedDocumentsById.Remove(id);
                     DocumentsByEntity[docInfo.Entity] = docInfo;
+                    TrackedEntities[id] = docInfo.ChangeVector;
                 }
                 OnAfterConversionToEntityInvoke(id, docInfo.Document, docInfo.Entity);
 
@@ -555,6 +561,8 @@ more responsive application.
                     IncludedDocumentsById.Remove(id);
                     DocumentsById.Add(docInfo);
                     DocumentsByEntity[docInfo.Entity] = docInfo;
+                    TrackedEntities[id] = docInfo.ChangeVector;
+
                 }
                 OnAfterConversionToEntityInvoke(id, docInfo.Document, docInfo.Entity);
 
@@ -579,6 +587,8 @@ more responsive application.
 
                 DocumentsById.Add(newDocumentInfo);
                 DocumentsByEntity[entity] = newDocumentInfo;
+                TrackedEntities[id] = newDocumentInfo.ChangeVector;
+
             }
             OnAfterConversionToEntityInvoke(id, document, entity);
 
@@ -613,7 +623,7 @@ more responsive application.
             DeletedEntities.Add(entity);
             IncludedDocumentsById.Remove(value.Id);
             _countersByDocId?.Remove(value.Id);
-            _knownMissingIds.Add(value.Id);
+            _knownMissingIds.Add(value.Id); // TODO: egor this should handle the case I remove item that was modified in another session 
         }
 
         /// <summary>
@@ -657,17 +667,14 @@ more responsive application.
             _knownMissingIds.Add(id);
             changeVector = UseOptimisticConcurrency ? changeVector : null;
 
-            if (TrackingMode == TrackingMode.TrackAllEntities)
+            if (string.IsNullOrEmpty(documentInfo.ChangeVector) == false) // this is tracked in session
             {
-                if (string.IsNullOrEmpty(documentInfo.ChangeVector) == false) // this is tracked in session
-                {
-                    _trackedEntities.Add(id, documentInfo.ChangeVector);
-                }
-                else
-                {
-                    // we are not checking it since this entity is not in session
-                    _trackedEntities.Add(id, null);
-                }
+                TrackedEntities.TryAdd(id, documentInfo.ChangeVector);
+            }
+            else
+            {
+                // we are not checking it since this entity is not in session
+                TrackedEntities.TryAdd(id, null);
             }
 
             _countersByDocId?.Remove(id);
@@ -840,6 +847,7 @@ more responsive application.
             DocumentsByEntity.Add(entity, documentInfo);
             if (id != null)
                 DocumentsById.Add(documentInfo);
+            TrackedEntities.TryAdd(id, changeVector);
         }
 
         protected void AssertNoNonUniqueInstance(object entity, string id)
@@ -878,10 +886,7 @@ more responsive application.
             foreach (var deferredCommand in result.DeferredCommands)
                 deferredCommand.OnBeforeSaveChanges(this);
 
-            if (TrackingMode == TrackingMode.TrackAllEntities)
-            {
-                PrepareForEntitiesTrack(result);
-            }
+            PrepareForEntitiesTrack(result);
 
             return result;
         }
@@ -1052,8 +1057,6 @@ more responsive application.
                 result.OnSuccess.ClearDeletedEntities();
         }
 
-        private readonly Dictionary<string, string> _trackedEntities = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
         private void PrepareForEntitiesPuts(SaveChangesData result)
         {
             using (DocumentsByEntity.PrepareEntitiesPuts())
@@ -1068,11 +1071,6 @@ more responsive application.
                     {
                         if (shouldIgnoreEntityChanges(this, entity.Value.Entity, entity.Value.Id))
                             continue;
-                    }
-
-                    if (TrackingMode == TrackingMode.TrackAllEntities)
-                    {
-                        _trackedEntities.Add(entity.Value.Id, entity.Value.ChangeVector);
                     }
 
                     if (IsDeleted(entity.Value.Id))
@@ -1160,27 +1158,33 @@ more responsive application.
 
         private void PrepareForEntitiesTrack(SaveChangesData result)
         {
-            if (result.SessionCommands.Count > 0 || result.DeferredCommands.Count > 0)
+            if (TrackingMode.TrackAllEntities == TrackingMode)
             {
-                if (_trackedEntities.Any() || _knownMissingIds.Any())
-                {
-                    var batchTrackingEntities = new Dictionary<string, string>(_trackedEntities, StringComparer.OrdinalIgnoreCase);
-
-                    foreach (var id in _knownMissingIds)
+                // TODO: egor 322 I have removed this check because we need to track changes even if there are no session commands,
+                
+                //if (result.SessionCommands.Count > 0 || result.DeferredCommands.Count > 0)
+                //{
+                if (TrackedEntities.Any() || _knownMissingIds.Any())
                     {
-                        if (batchTrackingEntities.TryGetValue(id, out var cv) == false)
-                        {
-                            batchTrackingEntities.Add(id, string.Empty);
-                        }
-                        else if (cv == null)
-                        {
-                            // this is when we delete by id a document that is not tracked in session
-                            batchTrackingEntities.Remove(id);
-                        }
-                    }
+                        var batchTrackingEntities = new Dictionary<string, string>(TrackedEntities.ToDictionary(), StringComparer.OrdinalIgnoreCase);
 
-                    result.TrackChangesCommandData = new BatchTrackChangesCommandData(batchTrackingEntities);
-                }
+                        foreach (var id in _knownMissingIds)
+                        {
+                            if (batchTrackingEntities.TryGetValue(id, out var cv) == false)
+                            {
+                                batchTrackingEntities.Add(id, string.Empty);
+                            }
+                            else if (cv == null)
+                            {
+                                // this is when we delete by id a document that is not tracked in session
+                                batchTrackingEntities.Remove(id);
+                            }
+                        }
+
+                        result.TrackChangesCommandData = new BatchTrackChangesCommandData(batchTrackingEntities);
+                        result.SessionCommands.Insert(0, result.TrackChangesCommandData);
+                    }
+                //}
             }
         }
 
@@ -1385,6 +1389,7 @@ more responsive application.
                 DocumentsById.Remove(documentInfo.Id);
                 _countersByDocId?.Remove(documentInfo.Id);
                 _timeSeriesByDocId?.Remove(documentInfo.Id);
+                TrackedEntities.TryRemove(documentInfo.Id);
 
                 documentInfo.Dispose();
             }
@@ -1409,6 +1414,7 @@ more responsive application.
             ClearClusterSession();
             PendingLazyOperations.Clear();
             JsonConverter.Clear();
+            TrackedEntities.Clear();
         }
 
         /// <summary>
@@ -2404,6 +2410,8 @@ more responsive application.
             if (DocumentsById.TryGetValue(documentInfo.Id, out DocumentInfo documentInfoById))
                 documentInfoById.Entity = entity;
 
+            TrackedEntities.TryUpdate(documentInfo.Id, documentInfo.ChangeVector);
+
             OnAfterConversionToEntityInvoke(documentInfo.Id, documentInfo.Document, documentInfo.Entity);
         }
 
@@ -2525,7 +2533,6 @@ more responsive application.
 
         protected void UpdateSessionAfterSaveChanges(BatchCommandResult result)
         {
-            _trackedEntities.Clear();
              var returnedTransactionIndex = result.TransactionIndex;
             _documentStore.SetLastTransactionIndex(DatabaseName, returnedTransactionIndex);
             _sessionInfo.LastClusterTransactionIndex = returnedTransactionIndex;
@@ -2927,4 +2934,86 @@ more responsive application.
             public bool ExecuteOnBeforeDelete { get; set; }
         }
     }
+
+    internal sealed class TrackedEntitiesHolder
+    {
+        private readonly Dictionary<string, string> _trackedEntities = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly TrackingMode TrackingMode;
+
+        private bool ShouldTrack => TrackingMode == TrackingMode.TrackAllEntities;
+
+        public TrackedEntitiesHolder(TrackingMode trackingMode)
+        {
+            TrackingMode = trackingMode;
+        }
+
+        public Dictionary<string, string> ToDictionary()
+        {
+            return _trackedEntities;
+        }
+
+        public bool Any()
+        {
+            if (ShouldTrack)
+                return _trackedEntities.Any();
+
+            return false;
+        }
+
+        public void TryRemove(string id)
+        {
+            if (ShouldTrack)
+                _trackedEntities.Remove(id);
+        }
+
+        public void TryAdd(string entity, string cv)
+        {
+            if (ShouldTrack && _trackedEntities.ContainsKey(entity) == false)
+            {
+                _trackedEntities[entity] = cv;
+            }
+        }
+
+        public void Clear()
+        {
+            if (ShouldTrack)
+                _trackedEntities.Clear();
+        }
+
+        public bool TryGetValue(string id, out string cv)
+        {
+            cv = null;
+
+            if (ShouldTrack == false)
+                return false;
+
+            if (_trackedEntities.TryGetValue(id, out cv))
+                return true;
+
+            return false;
+        }
+
+
+        public bool TryUpdate(string id, string cv)
+        {
+            if (TryGetValue(id, out _) == false)
+                return false;
+
+            _trackedEntities[id] = cv;
+            return true;
+
+        }
+
+        public string this[string id]
+        {
+            set
+            {
+                if (ShouldTrack)
+                    _trackedEntities[id] = value;
+
+            }
+        }
+    }
+
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.IO;
 using System.Linq;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -211,7 +211,6 @@ namespace Raven.Client.Documents.Session
         protected internal readonly Dictionary<(string, CommandType, string), ICommandData> DeferredCommandsDictionary =
             new Dictionary<(string, CommandType, string), ICommandData>();
 
-        public readonly bool NoTracking;
         public readonly TrackingMode TrackingMode;
 
         internal Dictionary<string, ForceRevisionStrategy> IdsForCreatingForcedRevisions = new Dictionary<string, ForceRevisionStrategy>(StringComparer.OrdinalIgnoreCase);
@@ -240,7 +239,6 @@ namespace Raven.Client.Documents.Session
             _requestExecutor = options.RequestExecutor ?? documentStore.GetRequestExecutor(DatabaseName);
             _releaseOperationContext = _requestExecutor.ContextPool.AllocateOperationContext(out _context);
 
-            NoTracking = options.TrackingMode == TrackingMode.NoTracking;
             TrackingMode = options.TrackingMode;
 
             TrackedEntities = new TrackedEntitiesHolder(options.TrackingMode);
@@ -489,12 +487,12 @@ more responsive application.
         /// <returns></returns>
         private object TrackEntity(Type entityType, DocumentInfo documentFound)
         {
-            return TrackEntity(entityType, documentFound.Id, documentFound.Document, documentFound.Metadata, noTracking: NoTracking);
+            return TrackEntity(entityType, documentFound.Id, documentFound.Document, documentFound.Metadata, noTracking: TrackingMode == TrackingMode.NoTracking);
         }
 
         internal void RegisterExternalLoadedIntoTheSession(DocumentInfo info)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (DocumentsById.TryGetValue(info.Id, out var existing))
@@ -526,7 +524,7 @@ more responsive application.
         /// <returns></returns>
         private object TrackEntity(Type entityType, string id, BlittableJsonReaderObject document, BlittableJsonReaderObject metadata, bool noTracking)
         {
-            noTracking = NoTracking || noTracking; // if noTracking is session-wide then we want to override the passed argument
+            noTracking = TrackingMode == TrackingMode.NoTracking || noTracking; // if noTracking is session-wide then we want to override the passed argument
 
             if (string.IsNullOrEmpty(id))
             {
@@ -703,7 +701,7 @@ more responsive application.
 
         private void StoreInternal(object entity, string changeVector, string id, ConcurrencyCheckMode forceConcurrencyCheck)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 throw new InvalidOperationException("Cannot store entity. Entity tracking is disabled in this session.");
 
             if (entity == null)
@@ -1498,7 +1496,7 @@ more responsive application.
 
         public void RegisterMissing(string id)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             _knownMissingIds.Add(id);
@@ -1506,7 +1504,7 @@ more responsive application.
 
         public void RegisterMissing(IEnumerable<string> ids)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             _knownMissingIds.UnionWith(ids);
@@ -1514,7 +1512,7 @@ more responsive application.
 
         internal void RegisterIncludes(BlittableJsonReaderObject includes, bool registerMissingIds = false)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (includes == null)
@@ -1544,7 +1542,7 @@ more responsive application.
 
         internal void RegisterRevisionIncludes(BlittableJsonReaderArray revisionIncludes)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (revisionIncludes == null)
@@ -1576,7 +1574,7 @@ more responsive application.
 
         public void RegisterMissingIncludes(BlittableJsonReaderArray results, BlittableJsonReaderObject includes, ICollection<string> includePaths)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (includePaths == null || includePaths.Count == 0)
@@ -1612,7 +1610,7 @@ more responsive application.
 
         internal void RegisterCounters(BlittableJsonReaderObject resultCounters, string[] ids, string[] countersToInclude, bool gotAll)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (resultCounters == null || resultCounters.Count == 0)
@@ -1637,7 +1635,7 @@ more responsive application.
 
         internal void RegisterCounters(BlittableJsonReaderObject resultCounters, Dictionary<string, string[]> countersToInclude)
         {
-            if (NoTracking)
+            if (TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (resultCounters == null || resultCounters.Count == 0)
@@ -1797,7 +1795,7 @@ more responsive application.
 
         internal void RegisterTimeSeries(BlittableJsonReaderObject resultTimeSeries)
         {
-            if (NoTracking || resultTimeSeries == null)
+            if (TrackingMode == TrackingMode.NoTracking || resultTimeSeries == null)
                 return;
 
             var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
@@ -2353,10 +2351,10 @@ more responsive application.
                 documentInfo.ChangeVector = (LazyStringValue)changeVector;
             }
 
-            if (documentInfo.Entity != null && NoTracking == false)
+            if (documentInfo.Entity != null && TrackingMode != TrackingMode.NoTracking)
                 JsonConverter.RemoveFromMissing(documentInfo.Entity);
 
-            documentInfo.Entity = JsonConverter.FromBlittable<T>(ref document, documentInfo.Id, NoTracking == false);
+            documentInfo.Entity = JsonConverter.FromBlittable<T>(ref document, documentInfo.Id, TrackingMode != TrackingMode.NoTracking);
             documentInfo.Document = document;
 
             var type = entity.GetType();
@@ -2658,7 +2656,7 @@ more responsive application.
 
         internal void AssertNoIncludesInNonTrackingSession()
         {
-            if (NoTracking == false)
+            if (TrackingMode != TrackingMode.NoTracking)
                 return;
 
             throw new InvalidOperationException(

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -39,7 +39,6 @@ namespace Raven.Client.Documents.Session
     /// <summary>
     /// Abstract implementation for in memory session operations
     /// </summary>
-    [SuppressMessage("ReSharper", "CanSimplifyDictionaryLookupWithTryAdd")]
     public abstract partial class InMemoryDocumentSessionOperations : IDisposable
     {
         internal long _asyncTasksCounter;
@@ -90,8 +89,7 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         /// Entities whose id we already know do not exists, because they are a missing include, or a missing load, etc.
         /// </summary>
-        protected readonly HashSet<string> _knownMissingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
+        internal readonly KnownMissingIdsHolder _knownMissingIds;
         private Dictionary<string, object> _externalState;
 
         public IDictionary<string, object> ExternalState => _externalState ??= new Dictionary<string, object>();
@@ -245,7 +243,10 @@ namespace Raven.Client.Documents.Session
             //TODO: egor drop this NoTracking
             NoTracking = options.TrackingMode == TrackingMode.NoTracking;
             TrackingMode = options.TrackingMode;
+
             TrackedEntities = new TrackedEntitiesHolder(options.TrackingMode);
+            _knownMissingIds = new KnownMissingIdsHolder(TrackedEntities);
+
             UseOptimisticConcurrency = _requestExecutor.Conventions.UseOptimisticConcurrency;
             MaxNumberOfRequestsPerSession = _requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
             GenerateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, entity => _requestExecutor.Conventions.GenerateDocumentIdAsync(DatabaseName, entity));
@@ -623,7 +624,7 @@ more responsive application.
             DeletedEntities.Add(entity);
             IncludedDocumentsById.Remove(value.Id);
             _countersByDocId?.Remove(value.Id);
-            _knownMissingIds.Add(value.Id); // TODO: egor this should handle the case I remove item that was modified in another session 
+            _knownMissingIds.AddWithTracking(value.Id, value.ChangeVector);
         }
 
         /// <summary>
@@ -662,20 +663,15 @@ more responsive application.
                         DocumentsById.Remove(id);
                     }
                 }
-            }
 
-            _knownMissingIds.Add(id);
-            changeVector = UseOptimisticConcurrency ? changeVector : null;
-
-            if (string.IsNullOrEmpty(documentInfo.ChangeVector) == false) // this is tracked in session
-            {
-                TrackedEntities.TryAdd(id, documentInfo.ChangeVector);
+                _knownMissingIds.AddWithTracking(id, changeVector);
             }
             else
             {
-                // we are not checking it since this entity is not in session
-                TrackedEntities.TryAdd(id, null);
+                _knownMissingIds.AddWithoutTracking(id);
             }
+
+            changeVector = UseOptimisticConcurrency ? changeVector : null;
 
             _countersByDocId?.Remove(id);
             Defer(new DeleteCommandData(id, expectedChangeVector ?? changeVector, expectedChangeVector ?? documentInfo?.ChangeVector));
@@ -886,7 +882,7 @@ more responsive application.
             foreach (var deferredCommand in result.DeferredCommands)
                 deferredCommand.OnBeforeSaveChanges(this);
 
-            PrepareForEntitiesTrack(result);
+            TrackedEntities.PrepareForEntitiesTrack(result);
 
             return result;
         }
@@ -1153,38 +1149,6 @@ more responsive application.
 
                     result.SessionCommands.Add(new PutCommandDataWithBlittableJson(entity.Value.Id, changeVector, entity.Value.ChangeVector, document, forceRevisionCreationStrategy));
                 }
-            }
-        }
-
-        private void PrepareForEntitiesTrack(SaveChangesData result)
-        {
-            if (TrackingMode.TrackAllEntities == TrackingMode)
-            {
-                // TODO: egor 322 I have removed this check because we need to track changes even if there are no session commands,
-                
-                //if (result.SessionCommands.Count > 0 || result.DeferredCommands.Count > 0)
-                //{
-                if (TrackedEntities.Any() || _knownMissingIds.Any())
-                    {
-                        var batchTrackingEntities = new Dictionary<string, string>(TrackedEntities.ToDictionary(), StringComparer.OrdinalIgnoreCase);
-
-                        foreach (var id in _knownMissingIds)
-                        {
-                            if (batchTrackingEntities.TryGetValue(id, out var cv) == false)
-                            {
-                                batchTrackingEntities.Add(id, string.Empty);
-                            }
-                            else if (cv == null)
-                            {
-                                // this is when we delete by id a document that is not tracked in session
-                                batchTrackingEntities.Remove(id);
-                            }
-                        }
-
-                        result.TrackChangesCommandData = new BatchTrackChangesCommandData(batchTrackingEntities);
-                        result.SessionCommands.Insert(0, result.TrackChangesCommandData);
-                    }
-                //}
             }
         }
 
@@ -1575,6 +1539,7 @@ more responsive application.
                     continue;
 
                 IncludedDocumentsById[newDocumentInfo.Id] = newDocumentInfo;
+                TrackedEntities.TryAdd(newDocumentInfo.Id, newDocumentInfo.ChangeVector);
             }
         }
 
@@ -2935,7 +2900,7 @@ more responsive application.
         }
     }
 
-    internal sealed class TrackedEntitiesHolder
+    internal sealed class TrackedEntitiesHolder 
     {
         private readonly Dictionary<string, string> _trackedEntities = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -2946,11 +2911,6 @@ more responsive application.
         public TrackedEntitiesHolder(TrackingMode trackingMode)
         {
             TrackingMode = trackingMode;
-        }
-
-        public Dictionary<string, string> ToDictionary()
-        {
-            return _trackedEntities;
         }
 
         public bool Any()
@@ -3014,6 +2974,77 @@ more responsive application.
 
             }
         }
+
+        public void PrepareForEntitiesTrack(InMemoryDocumentSessionOperations.SaveChangesData result)
+        {
+            if (Any() == false) 
+                return;
+
+            result.TrackChangesCommandData = new BatchTrackChangesCommandData(_trackedEntities);
+            result.SessionCommands.Insert(0, result.TrackChangesCommandData);
+        }
     }
 
+    internal sealed class KnownMissingIdsHolder
+    {
+        private readonly HashSet<string> _knownMissingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private readonly TrackedEntitiesHolder _trackedEntities;
+
+
+        public KnownMissingIdsHolder(TrackedEntitiesHolder trackedEntities)
+        {
+            _trackedEntities = trackedEntities;
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return _knownMissingIds.GetEnumerator();
+        }
+
+        public bool Any()
+        {
+                return _knownMissingIds.Any();
+        }
+        public bool Contains(string id)
+        {
+            return _knownMissingIds.Contains(id);
+        }
+
+        public void Remove(string id)
+        {
+            _knownMissingIds.Remove(id);
+        }
+
+        public bool Add(string id)
+        {
+            _trackedEntities.TryAdd(id, string.Empty);
+            return _knownMissingIds.Add(id);
+        }
+
+        public void UnionWith(IEnumerable<string> ids)
+        {
+            foreach (var id in ids)
+            {
+                Add(id);
+            }
+        }
+
+        public void Clear()
+        {
+            _knownMissingIds.Clear();
+        }
+
+        public bool AddWithTracking(string id, string cv)
+        {
+            _trackedEntities.TryUpdate(id, cv);
+            return _knownMissingIds.Add(id);
+        }
+
+        public bool AddWithoutTracking(string id )
+        {
+            _trackedEntities.TryRemove(id);
+            return _knownMissingIds.Add(id);
+        }
+    }
 }

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -55,7 +55,7 @@ namespace Raven.Client.Documents.Session.Operations
                     _session.DisableAtomicDocumentWritesInClusterWideTransaction);
             }
 
-            return new SingleNodeBatchWithTrackingCommand(_session.Conventions, result.SessionCommands, result.TrackChangesCommandData, result.Options);
+            return new SingleNodeBatchCommand(_session.Conventions, result.SessionCommands, result.Options);
 
         }
 
@@ -475,6 +475,7 @@ namespace Raven.Client.Documents.Session.Operations
             using (documentInfo)
             {
                 _session.DocumentsById.Remove(id);
+                _session.TrackedEntities.TryRemove(id);
 
                 if (documentInfo.Entity != null)
                 {
@@ -555,9 +556,11 @@ namespace Raven.Client.Documents.Session.Operations
 
                 documentInfo.Metadata.Modifications[propertyName] = batchResult[propertyName];
             }
-
+            //TODO: egor check if we can use docInfo in _trackedEntities so the obj is tracked
             documentInfo.Id = id;
             documentInfo.ChangeVector = changeVector;
+       
+            _session.TrackedEntities.TryUpdate(id, changeVector);
 
             ApplyMetadataModifications(id, documentInfo);
         }

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -55,22 +55,12 @@ namespace Raven.Client.Documents.Session.Operations
                     _session.DisableAtomicDocumentWritesInClusterWideTransaction);
             }
 
-            return new SingleNodeBatchCommand(_session.Conventions, result.SessionCommands, result.Options);
+            return new SingleNodeBatchWithTrackingCommand(_session.Conventions, result.SessionCommands, result.TrackChangesCommandData, result.Options);
+
         }
 
         public void SetResult(BatchCommandResult result)
         {
-            CommandType GetCommandType(BlittableJsonReaderObject batchResult)
-            {
-                if (batchResult.TryGet(nameof(ICommandData.Type), out string typeAsString) == false)
-                    return CommandType.None;
-
-                if (Enum.TryParse(typeAsString, ignoreCase: true, out CommandType type) == false)
-                    return CommandType.None;
-
-                return type;
-            }
-
             if (result.Results == null) //precaution
             {
                 ThrowOnNullResults();
@@ -86,34 +76,13 @@ namespace Raven.Client.Documents.Session.Operations
                         $"Cluster transaction was send to a node that is not supporting it. So it was executed ONLY on the requested node on {_session.RequestExecutor.Url}.");
             }
 
-            for (var i = 0; i < _sessionCommandsCount; i++)
+            if (result.Results[0] is BlittableJsonReaderObject blittableJsonReaderObject && GetCommandType(blittableJsonReaderObject) == CommandType.BatchTrackChanges)
             {
-                var batchResult = result.Results[i] as BlittableJsonReaderObject;
-                if (batchResult == null)
-                    continue;
-
-                var type = GetCommandType(batchResult);
-
-                switch (type)
-                {
-                    case CommandType.PUT:
-                        HandlePut(i, batchResult, isDeferred: false);
-                        break;
-                    case CommandType.ForceRevisionCreation:
-                        HandleForceRevisionCreation(batchResult);
-                        break;
-                    case CommandType.DELETE:
-                        HandleDelete(batchResult);
-                        break;
-                    case CommandType.CompareExchangePUT:
-                        HandleCompareExchangePut(batchResult);
-                        break;
-                    case CommandType.CompareExchangeDELETE:
-                        HandleCompareExchangeDelete(batchResult);
-                        break;
-                    default:
-                        throw new NotSupportedException($"Command '{type}' is not supported.");
-                }
+                HandleBatchOperationResult(start: 1, result);
+            }
+            else
+            {
+                HandleBatchOperationResult(start: 0, result);
             }
 
             for (var i = _sessionCommandsCount; i < _allCommandsCount; i++)
@@ -171,6 +140,51 @@ namespace Raven.Client.Documents.Session.Operations
             }
 
             FinalizeResult();
+        }
+
+        private void HandleBatchOperationResult(int start, BatchCommandResult result)
+        {
+            for (var i = start; i < _sessionCommandsCount; i++)
+            {
+                var batchResult = result.Results[i] as BlittableJsonReaderObject;
+                if (batchResult == null)
+                    continue;
+
+                var type = GetCommandType(batchResult);
+
+                switch (type)
+                {
+                    case CommandType.PUT:
+                        HandlePut(i - start, batchResult, isDeferred: false);
+                        break;
+                    case CommandType.ForceRevisionCreation:
+                        HandleForceRevisionCreation(batchResult);
+                        break;
+                    case CommandType.DELETE:
+                        HandleDelete(batchResult);
+                        break;
+                    case CommandType.CompareExchangePUT:
+                        HandleCompareExchangePut(batchResult);
+                        break;
+                    case CommandType.CompareExchangeDELETE:
+                        HandleCompareExchangeDelete(batchResult);
+                        break;
+       
+                    default:
+                        throw new NotSupportedException($"Command '{type}' is not supported.");
+                }
+            }
+        }
+
+        private CommandType GetCommandType(BlittableJsonReaderObject batchResult)
+        {
+            if (batchResult.TryGet(nameof(ICommandData.Type), out string typeAsString) == false)
+                return CommandType.None;
+
+            if (Enum.TryParse(typeAsString, ignoreCase: true, out CommandType type) == false)
+                return CommandType.None;
+
+            return type;
         }
 
         private void FinalizeResult()

--- a/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/BatchOperation.cs
@@ -76,103 +76,109 @@ namespace Raven.Client.Documents.Session.Operations
                         $"Cluster transaction was send to a node that is not supporting it. So it was executed ONLY on the requested node on {_session.RequestExecutor.Url}.");
             }
 
-            if (result.Results[0] is BlittableJsonReaderObject blittableJsonReaderObject && GetCommandType(blittableJsonReaderObject) == CommandType.BatchTrackChanges)
-            {
-                HandleBatchOperationResult(start: 1, result);
-            }
-            else
-            {
-                HandleBatchOperationResult(start: 0, result);
-            }
-
-            for (var i = _sessionCommandsCount; i < _allCommandsCount; i++)
-            {
-                var batchResult = result.Results[i] as BlittableJsonReaderObject;
-                if (batchResult == null)
-                    continue;
-
-                var type = GetCommandType(batchResult);
-
-                switch (type)
-                {
-                    case CommandType.PUT:
-                        HandlePut(i, batchResult, isDeferred: true);
-                        break;
-                    case CommandType.DELETE:
-                        HandleDelete(batchResult);
-                        break;
-                    case CommandType.PATCH:
-                        HandlePatch(batchResult);
-                        break;
-                    case CommandType.JsonPatch:
-                        HandleJsonPatch(batchResult);
-                        break;
-                    case CommandType.AttachmentPUT:
-                        HandleAttachmentPut(batchResult);
-                        break;
-                    case CommandType.AttachmentDELETE:
-                        HandleAttachmentDelete(batchResult);
-                        break;
-                    case CommandType.AttachmentMOVE:
-                        HandleAttachmentMove(batchResult);
-                        break;
-                    case CommandType.AttachmentCOPY:
-                        HandleAttachmentCopy(batchResult);
-                        break;
-                    case CommandType.CompareExchangePUT:
-                    case CommandType.CompareExchangeDELETE:
-                    case CommandType.ForceRevisionCreation:
-                        break;
-                    case CommandType.Counters:
-                        HandleCounters(batchResult);
-                        break;
-                    case CommandType.TimeSeries:
-                    case CommandType.TimeSeriesWithIncrements:
-                        //TODO: RavenDB-13474 add to time series cache
-                        break;
-                    case CommandType.TimeSeriesCopy:
-                        break;
-                    case CommandType.BatchPATCH:
-                        break;
-                    default:
-                        throw new NotSupportedException($"Command '{type}' is not supported.");
-                }
-            }
+            HandleBatchOperationResult(result, start: 0, _sessionCommandsCount, isDeferred: false);
+            HandleBatchOperationResult(result, start: _sessionCommandsCount, _allCommandsCount, isDeferred: true);
 
             FinalizeResult();
         }
 
-        private void HandleBatchOperationResult(int start, BatchCommandResult result)
+        private void HandleBatchOperationResult(BatchCommandResult result, int start, int end, bool isDeferred)
         {
-            for (var i = start; i < _sessionCommandsCount; i++)
+            int skip = 0;
+
+            for (var i = start; i < end; i++)
             {
                 var batchResult = result.Results[i] as BlittableJsonReaderObject;
                 if (batchResult == null)
                     continue;
 
-                var type = GetCommandType(batchResult);
-
-                switch (type)
+                if (isDeferred)
                 {
-                    case CommandType.PUT:
-                        HandlePut(i - start, batchResult, isDeferred: false);
-                        break;
-                    case CommandType.ForceRevisionCreation:
-                        HandleForceRevisionCreation(batchResult);
-                        break;
-                    case CommandType.DELETE:
-                        HandleDelete(batchResult);
-                        break;
-                    case CommandType.CompareExchangePUT:
-                        HandleCompareExchangePut(batchResult);
-                        break;
-                    case CommandType.CompareExchangeDELETE:
-                        HandleCompareExchangeDelete(batchResult);
-                        break;
-       
-                    default:
-                        throw new NotSupportedException($"Command '{type}' is not supported.");
+                    HandleDeferredCommand(i, batchResult);
                 }
+                else
+                {
+                    HandleSessionCommand(i, batchResult, ref skip);
+                }
+            }
+        }
+
+        private void HandleSessionCommand(int index, BlittableJsonReaderObject batchResult, ref int skip)
+        {
+            CommandType type = GetCommandType(batchResult);
+            switch (type)
+            {
+                case CommandType.PUT:
+                    HandlePut(index - skip, batchResult, isDeferred: false);
+                    break;
+                case CommandType.ForceRevisionCreation:
+                    HandleForceRevisionCreation(batchResult);
+                    break;
+                case CommandType.DELETE:
+                    HandleDelete(batchResult);
+                    break;
+                case CommandType.CompareExchangePUT:
+                    HandleCompareExchangePut(batchResult);
+                    break;
+                case CommandType.CompareExchangeDELETE:
+                    HandleCompareExchangeDelete(batchResult);
+                    break;
+                case CommandType.BatchTrackChanges:
+                    skip++;
+                    break;
+                default:
+                    throw new NotSupportedException($"Command '{type}' is not supported.");
+            }
+        }
+
+        private void HandleDeferredCommand(int index, BlittableJsonReaderObject batchResult)
+        {
+            CommandType type = GetCommandType(batchResult);
+            switch (type)
+            {
+                case CommandType.PUT:
+                    HandlePut(index, batchResult, isDeferred: true);
+                    break;
+                case CommandType.DELETE:
+                    HandleDelete(batchResult);
+                    break;
+                case CommandType.PATCH:
+                    HandlePatch(batchResult);
+                    break;
+                case CommandType.JsonPatch:
+                    HandleJsonPatch(batchResult);
+                    break;
+                case CommandType.AttachmentPUT:
+                    HandleAttachmentPut(batchResult);
+                    break;
+                case CommandType.AttachmentDELETE:
+                    HandleAttachmentDelete(batchResult);
+                    break;
+                case CommandType.AttachmentMOVE:
+                    HandleAttachmentMove(batchResult);
+                    break;
+                case CommandType.AttachmentCOPY:
+                    HandleAttachmentCopy(batchResult);
+                    break;
+                case CommandType.CompareExchangePUT:
+                case CommandType.CompareExchangeDELETE:
+                case CommandType.ForceRevisionCreation:
+                    break;
+                case CommandType.Counters:
+                    HandleCounters(batchResult);
+                    break;
+                case CommandType.TimeSeries:
+                case CommandType.TimeSeriesWithIncrements:
+                    //TODO: RavenDB-13474 add to time series cache
+                    break;
+                case CommandType.TimeSeriesCopy:
+                    break;
+                case CommandType.BatchPATCH:
+                    break;
+                case CommandType.BatchTrackChanges:
+                    break;
+                default:
+                    throw new NotSupportedException($"Command '{type}' is not supported.");
             }
         }
 
@@ -556,7 +562,6 @@ namespace Raven.Client.Documents.Session.Operations
 
                 documentInfo.Metadata.Modifications[propertyName] = batchResult[propertyName];
             }
-            //TODO: egor check if we can use docInfo in _trackedEntities so the obj is tracked
             documentInfo.Id = id;
             documentInfo.ChangeVector = changeVector;
        

--- a/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
@@ -71,7 +71,7 @@ namespace Raven.Client.Documents.Session.Operations
 
             var metadata = document.GetMetadata();
             var id = metadata.GetId();
-            var entity = _session.JsonConverter.FromBlittable<T>(ref document, id, _session.NoTracking == false);
+            var entity = _session.JsonConverter.FromBlittable<T>(ref document, id, _session.TrackingMode != TrackingMode.NoTracking);
 
             _session.DocumentsByEntity[entity] = new DocumentInfo
             {

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValueOperation.cs
@@ -61,7 +61,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
             {
                 var value = CompareExchangeValueResultParser<BlittableJsonReaderObject>.GetValue((BlittableJsonReaderObject)response.Result, materializeMetadata: false, _conventions);
 
-                if (_clusterSession._session.NoTracking)
+                if (_clusterSession._session.TrackingMode == TrackingMode.NoTracking)
                 {
                     if (value == null)
                     {
@@ -81,7 +81,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
                 _clusterSession.RegisterMissingCompareExchangeValue(_key);
 
             Result = _clusterSession.GetCompareExchangeValueFromSessionInternal<T>(_key, out var notTracked);
-            Debug.Assert(_clusterSession._session.NoTracking || notTracked == false, "notTracked == false");
+            Debug.Assert(_clusterSession._session.TrackingMode == TrackingMode.NoTracking || notTracked == false, "notTracked == false");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValuesOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValuesOperation.cs
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
 
             if (response.Result != null)
             {
-                if (_clusterSession._session.NoTracking)
+                if (_clusterSession._session.TrackingMode == TrackingMode.NoTracking)
                 {
                     var result = new Dictionary<string, CompareExchangeValue<T>>(StringComparer.OrdinalIgnoreCase);
                     foreach (var kvp in CompareExchangeValueResultParser<BlittableJsonReaderObject>.GetValues((BlittableJsonReaderObject)response.Result, materializeMetadata: false, _conventions))
@@ -137,7 +137,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
             }
 
             Result = _clusterSession.GetCompareExchangeValuesFromSessionInternal<T>(_keys, out var notTrackedKeys);
-            Debug.Assert(_clusterSession._session.NoTracking || notTrackedKeys == null, "notTrackedKeys == null");
+            Debug.Assert(_clusterSession._session.TrackingMode == TrackingMode.NoTracking || notTrackedKeys == null, "notTrackedKeys == null");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -144,7 +144,7 @@ namespace Raven.Client.Documents.Session.Operations
 
         public T GetDocument<T>()
         {
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
             {
                 if (_resultsSet == false && _ids.Length > 0)
                     throw new InvalidOperationException($"Cannot execute '{nameof(GetDocument)}' before operation execution.");
@@ -184,7 +184,7 @@ namespace Raven.Client.Documents.Session.Operations
         public Dictionary<string, T> GetDocuments<T>()
         {
             var finalResults = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
             {
                 if (_resultsSet == false && _ids.Length > 0)
                     throw new InvalidOperationException($"Cannot execute '{nameof(GetDocuments)}' before operation execution.");
@@ -220,7 +220,7 @@ namespace Raven.Client.Documents.Session.Operations
         {
             _resultsSet = true;
 
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
             {
                 _results = result;
                 return;

--- a/src/Raven.Client/Documents/Session/Operations/LoadStartingWithOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadStartingWithOperation.cs
@@ -53,7 +53,7 @@ namespace Raven.Client.Documents.Session.Operations
         {
             _resultsSet = true;
 
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
             {
                 _results = result;
                 return;
@@ -71,7 +71,7 @@ namespace Raven.Client.Documents.Session.Operations
             var i = 0;
             T[] finalResults;
 
-            if (_session.NoTracking)
+            if (_session.TrackingMode == TrackingMode.NoTracking)
             {
                 if (_resultsSet == false)
                     throw new InvalidOperationException($"Cannot execute '{nameof(GetDocuments)}' before operation execution.");

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -73,16 +73,38 @@ namespace Raven.Client.Documents.Session
         /// Disable tracking for all entities in the session<br/>
         /// </summary>
         /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.NoTracking"/></remarks>
-        // [Obsolete("InMemoryDocumentSessionOperations.NoTracking is not supported anymore. Will be removed in next major version of the product. Please use `InMemoryDocumentSessionOperations.TrackingMode` instead")]
-        public bool NoTracking { get => TrackingMode == TrackingMode.NoTracking; set => TrackingMode = TrackingMode.NoTracking; }
+        [Obsolete("SessionOptions.NoTracking is obsolete and will be removed in the next major version. Please use " +
+                  nameof(SessionOptions) + "." + nameof(TrackingMode) + " instead. " +
+                  "See: https://ravendb.net/docs/article-page/latest/csharp/client-api/session/options#notracking")]
+        public bool NoTracking
+        {
+            get => TrackingMode == TrackingMode.NoTracking;
+            set
+            {
+                if (value)
+                    TrackingMode = TrackingMode.NoTracking;
+            }
+        }
 
         /// <summary>
-        /// Enable tracking for all entities in the session<br/>
+        /// Enable tracking mode in the session<br/>
         /// </summary>
         /// <remarks>For more details visit: <inheritdoc cref="Session.TrackingMode"/></remarks>
-        public TrackingMode TrackingMode { get; set; }
-        // TODO: egor   public TrackingMode TrackingMode { get; set => this.TransactionMode == TransactionMode.ClusterWide ? throw new InvalidOperationException("TrackingMode cannot be set when TransactionMode is ClusterWide.") : value; }
-     
+        public TrackingMode TrackingMode
+        {
+            get;
+            set
+            {
+                if (value == TrackingMode.TrackAllEntities)
+                {
+                    if (TransactionMode == TransactionMode.ClusterWide)
+                        throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set to {nameof(TrackingMode.TrackAllEntities)} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
+                }
+
+                field = value;
+            }
+        }
+
         /// <summary>
         /// Disable caching of HTTP responses for the session<br/>
         /// </summary>

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -135,7 +135,7 @@ namespace Raven.Client.Documents.Session
             get;
             set
             {
-                if (TrackingMode == TrackingMode.TrackAllEntities)
+                if (value == TransactionMode.ClusterWide && TrackingMode == TrackingMode.TrackAllEntities)
                     throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set to {nameof(TrackingMode.TrackAllEntities)} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
 
                 field = value;

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -81,7 +81,8 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         /// <remarks>For more details visit: <inheritdoc cref="Session.TrackingMode"/></remarks>
         public TrackingMode TrackingMode { get; set; }
-
+        // TODO: egor   public TrackingMode TrackingMode { get; set => this.TransactionMode == TransactionMode.ClusterWide ? throw new InvalidOperationException("TrackingMode cannot be set when TransactionMode is ClusterWide.") : value; }
+     
         /// <summary>
         /// Disable caching of HTTP responses for the session<br/>
         /// </summary>

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -85,13 +85,14 @@ namespace Raven.Client.Documents.Session
                 if (TrackingModeWasSet)
                     throw new InvalidOperationException($"{nameof(NoTracking)} cannot be set when {nameof(TrackingMode)} was set. Please use {nameof(TrackingMode)} instead of {nameof(NoTracking)}.");
 
-                TrackingMode = value ? TrackingMode.NoTracking : TrackingMode.Default;
+                _trackingMode = value ? TrackingMode.NoTracking : TrackingMode.Default;
                 NoTrackingWasSet = true;
             }
         }
 
         internal bool NoTrackingWasSet { get; set; }
         internal bool TrackingModeWasSet { get; set; }
+        private TrackingMode _trackingMode;
 
         /// <summary>
         /// Enable tracking mode in the session<br/>
@@ -99,7 +100,7 @@ namespace Raven.Client.Documents.Session
         /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.TrackingMode"/></remarks>
         public TrackingMode TrackingMode
         {
-            get;
+            get => _trackingMode;
             set
             {
                 if (NoTrackingWasSet)
@@ -113,7 +114,7 @@ namespace Raven.Client.Documents.Session
                         throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set to {nameof(TrackingMode.TrackAllEntities)} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
                 }
 
-                field = value;
+                _trackingMode = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -73,7 +73,7 @@ namespace Raven.Client.Documents.Session
         /// Disable tracking for all entities in the session<br/>
         /// </summary>
         /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.NoTracking"/></remarks>
-      //  [Obsolete("This bool is obsolete! Will be removed in next major version of the product! please use `TrackingMode` instead", true)]
+        // [Obsolete("InMemoryDocumentSessionOperations.NoTracking is not supported anymore. Will be removed in next major version of the product. Please use `InMemoryDocumentSessionOperations.TrackingMode` instead")]
         public bool NoTracking { get => TrackingMode == TrackingMode.NoTracking; set => TrackingMode = TrackingMode.NoTracking; }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using Raven.Client.Http;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Raven.Client.Documents.Session
 {

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using Raven.Client.Http;
 
 namespace Raven.Client.Documents.Session
@@ -40,6 +41,24 @@ namespace Raven.Client.Documents.Session
         NonTransactionalMultiBucket
     }
 
+    public enum TrackingMode
+    {
+        /// <summary>
+        /// Do not force any behavior from the Client API and rely on Server's default
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// Disable tracking for all entities in the session<br/>
+        /// </summary>
+        NoTracking,
+
+        /// <summary>
+        /// Enable tracking for all entities in the session<br/>
+        /// </summary>
+        TrackAllEntities
+    }
+
     /// <summary>
     /// Configure the Session's behavior
     /// </summary>
@@ -54,7 +73,14 @@ namespace Raven.Client.Documents.Session
         /// Disable tracking for all entities in the session<br/>
         /// </summary>
         /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.NoTracking"/></remarks>
-        public bool NoTracking { get; set; }
+      //  [Obsolete("This bool is obsolete! Will be removed in next major version of the product! please use `TrackingMode` instead", true)]
+        public bool NoTracking { get => TrackingMode == TrackingMode.NoTracking; set => TrackingMode = TrackingMode.NoTracking; }
+
+        /// <summary>
+        /// Enable tracking for all entities in the session<br/>
+        /// </summary>
+        /// <remarks>For more details visit: <inheritdoc cref="Session.TrackingMode"/></remarks>
+        public TrackingMode TrackingMode { get; set; }
 
         /// <summary>
         /// Disable caching of HTTP responses for the session<br/>

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -72,7 +72,7 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         /// Disable tracking for all entities in the session<br/>
         /// </summary>
-        /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.NoTracking"/></remarks>
+        /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.TrackingMode"/></remarks>
         [Obsolete("SessionOptions.NoTracking is obsolete and will be removed in the next major version. Please use " +
                   nameof(SessionOptions) + "." + nameof(TrackingMode) + " instead. " +
                   "See: https://ravendb.net/docs/article-page/latest/csharp/client-api/session/options#notracking")]

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -81,20 +81,31 @@ namespace Raven.Client.Documents.Session
             get => TrackingMode == TrackingMode.NoTracking;
             set
             {
-                if (value)
-                    TrackingMode = TrackingMode.NoTracking;
+                if (TrackingModeWasSet)
+                    throw new InvalidOperationException($"{nameof(NoTracking)} cannot be set when {nameof(TrackingMode)} was set. Please use {nameof(TrackingMode)} instead of {nameof(NoTracking)}.");
+
+                TrackingMode = value ? TrackingMode.NoTracking : TrackingMode.Default;
+                NoTrackingWasSet = true;
             }
         }
+
+        internal bool NoTrackingWasSet { get; set; }
+        internal bool TrackingModeWasSet { get; set; }
 
         /// <summary>
         /// Enable tracking mode in the session<br/>
         /// </summary>
-        /// <remarks>For more details visit: <inheritdoc cref="Session.TrackingMode"/></remarks>
+        /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.TrackingMode"/></remarks>
         public TrackingMode TrackingMode
         {
             get;
             set
             {
+                if (NoTrackingWasSet)
+                    throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set when {nameof(NoTracking)} was set. Please use {nameof(TrackingMode)} instead of {nameof(NoTracking)}.");
+
+                TrackingModeWasSet = true;
+
                 if (value == TrackingMode.TrackAllEntities)
                 {
                     if (TransactionMode == TransactionMode.ClusterWide)
@@ -118,7 +129,17 @@ namespace Raven.Client.Documents.Session
         /// Each <see cref="TransactionMode"/> offers a different isolation and consistency guarantees
         /// </summary>
         /// <remarks>For more details: <inheritdoc cref="DocumentationUrls.Session.Transactions.TransactionSupport"/></remarks>
-        public TransactionMode TransactionMode { get; set; }
+        public TransactionMode TransactionMode
+        {
+            get;
+            set
+            {
+                if (TrackingMode == TrackingMode.TrackAllEntities)
+                    throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set to {nameof(TrackingMode.TrackAllEntities)} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
+
+                field = value;
+            }
+        }
 
         /// <summary>
         ///EXPERT: Disable automatic atomic writes with cluster write transactions. If set to 'true',

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -136,7 +136,7 @@ namespace Raven.Client.Documents.Subscriptions
 
         private void LoadDataToSession(InMemoryDocumentSessionOperations s)
         {
-            if (s.NoTracking)
+            if (s.TrackingMode == TrackingMode.NoTracking)
                 return;
 
             if (_includes?.Count > 0)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -941,20 +941,23 @@ namespace Raven.Server.Documents
 
                         yield return new Document()
                         {
-                            Id = context.GetLazyString(id)
+                            Id = context.GetLazyString(id),
+                            ChangeVector = string.Empty // doesn't exists
                         };
                     }
-
-                    if (start > 0)
+                    else
                     {
-                        start--;
-                        continue;
+                        if (start > 0)
+                        {
+                            start--;
+                            continue;
+                        }
+
+                        if (take-- <= 0)
+                            continue; // we need to calculate totalCount correctly
+
+                        yield return TableValueToDocument(context, ref reader, fields);
                     }
-
-                    if (take-- <= 0)
-                        continue; // we need to calculate totalCount correctly
-
-                    yield return TableValueToDocument(context, ref reader, fields);
                 }
             }
         }

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -903,7 +903,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document>  GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, DocumentFields fields = DocumentFields.All)
+        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -912,7 +912,7 @@ namespace Raven.Server.Documents
                 // id must be lowercased
                 if (table.ReadByKey(id, out TableValueReader reader) == false)
                     continue;
-                
+
                 if (start > 0)
                 {
                     start--;
@@ -926,16 +926,37 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take, DocumentFields fields = DocumentFields.All)
+        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take, DocumentFields fields = DocumentFields.All, bool returnNonExists = false)
         {
-            var listOfIds = new List<Slice>();
+            var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
             foreach (var id in ids)
             {
-                Slice.From(context.Allocator, id.ToLowerInvariant(), out Slice slice);
-                listOfIds.Add(slice);
-            }
+                using (Slice.From(context.Allocator, id.ToLowerInvariant(), out Slice lowerId))
+                {
+                    // id must be lowercased
+                    if (table.ReadByKey(lowerId, out TableValueReader reader) == false)
+                    {
+                        if (returnNonExists == false)
+                            continue;
 
-            return GetDocuments(context, listOfIds, start, take, fields);
+                        yield return new Document()
+                        {
+                            Id = context.GetLazyString(id)
+                        };
+                    }
+
+                    if (start > 0)
+                    {
+                        start--;
+                        continue;
+                    }
+
+                    if (take-- <= 0)
+                        continue; // we need to calculate totalCount correctly
+
+                    yield return TableValueToDocument(context, ref reader, fields);
+                }
+            }
         }
 
         public IEnumerable<Document> GetDocumentsForCollection(DocumentsOperationContext context, IEnumerable<Slice> ids, string collection, long start, long take)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -903,7 +903,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<Document>  GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take)
+        public IEnumerable<Document>  GetDocuments(DocumentsOperationContext context, IEnumerable<Slice> ids, long start, long take, DocumentFields fields = DocumentFields.All)
         {
             var table = new Table(DocsSchema, context.Transaction.InnerTransaction);
 
@@ -922,11 +922,11 @@ namespace Raven.Server.Documents
                 if (take-- <= 0)
                     continue; // we need to calculate totalCount correctly
 
-                yield return TableValueToDocument(context, ref reader);
+                yield return TableValueToDocument(context, ref reader, fields);
             }
         }
 
-        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take)
+        public IEnumerable<Document> GetDocuments(DocumentsOperationContext context, IEnumerable<string> ids, long start, long take, DocumentFields fields = DocumentFields.All)
         {
             var listOfIds = new List<Slice>();
             foreach (var id in ids)
@@ -935,7 +935,7 @@ namespace Raven.Server.Documents
                 listOfIds.Add(slice);
             }
 
-            return GetDocuments(context, listOfIds, start, take);
+            return GetDocuments(context, listOfIds, start, take, fields);
         }
 
         public IEnumerable<Document> GetDocumentsForCollection(DocumentsOperationContext context, IEnumerable<Slice> ids, string collection, long start, long take)

--- a/src/Raven.Server/Documents/Handlers/Batches/AbstractBatchCommandReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/AbstractBatchCommandReader.cs
@@ -52,6 +52,8 @@ public abstract class AbstractBatchCommandsReader<TBatchCommand, TOperationConte
         BatchRequestParser = batchRequestParser;
     }
 
+    protected abstract void CreateBatchTrackChangesCommand(BatchRequestParser.CommandData commandData);
+
     private void AddIdentity(JsonOperationContext ctx, ref BatchRequestParser.CommandData command, int index)
     {
         Identities ??= new List<string>();
@@ -175,6 +177,11 @@ public abstract class AbstractBatchCommandsReader<TBatchCommand, TOperationConte
                         commandData.JsonPatchCommands,
                         commandData.ReturnDocument,
                         context);
+                }
+
+                if (commandData.Type == CommandType.BatchTrackChanges)
+                {
+                    CreateBatchTrackChangesCommand(commandData);
                 }
 
                 if (commandData.Type == CommandType.BatchPATCH)

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -807,7 +807,6 @@ namespace Raven.Server.Documents.Handlers.Batches
             FromEtl,
 
             JsonPatch,
-            BatchTrackChanges,
             TrackedEntities
             // other properties are ignore (for legacy support)
 
@@ -943,12 +942,6 @@ namespace Raven.Server.Documents.Handlers.Batches
                 case 9:
                     if ("JsonPatch"u8.IsEqualConstant(state.StringBuffer))
                         return CommandPropertyName.JsonPatch;
-
-                    return CommandPropertyName.NoSuchProperty;
-
-                case 18:
-                    if ("BatchTrackChanges"u8.IsEqualConstant(state.StringBuffer))
-                        return CommandPropertyName.BatchTrackChanges;
 
                     return CommandPropertyName.NoSuchProperty;
 

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -433,8 +433,10 @@ namespace Raven.Server.Documents.Handlers.Batches
                     case CommandPropertyName.TrackedEntities:
                         while (parser.Read() == false)
                             await RefillParserBuffer(stream, buffer, parser, token);
-                        var trackedEntities = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
-                        commandData.TrackedEntities = BatchTrackChangesCommand.Parse(trackedEntities);
+                        using (var trackedEntities = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token))
+                        {
+                            commandData.TrackedEntities = BatchTrackChangesCommand.Parse(trackedEntities);
+                        }
                         break;
 
                     case CommandPropertyName.TimeSeries:

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -60,6 +60,14 @@ namespace Raven.Server.Documents.Handlers.Batches
             [JsonIgnore]
             public JsonPatchCommand JsonPatchCommand;
 
+            #region BatchTrackChanges
+
+            [JsonIgnore]
+            public BatchTrackChangesCommand BatchTrackChangesCommand;
+            public Dictionary<string, string> TrackedEntities;
+
+            #endregion BatchTrackChanges
+
             #region Attachment
 
             public string Name;
@@ -420,6 +428,13 @@ namespace Raven.Server.Documents.Handlers.Batches
                             await RefillParserBuffer(stream, buffer, parser, token);
                         var jsonPatch = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
                         commandData.JsonPatchCommands = JsonPatchCommand.Parse(jsonPatch);
+                        break;
+
+                    case CommandPropertyName.TrackedEntities:
+                        while (parser.Read() == false)
+                            await RefillParserBuffer(stream, buffer, parser, token);
+                        var trackedEntities = await ReadJsonObject(ctx, stream, commandData.Id, parser, state, buffer, modifier, token);
+                        commandData.TrackedEntities = BatchTrackChangesCommand.Parse(trackedEntities);
                         break;
 
                     case CommandPropertyName.TimeSeries:
@@ -791,8 +806,9 @@ namespace Raven.Server.Documents.Handlers.Batches
 
             FromEtl,
 
-            JsonPatch
-
+            JsonPatch,
+            BatchTrackChanges,
+            TrackedEntities
             // other properties are ignore (for legacy support)
 
         }
@@ -902,13 +918,15 @@ namespace Raven.Server.Documents.Handlers.Batches
                     if ("CreateIfMissing"u8.IsEqualConstant(state.StringBuffer))
                         return CommandPropertyName.CreateIfMissing;
 
+                    if ("TrackedEntities"u8.IsEqualConstant(state.StringBuffer))
+                        return CommandPropertyName.TrackedEntities;
+
                     return CommandPropertyName.NoSuchProperty;
 
                 case 16:
                     if ("RemoteParameters"u8.IsEqualConstant(state.StringBuffer))
                         return CommandPropertyName.RemoteParameters;
                     return CommandPropertyName.NoSuchProperty;
-
                 case 20:
                     if ("OriginalChangeVector"u8.IsEqualConstant(state.StringBuffer))
                         return CommandPropertyName.OriginalChangeVector;
@@ -927,6 +945,13 @@ namespace Raven.Server.Documents.Handlers.Batches
                         return CommandPropertyName.JsonPatch;
 
                     return CommandPropertyName.NoSuchProperty;
+
+                case 18:
+                    if ("BatchTrackChanges"u8.IsEqualConstant(state.StringBuffer))
+                        return CommandPropertyName.BatchTrackChanges;
+
+                    return CommandPropertyName.NoSuchProperty;
+
                 default:
                     return CommandPropertyName.NoSuchProperty;
             }
@@ -1036,6 +1061,11 @@ namespace Raven.Server.Documents.Handlers.Batches
                 case 16:
                     if ("AttachmentDELETE"u8.IsEqualConstant(state.StringBuffer))
                         return CommandType.AttachmentDELETE;
+                    break;
+
+                case 17:
+                    if ("BatchTrackChanges"u8.IsEqualConstant(state.StringBuffer))
+                        return CommandType.BatchTrackChanges;
                     break;
 
                 case 18:

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommand.cs
@@ -143,6 +143,15 @@ public sealed class MergedBatchCommand : TransactionMergedCommand
 
                     break;
 
+                case CommandType.BatchTrackChanges:
+                    var result = cmd.BatchTrackChangesCommand.ExecuteDirectly(context);
+                    Reply.Add(new DynamicJsonValue
+                    {
+                        [nameof(BatchRequestParser.CommandData.Type)] = cmd.Type,
+                        ["Result"] = result
+                    });
+                    break;
+
                 case CommandType.DELETE:
                     if (cmd.IdPrefixed == false)
                     {

--- a/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
@@ -40,7 +40,7 @@ public sealed class DatabaseBatchCommandsReader : AbstractBatchCommandsReader<Me
 
     protected override void CreateBatchTrackChangesCommand(BatchRequestParser.CommandData commandData)
     {
-        commandData.BatchTrackChangesCommand = new BatchTrackChangesCommand(commandData.TrackedEntities, _database);
+        commandData.BatchTrackChangesCommand = new BatchTrackChangesCommand(commandData.TrackedEntities);
     }
 
     public override async ValueTask<MergedBatchCommand> GetCommandAsync(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/DatabaseBatchCommandsReader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Server.Documents.Handlers.Batches.Commands;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Web;
 using Sparrow.Json;
@@ -35,6 +36,11 @@ public sealed class DatabaseBatchCommandsReader : AbstractBatchCommandsReader<Me
         attachmentStream.Hash = await AttachmentsStorageHelper.CopyStreamToFileAndCalculateHash(context, input, attachmentStream.Stream, token);
         await attachmentStream.Stream.FlushAsync(token);
         AttachmentStreams.Add(attachmentStream);
+    }
+
+    protected override void CreateBatchTrackChangesCommand(BatchRequestParser.CommandData commandData)
+    {
+        commandData.BatchTrackChangesCommand = new BatchTrackChangesCommand(commandData.TrackedEntities, _database);
     }
 
     public override async ValueTask<MergedBatchCommand> GetCommandAsync(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommandsReader.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Batches;
-using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommandsReader.cs
@@ -101,11 +101,7 @@ public sealed class ShardedBatchCommandsReader : AbstractBatchCommandsReader<Sha
 
     protected override void CreateBatchTrackChangesCommand(BatchRequestParser.CommandData commandData)
     {
-        //TODO: egor
-        // commandData.BatchTrackChangesCommand = new BatchTrackChangesCommand(commandData.TrackedEntities, _databaseContext);
-
-        throw new NotSupportedInShardingException($"BatchTrackChangesCommand is not supported in sharding.");
-
+        throw new NotSupportedInShardingException("BatchTrackChangesCommand is not supported in sharding.");
     }
 
     public override void Dispose()

--- a/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommandsReader.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Batches/ShardedBatchCommandsReader.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Handlers.Batches;
+using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -96,6 +97,15 @@ public sealed class ShardedBatchCommandsReader : AbstractBatchCommandsReader<Sha
             AttachmentStreams = Streams,
             IsClusterTransaction = IsClusterTransactionRequest
         };
+    }
+
+    protected override void CreateBatchTrackChangesCommand(BatchRequestParser.CommandData commandData)
+    {
+        //TODO: egor
+        // commandData.BatchTrackChangesCommand = new BatchTrackChangesCommand(commandData.TrackedEntities, _databaseContext);
+
+        throw new NotSupportedInShardingException($"BatchTrackChangesCommand is not supported in sharding.");
+
     }
 
     public override void Dispose()

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using Raven.Client.Exceptions;
+using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.TransactionMerger.Commands
+{
+    public sealed class BatchTrackChangesCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+    {
+        private readonly Dictionary<string, string> _trackedEntities;
+        private readonly DocumentDatabase _database;
+
+        public BatchTrackChangesCommand(Dictionary<string, string> trackedEntities, DocumentDatabase database)
+        {
+            _trackedEntities = trackedEntities;
+            _database = database;
+        }
+
+        protected override long ExecuteCmd(DocumentsOperationContext context)
+        {
+            foreach (Document document in _database.DocumentsStorage.GetDocuments(context, _trackedEntities.Keys, start: 0, take: int.MaxValue, DocumentFields.Id | DocumentFields.ChangeVector))
+            {
+                //TODO: egor use CVs
+                ChangeVector docCv = context.GetChangeVector(document.ChangeVector);
+
+                var expectedCv = _trackedEntities[document.Id];
+
+                docCv.IsEqual(context.GetChangeVector(expectedCv));
+
+                if (expectedCv != document.ChangeVector)
+                {
+                    throw new ConcurrencyException("Document change vector mismatch")
+                    {
+                        Id = document.Id,
+                        ActualChangeVector = document.ChangeVector,
+                        ExpectedChangeVector = expectedCv
+                    };
+                }
+            }
+
+            return 1;
+        }
+
+
+        public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+        {
+            return new BatchTrackChangesCommandDto();
+        }
+
+        public sealed class BatchTrackChangesCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>>
+        {
+
+            public MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction> ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+            {
+                return null;
+                // return new BatchTrackChangesCommand();
+            }
+        }
+
+        public static Dictionary<string, string> Parse(BlittableJsonReaderObject trackedEntities)
+        {
+            var dic = new Dictionary<string, string>();
+
+            foreach (var key in trackedEntities.GetPropertyNames())
+            {
+                if (trackedEntities.TryGet(key, out string value) == false)
+                    continue;
+
+                dic[key] = value;
+            }
+
+            return dic;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
@@ -22,13 +22,25 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
             {
                 var expected = _trackedEntities[document.Id];
                 if (expected == null)
+                {
+                    // we don't care
                     continue;
+                }
+
+                if (document.ChangeVector == string.Empty && expected == string.Empty)
+                {
+                    // this document doesn't exist, and it wasn't existing when we loaded it, so we are good
+                    continue;
+                }
 
                 ChangeVector current = context.GetChangeVector(document.ChangeVector);
 
                 if (current.IsEqual(context.GetChangeVector(expected)) == false)
                 {
-                    throw new ConcurrencyException($"Document '{document.Id}' has been modified since it was loaded. The expected change vector '{expected}' does not match the current change vector '{document.ChangeVector}'.")
+
+                    var expectedStr = expected == string.Empty ? "string.Empty" : expected;
+                    var currentStr = document.ChangeVector == null ? "NULL" : document.ChangeVector == string.Empty ? "string.Empty" : document.ChangeVector;
+                    throw new ConcurrencyException($"Document '{document.Id}' has been modified since it was loaded. The expected change vector '{expectedStr}' does not match the current change vector '{currentStr}'.")
                     {
                         Id = document.Id,
                         ActualChangeVector = document.ChangeVector,

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
@@ -21,20 +21,16 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
         {
             foreach (Document document in _database.DocumentsStorage.GetDocuments(context, _trackedEntities.Keys, start: 0, take: int.MaxValue, DocumentFields.Id | DocumentFields.ChangeVector))
             {
-                //TODO: egor use CVs
-                ChangeVector docCv = context.GetChangeVector(document.ChangeVector);
+                ChangeVector current = context.GetChangeVector(document.ChangeVector);
+                var expected = _trackedEntities[document.Id];
 
-                var expectedCv = _trackedEntities[document.Id];
-
-                docCv.IsEqual(context.GetChangeVector(expectedCv));
-
-                if (expectedCv != document.ChangeVector)
+                if (current.IsEqual(context.GetChangeVector(expected)) == false)
                 {
                     throw new ConcurrencyException("Document change vector mismatch")
                     {
                         Id = document.Id,
                         ActualChangeVector = document.ChangeVector,
-                        ExpectedChangeVector = expectedCv
+                        ExpectedChangeVector = expected
                     };
                 }
             }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Raven.Client.Exceptions;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -17,7 +18,7 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
 
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
-            foreach (Document document in context.DocumentDatabase.DocumentsStorage.GetDocuments(context, _trackedEntities.Keys, start: 0, take: int.MaxValue, DocumentFields.Id | DocumentFields.ChangeVector))
+            foreach (Document document in context.DocumentDatabase.DocumentsStorage.GetDocuments(context, _trackedEntities.Keys, start: 0, take: int.MaxValue, DocumentFields.Id | DocumentFields.ChangeVector, returnNonExists: true))
             {
                 var expected = _trackedEntities[document.Id];
                 if (expected == null)
@@ -59,7 +60,7 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
 
         public static Dictionary<string, string> Parse(BlittableJsonReaderObject trackedEntities)
         {
-            var dic = new Dictionary<string, string>();
+            var dic = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var key in trackedEntities.GetPropertyNames())
             {

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/BatchTrackChangesCommand.cs
@@ -9,24 +9,25 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
     public sealed class BatchTrackChangesCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
     {
         private readonly Dictionary<string, string> _trackedEntities;
-        private readonly DocumentDatabase _database;
 
-        public BatchTrackChangesCommand(Dictionary<string, string> trackedEntities, DocumentDatabase database)
+        public BatchTrackChangesCommand(Dictionary<string, string> trackedEntities)
         {
             _trackedEntities = trackedEntities;
-            _database = database;
         }
 
         protected override long ExecuteCmd(DocumentsOperationContext context)
         {
-            foreach (Document document in _database.DocumentsStorage.GetDocuments(context, _trackedEntities.Keys, start: 0, take: int.MaxValue, DocumentFields.Id | DocumentFields.ChangeVector))
+            foreach (Document document in context.DocumentDatabase.DocumentsStorage.GetDocuments(context, _trackedEntities.Keys, start: 0, take: int.MaxValue, DocumentFields.Id | DocumentFields.ChangeVector))
             {
-                ChangeVector current = context.GetChangeVector(document.ChangeVector);
                 var expected = _trackedEntities[document.Id];
+                if (expected == null)
+                    continue;
+
+                ChangeVector current = context.GetChangeVector(document.ChangeVector);
 
                 if (current.IsEqual(context.GetChangeVector(expected)) == false)
                 {
-                    throw new ConcurrencyException("Document change vector mismatch")
+                    throw new ConcurrencyException($"Document '{document.Id}' has been modified since it was loaded. The expected change vector '{expected}' does not match the current change vector '{document.ChangeVector}'.")
                     {
                         Id = document.Id,
                         ActualChangeVector = document.ChangeVector,
@@ -38,19 +39,21 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
             return 1;
         }
 
-
         public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
         {
-            return new BatchTrackChangesCommandDto();
+            return new BatchTrackChangesCommandDto
+            {
+                TrackedEntities = _trackedEntities
+            };
         }
 
         public sealed class BatchTrackChangesCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>>
         {
+            public Dictionary<string, string> TrackedEntities { get; set; }
 
             public MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction> ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                return null;
-                // return new BatchTrackChangesCommand();
+                return new BatchTrackChangesCommand(TrackedEntities);
             }
         }
 
@@ -68,5 +71,6 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
 
             return dic;
         }
+
     }
 }

--- a/test/FastTests/Client/TrackingModeTests.cs
+++ b/test/FastTests/Client/TrackingModeTests.cs
@@ -3,6 +3,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace FastTests.Client
 {

--- a/test/FastTests/Client/TrackingModeTests.cs
+++ b/test/FastTests/Client/TrackingModeTests.cs
@@ -12,253 +12,247 @@ namespace FastTests.Client
         public TrackingModeTests(ITestOutputHelper output) : base(output)
         {
         }
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void NoTracking_CanBeSetMultipleTimes_WithoutThrowingMisleadingError()
+        {
+            var options = new SessionOptions();
+
+            // First assignment - should not throw
+            options.NoTracking = true;
+            Assert.True(options.NoTracking);
+            Assert.Equal(TrackingMode.NoTracking, options.TrackingMode);
+
+            // Second assignment (toggling off) - must not throw with a misleading
+            // "TrackingMode was set" message, because TrackingMode was never set explicitly
+            var ex = Record.Exception(() => options.NoTracking = false);
+            Assert.Null(ex);
+            Assert.False(options.NoTracking);
+            Assert.Equal(TrackingMode.Default, options.TrackingMode);
+
+            // Third assignment (toggling back on) - must still not throw
+            ex = Record.Exception(() => options.NoTracking = true);
+            Assert.Null(ex);
+            Assert.True(options.NoTracking);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void NoTracking_DoesNotSetTrackingModeWasSet_Flag()
+        {
+            var options = new SessionOptions();
+
+            options.NoTracking = true;
+
+            // TrackingModeWasSet must remain false so that the cross-flag guard between
+            // NoTracking and TrackingMode still works correctly in both directions
+            Assert.False(options.TrackingModeWasSet);
+            Assert.True(options.NoTrackingWasSet);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void TrackingMode_AfterNoTracking_ShouldThrow()
+        {
+            var options = new SessionOptions();
+            options.NoTracking = true;
+
+            // Setting TrackingMode explicitly after NoTracking was used must still throw
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                options.TrackingMode = TrackingMode.TrackAllEntities);
+
+            Assert.Contains(nameof(SessionOptions.TrackingMode), ex.Message);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void NoTracking_AfterTrackingMode_ShouldThrow()
+        {
+            var options = new SessionOptions();
+            options.TrackingMode = TrackingMode.NoTracking;
+
+            // Setting NoTracking explicitly after TrackingMode was used must still throw
+            var ex = Assert.Throws<InvalidOperationException>(() => options.NoTracking = false);
+
+            Assert.Contains(nameof(SessionOptions.NoTracking), ex.Message);
+        }
 
         [RavenTheory(RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void CanConfigureTrackingModeForClusterwideSessions(Options options)
         {
-            using (var store = GetDocumentStore(options))
+            var exp = Assert.Throws<InvalidOperationException>(() =>
             {
-                var exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TransactionMode = TransactionMode.ClusterWide,
-                        TrackingMode = TrackingMode.TrackAllEntities,
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
-
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.TrackAllEntities,
-                        TransactionMode = TransactionMode.ClusterWide,
-
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
-
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                {
-                    NoTracking = true,
-                    TransactionMode = TransactionMode.ClusterWide,
-
-                }))
-                {
-
-                }
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                var ses = new SessionOptions()
                 {
                     TransactionMode = TransactionMode.ClusterWide,
-                    NoTracking = true,
-
-
-                }))
-                {
-
-                }
-
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                {
-                    NoTracking = false,
-                    TransactionMode = TransactionMode.ClusterWide,
-
-                }))
-                {
-
-                }
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                {
-                    TransactionMode = TransactionMode.ClusterWide,
-                    NoTracking = false,
-
-
-                }))
-                {
-
-                }
-
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                {
-                    TransactionMode = TransactionMode.SingleNode,
                     TrackingMode = TrackingMode.TrackAllEntities,
-                }))
-                {
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
 
-                }
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
                 {
                     TrackingMode = TrackingMode.TrackAllEntities,
-                    TransactionMode = TransactionMode.SingleNode,
+                    TransactionMode = TransactionMode.ClusterWide,
 
-                }))
-                {
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
 
-                }
-            }
+            var session = new SessionOptions()
+            {
+                NoTracking = true,
+                TransactionMode = TransactionMode.ClusterWide,
+            };
+
+            session = new SessionOptions()
+            {
+                TransactionMode = TransactionMode.ClusterWide,
+                NoTracking = true,
+            };
+
+            session = new SessionOptions()
+            {
+                NoTracking = false,
+                TransactionMode = TransactionMode.ClusterWide,
+
+            };
+            session = new SessionOptions()
+            {
+                TransactionMode = TransactionMode.ClusterWide,
+                NoTracking = false,
+
+
+            };
+
+            session = new SessionOptions()
+            {
+                TransactionMode = TransactionMode.SingleNode,
+                TrackingMode = TrackingMode.TrackAllEntities,
+            };
+            session = new SessionOptions()
+            {
+                TrackingMode = TrackingMode.TrackAllEntities,
+                TransactionMode = TransactionMode.SingleNode,
+
+            };
         }
 
         [RavenTheory(RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void CanConfigureTrackingModeForSessions(Options options)
         {
+            var exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                    NoTracking = true
+                };
+            });
+            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.Default,
+                    NoTracking = true
+                };
+            });
+            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.NoTracking,
+                    NoTracking = true
+                };
+
+            });
+            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                    NoTracking = false
+                };
+            });
+            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+
+                var session = new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.Default,
+                    NoTracking = false
+                };
+            });
+            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.NoTracking,
+                    NoTracking = false
+                };
+            });
+            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    NoTracking = true,
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    NoTracking = true,
+                    TrackingMode = TrackingMode.Default,
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    NoTracking = true,
+                    TrackingMode = TrackingMode.NoTracking,
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    NoTracking = false,
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+
+                var session = new SessionOptions()
+                {
+                    NoTracking = false,
+                    TrackingMode = TrackingMode.Default,
+                };
+            });
+            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                var session = new SessionOptions()
+                {
+                    NoTracking = false,
+                    TrackingMode = TrackingMode.NoTracking,
+                };
+            });
             using (var store = GetDocumentStore(options))
             {
-                var exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.TrackAllEntities,
-                        NoTracking = true
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.Default,
-                        NoTracking = true
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.NoTracking,
-                        NoTracking = true
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.TrackAllEntities,
-                        NoTracking = false
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.Default,
-                        NoTracking = false
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        TrackingMode = TrackingMode.NoTracking,
-                        NoTracking = false
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        NoTracking = true,
-                        TrackingMode = TrackingMode.TrackAllEntities,
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        NoTracking = true,
-                        TrackingMode = TrackingMode.Default,
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        NoTracking = true,
-                        TrackingMode = TrackingMode.NoTracking,
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        NoTracking = false,
-                        TrackingMode = TrackingMode.TrackAllEntities,
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        NoTracking = false,
-                        TrackingMode = TrackingMode.Default,
-                    }))
-                    {
-
-                    }
-                });
-                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-                exp = Assert.Throws<InvalidOperationException>(() =>
-                {
-                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                    {
-                        NoTracking = false,
-                        TrackingMode = TrackingMode.NoTracking,
-                    }))
-                    {
-
-                    }
-                });
-
-
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
                     NoTracking = false
@@ -267,6 +261,7 @@ namespace FastTests.Client
                     var inMemSes = ((InMemoryDocumentSessionOperations)session);
                     Assert.Equal(inMemSes.TrackingMode, TrackingMode.Default);
                 }
+
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
                     NoTracking = true

--- a/test/FastTests/Client/TrackingModeTests.cs
+++ b/test/FastTests/Client/TrackingModeTests.cs
@@ -67,21 +67,39 @@ namespace FastTests.Client
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                       {
-                           NoTracking = false,
-                           TransactionMode = TransactionMode.ClusterWide,
+                {
+                    NoTracking = false,
+                    TransactionMode = TransactionMode.ClusterWide,
 
-                       }))
+                }))
                 {
 
                 }
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                       {
-                           TransactionMode = TransactionMode.ClusterWide,
-                           NoTracking = false,
+                {
+                    TransactionMode = TransactionMode.ClusterWide,
+                    NoTracking = false,
 
 
-                       }))
+                }))
+                {
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TransactionMode = TransactionMode.SingleNode,
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+
+                }
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                    TransactionMode = TransactionMode.SingleNode,
+
+                }))
                 {
 
                 }

--- a/test/FastTests/Client/TrackingModeTests.cs
+++ b/test/FastTests/Client/TrackingModeTests.cs
@@ -1,0 +1,289 @@
+﻿using System;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Client
+{
+    public class TrackingModeTests : RavenTestBase
+    {
+        public TrackingModeTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanConfigureTrackingModeForClusterwideSessions(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TransactionMode = TransactionMode.ClusterWide,
+                        TrackingMode = TrackingMode.TrackAllEntities,
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
+
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.TrackAllEntities,
+                        TransactionMode = TransactionMode.ClusterWide,
+
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    NoTracking = true,
+                    TransactionMode = TransactionMode.ClusterWide,
+
+                }))
+                {
+
+                }
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TransactionMode = TransactionMode.ClusterWide,
+                    NoTracking = true,
+
+
+                }))
+                {
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           NoTracking = false,
+                           TransactionMode = TransactionMode.ClusterWide,
+
+                       }))
+                {
+
+                }
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TransactionMode = TransactionMode.ClusterWide,
+                           NoTracking = false,
+
+
+                       }))
+                {
+
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void CanConfigureTrackingModeForSessions(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.TrackAllEntities,
+                        NoTracking = true
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.Default,
+                        NoTracking = true
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.NoTracking,
+                        NoTracking = true
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.TrackAllEntities,
+                        NoTracking = false
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.Default,
+                        NoTracking = false
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        TrackingMode = TrackingMode.NoTracking,
+                        NoTracking = false
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        NoTracking = true,
+                        TrackingMode = TrackingMode.TrackAllEntities,
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        NoTracking = true,
+                        TrackingMode = TrackingMode.Default,
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        NoTracking = true,
+                        TrackingMode = TrackingMode.NoTracking,
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        NoTracking = false,
+                        TrackingMode = TrackingMode.TrackAllEntities,
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        NoTracking = false,
+                        TrackingMode = TrackingMode.Default,
+                    }))
+                    {
+
+                    }
+                });
+                Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
+                exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    {
+                        NoTracking = false,
+                        TrackingMode = TrackingMode.NoTracking,
+                    }))
+                    {
+
+                    }
+                });
+
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    NoTracking = false
+                }))
+                {
+                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
+                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.Default);
+                }
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    NoTracking = true
+                }))
+                {
+                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
+                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.NoTracking);
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.NoTracking,
+                }))
+                {
+                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
+                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.NoTracking);
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.Default,
+                }))
+                {
+                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
+                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.Default);
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
+                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.TrackAllEntities);
+                }
+            }
+        }
+    }
+}

--- a/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
+++ b/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace FastTests.Corax.Vectors;
 

--- a/test/SlowTests.Issues/Issues/RavenDB_11217.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_11217.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_12985.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_12985.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_14005.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14005.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_14006.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14006.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_14178.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14178.cs
@@ -5,6 +5,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_14461.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14461.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_21339.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21339.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues;
 

--- a/test/SlowTests.Issues/Issues/RavenDB_22110.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22110.cs
@@ -11,6 +11,7 @@ using Raven.Client.ServerWide;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Issues;
 

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -1,0 +1,891 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using FastTests;
+using Raven.Client.Documents.Session;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_25154 : RavenTestBase
+    {
+        public RavenDB_25154(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Employee
+        {
+            public string FirstName { get; set; }
+            public Address Address { get; set; }
+        }
+
+        internal static IEnumerable<object[]> SessionActions()
+        {
+            yield return [(Action<IDocumentSession>)ModifyEgorInSession];
+            yield return [(Action<IDocumentSession>)ModifyEgorInPatchAfterLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorInPatchNoLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithStoreOverwriteAfterLoadAndEvict];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithStoreOverwriteWithoutLoad];
+            //yield return [(Action<IDocumentSession>)ModifyEgorWithDelete];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithLoadAndDeleteById];
+
+
+            yield return [(Action<IDocumentSession>)ModifyEgorWithLoadAndDeleteByEntity];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithMultiplePatches];
+            yield return [(Action<IDocumentSession>)ModifyEgorByReplacingAddress];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithAttachmentWithLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithAttachmentNoLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithTimeSeriesNoLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithTimeSeriesWithLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithCounterWithLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithCounterNoLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithRevisionNoLoad];
+            yield return [(Action<IDocumentSession>)ModifyEgorWithRevisionWithLoad];
+        }
+
+        internal static void ModifyEgorInPatchAfterLoad(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.Advanced.Patch(egor, e => e.Address.Street, "Mul HaHof Village");
+        }
+
+        internal static void ModifyEgorInPatchNoLoad(IDocumentSession session)
+        {
+            session.Advanced.Patch<Employee, string>("employees/2-A", e => e.Address.Street, "Mul HaHof Village");
+        }
+
+        internal static void ModifyEgorInSession(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            egor.Address = new Address()
+            {
+                Street = "Mul HaHof Village"
+            };
+        }
+
+        internal static void ModifyEgorWithStoreOverwriteAfterLoadAndEvict(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.Advanced.Evict(egor);
+            session.Store(new Employee
+            {
+                FirstName = "Egor",
+                Address = new Address()
+                {
+                    Street = "Mul HaHof Village"
+                }
+            }, "employees/2-A");
+        }
+
+        internal static void ModifyEgorWithStoreOverwriteWithoutLoad(IDocumentSession session)
+        {
+            session.Store(new Employee
+            {
+                FirstName = "Egor",
+                Address = new Address()
+                {
+                    Street = "Mul HaHof Village"
+                }
+            }, "employees/2-A");
+        }
+
+        // TODO: egor this is not tracked in sessions, so we don't care!
+        internal static void ModifyEgorWithDelete(IDocumentSession session)
+        {
+            session.Delete("employees/2-A");
+
+        }
+
+        internal static void ModifyEgorWithLoadAndDeleteById(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.Delete("employees/2-A");
+        }
+
+        internal static void ModifyEgorWithLoadAndDeleteByEntity(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+
+            session.Delete(egor);
+        }
+        ////TODO: doesn twork
+        //internal static void ModifyEgorWithDeleteAndStore(IDocumentSession session)
+        //{
+        //    session.Delete("employees/2-A");
+        //    session.Store(new Employee
+        //    {
+        //        FirstName = "Egor",
+        //        Address = new Address()
+        //        {
+        //            Street = "Mul HaHof Village"
+        //        }
+        //    }, "employees/2-A");
+        //}
+
+        ////TODO: doesn twork
+        //internal static void ModifyEgorWithLoadDeleteAndStore(IDocumentSession session)
+        //{
+        //    var egor = session.Load<Employee>("employees/2-A");
+        //    session.Delete(egor);
+        //    session.Store(new Employee
+        //    {
+        //        FirstName = "Egor",
+        //        Address = new Address()
+        //        {
+        //            Street = "Mul HaHof Village"
+        //        }
+        //    }, "employees/2-A");
+        //}
+
+        internal static void ModifyEgorWithMultiplePatches(IDocumentSession session)
+        {
+            session.Advanced.Patch<Employee, string>("employees/2-A", e => e.Address.Street, "Mul HaHof Village");
+            session.Advanced.Patch<Employee, string>("employees/2-A", e => e.FirstName, "Egor");
+        }
+
+        internal static void ModifyEgorByReplacingAddress(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.Advanced.Patch(egor, e => e.Address, new Address()
+            {
+                Street = "Mul HaHof Village",
+                City = "Hadera"
+            });
+        }
+
+        internal static void ModifyEgorWithAttachmentWithLoad(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.Advanced.Attachments.Store(egor, "profile-picture", new MemoryStream("image data"u8.ToArray()));
+        }
+
+        internal static void ModifyEgorWithAttachmentNoLoad(IDocumentSession session)
+        {
+            session.Advanced.Attachments.Store("employees/2-A", "profile-picture", new MemoryStream("image data"u8.ToArray()));
+        }
+
+        internal static void ModifyEgorWithTimeSeriesNoLoad(IDocumentSession session)
+        {
+            session.TimeSeriesFor("employees/2-A", "profile-picture-likes")
+                .Append(DateTime.UtcNow, new[] { 322d }, "super-like");
+        }
+
+        internal static void ModifyEgorWithTimeSeriesWithLoad(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.TimeSeriesFor(egor, "profile-picture-likes")
+                .Append(DateTime.UtcNow, new[] { 322d }, "super-like");
+        }
+
+        internal static void ModifyEgorWithCounterWithLoad(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.CountersFor(egor).Increment("profile-picture-likes");
+        }
+
+        internal static void ModifyEgorWithCounterNoLoad(IDocumentSession session)
+        {
+            session.CountersFor("employees/2-A").Increment("profile-picture-likes");
+        }
+
+
+        internal static void ModifyEgorWithRevisionNoLoad(IDocumentSession session)
+        {
+            session.Advanced.Revisions.ForceRevisionCreationFor("employees/2-A");
+        }
+
+        internal static void ModifyEgorWithRevisionWithLoad(IDocumentSession session)
+        {
+            var egor = session.Load<Employee>("employees/2-A");
+            session.Advanced.Revisions.ForceRevisionCreationFor(egor);
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [MemberData(nameof(SessionActions))]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityWasChangedInBackgroundSession(Action<IDocumentSession> sessionAction)
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    sessionAction.Invoke(session);
+
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Hadera"
+                        };
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities
+                       }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
+        //TODO: egor what happends when I load the document but its null, then I try to SaveChanges but thsi document was added meanwhile but another session
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityIsNullButThenWasAddedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    Assert.Null(jerry);
+
+                    ModifyEgorInSession(session);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = new Employee
+                        {
+                            FirstName = "Jerry",
+                            Address = new Address()
+                            {
+                                City = "Hadera"
+                            }
+                        };
+                        s.Store(j, "employees/1-A");
+
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(string.Empty, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities
+                       }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
+        //TODO: egor what happends when I delete the document , then I try to SaveChanges but thsi document was added meanwhile but another session
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByEntityButThenWasEditedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    session.Delete<Employee>(jerry);
+                    ModifyEgorInSession(session);
+
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Hadera"
+                        };
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities
+                       }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityDeletedByIdWithoutChangeVectorButThenWasNotEditedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    session.Delete("employees/1-A");
+                    ModifyEgorInSession(session);
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Null(j);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityDeletedByIdWithChangeVectorButThenWasNotEditedInBackgroundSession2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var actual = session.Advanced.GetChangeVectorFor(jerry);
+                    session.Delete("employees/1-A", "test");
+                    ModifyEgorInSession(session);
+
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains($"Document {e.Id} has change vector {e.ActualChangeVector}, but Delete was called with change vector '{e.ExpectedChangeVector}'. Optimistic concurrency violation, transaction will be aborted.", e.Message);
+
+
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal("test", e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Jerry", j.FirstName);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByIdButThenWasEditedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+                    session.Delete("employees/1-A");
+                    ModifyEgorInSession(session);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Hadera"
+                        };
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                             Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [MemberData(nameof(SessionActions))]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityIncludedBySessionButThenWasEditedInBackgroundSession(Action<IDocumentSession> sessionAction)
+        {
+            using (var store = GetDocumentStore())
+            {
+                string addressId;
+                using (var session = store.OpenSession())
+                {
+                    var address = new Address()
+                    {
+                        City = "Harish",
+                        Street = "Erets Rd"
+                    };
+                    session.Store(address);
+                    addressId = session.Advanced.GetDocumentId(address);
+                    Assert.NotNull(addressId);
+                    address.Id = addressId;
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
+                {
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var numOfRequests = session.Advanced.NumberOfRequests;
+
+                    var address = session.Load<Address>(jerry.Address.Id);
+
+                    Assert.NotNull(address);
+                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                    sessionAction.Invoke(session);
+
+                    var expected = session.Advanced.GetChangeVectorFor(address);
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var a = s.Load<Address>(addressId);
+                        a.City = "Hadera";
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(a);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal(addressId, e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities
+                       }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.Equal("Hadera", j.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasAddedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string addressId = "addresses/1-A";
+                var address = new Address()
+                {
+                    City = "Harish",
+                    Street = "Erets Rd",
+                    Id = addressId
+                };
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // this should put the include into missing ids
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var numOfRequests = session.Advanced.NumberOfRequests;
+
+                    Assert.Null(session.Load<Address>(jerry.Address.Id));
+                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                    ModifyEgorInSession(session);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        s.Store(address, addressId);
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(address);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal(addressId, e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(string.Empty, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.NotNull(j);
+                    Assert.Equal("Harish", j.City);
+                }
+            }
+        }
+
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasEditedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string addressId = "addresses/1-A";
+                var address = new Address()
+                {
+                    City = "Harish",
+                    Street = "Erets Rd",
+                    Id = addressId
+                };
+                using (var session = store.OpenSession())
+                {
+                    session.Store(address);
+                    Assert.Equal(addressId, session.Advanced.GetDocumentId(address));
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // this should put the include into missing ids
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var numOfRequests = session.Advanced.NumberOfRequests;
+                    var adr = session.Load<Address>(jerry.Address.Id);
+                    Assert.NotNull(adr);
+                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                    ModifyEgorInSession(session);
+
+                    var expected = session.Advanced.GetChangeVectorFor(adr);
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var adrInternal = s.Load<Address>(addressId);
+                        adrInternal.City = "Hadera";
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(adrInternal);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal(addressId, e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.NotNull(j);
+                    Assert.Equal("Hadera", j.City);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using FastTests;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json.Parsing;
@@ -30,7 +31,6 @@ namespace SlowTests.Issues
             yield return [(Action<IDocumentSession>)ModifyEgorInPatchNoLoad];
             yield return [(Action<IDocumentSession>)ModifyEgorWithStoreOverwriteAfterLoadAndEvict];
             yield return [(Action<IDocumentSession>)ModifyEgorWithStoreOverwriteWithoutLoad];
-            //yield return [(Action<IDocumentSession>)ModifyEgorWithDelete];
             yield return [(Action<IDocumentSession>)ModifyEgorWithLoadAndDeleteById];
 
 
@@ -70,8 +70,11 @@ namespace SlowTests.Issues
         internal static void ModifyEgorWithStoreOverwriteAfterLoadAndEvict(IDocumentSession session)
         {
             var egor = session.Load<Employee>("employees/2-A");
+
+            // tracked entity is evicted from the session, so its not in the trackedEntities list anymore
             session.Advanced.Evict(egor);
-            session.Store(new Employee
+            // store after evict is treated as _new_ document, so it will be added to the trackedEntities list again with null change vector, and this should not cause concurrency exception because the original entity is evicted !
+            session.Store(new Employee 
             {
                 FirstName = "Egor",
                 Address = new Address()
@@ -175,49 +178,55 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore())
             {
-                using (var session = store.OpenSession())
+                ShouldThrowConcurrencyException_WhenTrackedEntityWasChangedInBackgroundSessionInternal(sessionAction, store);
+            }
+        }
+
+        private static void ShouldThrowConcurrencyException_WhenTrackedEntityWasChangedInBackgroundSessionInternal(Action<IDocumentSession> sessionAction, DocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee
                 {
-                    session.Store(new Employee
-                    {
-                        FirstName = "Jerry"
-                    }, "employees/1-A");
-                    session.Store(new Employee
-                    {
-                        FirstName = "Egor",
-                        Address = new Address()
-                        {
-                            Street = "Ahad Ha'am"
-                        }
-                    }, "employees/2-A");
-                    session.SaveChanges();
-
-                }
-
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                    FirstName = "Jerry"
+                }, "employees/1-A");
+                session.Store(new Employee
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                }))
-                {
-                    var jerry = session.Load<Employee>("employees/1-A");
-
-                    sessionAction.Invoke(session);
-
-                    var expected = session.Advanced.GetChangeVectorFor(jerry);
-                    Assert.NotEmpty(expected);
-                    Assert.NotNull(expected);
-
-                    var actual = string.Empty;
-                    using (var s = store.OpenSession())
+                    FirstName = "Egor",
+                    Address = new Address()
                     {
-                        var j = s.Load<Employee>("employees/1-A");
-                        j.Address = new Address()
-                        {
-                            City = "Hadera"
-                        };
-                        s.SaveChanges();
-
-                        actual = s.Advanced.GetChangeVectorFor(j);
+                        Street = "Ahad Ha'am"
                     }
+                }, "employees/2-A");
+                session.SaveChanges();
+
+            }
+
+            using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                   {
+                       TrackingMode = TrackingMode.TrackAllEntities,
+                   }))
+            {
+                var jerry = session.Load<Employee>("employees/1-A");
+
+                sessionAction.Invoke(session);
+
+                var expected = session.Advanced.GetChangeVectorFor(jerry);
+                Assert.NotEmpty(expected);
+                Assert.NotNull(expected);
+
+                var actual = string.Empty;
+                using (var s = store.OpenSession())
+                {
+                    var j = s.Load<Employee>("employees/1-A");
+                    j.Address = new Address()
+                    {
+                        City = "Hadera"
+                    };
+                    s.SaveChanges();
+
+                    actual = s.Advanced.GetChangeVectorFor(j);
+                }
 
                     Assert.NotEmpty(actual);
                     Assert.NotNull(actual);
@@ -225,32 +234,32 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
-                    Assert.Equal(expected, e.ExpectedChangeVector);
-                }
+                Assert.Equal(expected, e.ExpectedChangeVector);
+            }
 
-                using (var session = store.OpenSession(new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.TrackAllEntities
-                }))
-                {
-                    var egor = session.Load<Employee>("employees/2-A");
+            using (var session = store.OpenSession(new SessionOptions()
+                   {
+                       TrackingMode = TrackingMode.TrackAllEntities
+                   }))
+            {
+                var egor = session.Load<Employee>("employees/2-A");
 
-                    Assert.Equal("Egor", egor.FirstName);
-                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+                Assert.Equal("Egor", egor.FirstName);
+                Assert.Equal("Ahad Ha'am", egor.Address.Street);
 
-                    var j = session.Load<Employee>("employees/1-A");
-                    Assert.Equal("Hadera", j.Address.City);
-                }
+                var j = session.Load<Employee>("employees/1-A");
+                Assert.Equal("Hadera", j.Address.City);
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenNoCommandsInSessionButTrackedEntityWasChangedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenNoCommandsInSessionButTrackedEntityWasChangedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -304,7 +313,7 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
@@ -326,10 +335,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenTrackedEntityIsNullButThenWasAddedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityIsNullButThenWasAddedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -378,7 +388,7 @@ namespace SlowTests.Issues
 
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(string.Empty, e.ExpectedChangeVector);
@@ -400,10 +410,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByEntityButThenWasEditedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByEntityButThenWasEditedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -455,7 +466,7 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
@@ -477,10 +488,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityDeletedByIdWithoutChangeVectorButThenWasNotEditedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityDeletedByIdWithoutChangeVectorButThenWasNotEditedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -528,10 +540,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityDeletedByIdWithChangeVectorButThenWasNotEditedInBackgroundSession2()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityDeletedByIdWithChangeVectorButThenWasNotEditedInBackgroundSession2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -587,10 +600,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByIdButThenWasEditedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByIdButThenWasEditedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -638,7 +652,7 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
@@ -665,6 +679,103 @@ namespace SlowTests.Issues
         public void ShouldThrowConcurrencyException_WhenTrackedEntityIncludedBySessionButThenWasEditedInBackgroundSession(Action<IDocumentSession> sessionAction)
         {
             using (var store = GetDocumentStore())
+            {
+                ShouldThrowConcurrencyException_WhenTrackedEntityIncludedBySessionButThenWasEditedInBackgroundSessionInternal(sessionAction, store);
+            }
+        }
+
+        private static void ShouldThrowConcurrencyException_WhenTrackedEntityIncludedBySessionButThenWasEditedInBackgroundSessionInternal(Action<IDocumentSession> sessionAction, DocumentStore store)
+        {
+            string addressId;
+            using (var session = store.OpenSession())
+            {
+                var address = new Address()
+                {
+                    City = "Harish",
+                    Street = "Erets Rd"
+                };
+                session.Store(address);
+                addressId = session.Advanced.GetDocumentId(address);
+                Assert.NotNull(addressId);
+                address.Id = addressId;
+                session.Store(new Employee
+                {
+                    FirstName = "Jerry",
+                    Address = address
+                }, "employees/1-A");
+                session.Store(new Employee
+                {
+                    FirstName = "Egor",
+                    Address = new Address()
+                    {
+                        Street = "Ahad Ha'am"
+                    }
+                }, "employees/2-A");
+                session.SaveChanges();
+
+            }
+
+            using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                   {
+                       TrackingMode = TrackingMode.TrackAllEntities,
+                   }))
+            {
+                var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                var numOfRequests = session.Advanced.NumberOfRequests;
+
+                var address = session.Load<Address>(jerry.Address.Id);
+
+                Assert.NotNull(address);
+                Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                sessionAction.Invoke(session);
+
+                var expected = session.Advanced.GetChangeVectorFor(address);
+                Assert.NotEmpty(expected);
+                Assert.NotNull(expected);
+
+                var actual = string.Empty;
+                using (var s = store.OpenSession())
+                {
+                    var a = s.Load<Address>(addressId);
+                    a.City = "Hadera";
+                    s.SaveChanges();
+
+                    actual = s.Advanced.GetChangeVectorFor(a);
+                }
+
+                Assert.NotEmpty(actual);
+                Assert.NotNull(actual);
+
+                // this should throw concurrency exception for jerry
+                var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                Assert.Contains($"Document '{addressId}' has been modified", e.Message);
+                Assert.Equal(addressId, e.Id);
+                Assert.Equal(actual, e.ActualChangeVector);
+                Assert.Equal(expected, e.ExpectedChangeVector);
+            }
+
+            using (var session = store.OpenSession(new SessionOptions()
+                   {
+                       TrackingMode = TrackingMode.TrackAllEntities
+                   }))
+            {
+                var egor = session.Load<Employee>("employees/2-A");
+
+                Assert.Equal("Egor", egor.FirstName);
+                Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                var j = session.Load<Address>(addressId);
+                Assert.Equal("Hadera", j.City);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityEvictedFromTheSessionAndThenAddedBack()
+        {
+            using (var store = GetDocumentStore(Options.ForMode(RavenDatabaseMode.Single)))
             {
                 string addressId;
                 using (var session = store.OpenSession())
@@ -696,9 +807,9 @@ namespace SlowTests.Issues
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                }))
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
 
@@ -709,32 +820,67 @@ namespace SlowTests.Issues
                     Assert.NotNull(address);
                     Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
 
-                    sessionAction.Invoke(session);
+                    ModifyEgorWithStoreOverwriteAfterLoadAndEvict(session);
 
                     var expected = session.Advanced.GetChangeVectorFor(address);
                     Assert.NotEmpty(expected);
                     Assert.NotNull(expected);
 
-                    var actual = string.Empty;
-                    using (var s = store.OpenSession())
+                    // this should not throw concurrency exception
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities
+                       }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.Equal("Harish", j.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityReStored()
+        {
+            using (var store = GetDocumentStore(Options.ForMode(RavenDatabaseMode.Single)))
+            {
+                string addressId;
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
                     {
-                        var a = s.Load<Address>(addressId);
-                        a.City = "Hadera";
-                        s.SaveChanges();
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
 
-                        actual = s.Advanced.GetChangeVectorFor(a);
-                    }
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Mul HaHof Village"
+                        }
+                    }, "employees/2-A");
 
-                    Assert.NotEmpty(actual);
-                    Assert.NotNull(actual);
-
-                    // this should throw concurrency exception for jerry
-                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
-
-                    Assert.Contains("Document change vector mismatch", e.Message);
-                    Assert.Equal(addressId, e.Id);
-                    Assert.Equal(actual, e.ActualChangeVector);
-                    Assert.Equal(expected, e.ExpectedChangeVector);
+                    // this should not throw concurrency exception
+                    session.SaveChanges();
                 }
 
                 using (var session = store.OpenSession(new SessionOptions()
@@ -745,18 +891,16 @@ namespace SlowTests.Issues
                     var egor = session.Load<Employee>("employees/2-A");
 
                     Assert.Equal("Egor", egor.FirstName);
-                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
-
-                    var j = session.Load<Address>(addressId);
-                    Assert.Equal("Hadera", j.City);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
                 }
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasAddedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasAddedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 string addressId = "addresses/1-A";
                 var address = new Address()
@@ -815,7 +959,7 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'addresses/1-A' has been modified", e.Message);
                     Assert.Equal(addressId, e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(string.Empty, e.ExpectedChangeVector);
@@ -839,10 +983,11 @@ namespace SlowTests.Issues
         }
 
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasEditedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasEditedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 string addressId = "addresses/1-A";
                 var address = new Address()
@@ -907,7 +1052,7 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'addresses/1-A' has been modified", e.Message);
                     Assert.Equal(addressId, e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
@@ -930,10 +1075,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenEntityIncludedByIdInSessionButThenWasEditedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenEntityIncludedByIdInSessionButThenWasEditedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 string addressId;
                 using (var session = store.OpenSession())
@@ -994,7 +1140,7 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'addresses/1-A' has been modified", e.Message);
                     Assert.Equal(addressId, e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
@@ -1016,10 +1162,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityEvictedFromSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityEvictedFromSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1087,10 +1234,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenIncludedDocumentEvictedFromSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenIncludedDocumentEvictedFromSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 string addressId;
                 using (var session = store.OpenSession())
@@ -1172,10 +1320,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenEntityModifiedInBackgroundSessionButThenRefreshed()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenEntityModifiedInBackgroundSessionButThenRefreshed(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1245,10 +1394,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowConcurrencyException_WhenRefreshedEntityModifiedInBackgroundSession()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenRefreshedEntityModifiedInBackgroundSession(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1318,7 +1468,7 @@ namespace SlowTests.Issues
                     // Should throw concurrency exception for Jerry (refreshed entity was modified)
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actualJerryCv, e.ActualChangeVector);
                     Assert.Equal(expectedJerryCv, e.ExpectedChangeVector);
@@ -1340,10 +1490,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldUpdateChangeVector_WhenRefreshingMultipleEntities()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldUpdateChangeVector_WhenRefreshingMultipleEntities(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1400,10 +1551,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowException_WhenEvictingEntityDuringOnBeforeStore()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowException_WhenEvictingEntityDuringOnBeforeStore(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1430,10 +1582,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldHandleEvictAndReload_WithTrackingEnabled()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldHandleEvictAndReload_WithTrackingEnabled(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1484,16 +1637,17 @@ namespace SlowTests.Issues
                     // The entity tracking should have the new change vector
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                 }
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldHandleEvictAndReload_WithTrackingEnabled2()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldHandleEvictAndReload_WithTrackingEnabled2(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1552,10 +1706,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldHandleEvictAndReload_WithTrackingEnabled3()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldHandleEvictAndReload_WithTrackingEnabled3(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1616,10 +1771,11 @@ namespace SlowTests.Issues
 
 
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotTrack_AfterEvictingAllLoadedEntities()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotTrack_AfterEvictingAllLoadedEntities(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1671,10 +1827,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldRefreshAndMaintainTracking_WhenEntityModifiedLocally()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldRefreshAndMaintainTracking_WhenEntityModifiedLocally(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1720,10 +1877,11 @@ namespace SlowTests.Issues
         }
 
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldTrackExternalEntity_WhenAddedViaTrackEntityMethod()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldTrackExternalEntity_WhenAddedViaTrackEntityMethod(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1794,7 +1952,7 @@ namespace SlowTests.Issues
                     // This should throw concurrency exception for Egor (the externally tracked entity)
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Contains("Document 'employees/2-A' has been modified", ex.Message);
                     Assert.Equal("employees/2-A", ex.Id);
                     Assert.Equal(actualEgorCv, ex.ActualChangeVector);
                     Assert.Equal(externalChangeVector, ex.ExpectedChangeVector);
@@ -1802,10 +1960,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenExternallyTrackedEntityNotModified()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenExternallyTrackedEntityNotModified(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1872,7 +2031,7 @@ namespace SlowTests.Issues
                     // Should throw concurrency exception only for Jerry, not Egor
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Contains("Document 'employees/1-A' has been modified", ex.Message);
                     Assert.Equal("employees/1-A", ex.Id);
                 }
 
@@ -1887,10 +2046,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldThrowException_WhenRegisteringExternalEntityWithDifferentInstanceForSameId()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowException_WhenRegisteringExternalEntityWithDifferentInstanceForSameId(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1934,10 +2094,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldAllowReregisteringSameEntityInstance()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldAllowReregisteringSameEntityInstance(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1982,10 +2143,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldTrackMultipleExternalEntities_AndDetectConcurrencyViolations()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldTrackMultipleExternalEntities_AndDetectConcurrencyViolations(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -2070,7 +2232,7 @@ namespace SlowTests.Issues
                     // Should throw concurrency exception for Alice
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Contains("Document 'employees/3-A' has been modified", ex.Message);
                     Assert.Equal("employees/3-A", ex.Id);
                     Assert.Equal(actualAliceCv, ex.ActualChangeVector);
                     Assert.Equal(aliceCv, ex.ExpectedChangeVector);
@@ -2078,10 +2240,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotTrackExternalEntity_WhenNoTrackingModeEnabled()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotTrackExternalEntity_WhenNoTrackingModeEnabled(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 using (var session = store.OpenSession())
                 {
@@ -2138,10 +2301,11 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldRemoveFromIncluded_WhenRegisteringExternalEntityThatWasIncluded()
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldRemoveFromIncluded_WhenRegisteringExternalEntityThatWasIncluded(Options options)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetDocumentStore(options))
             {
                 string addressId;
                 using (var session = store.OpenSession())
@@ -2215,7 +2379,7 @@ namespace SlowTests.Issues
                     // Should throw concurrency exception for the address
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Contains("Document 'addresses/1-A' has been modified", ex.Message);
                     Assert.Equal(addressId, ex.Id);
                     Assert.Equal(actualAddressCv, ex.ActualChangeVector);
                     Assert.Equal(addressCv, ex.ExpectedChangeVector);

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
@@ -1303,12 +1304,103 @@ namespace SlowTests.Issues
 
         [RavenTheory(RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldNotThrowConcurrencyException_WhenIncludedDocumentEvictedFromSessionAsync(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                string addressId;
+                using (var session = store.OpenAsyncSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
+                {
+                    var address = new Address()
+                    {
+                        City = "Harish",
+                        Street = "Erets Rd"
+                    };
+                 await   session.StoreAsync(address);
+                    addressId = session.Advanced.GetDocumentId(address);
+                    Assert.NotNull(addressId);
+                    address.Id = addressId;
+                    await session.StoreAsync(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    await session.StoreAsync(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                 await   session.SaveChangesAsync();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var numOfRequests = session.Advanced.NumberOfRequests;
+                    var address = session.Load<Address>(jerry.Address.Id);
+                    Assert.NotNull(address);
+                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                    var expected = session.Advanced.GetChangeVectorFor(address);
+
+                    // Evict the included address from tracking
+                    session.Advanced.Evict(address);
+
+                    ModifyEgorInSession(session);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var a = s.Load<Address>(addressId);
+                        a.City = "Hadera";
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(a);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+                    Assert.NotEqual(expected, actual);
+
+                    // Should NOT throw concurrency exception because address was evicted
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.Equal("Hadera", j.City);
+                }
+            }
+        }
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void ShouldNotThrowConcurrencyException_WhenIncludedDocumentEvictedFromSession(Options options)
         {
             using (var store = GetDocumentStore(options))
             {
                 string addressId;
-                using (var session = store.OpenSession())
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
                 {
                     var address = new Address()
                     {
@@ -2627,6 +2719,231 @@ namespace SlowTests.Issues
                     var j = session.Load<Employee>("employees/1-A");
                     Assert.Null(j);
                 }
+            }
+        }
+
+        internal static IEnumerable<object[]> SessionAsyncActions()
+        {
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorInSessionAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorInPatchAfterLoadAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)(s => { ModifyEgorInPatchNoLoad(s); return Task.CompletedTask; })];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithStoreOverwriteAfterLoadAndEvictAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithStoreOverwriteWithoutLoadAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithLoadAndDeleteByIdAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithLoadAndDeleteByEntityAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)(s => { ModifyEgorWithMultiplePatchesAsync(s); return Task.CompletedTask; })];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorByReplacingAddressAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithAttachmentWithLoadAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)(s => { ModifyEgorWithAttachmentNoLoadAsync(s); return Task.CompletedTask; })];
+            yield return [(Func<IAsyncDocumentSession, Task>)(s => { ModifyEgorWithTimeSeriesNoLoadAsync(s); return Task.CompletedTask; })];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithTimeSeriesWithLoadAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithCounterWithLoadAsync];
+            yield return [(Func<IAsyncDocumentSession, Task>)(s => { ModifyEgorWithCounterNoLoadAsync(s); return Task.CompletedTask; })];
+            yield return [(Func<IAsyncDocumentSession, Task>)(s => { ModifyEgorWithRevisionNoLoadAsync(s); return Task.CompletedTask; })];
+            yield return [(Func<IAsyncDocumentSession, Task>)ModifyEgorWithRevisionWithLoadAsync];
+        }
+        internal static async Task ModifyEgorInPatchAfterLoadAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.Advanced.Patch(egor, e => e.Address.Street, "Mul HaHof Village");
+        }
+
+        internal static void ModifyEgorInPatchNoLoad(IAsyncDocumentSession session)
+        {
+            session.Advanced.Patch<Employee, string>("employees/2-A", e => e.Address.Street, "Mul HaHof Village");
+        }
+
+        internal static async Task ModifyEgorInSessionAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            egor.Address = new Address()
+            {
+                Street = "Mul HaHof Village"
+            };
+        }
+
+        internal static async Task ModifyEgorWithStoreOverwriteAfterLoadAndEvictAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+
+            // tracked entity is evicted from the session, so its not in the trackedEntities list anymore
+            session.Advanced.Evict(egor);
+            // store after evict is treated as _new_ document, so it will be added to the trackedEntities list again with null change vector, and this should not cause concurrency exception because the original entity is evicted !
+            await session.StoreAsync(new Employee
+            {
+                FirstName = "Egor",
+                Address = new Address()
+                {
+                    Street = "Mul HaHof Village"
+                }
+            }, "employees/2-A");
+        }
+
+        internal static async Task ModifyEgorWithStoreOverwriteWithoutLoadAsync(IAsyncDocumentSession session)
+        {
+            await session.StoreAsync(new Employee
+            {
+                FirstName = "Egor",
+                Address = new Address()
+                {
+                    Street = "Mul HaHof Village"
+                }
+            }, "employees/2-A");
+        }
+
+        internal static async Task ModifyEgorWithLoadAndDeleteByIdAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.Delete("employees/2-A");
+        }
+
+        internal static async Task ModifyEgorWithLoadAndDeleteByEntityAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.Delete(egor);
+        }
+
+        internal static void ModifyEgorWithMultiplePatchesAsync(IAsyncDocumentSession session)
+        {
+            session.Advanced.Patch<Employee, string>("employees/2-A", e => e.Address.Street, "Mul HaHof Village");
+            session.Advanced.Patch<Employee, string>("employees/2-A", e => e.FirstName, "Egor");
+        }
+
+        internal static async Task ModifyEgorByReplacingAddressAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.Advanced.Patch(egor, e => e.Address, new Address()
+            {
+                Street = "Mul HaHof Village",
+                City = "Hadera"
+            });
+        }
+
+        internal static async Task ModifyEgorWithAttachmentWithLoadAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.Advanced.Attachments.Store(egor, "profile-picture", new MemoryStream("image data"u8.ToArray()));
+        }
+
+        internal static void ModifyEgorWithAttachmentNoLoadAsync(IAsyncDocumentSession session)
+        {
+            session.Advanced.Attachments.Store("employees/2-A", "profile-picture", new MemoryStream("image data"u8.ToArray()));
+        }
+
+        internal static void ModifyEgorWithTimeSeriesNoLoadAsync(IAsyncDocumentSession session)
+        {
+            session.TimeSeriesFor("employees/2-A", "profile-picture-likes")
+                .Append(DateTime.UtcNow, new[] { 322d }, "super-like");
+        }
+
+        internal static async Task ModifyEgorWithTimeSeriesWithLoadAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.TimeSeriesFor(egor, "profile-picture-likes")
+                .Append(DateTime.UtcNow, new[] { 322d }, "super-like");
+        }
+
+        internal static async Task ModifyEgorWithCounterWithLoadAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.CountersFor(egor).Increment("profile-picture-likes");
+        }
+
+        internal static void ModifyEgorWithCounterNoLoadAsync(IAsyncDocumentSession session)
+        {
+            session.CountersFor("employees/2-A").Increment("profile-picture-likes");
+        }
+
+        internal static void ModifyEgorWithRevisionNoLoadAsync(IAsyncDocumentSession session)
+        {
+            session.Advanced.Revisions.ForceRevisionCreationFor("employees/2-A");
+        }
+
+        internal static async Task ModifyEgorWithRevisionWithLoadAsync(IAsyncDocumentSession session)
+        {
+            var egor = await session.LoadAsync<Employee>("employees/2-A");
+            session.Advanced.Revisions.ForceRevisionCreationFor(egor);
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [MemberData(nameof(SessionAsyncActions))]
+        public async Task ShouldThrowConcurrencyException_WhenTrackedEntityWasChangedInBackgroundSessionAsync(Func<IAsyncDocumentSession, Task> sessionAction)
+        {
+            using (var store = GetDocumentStore())
+            {
+                await ShouldThrowConcurrencyException_WhenTrackedEntityWasChangedInBackgroundSessionInternalAsync(sessionAction, store);
+            }
+        }
+
+        private static async Task ShouldThrowConcurrencyException_WhenTrackedEntityWasChangedInBackgroundSessionInternalAsync(Func<IAsyncDocumentSession, Task> sessionAction, DocumentStore store)
+        {
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Employee
+                {
+                    FirstName = "Jerry"
+                }, "employees/1-A");
+                await session.StoreAsync(new Employee
+                {
+                    FirstName = "Egor",
+                    Address = new Address()
+                    {
+                        Street = "Ahad Ha'am"
+                    }
+                }, "employees/2-A");
+                await session.SaveChangesAsync();
+            }
+
+            using (IAsyncDocumentSession session = store.OpenAsyncSession(new SessionOptions()
+            {
+                TrackingMode = TrackingMode.TrackAllEntities,
+            }))
+            {
+                var jerry = await session.LoadAsync<Employee>("employees/1-A");
+
+                await sessionAction.Invoke(session);
+
+                var expected = session.Advanced.GetChangeVectorFor(jerry);
+                Assert.NotEmpty(expected);
+                Assert.NotNull(expected);
+
+                var actual = string.Empty;
+                using (var s = store.OpenSession())
+                {
+                    var j = s.Load<Employee>("employees/1-A");
+                    j.Address = new Address()
+                    {
+                        City = "Hadera"
+                    };
+                    s.SaveChanges();
+
+                    actual = s.Advanced.GetChangeVectorFor(j);
+                }
+
+                Assert.NotEmpty(actual);
+                Assert.NotNull(actual);
+
+                // this should throw concurrency exception for jerry
+                var e = await Assert.ThrowsAsync<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChangesAsync());
+
+                Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
+                Assert.Equal("employees/1-A", e.Id);
+                Assert.Equal(actual, e.ActualChangeVector);
+                Assert.Equal(expected, e.ExpectedChangeVector);
+            }
+
+            using (var session = store.OpenSession(new SessionOptions()
+            {
+                TrackingMode = TrackingMode.TrackAllEntities
+            }))
+            {
+                var egor = session.Load<Employee>("employees/2-A");
+
+                Assert.Equal("Egor", egor.FirstName);
+                Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                var j = session.Load<Employee>("employees/1-A");
+                Assert.Equal("Hadera", j.Address.City);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -2386,5 +2386,181 @@ namespace SlowTests.Issues
                 }
             }
         }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityLoadedButThenWasDeletedInBackgroundSession(Options options)
+        {
+            ShouldThrowConcurrencyException_WhenTrackedEntityLoadedButThenWasDeletedInternal(options, deleteById: false);
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityLoadedButThenWasDeletedByIdInBackgroundSession(Options options)
+        {
+            ShouldThrowConcurrencyException_WhenTrackedEntityLoadedButThenWasDeletedInternal(options, deleteById: true);
+        }
+
+        private void ShouldThrowConcurrencyException_WhenTrackedEntityLoadedButThenWasDeletedInternal(Options options, bool deleteById)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities,
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    //session.Delete("employees/1-A");
+                    // delete / delete by id (both here and in background)
+
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+                    using (var s = store.OpenSession())
+                    {
+                        if (deleteById == false)
+                        {
+                            var j = s.Load<Employee>("employees/1-A");
+                            s.Delete(j);
+                        }
+                        else
+                        {
+                            s.Delete("employees/1-A");
+                        }
+
+                        s.SaveChanges();
+                    }
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Null(e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                       {
+                           TrackingMode = TrackingMode.TrackAllEntities
+                       }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Null(j);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = [false, false])]
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityLoadedButThenWasDeletedInBackgroundSession2(Options options, bool deleteById, bool deleteByIdInBackgroundSession)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    string expected = null;
+                    if (deleteByIdInBackgroundSession == false)
+                    {
+                        var jerry = session.Load<Employee>("employees/1-A");
+                        expected = session.Advanced.GetChangeVectorFor(jerry);
+
+                        session.Delete(jerry);
+                    }
+                    else
+                    {
+                        session.Delete("employees/1-A");
+                    }
+
+                    using (var s = store.OpenSession())
+                    {
+                        if (deleteById == false)
+                        {
+                            var j = s.Load<Employee>("employees/1-A");
+                            s.Delete(j);
+                        }
+                        else
+                        {
+                            s.Delete("employees/1-A");
+                        }
+
+                        s.SaveChanges();
+                    }
+
+                    if (deleteByIdInBackgroundSession == false)
+                    {
+                        // this should throw concurrency exception for jerry since it was tracked in session when deleted
+                        var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+                        Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
+                        Assert.Equal("employees/1-A", e.Id);
+                        Assert.Null(e.ActualChangeVector);
+                        Assert.Equal(expected, e.ExpectedChangeVector);
+                    }
+                    else
+                    {
+                        // this should not throw concurrency exception for jerry
+                        session.SaveChanges();
+                    }
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Null(j);
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -4,13 +4,14 @@ using System.IO;
 using FastTests;
 using Raven.Client.Documents.Session;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_25154 : RavenTestBase
+    public partial class RavenDB_25154 : RavenTestBase
     {
         public RavenDB_25154(ITestOutputHelper output) : base(output)
         {
@@ -92,13 +93,6 @@ namespace SlowTests.Issues
             }, "employees/2-A");
         }
 
-        // TODO: egor this is not tracked in sessions, so we don't care!
-        internal static void ModifyEgorWithDelete(IDocumentSession session)
-        {
-            session.Delete("employees/2-A");
-
-        }
-
         internal static void ModifyEgorWithLoadAndDeleteById(IDocumentSession session)
         {
             var egor = session.Load<Employee>("employees/2-A");
@@ -111,34 +105,6 @@ namespace SlowTests.Issues
 
             session.Delete(egor);
         }
-        ////TODO: egor doesn't twork
-        //internal static void ModifyEgorWithDeleteAndStore(IDocumentSession session)
-        //{
-        //    session.Delete("employees/2-A");
-        //    session.Store(new Employee
-        //    {
-        //        FirstName = "Egor",
-        //        Address = new Address()
-        //        {
-        //            Street = "Mul HaHof Village"
-        //        }
-        //    }, "employees/2-A");
-        //}
-
-        ////TODO: egor doesn't twork
-        //internal static void ModifyEgorWithLoadDeleteAndStore(IDocumentSession session)
-        //{
-        //    var egor = session.Load<Employee>("employees/2-A");
-        //    session.Delete(egor);
-        //    session.Store(new Employee
-        //    {
-        //        FirstName = "Egor",
-        //        Address = new Address()
-        //        {
-        //            Street = "Mul HaHof Village"
-        //        }
-        //    }, "employees/2-A");
-        //}
 
         internal static void ModifyEgorWithMultiplePatches(IDocumentSession session)
         {
@@ -281,7 +247,6 @@ namespace SlowTests.Issues
             }
         }
 
-        // TODO: egor 322
         [RavenFact(RavenTestCategory.ClientApi)]
         public void ShouldThrowConcurrencyException_WhenNoCommandsInSessionButTrackedEntityWasChangedInBackgroundSession()
         {
@@ -968,7 +933,6 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.ClientApi)]
         public void ShouldThrowConcurrencyException_WhenEntityIncludedByIdInSessionButThenWasEditedInBackgroundSession()
         {
-            throw new NotImplementedException("TODO: egor This test is for the case when we include by id and not by lambda, but currently we only support include by lambda");
             using (var store = GetDocumentStore())
             {
                 string addressId;
@@ -997,7 +961,6 @@ namespace SlowTests.Issues
                         }
                     }, "employees/2-A");
                     session.SaveChanges();
-
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
@@ -1007,9 +970,13 @@ namespace SlowTests.Issues
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
                     ModifyEgorInSession(session);
-                    //var expected = session.Advanced.GetChangeVectorFor(address);
-                    //Assert.NotEmpty(expected);
-                    //Assert.NotNull(expected);
+
+                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
+                    inMemSes.IncludedDocumentsById.TryGetValue(addressId, out var included);
+                    Assert.NotNull(included);
+                    var expected = included.ChangeVector;
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
 
                     var actual = string.Empty;
                     using (var s = store.OpenSession())
@@ -1024,15 +991,13 @@ namespace SlowTests.Issues
                     Assert.NotEmpty(actual);
                     Assert.NotNull(actual);
 
-                    //TODO: egor fix this
-
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
                     Assert.Contains("Document change vector mismatch", e.Message);
                     Assert.Equal(addressId, e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
-                    // Assert.Equal(expected, e.ExpectedChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
                 }
 
                 using (var session = store.OpenSession(new SessionOptions()
@@ -1047,6 +1012,1213 @@ namespace SlowTests.Issues
 
                     var j = session.Load<Address>(addressId);
                     Assert.Equal("Hadera", j.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityEvictedFromSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+
+                    ModifyEgorInSession(session);
+
+                    // Evict Jerry from the session - this should stop tracking him
+                    session.Advanced.Evict(jerry);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Hadera"
+                        };
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+                    Assert.NotEqual(expected, actual);
+
+                    // Should NOT throw concurrency exception because Jerry was evicted
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenIncludedDocumentEvictedFromSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string addressId;
+                using (var session = store.OpenSession())
+                {
+                    var address = new Address()
+                    {
+                        City = "Harish",
+                        Street = "Erets Rd"
+                    };
+                    session.Store(address);
+                    addressId = session.Advanced.GetDocumentId(address);
+                    Assert.NotNull(addressId);
+                    address.Id = addressId;
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var numOfRequests = session.Advanced.NumberOfRequests;
+                    var address = session.Load<Address>(jerry.Address.Id);
+                    Assert.NotNull(address);
+                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                    var expected = session.Advanced.GetChangeVectorFor(address);
+
+                    // Evict the included address from tracking
+                    session.Advanced.Evict(address);
+
+                    ModifyEgorInSession(session);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var a = s.Load<Address>(addressId);
+                        a.City = "Hadera";
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(a);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+                    Assert.NotEqual(expected, actual);
+
+                    // Should NOT throw concurrency exception because address was evicted
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.Equal("Hadera", j.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenEntityModifiedInBackgroundSessionButThenRefreshed()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = new Address()
+                        {
+                            City = "Hadera"
+                        }
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egorFromSession = session.Load<Employee>("employees/2-A");
+
+                    // Modify Jerry in background session
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Tel Aviv"
+                        };
+                        s.SaveChanges();
+                    }
+
+                    // Refresh Jerry to get the latest version
+                    session.Advanced.Refresh(jerry);
+
+                    // Verify Jerry has updated data
+                    Assert.Equal("Tel Aviv", jerry.Address.City);
+
+                    ModifyEgorInSession(session);
+
+                    //should work since we refreshed jerry after modification in background session
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Jerry", j.FirstName);
+                    Assert.Equal("Tel Aviv", j.Address.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenRefreshedEntityModifiedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = new Address()
+                        {
+                            City = "Hadera"
+                        }
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egorFromSession = session.Load<Employee>("employees/2-A");
+
+                    // Modify Jerry in background session
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Tel Aviv"
+                        };
+                        s.SaveChanges();
+                    }
+
+                    // Refresh Jerry to get the latest version
+                    session.Advanced.Refresh(jerry);
+
+                    // Verify Jerry has updated data
+                    Assert.Equal("Tel Aviv", jerry.Address.City);
+
+                    var expectedJerryCv = session.Advanced.GetChangeVectorFor(jerry);
+
+                    ModifyEgorInSession(session);
+
+                    // Now modify Jerry again in background session
+                    var actualJerryCv = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.FirstName = "Jeremy";
+                        s.SaveChanges();
+
+                        actualJerryCv = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actualJerryCv);
+                    Assert.NotNull(actualJerryCv);
+                    Assert.NotEqual(expectedJerryCv, actualJerryCv);
+
+                    // Should throw concurrency exception for Jerry (refreshed entity was modified)
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Equal(actualJerryCv, e.ActualChangeVector);
+                    Assert.Equal(expectedJerryCv, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Jeremy", j.FirstName);
+                    Assert.Equal("Tel Aviv", j.Address.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldUpdateChangeVector_WhenRefreshingMultipleEntities()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.Store(new Employee { FirstName = "Alice" }, "employees/3-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egor = session.Load<Employee>("employees/2-A");
+                    var alice = session.Load<Employee>("employees/3-A");
+
+                    var originalJerryCv = session.Advanced.GetChangeVectorFor(jerry);
+                    var originalEgorCv = session.Advanced.GetChangeVectorFor(egor);
+                    var originalAliceCv = session.Advanced.GetChangeVectorFor(alice);
+
+                    // Modify entities in background session
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.FirstName = "Jeremy";
+
+                        var e = s.Load<Employee>("employees/2-A");
+                        e.FirstName = "Greg";
+
+                        s.SaveChanges();
+                    }
+
+                    // Refresh multiple entities at once
+                    session.Advanced.Refresh<Employee>(new List<Employee>() { jerry, egor, alice });
+
+                    // Verify change vectors updated for modified entities
+                    var newJerryCv = session.Advanced.GetChangeVectorFor(jerry);
+                    var newEgorCv = session.Advanced.GetChangeVectorFor(egor);
+                    var newAliceCv = session.Advanced.GetChangeVectorFor(alice);
+
+                    Assert.NotEqual(originalJerryCv, newJerryCv);
+                    Assert.NotEqual(originalEgorCv, newEgorCv);
+                    Assert.Equal(originalAliceCv, newAliceCv); // Alice wasn't modified
+
+                    // Verify data was refreshed
+                    Assert.Equal("Jeremy", jerry.FirstName);
+                    Assert.Equal("Greg", egor.FirstName);
+                    Assert.Equal("Alice", alice.FirstName);
+
+                    session.SaveChanges(); // Should not throw
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowException_WhenEvictingEntityDuringOnBeforeStore()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    session.Advanced.OnBeforeStore += (sender, args) =>
+                    {
+                        // This should throw because we can't evict during OnBeforeStore
+                        Assert.Throws<InvalidOperationException>(() => session.Advanced.Evict(args.Entity));
+                    };
+
+                    jerry.FirstName = "Jeremy";
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldHandleEvictAndReload_WithTrackingEnabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = new Address { City = "Hadera" }
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var originalCv = session.Advanced.GetChangeVectorFor(jerry);
+
+                    // Modify in background
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address.City = "Tel Aviv";
+                        s.SaveChanges();
+                    }
+
+                    // Evict the entity
+                    session.Advanced.Evict(jerry);
+
+                    // Reload - should get fresh data from server
+                    var jerryReloaded = session.Load<Employee>("employees/1-A");
+                    var newCv = session.Advanced.GetChangeVectorFor(jerryReloaded);
+
+                    Assert.NotSame(jerry, jerryReloaded); // Different instances
+                    Assert.NotEqual(originalCv, newCv);
+                    Assert.Equal("Tel Aviv", jerryReloaded.Address.City);
+
+                    // Make another background change
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.FirstName = "Jeremy";
+                        s.SaveChanges();
+                    }
+
+
+                    // The entity tracking should have the new change vector
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldHandleEvictAndReload_WithTrackingEnabled2()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = new Address { City = "Hadera" }
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var originalCv = session.Advanced.GetChangeVectorFor(jerry);
+                    ModifyEgorInSession(session);
+
+                    // Modify in background
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address.City = "Tel Aviv";
+                        s.SaveChanges();
+                    }
+
+                    // Evict the entity
+                    session.Advanced.Evict(jerry);
+
+                    // Should not throw because entities were evicted
+                    session.SaveChanges();
+                }
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Jerry", j.FirstName);
+                    Assert.Equal("Tel Aviv", j.Address.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldHandleEvictAndReload_WithTrackingEnabled3()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = new Address { City = "Hadera" }
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var originalCv = session.Advanced.GetChangeVectorFor(jerry);
+                    ModifyEgorInSession(session);
+
+                    // Evict the entity
+                    session.Advanced.Evict(jerry);
+
+                    // Modify in background
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address.City = "Tel Aviv";
+                        s.SaveChanges();
+                    }
+
+                    // Should not throw because entities were evicted
+                    session.SaveChanges();
+                }
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Jerry", j.FirstName);
+                    Assert.Equal("Tel Aviv", j.Address.City);
+                }
+            }
+        }
+
+
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotTrack_AfterEvictingAllLoadedEntities()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal(2, ((InMemoryDocumentSessionOperations)session).NumberOfEntitiesInUnitOfWork);
+
+                    // Evict both entities
+                    session.Advanced.Evict(jerry);
+                    session.Advanced.Evict(egor);
+
+                    Assert.Equal(0, ((InMemoryDocumentSessionOperations)session).NumberOfEntitiesInUnitOfWork);
+
+                    // Modify both in background
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.FirstName = "Jeremy";
+
+                        var e = s.Load<Employee>("employees/2-A");
+                        e.FirstName = "Greg";
+
+                        s.SaveChanges();
+                    }
+
+                    // Should not throw because entities were evicted
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Jeremy", jerry.FirstName);
+                    Assert.Equal("Greg", egor.FirstName);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldRefreshAndMaintainTracking_WhenEntityModifiedLocally()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = new Address { City = "Hadera" }
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    // Modify locally
+                    jerry.Address.Street = "Local Street";
+
+                    // Refresh should discard local changes and get server data
+                    session.Advanced.Refresh(jerry);
+
+                    // Local changes should be lost
+                    Assert.Null(jerry.Address.Street);
+                    Assert.Equal("Hadera", jerry.Address.City);
+
+                    // Entity should still be tracked
+                    Assert.True(session.Advanced.IsLoaded("employees/1-A"));
+
+                    // Make a change and save
+                    jerry.FirstName = "Jeremy";
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Jeremy", jerry.FirstName);
+                }
+            }
+        }
+
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldTrackExternalEntity_WhenAddedViaTrackEntityMethod()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // Load Jerry to get his change vector
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var jerryChangeVector = session.Advanced.GetChangeVectorFor(jerry);
+
+                    // Create an external entity (from another session or source)
+                    Employee externalEmployee;
+                    string externalChangeVector;
+                    using (var externalSession = store.OpenSession())
+                    {
+                        externalEmployee = externalSession.Load<Employee>("employees/2-A");
+                        externalChangeVector = externalSession.Advanced.GetChangeVectorFor(externalEmployee);
+                    }
+
+                    // Register the external entity using TrackEntity
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+                    var documentInfo = new DocumentInfo
+                    {
+                        Id = "employees/2-A",
+                        Entity = externalEmployee,
+                        ChangeVector = externalChangeVector,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = externalChangeVector
+                        }, "employees/2-A")
+                    };
+
+                    inMemSession.RegisterExternalLoadedIntoTheSession(documentInfo);
+
+                    // Verify tracking
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue("employees/2-A", out var trackedCv));
+                    Assert.Equal(externalChangeVector, trackedCv);
+
+                    // Modify Egor in background (the externally tracked entity)
+                    var actualEgorCv = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var e = s.Load<Employee>("employees/2-A");
+                        e.Address = new Address() { Street = "Mul HaHof Village" };
+                        s.SaveChanges();
+                        actualEgorCv = s.Advanced.GetChangeVectorFor(e);
+                    }
+
+                    // This should throw concurrency exception for Egor (the externally tracked entity)
+                    var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Equal("employees/2-A", ex.Id);
+                    Assert.Equal(actualEgorCv, ex.ActualChangeVector);
+                    Assert.Equal(externalChangeVector, ex.ExpectedChangeVector);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotThrowConcurrencyException_WhenExternallyTrackedEntityNotModified()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // Load Jerry normally
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    // Create an external entity (from another session)
+                    Employee externalEmployee;
+                    string externalChangeVector;
+                    using (var externalSession = store.OpenSession())
+                    {
+                        externalEmployee = externalSession.Load<Employee>("employees/2-A");
+                        externalChangeVector = externalSession.Advanced.GetChangeVectorFor(externalEmployee);
+                    }
+
+                    // Register the external entity using TrackEntity
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+                    var documentInfo = new DocumentInfo
+                    {
+                        Id = "employees/2-A",
+                        Entity = externalEmployee,
+                        ChangeVector = externalChangeVector,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = externalChangeVector
+                        }, "employees/2-A")
+                    };
+
+                    using var newInstance = inMemSession.JsonConverter.ToBlittable(externalEmployee, null);
+
+                    documentInfo.Document = newInstance;
+                    inMemSession.TrackEntity<Employee>(documentInfo);
+
+                    // Modify only Jerry in background
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address() { City = "Hadera" };
+                        s.SaveChanges();
+                    }
+
+                    // Should throw concurrency exception only for Jerry, not Egor
+                    var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Equal("employees/1-A", ex.Id);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Hadera", jerry.Address.City);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowException_WhenRegisteringExternalEntityWithDifferentInstanceForSameId()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // Load Jerry normally
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var jerryChangeVector = session.Advanced.GetChangeVectorFor(jerry);
+
+                    // Try to register a different instance for the same ID
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+                    var documentInfo = new DocumentInfo
+                    {
+                        Id = "employees/1-A",
+                        Entity = new Employee { FirstName = "Different Jerry" },
+                        ChangeVector = jerryChangeVector,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = jerryChangeVector
+                        }, "employees/1-A")
+                    };
+
+                    // Should throw because we already have a different instance tracked for this ID
+                    var ex = Assert.Throws<InvalidOperationException>(() =>
+                        inMemSession.RegisterExternalLoadedIntoTheSession(documentInfo));
+
+                    Assert.Contains("is already in the session with a different entity instance", ex.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldAllowReregisteringSameEntityInstance()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // Load Jerry normally
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var jerryChangeVector = session.Advanced.GetChangeVectorFor(jerry);
+
+                    // Try to re-register the same instance
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+                    var documentInfo = new DocumentInfo
+                    {
+                        Id = "employees/1-A",
+                        Entity = jerry,
+                        ChangeVector = jerryChangeVector,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = jerryChangeVector
+                        }, "employees/1-A")
+                    };
+
+                    // Should not throw - same instance is ok
+                    inMemSession.RegisterExternalLoadedIntoTheSession(documentInfo);
+
+                    // Verify it's still tracked
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue("employees/1-A", out var trackedCv));
+                    Assert.Equal(jerryChangeVector, trackedCv);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldTrackMultipleExternalEntities_AndDetectConcurrencyViolations()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.Store(new Employee { FirstName = "Alice" }, "employees/3-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // Load Jerry normally
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    // Register Egor and Alice as external entities
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+
+                    // Register Egor
+                    Employee egor;
+                    string egorCv;
+                    using (var externalSession = store.OpenSession())
+                    {
+                        egor = externalSession.Load<Employee>("employees/2-A");
+                        egorCv = externalSession.Advanced.GetChangeVectorFor(egor);
+                    }
+
+                    var egorDocInfo = new DocumentInfo
+                    {
+                        Id = "employees/2-A",
+                        Entity = egor,
+                        ChangeVector = egorCv,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = egorCv
+                        }, "employees/2-A")
+                    };
+                    inMemSession.RegisterExternalLoadedIntoTheSession(egorDocInfo);
+
+                    // Register Alice
+                    Employee alice;
+                    string aliceCv;
+                    using (var externalSession = store.OpenSession())
+                    {
+                        alice = externalSession.Load<Employee>("employees/3-A");
+                        aliceCv = externalSession.Advanced.GetChangeVectorFor(alice);
+                    }
+
+                    var aliceDocInfo = new DocumentInfo
+                    {
+                        Id = "employees/3-A",
+                        Entity = alice,
+                        ChangeVector = aliceCv,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = aliceCv
+                        }, "employees/3-A")
+                    };
+                    inMemSession.RegisterExternalLoadedIntoTheSession(aliceDocInfo);
+
+                    // Verify all are tracked
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue("employees/1-A", out _));
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue("employees/2-A", out _));
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue("employees/3-A", out _));
+
+                    // Modify Alice in background
+                    var actualAliceCv = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var a = s.Load<Employee>("employees/3-A");
+                        a.FirstName = "Alicia";
+                        s.SaveChanges();
+                        actualAliceCv = s.Advanced.GetChangeVectorFor(a);
+                    }
+
+                    // Should throw concurrency exception for Alice
+                    var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Equal("employees/3-A", ex.Id);
+                    Assert.Equal(actualAliceCv, ex.ActualChangeVector);
+                    Assert.Equal(aliceCv, ex.ExpectedChangeVector);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldNotTrackExternalEntity_WhenNoTrackingModeEnabled()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.NoTracking,
+                }))
+                {
+                    // Try to register an external entity in NoTracking session
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+
+                    Employee egor;
+                    string egorCv;
+                    using (var externalSession = store.OpenSession())
+                    {
+                        egor = externalSession.Load<Employee>("employees/2-A");
+                        egorCv = externalSession.Advanced.GetChangeVectorFor(egor);
+                    }
+
+                    var documentInfo = new DocumentInfo
+                    {
+                        Id = "employees/2-A",
+                        Entity = egor,
+                        ChangeVector = egorCv,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Employees",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = egorCv
+                        }, "employees/2-A")
+                    };
+
+                    // Should not track in NoTracking mode
+                    inMemSession.RegisterExternalLoadedIntoTheSession(documentInfo);
+
+                    // Verify it's not tracked
+                    Assert.False(inMemSession.TrackedEntities.TryGetValue("employees/2-A", out _));
+
+                    // Modify in background - should NOT throw concurrency exception
+                    using (var s = store.OpenSession())
+                    {
+                        var e = s.Load<Employee>("employees/2-A");
+                        e.FirstName = "Greg";
+                        s.SaveChanges();
+                    }
+
+                    session.SaveChanges(); // Should not throw
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldRemoveFromIncluded_WhenRegisteringExternalEntityThatWasIncluded()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string addressId;
+                using (var session = store.OpenSession())
+                {
+                    var address = new Address { City = "Harish", Street = "Erets Rd" };
+                    session.Store(address);
+                    addressId = session.Advanced.GetDocumentId(address);
+                    address.Id = addressId;
+
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // Load with include
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var inMemSession = (InMemoryDocumentSessionOperations)session;
+
+                    // Verify address is in included documents
+                    Assert.True(inMemSession.IncludedDocumentsById.ContainsKey(addressId));
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue(addressId, out _));
+
+                    // Now register the same address as external entity
+                    Address externalAddress;
+                    string addressCv;
+                    using (var externalSession = store.OpenSession())
+                    {
+                        externalAddress = externalSession.Load<Address>(addressId);
+                        addressCv = externalSession.Advanced.GetChangeVectorFor(externalAddress);
+                    }
+
+                    var documentInfo = new DocumentInfo
+                    {
+                        Id = addressId,
+                        Entity = externalAddress,
+                        ChangeVector = addressCv,
+                        Document = null,
+                        Metadata = inMemSession.Context.ReadObject(new DynamicJsonValue
+                        {
+                            [Raven.Client.Constants.Documents.Metadata.Collection] = "Addresses",
+                            [Raven.Client.Constants.Documents.Metadata.ChangeVector] = addressCv
+                        }, addressId)
+                    };
+
+                    inMemSession.RegisterExternalLoadedIntoTheSession(documentInfo);
+
+                    // Verify it's no longer in included documents but is tracked
+                    Assert.False(inMemSession.IncludedDocumentsById.ContainsKey(addressId));
+                    Assert.True(inMemSession.TrackedEntities.TryGetValue(addressId, out var trackedCv));
+                    Assert.Equal(addressCv, trackedCv);
+
+                    // Modify address in background
+                    var actualAddressCv = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var a = s.Load<Address>(addressId);
+                        a.City = "Hadera";
+                        s.SaveChanges();
+                        actualAddressCv = s.Advanced.GetChangeVectorFor(a);
+                    }
+
+                    // Should throw concurrency exception for the address
+                    var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", ex.Message);
+                    Assert.Equal(addressId, ex.Id);
+                    Assert.Equal(actualAddressCv, ex.ActualChangeVector);
+                    Assert.Equal(addressCv, ex.ExpectedChangeVector);
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -111,7 +111,7 @@ namespace SlowTests.Issues
 
             session.Delete(egor);
         }
-        ////TODO: doesn twork
+        ////TODO: egor doesn't twork
         //internal static void ModifyEgorWithDeleteAndStore(IDocumentSession session)
         //{
         //    session.Delete("employees/2-A");
@@ -125,7 +125,7 @@ namespace SlowTests.Issues
         //    }, "employees/2-A");
         //}
 
-        ////TODO: doesn twork
+        ////TODO: egor doesn't twork
         //internal static void ModifyEgorWithLoadDeleteAndStore(IDocumentSession session)
         //{
         //    var egor = session.Load<Employee>("employees/2-A");
@@ -228,9 +228,9 @@ namespace SlowTests.Issues
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities,
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
 
@@ -266,9 +266,9 @@ namespace SlowTests.Issues
                 }
 
                 using (var session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
 
@@ -281,7 +281,86 @@ namespace SlowTests.Issues
             }
         }
 
-        //TODO: egor what happends when I load the document but its null, then I try to SaveChanges but thsi document was added meanwhile but another session
+        // TODO: egor 322
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenNoCommandsInSessionButTrackedEntityWasChangedInBackgroundSession()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    ModifyEgorInSession(session);
+
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
+
+                    session.SaveChanges();
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Hadera"
+                        };
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(j);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
         [RavenFact(RavenTestCategory.ClientApi)]
         public void ShouldThrowConcurrencyException_WhenTrackedEntityIsNullButThenWasAddedInBackgroundSession()
         {
@@ -302,9 +381,9 @@ namespace SlowTests.Issues
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities,
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
                     Assert.Null(jerry);
@@ -341,9 +420,9 @@ namespace SlowTests.Issues
                 }
 
                 using (var session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
 
@@ -356,7 +435,6 @@ namespace SlowTests.Issues
             }
         }
 
-        //TODO: egor what happends when I delete the document , then I try to SaveChanges but thsi document was added meanwhile but another session
         [RavenFact(RavenTestCategory.ClientApi)]
         public void ShouldThrowConcurrencyException_WhenTrackedEntityDeletedByEntityButThenWasEditedInBackgroundSession()
         {
@@ -381,9 +459,9 @@ namespace SlowTests.Issues
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities,
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
                     session.Delete<Employee>(jerry);
@@ -419,9 +497,9 @@ namespace SlowTests.Issues
                 }
 
                 using (var session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
 
@@ -564,7 +642,6 @@ namespace SlowTests.Issues
                         }
                     }, "employees/2-A");
                     session.SaveChanges();
-
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
@@ -598,7 +675,7 @@ namespace SlowTests.Issues
 
                     Assert.Contains("Document change vector mismatch", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
-                             Assert.Equal(actual, e.ActualChangeVector);
+                    Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
                 }
 
@@ -654,9 +731,9 @@ namespace SlowTests.Issues
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities,
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
 
@@ -696,9 +773,9 @@ namespace SlowTests.Issues
                 }
 
                 using (var session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities
-                       }))
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
 
@@ -883,6 +960,92 @@ namespace SlowTests.Issues
 
                     var j = session.Load<Address>(addressId);
                     Assert.NotNull(j);
+                    Assert.Equal("Hadera", j.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void ShouldThrowConcurrencyException_WhenEntityIncludedByIdInSessionButThenWasEditedInBackgroundSession()
+        {
+            throw new NotImplementedException("TODO: egor This test is for the case when we include by id and not by lambda, but currently we only support include by lambda");
+            using (var store = GetDocumentStore())
+            {
+                string addressId;
+                using (var session = store.OpenSession())
+                {
+                    var address = new Address()
+                    {
+                        City = "Harish",
+                        Street = "Erets Rd"
+                    };
+                    session.Store(address);
+                    addressId = session.Advanced.GetDocumentId(address);
+                    Assert.NotNull(addressId);
+                    address.Id = addressId;
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+                    ModifyEgorInSession(session);
+                    //var expected = session.Advanced.GetChangeVectorFor(address);
+                    //Assert.NotEmpty(expected);
+                    //Assert.NotNull(expected);
+
+                    var actual = string.Empty;
+                    using (var s = store.OpenSession())
+                    {
+                        var a = s.Load<Address>(addressId);
+                        a.City = "Hadera";
+                        s.SaveChanges();
+
+                        actual = s.Advanced.GetChangeVectorFor(a);
+                    }
+
+                    Assert.NotEmpty(actual);
+                    Assert.NotNull(actual);
+
+                    //TODO: egor fix this
+
+                    // this should throw concurrency exception for jerry
+                    var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document change vector mismatch", e.Message);
+                    Assert.Equal(addressId, e.Id);
+                    Assert.Equal(actual, e.ActualChangeVector);
+                    // Assert.Equal(expected, e.ExpectedChangeVector);
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
                     Assert.Equal("Hadera", j.City);
                 }
             }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -1164,6 +1164,73 @@ namespace SlowTests.Issues
 
         [RavenTheory(RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public void ShouldNotThrowConcurrencyException_WhenNonExistsEntityIncludedBySessionButThenWasNotAddedInBackgroundSession(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                string addressId = "addresses/1-A";
+                var address = new Address()
+                {
+                    City = "Harish",
+                    Street = "Erets Rd",
+                    Id = addressId
+                };
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities,
+                }))
+                {
+                    // this should put the include into missing ids
+                    var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
+
+                    var numOfRequests = session.Advanced.NumberOfRequests;
+                    Assert.Null(session.Load<Address>(jerry.Address.Id));
+                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
+
+                    ModifyEgorInSession(session);
+
+                   session.SaveChanges();
+
+                }
+
+                using (var session = store.OpenSession(new SessionOptions()
+                {
+                    TrackingMode = TrackingMode.TrackAllEntities
+                }))
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+
+                    var j = session.Load<Address>(addressId);
+                    Assert.Null(j);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void ShouldNotThrowConcurrencyException_WhenTrackedEntityEvictedFromSession(Options options)
         {
             using (var store = GetDocumentStore(options))
@@ -2450,9 +2517,9 @@ namespace SlowTests.Issues
                     // this should throw concurrency exception for jerry
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
+                    Assert.Contains($"Document 'employees/1-A' has been modified since it was loaded. The expected change vector '{expected}' does not match the current change vector 'string.Empty'.", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
-                    Assert.Null(e.ActualChangeVector);
+                    Assert.Empty(e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
                 }
 
@@ -2537,7 +2604,7 @@ namespace SlowTests.Issues
                         var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
                         Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
                         Assert.Equal("employees/1-A", e.Id);
-                        Assert.Null(e.ActualChangeVector);
+                        Assert.Empty(e.ActualChangeVector);
                         Assert.Equal(expected, e.ExpectedChangeVector);
                     }
                     else

--- a/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
@@ -1,0 +1,588 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public partial class RavenDB_25154
+    {
+        private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldDetectConcurrencyViolations()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.StoreAsync(new User { Name = "Egor", Age = 25 }, "users/2-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+                var concurrencyExceptionThrown = new AsyncManualResetEvent();
+                Exception caughtException = null;
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            foreach (var item in batch.Items)
+                            {
+                                var user = session.Load<User>(item.Id);
+                                Assert.NotNull(user);
+                            }
+
+                            processedBatch.Set();
+
+                            // Simulate concurrent modification
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                var jerry = backgroundSession.Load<User>("users/1-A");
+                                jerry.Age = 31;
+                                backgroundSession.SaveChanges();
+                            }
+
+                            try
+                            {
+                                session.SaveChanges();
+                            }
+                            catch (Raven.Client.Exceptions.ConcurrencyException ex)
+                            {
+                                caughtException = ex;
+                                concurrencyExceptionThrown.Set();
+                                throw;
+                            }
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
+                    Assert.NotNull(caughtException);
+                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Equal("users/1-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldNotThrowWhenNoModifications()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.StoreAsync(new User { Name = "Egor", Age = 25 }, "users/2-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            foreach (var item in batch.Items)
+                            {
+                                var user = session.Load<User>(item.Id);
+                                Assert.NotNull(user);
+                            }
+
+                            // Should not throw - entities are tracked but not modified
+                            session.SaveChanges();
+                            processedBatch.Set();
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldTrackIncludedDocuments()
+        {
+            using (var store = GetDocumentStore())
+            {
+                string addressId;
+                using (var session = store.OpenSession())
+                {
+                    var address = new Address { City = "Harish", Street = "Erets Rd" };
+                    session.Store(address);
+                    addressId = session.Advanced.GetDocumentId(address);
+                    address.Id = addressId;
+
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry",
+                        Address = address
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Employees include Address.Id"
+                });
+
+                var processedBatch = new AsyncManualResetEvent();
+                var concurrencyExceptionThrown = new AsyncManualResetEvent();
+                Exception caughtException = null;
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<Employee>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            foreach (var item in batch.Items)
+                            {
+                                var employee = session.Load<Employee>(item.Id);
+                                var address = session.Load<Address>(employee.Address.Id);
+                                Assert.NotNull(address);
+                                Assert.Equal(0, session.Advanced.NumberOfRequests); // Included, no request
+                            }
+
+                            processedBatch.Set();
+
+                            // Modify included address in background
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                var addr = backgroundSession.Load<Address>(addressId);
+                                addr.City = "Hadera";
+                                backgroundSession.SaveChanges();
+                            }
+
+                            try
+                            {
+                                session.SaveChanges();
+                            }
+                            catch (Raven.Client.Exceptions.ConcurrencyException ex)
+                            {
+                                caughtException = ex;
+                                concurrencyExceptionThrown.Set();
+                                throw;
+                            }
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
+                    Assert.NotNull(caughtException);
+                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Equal(addressId, ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldNotThrowAfterEvict()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.StoreAsync(new User { Name = "Egor", Age = 25 }, "users/2-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            var jerry = session.Load<User>("users/1-A");
+                            var egor = session.Load<User>("users/2-A");
+
+                            // Evict Jerry
+                            session.Advanced.Evict(jerry);
+
+                            // Modify Jerry in background
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                var j = backgroundSession.Load<User>("users/1-A");
+                                j.Age = 31;
+                                backgroundSession.SaveChanges();
+                            }
+
+                            // Should not throw - Jerry was evicted
+                            session.SaveChanges();
+                            processedBatch.Set();
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldUpdateChangeVectorAfterRefresh()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.StoreAsync(new User { Name = "Egor", Age = 25 }, "users/2-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            var jerry = session.Load<User>("users/1-A");
+                            var originalCv = session.Advanced.GetChangeVectorFor(jerry);
+
+                            // Modify Jerry in background
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                var j = backgroundSession.Load<User>("users/1-A");
+                                j.Age = 31;
+                                backgroundSession.SaveChanges();
+                            }
+
+                            // Refresh to get updated change vector
+                            session.Advanced.Refresh(jerry);
+
+                            var newCv = session.Advanced.GetChangeVectorFor(jerry);
+                            Assert.NotEqual(originalCv, newCv);
+                            Assert.Equal(31, jerry.Age);
+
+                            // Should not throw - refresh updated the change vector
+                            session.SaveChanges();
+                            processedBatch.Set();
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldHandleMultipleBatches()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                // Create documents in multiple batches
+                for (int i = 0; i < 5; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = $"User{i}", Age = 20 + i }, $"users/{i}-A");
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                var batchesProcessed = 0;
+                var allBatchesProcessed = new AsyncManualResetEvent();
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 2
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            foreach (var item in batch.Items)
+                            {
+                                var user = session.Load<User>(item.Id);
+                                Assert.NotNull(user);
+                            }
+
+                            session.SaveChanges();
+
+                            if (Interlocked.Increment(ref batchesProcessed) >= 3)
+                            {
+                                allBatchesProcessed.Set();
+                            }
+                        }
+                    });
+
+                    Assert.True(await allBatchesProcessed.WaitAsync(_reasonableWaitTime));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldDetectDeletedEntityConcurrency()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.StoreAsync(new User { Name = "Egor", Age = 25 }, "users/2-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+                var concurrencyExceptionThrown = new AsyncManualResetEvent();
+                Exception caughtException = null;
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            var jerry = session.Load<User>("users/1-A");
+                            var egor = session.Load<User>("users/2-A");
+
+                            // Mark Jerry for deletion
+                            session.Delete(jerry);
+
+                            processedBatch.Set();
+
+                            // Modify Jerry in background before the delete is committed
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                var j = backgroundSession.Load<User>("users/1-A");
+                                j.Age = 31;
+                                backgroundSession.SaveChanges();
+                            }
+
+                            try
+                            {
+                                session.SaveChanges();
+                            }
+                            catch (Raven.Client.Exceptions.ConcurrencyException ex)
+                            {
+                                caughtException = ex;
+                                concurrencyExceptionThrown.Set();
+                                throw;
+                            }
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
+                    Assert.NotNull(caughtException);
+                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Equal("users/1-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_AndNoTracking_ShouldNotTrack()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        // Use NoTracking mode - should not track entities
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.NoTracking
+                        }))
+                        {
+                            var jerry = session.Load<User>("users/1-A");
+                            Assert.NotNull(jerry);
+
+                            var inMemSession = (InMemoryDocumentSessionOperations)session;
+                            Assert.False(inMemSession.TrackedEntities.TryGetValue("users/1-A", out _));
+
+                            // Modify in background
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                var j = backgroundSession.Load<User>("users/1-A");
+                                j.Age = 31;
+                                backgroundSession.SaveChanges();
+                            }
+
+                            // Should not throw - NoTracking mode
+                            session.SaveChanges();
+                            processedBatch.Set();
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task Subscription_WithTrackAllEntities_ShouldTrackMissingDocuments()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var subscriptionName = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions
+                {
+                    Query = "from Users"
+                });
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "Jerry", Age = 30 }, "users/1-A");
+                    await session.SaveChangesAsync();
+                }
+
+                var processedBatch = new AsyncManualResetEvent();
+                var concurrencyExceptionThrown = new AsyncManualResetEvent();
+                Exception caughtException = null;
+
+                using (var subscription = store.Subscriptions.GetSubscriptionWorker<User>(new SubscriptionWorkerOptions(subscriptionName)
+                {
+                    MaxDocsPerBatch = 10
+                }))
+                {
+                    var t = subscription.Run(batch =>
+                    {
+                        using (var session = batch.OpenSession(new SessionOptions
+                        {
+                            TrackingMode = TrackingMode.TrackAllEntities
+                        }))
+                        {
+                            // Load a document that doesn't exist - should track as missing
+                            var missingUser = session.Load<User>("users/missing-A");
+                            Assert.Null(missingUser);
+
+                            var inMemSession = (InMemoryDocumentSessionOperations)session;
+                            Assert.True(inMemSession.TrackedEntities.TryGetValue("users/missing-A", out var cv));
+                            Assert.Equal(string.Empty, cv);
+
+                            processedBatch.Set();
+
+                            // Create the missing document in background
+                            using (var backgroundSession = store.OpenSession())
+                            {
+                                backgroundSession.Store(new User { Name = "Missing User", Age = 40 }, "users/missing-A");
+                                backgroundSession.SaveChanges();
+                            }
+
+                            try
+                            {
+                                session.SaveChanges();
+                            }
+                            catch (Raven.Client.Exceptions.ConcurrencyException ex)
+                            {
+                                caughtException = ex;
+                                concurrencyExceptionThrown.Set();
+                                throw;
+                            }
+                        }
+                    });
+
+                    Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
+                    Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
+                    Assert.NotNull(caughtException);
+                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Equal("users/missing-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
@@ -80,7 +80,7 @@ namespace SlowTests.Issues
                     Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
                     Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
                     Assert.NotNull(caughtException);
-                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Contains("Document 'users/1-A' has been modified", caughtException.Message);
                     Assert.Equal("users/1-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
                 }
             }
@@ -210,7 +210,7 @@ namespace SlowTests.Issues
                     Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
                     Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
                     Assert.NotNull(caughtException);
-                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Contains($"Document '{addressId}' has been modified", caughtException.Message);
                     Assert.Equal(addressId, ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
                 }
             }
@@ -452,7 +452,7 @@ namespace SlowTests.Issues
                     Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
                     Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
                     Assert.NotNull(caughtException);
-                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Contains("Document 'users/1-A' has been modified", caughtException.Message);
                     Assert.Equal("users/1-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
                 }
             }
@@ -579,7 +579,7 @@ namespace SlowTests.Issues
                     Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
                     Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
                     Assert.NotNull(caughtException);
-                    Assert.Contains("Document change vector mismatch", caughtException.Message);
+                    Assert.Contains($"Document 'users/missing-A' has been modified", caughtException.Message);
                     Assert.Equal("users/missing-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
                 }
             }

--- a/test/SlowTests/Cluster/ClusterTransactionTests.cs
+++ b/test/SlowTests/Cluster/ClusterTransactionTests.cs
@@ -38,6 +38,7 @@ using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace SlowTests.Cluster
 {

--- a/test/StressTests/Client/StreamingWithTimeout.cs
+++ b/test/StressTests/Client/StreamingWithTimeout.cs
@@ -6,6 +6,7 @@ using Tests.Infrastructure;
 using Tests.Infrastructure.Entities;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace StressTests.Client
 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25154

### Additional description

This pull request introduces a new mechanism to support tracking of all entities in a RavenDB client session, enabling more advanced change tracking scenarios. The main changes include the addition of a new `TrackingMode` option, infrastructure for tracking entity states during batch operations, and the introduction of a new batch command to communicate tracked entities to the server. The batch command execution and result handling logic are updated to support the new tracking workflow.

**Tracking infrastructure and session options:**

* Added a new `TrackingMode` enum to `SessionOptions`, allowing configuration of entity tracking behavior per session, including a new `TrackAllEntities` mode.
* Updated `InMemoryDocumentSessionOperations` to store and utilize the session's `TrackingMode`, deprecating the old `NoTracking` flag. [[1]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR214) [[2]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccL238-R244)

**Entity tracking during session operations:**

* Implemented logic to collect and maintain a dictionary of tracked entities and their change vectors during entity puts and deletes when `TrackingMode` is set to `TrackAllEntities`. [[1]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR659-R672) [[2]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR1073-R1077) [[3]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR1055-R1056)
* Added a method to prepare and inject tracked entities into the batch save operation, ensuring the tracked state is sent to the server as part of the batch. [[1]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR881-R885) [[2]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR1161-R1186) [[3]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR2443) [[4]](diffhunk://#diff-8757a4dc8c08665ed533b1e942c3c16b0321d1344747e773ce3d110d37586fccR2528)

**Batch command and protocol changes:**

* Introduced `BatchTrackChangesCommandData`, a new command type for carrying tracked entity information in batch requests. [[1]](diffhunk://#diff-a0ec88571c69d356cffdb3651c3201ddf2fd1899b8ff86b3ab63e606f14445dfR1-R40) [[2]](diffhunk://#diff-1476b9dbada80f909b665a08b9288e33e6975a35f0a07605ec60c01c2a5006b3L52-R54)
* Added `SingleNodeBatchWithTrackingCommand`, a new batch command class that injects the tracking command as the first operation in the batch (so we can throw faster) when tracking is enabled. [[1]](diffhunk://#diff-f995ebaff71c3a9662e3ecde667bc68335f15bb80b0371ac1eede8faab70b71bR37-R68) [[2]](diffhunk://#diff-f995ebaff71c3a9662e3ecde667bc68335f15bb80b0371ac1eede8faab70b71bL59-R102) [[3]](diffhunk://#diff-f995ebaff71c3a9662e3ecde667bc68335f15bb80b0371ac1eede8faab70b71bR119-R128)

**Batch operation and result handling:**

* Updated the batch operation logic to use the new batch command with tracking support, and to correctly handle the presence of the tracking command in the batch results. [[1]](diffhunk://#diff-0308db016dec5b348b76fa370c8f654eaa9ef69e7cefbb7c4fdb49c96f68966bL58-L73) [[2]](diffhunk://#diff-0308db016dec5b348b76fa370c8f654eaa9ef69e7cefbb7c4fdb49c96f68966bL89-R85) [[3]](diffhunk://#diff-0308db016dec5b348b76fa370c8f654eaa9ef69e7cefbb7c4fdb49c96f68966bR145-R189)

These changes lay the foundation for more robust and configurable entity tracking in client sessions, improving consistency and enabling new client-side features.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change - We obsolete the `SessionOptions.NoTracking` and add `SessionOptions.TrackingMode`
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes.
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
