### PR TITLE
RavenDB-25845 : GenAI doesn't handle null parameters

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -158,7 +158,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         foreach (var parameter in parameters)
         {
             var value = Parameters[parameter.Name];
-            sb.AppendLine($"{parameter.Name} = {value.ToString()}");
+            sb.AppendLine($"{parameter.Name} = {value?.ToString() ?? "null"}");
         }
 
         return sb.ToString();

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25845.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25845.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Documents.AI;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDB_25845(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task GenAi_ShouldHandleNullParameters(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore();
+
+            store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            config.Name = "GenAi-ShoppingCart-Suggestions";
+            config.Identifier = "shopping-cart-suggestions";
+            config.Collection = "ShoppingCarts";
+            config.Prompt = "assist in generating shopping cart suggestions";
+            config.JsonSchema = ChatCompletionClient.GetSchemaFromSampleObject(JsonConvert.SerializeObject(new { Suggestions = new[] { "milk", "bread" } }));
+
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script =
+                    "ai.genContext({ " +
+                    "  customerId: this.CustomerId, " +
+                    "  cartItems: this.Items " +
+                    "});"
+            };
+
+            config.UpdateScript = "this.SuggestedItems = $output.Suggestions;";
+            store.Maintenance.Send(new AddGenAiOperation(config));
+
+            var etlDone = Etl.WaitForEtlToComplete(store, (_, statistics) => statistics.LoadSuccesses > 0);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new ShoppingCart
+                {
+                    // no items in the cart
+                    Id = "carts/1-A",
+                    CustomerId = "customers/1-A",
+                    Items = null
+                });
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromSeconds(60)), await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+        }
+
+        private class ShoppingCart
+        {
+            public string Id { get; set; }
+            public string CustomerId { get; set; }
+            public string[] Items { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25845/GenAI-doesnt-handle-null-parameters

### Additional description

 fix NRE when the parameter value is null

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
