### PR TITLE
RavenDB-9187:  LZ4 performance improvements introduced after v131 (10 years ago)

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4ComparisonBenchmark.cs
+++ b/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4ComparisonBenchmark.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+using Sparrow.Compression;
+
+namespace Micro.Benchmark.Benchmarks.LZ4
+{
+    /// <summary>
+    /// Side-by-side comparison of the optimized LZ4 vs the reference (pre-optimization) implementation.
+    /// Measures both compression and decompression throughput for small data sizes.
+    /// </summary>
+    [Config(typeof(Config))]
+    public unsafe class LZ4ComparisonBenchmark
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(new Job
+                {
+                    Environment =
+                    {
+                        Runtime = CoreRuntime.Core10_0,
+                        Platform = Platform.X64,
+                        Jit = Jit.RyuJit
+                    }
+                });
+
+                AddExporter(GetExporters().ToArray());
+                AddColumn(StatisticColumn.AllStatistics);
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        [Params(16, 256, 4096)]
+        public int DataSize { get; set; }
+
+        [Params("sequential", "highly_compressible", "mixed")]
+        public string Pattern { get; set; }
+
+        private byte[] _inputData;
+        private byte[] _outputBuffer;
+
+        // Pre-compressed by each implementation (they may produce different compressed output)
+        private byte[] _compressedByOptimized;
+        private byte[] _compressedByReference;
+        private int _compressedSizeOptimized;
+        private int _compressedSizeReference;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _inputData = GenerateTestData(DataSize, Pattern);
+
+            int maxCompressedSize = Sparrow.Compression.LZ4.MaximumOutputLength(DataSize);
+            _compressedByOptimized = new byte[maxCompressedSize];
+            _compressedByReference = new byte[maxCompressedSize];
+            _outputBuffer = new byte[DataSize];
+
+            fixed (byte* inputPtr = _inputData)
+            fixed (byte* compOptPtr = _compressedByOptimized)
+            fixed (byte* compRefPtr = _compressedByReference)
+            {
+                _compressedSizeOptimized = Sparrow.Compression.LZ4.Encode64(inputPtr, compOptPtr, DataSize, maxCompressedSize);
+                _compressedSizeReference = LZ4Reference.Encode64(inputPtr, compRefPtr, DataSize, maxCompressedSize);
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public int Compress_Reference()
+        {
+            fixed (byte* inputPtr = _inputData)
+            fixed (byte* outputPtr = _outputBuffer)
+            {
+                return LZ4Reference.Encode64(inputPtr, outputPtr, DataSize, _outputBuffer.Length);
+            }
+        }
+
+        [Benchmark]
+        public int Compress_Optimized()
+        {
+            fixed (byte* inputPtr = _inputData)
+            fixed (byte* outputPtr = _outputBuffer)
+            {
+                return Sparrow.Compression.LZ4.Encode64(inputPtr, outputPtr, DataSize, _outputBuffer.Length);
+            }
+        }
+
+        [Benchmark]
+        public int Decompress_Reference()
+        {
+            fixed (byte* compressedPtr = _compressedByReference)
+            fixed (byte* outputPtr = _outputBuffer)
+            {
+                return LZ4Reference.Decode64(compressedPtr, _compressedSizeReference, outputPtr, DataSize, true);
+            }
+        }
+
+        [Benchmark]
+        public int Decompress_Optimized()
+        {
+            fixed (byte* compressedPtr = _compressedByOptimized)
+            fixed (byte* outputPtr = _outputBuffer)
+            {
+                return Sparrow.Compression.LZ4.Decode64(compressedPtr, _compressedSizeOptimized, outputPtr, DataSize, true);
+            }
+        }
+
+        private static byte[] GenerateTestData(int size, string pattern)
+        {
+            var data = new byte[size];
+            var rng = new Random(42);
+
+            switch (pattern)
+            {
+                case "sequential":
+                    for (int i = 0; i < size; i++)
+                        data[i] = (byte)(i & 0xFF);
+                    break;
+
+                case "highly_compressible":
+                    for (int i = 0; i < size; i++)
+                        data[i] = (byte)(i % 4);
+                    break;
+
+                case "mixed":
+                    int pos = 0;
+                    while (pos < size)
+                    {
+                        int chunkSize = Math.Min(rng.Next(8, 64), size - pos);
+                        bool usePattern = rng.NextDouble() < 0.6;
+
+                        if (usePattern)
+                        {
+                            byte patternByte = (byte)rng.Next(32, 127);
+                            for (int i = 0; i < chunkSize && pos < size; i++, pos++)
+                                data[pos] = patternByte;
+                        }
+                        else
+                        {
+                            for (int i = 0; i < chunkSize && pos < size; i++, pos++)
+                                data[pos] = (byte)rng.Next(256);
+                        }
+                    }
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unknown pattern: {pattern}");
+            }
+
+            return data;
+        }
+    }
+}

--- a/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4Reference.cs
+++ b/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4Reference.cs
@@ -1,10 +1,11 @@
 using System;
+using Sparrow;
 using Sparrow.Global;
 using System.Runtime.InteropServices;
 using Sparrow.Binary;
 using System.Runtime.CompilerServices;
 
-namespace Sparrow.Compression
+namespace Micro.Benchmark.Benchmarks.LZ4
 {
     /// <summary>
     /// Reference LZ4 implementation preserved for backward compatibility verification.

--- a/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4SmallDataBenchmark.cs
+++ b/bench/Micro.Benchmark/Benchmarks/LZ4/LZ4SmallDataBenchmark.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Validators;
+namespace Micro.Benchmark.Benchmarks.LZ4
+{
+    /// <summary>
+    /// Benchmark for LZ4 compression/decompression focusing on small data sizes
+    /// typical in RavenDB (128 bytes to several KB). Used to track performance
+    /// improvements from RavenDB-9187 LZ4 optimizations.
+    /// </summary>
+    [Config(typeof(Config))]
+    public unsafe class LZ4SmallDataBenchmark
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(new Job
+                {
+                    Environment =
+                    {
+                        Runtime = CoreRuntime.Core10_0,
+                        Platform = Platform.X64,
+                        Jit = Jit.RyuJit
+                    }
+                });
+
+                AddExporter(GetExporters().ToArray());
+                AddColumn(StatisticColumn.AllStatistics);
+                AddValidator(BaselineValidator.FailOnError);
+                AddValidator(JitOptimizationsValidator.FailOnError);
+                AddAnalyser(EnvironmentAnalyser.Default);
+            }
+        }
+
+        // Small data sizes typical in RavenDB
+        [Params(128, 256, 512, 1024, 2048, 4096, 8192)]
+        public int DataSize { get; set; }
+
+        // Different data patterns to test various compression scenarios
+        [Params("sequential", "highly_compressible", "mixed")]
+        public string Pattern { get; set; }
+
+        private byte[] _inputData;
+        private byte[] _compressedData;
+        private byte[] _outputBuffer;
+        private int _compressedSize;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _inputData = GenerateTestData(DataSize, Pattern);
+
+            int maxCompressedSize = Sparrow.Compression.LZ4.MaximumOutputLength(DataSize);
+            _compressedData = new byte[maxCompressedSize];
+            _outputBuffer = new byte[DataSize];
+
+            // Pre-compress for decompression benchmark
+            fixed (byte* inputPtr = _inputData)
+            fixed (byte* compressedPtr = _compressedData)
+            {
+                _compressedSize = Sparrow.Compression.LZ4.Encode64(inputPtr, compressedPtr, DataSize, maxCompressedSize);
+            }
+        }
+
+        [Benchmark]
+        public int Compress()
+        {
+            fixed (byte* inputPtr = _inputData)
+            fixed (byte* outputPtr = _outputBuffer)
+            {
+                return Sparrow.Compression.LZ4.Encode64(inputPtr, outputPtr, DataSize, _outputBuffer.Length);
+            }
+        }
+
+        [Benchmark]
+        public int Decompress()
+        {
+            fixed (byte* compressedPtr = _compressedData)
+            fixed (byte* outputPtr = _outputBuffer)
+            {
+                return Sparrow.Compression.LZ4.Decode64(compressedPtr, _compressedSize, outputPtr, DataSize, true);
+            }
+        }
+
+        private static byte[] GenerateTestData(int size, string pattern)
+        {
+            var data = new byte[size];
+            var rng = new Random(42); // Seeded for reproducibility
+
+            switch (pattern)
+            {
+                case "sequential":
+                    // Sequential bytes 0,1,2,3... - moderately compressible
+                    for (int i = 0; i < size; i++)
+                        data[i] = (byte)(i & 0xFF);
+                    break;
+
+                case "highly_compressible":
+                    // Repeated patterns - very compressible (common in JSON)
+                    for (int i = 0; i < size; i++)
+                        data[i] = (byte)(i % 4);
+                    break;
+
+                case "mixed":
+                    // Mix of patterns simulating real JSON documents
+                    int pos = 0;
+                    while (pos < size)
+                    {
+                        // Simulate JSON structure with repeated patterns and variable data
+                        int chunkSize = Math.Min(rng.Next(8, 64), size - pos);
+                        bool usePattern = rng.NextDouble() < 0.6;
+
+                        if (usePattern)
+                        {
+                            // Repeated pattern (like JSON keys/structure)
+                            byte patternByte = (byte)rng.Next(32, 127);
+                            for (int i = 0; i < chunkSize && pos < size; i++, pos++)
+                                data[pos] = patternByte;
+                        }
+                        else
+                        {
+                            // Variable data (like JSON values)
+                            for (int i = 0; i < chunkSize && pos < size; i++, pos++)
+                                data[pos] = (byte)rng.Next(256);
+                        }
+                    }
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unknown pattern: {pattern}");
+            }
+
+            return data;
+        }
+    }
+}

--- a/src/Sparrow/Compression/LZ4.cs
+++ b/src/Sparrow/Compression/LZ4.cs
@@ -323,8 +323,8 @@ namespace Sparrow.Compression
                         }
                         else if (typeof(TTableType) == typeof(ByU32))
                         {
-                            ulong value = (*((ulong*)forwardIp) * prime5bytes >> (40 - ByU32HashLog));
-                            forwardH = (int)(value & ByU32HashMask);
+                            ulong value = (*(ulong*)forwardIp << 24) * prime5bytes >> (64 - ByU32HashLog);
+                            forwardH = (int)value;
                             ctx->hashTable[h] = (int)(ip - @base);
                         }
                         else throw new NotSupportedException("TTableType directive is not supported.");
@@ -869,9 +869,9 @@ namespace Sparrow.Compression
                     /* --- copy match within block (fast loop) --- */
                     cpy = op + length;
 
-                    if (offset < 8)
+                    if (offset < 16)
                     {
-                        CopySmallOffset(op, match, cpy, offset);
+                        CopyWithOverlap(op, match, cpy, offset);
                     }
                     else
                     {
@@ -1198,7 +1198,32 @@ namespace Sparrow.Compression
         }
 
         /// <summary>
-        /// v1.9.0: Optimized copy for small offsets (1, 2, 4).
+        /// Copy match data for offsets &lt; 16 where source and destination overlap.
+        /// For offset &lt; 8: pattern-based or table-based copy (avoids load-blocked-by-store hazards).
+        /// For offset 8-15: 8-byte copy + WildCopy8 (safe because each 8-byte read is from already-written data).
+        /// WildCopy32 cannot be used here because its 16-byte Vector128 loads would read unwritten output.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyWithOverlap(byte* op, byte* match, byte* cpy, int offset)
+        {
+            if (offset < 8)
+            {
+                CopySmallOffset(op, match, cpy, offset);
+            }
+            else
+            {
+                // Offset 8-15: straight 8-byte copy establishes the base,
+                // then WildCopy8 (8-byte steps) is overlap-safe since offset >= 8.
+                *((ulong*)op) = *(ulong*)match;
+                op += 8;
+                match += 8;
+                if (op < cpy)
+                    WildCopy8(op, match, cpy);
+            }
+        }
+
+        /// <summary>
+        /// Optimized copy for small offsets (1, 2, 4).
         /// For these offsets, we build an 8-byte pattern and use pattern repetition
         /// instead of overlapped byte-by-byte copies. This avoids load-blocked-by-store
         /// hazards that occur when reading from recently written memory locations.

--- a/src/Sparrow/Compression/LZ4.cs
+++ b/src/Sparrow/Compression/LZ4.cs
@@ -1,8 +1,11 @@
-﻿using System;
+using System;
 using Sparrow.Global;
 using System.Runtime.InteropServices;
 using Sparrow.Binary;
 using System.Runtime.CompilerServices;
+#if NET7_0_OR_GREATER
+using System.Runtime.Intrinsics;
+#endif
 
 namespace Sparrow.Compression
 {
@@ -28,6 +31,8 @@ namespace Sparrow.Compression
         private const byte RUN_MASK = ((1 << RUN_BITS) - 1);
 
         private const uint LZ4_MAX_INPUT_SIZE = 0x7E000000;  /* 2 113 929 216 bytes */
+        private const int FASTLOOP_SAFE_DISTANCE = 64;
+        private const int MATCH_SAFEGUARD_DISTANCE = (2 * COPYLENGTH) - MINMATCH; /* == 12 */
 
         /// <summary>
         /// LZ4_MEMORY_USAGE :
@@ -40,6 +45,10 @@ namespace Sparrow.Compression
         private const int LZ4_HASHLOG = LZ4_MEMORY_USAGE - 2;
         private const int HASH_SIZE_U32 = 1 << LZ4_HASHLOG;
         private const int MAX_INPUT_LENGTH_PER_SEGMENT = int.MaxValue/2;
+
+        private const uint TABLE_TYPE_CLEARED = 0;
+        private const uint TABLE_TYPE_BY_U16 = 1;
+        private const uint TABLE_TYPE_BY_U32 = 2;
 
         private interface ILimitedOutputDirective { };
         private struct NotLimited : ILimitedOutputDirective { };
@@ -73,7 +82,28 @@ namespace Sparrow.Compression
             public uint dictSize;
             public uint currentOffset;
             public byte* dictionary;
-            public uint initCheck;
+            public uint tableType;
+        }
+
+        [ThreadStatic]
+        private static LZ4_stream_t_internal* _cachedCtx;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static LZ4_stream_t_internal* GetCachedCtx()
+        {
+            var ctx = _cachedCtx;
+            if (ctx != null) return ctx;
+            return AllocateCachedCtx();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static LZ4_stream_t_internal* AllocateCachedCtx()
+        {
+            var ptr = (LZ4_stream_t_internal*)Sparrow.Utils.NativeMemory.AllocateMemory(
+                sizeof(LZ4_stream_t_internal));
+            Memory.Set((byte*)ptr, 0, (uint)sizeof(LZ4_stream_t_internal));
+            _cachedCtx = ptr;
+            return ptr;
         }
 
         public static long Encode64LongBuffer(
@@ -107,6 +137,27 @@ namespace Sparrow.Compression
             return totalOutputSize;
         }
 
+        private static void LZ4_prepareTable(LZ4_stream_t_internal* ctx, int inputSize, uint tableType)
+        {
+            if (ctx->tableType != TABLE_TYPE_CLEARED)
+            {
+                if (ctx->tableType != tableType
+                    || (tableType == TABLE_TYPE_BY_U16 && ctx->currentOffset + (uint)inputSize >= 0xFFFFu)
+                    || (tableType == TABLE_TYPE_BY_U32 && ctx->currentOffset > 1u << 30)
+                    || inputSize >= 4 * Constants.Size.Kilobyte)
+                {
+                    Memory.Set((byte*)ctx->hashTable, 0, HASH_SIZE_U32 * sizeof(int));
+                    ctx->currentOffset = 0;
+                    ctx->tableType = TABLE_TYPE_CLEARED;
+                }
+            }
+            if (ctx->currentOffset != 0 && tableType == TABLE_TYPE_BY_U32)
+                ctx->currentOffset += 64 * (uint)Constants.Size.Kilobyte;
+
+            ctx->dictionary = null;
+            ctx->dictSize = 0;
+        }
+
         public static int Encode64(
                 byte* input,
                 byte* output,
@@ -117,21 +168,39 @@ namespace Sparrow.Compression
             if (acceleration < 1)
                 acceleration = ACCELERATION_DEFAULT;
 
-            LZ4_stream_t_internal ctx = new LZ4_stream_t_internal();
+            LZ4_stream_t_internal* ctx = GetCachedCtx();
 
             if (outputLength >= MaximumOutputLength(inputLength))
             {
                 if (inputLength < LZ4_64Klimit)
-                    return LZ4_compress_generic<NotLimited, ByU16, NoDict, NoDictIssue>(&ctx, input, output, inputLength, 0, acceleration);
+                {
+                    LZ4_prepareTable(ctx, inputLength, TABLE_TYPE_BY_U16);
+                    if (ctx->currentOffset != 0)
+                        return LZ4_compress_generic<NotLimited, ByU16, NoDict, DictSmall>(ctx, input, output, inputLength, 0, acceleration);
+                    else
+                        return LZ4_compress_generic<NotLimited, ByU16, NoDict, NoDictIssue>(ctx, input, output, inputLength, 0, acceleration);
+                }
                 else
-                    return LZ4_compress_generic<NotLimited, ByU32, NoDict, NoDictIssue>(&ctx, input, output, inputLength, 0, acceleration);
+                {
+                    LZ4_prepareTable(ctx, inputLength, TABLE_TYPE_BY_U32);
+                    return LZ4_compress_generic<NotLimited, ByU32, NoDict, NoDictIssue>(ctx, input, output, inputLength, 0, acceleration);
+                }
             }
             else
             {
                 if (inputLength < LZ4_64Klimit)
-                    return LZ4_compress_generic<LimitedOutput, ByU16, NoDict, NoDictIssue>(&ctx, input, output, inputLength, outputLength, acceleration);
+                {
+                    LZ4_prepareTable(ctx, inputLength, TABLE_TYPE_BY_U16);
+                    if (ctx->currentOffset != 0)
+                        return LZ4_compress_generic<LimitedOutput, ByU16, NoDict, DictSmall>(ctx, input, output, inputLength, outputLength, acceleration);
+                    else
+                        return LZ4_compress_generic<LimitedOutput, ByU16, NoDict, NoDictIssue>(ctx, input, output, inputLength, outputLength, acceleration);
+                }
                 else
-                    return LZ4_compress_generic<LimitedOutput, ByU32, NoDict, NoDictIssue>(&ctx, input, output, inputLength, outputLength, acceleration);
+                {
+                    LZ4_prepareTable(ctx, inputLength, TABLE_TYPE_BY_U32);
+                    return LZ4_compress_generic<LimitedOutput, ByU32, NoDict, NoDictIssue>(ctx, input, output, inputLength, outputLength, acceleration);
+                }
             }
         }
 
@@ -181,7 +250,7 @@ namespace Sparrow.Compression
 
             if (typeof(TDictionaryType) == typeof(NoDict))
             {
-                @base = source;
+                @base = source - ctx->currentOffset;
                 lowLimit = source;
             }
             else if (typeof(TDictionaryType) == typeof(WithPrefix64K))
@@ -201,6 +270,9 @@ namespace Sparrow.Compression
 
             if (inputSize < LZ4_minLength) // Input too small, no compression (all literals)
                 goto _last_literals;
+
+            ctx->currentOffset += (uint)inputSize;
+            ctx->tableType = (typeof(TTableType) == typeof(ByU16)) ? TABLE_TYPE_BY_U16 : TABLE_TYPE_BY_U32;
 
             // First Byte
             LZ4_putPosition<TTableType>(ip, ctx, @base);
@@ -257,7 +329,7 @@ namespace Sparrow.Compression
                         }
                         else throw new NotSupportedException("TTableType directive is not supported.");
                     }
-                    while (((typeof(TDictionaryType) == typeof(DictSmall)) ? (match < lowRefLimit) : false) ||
+                    while (((typeof(TDictionaryIssue) == typeof(DictSmall)) ? (match < lowRefLimit) : false) ||
                            ((typeof(TTableType) == typeof(ByU16)) ? false : (match + MAX_DISTANCE < ip)) ||
                            (*(uint*)(match + refDelta) != *((uint*)ip)));
                 }
@@ -295,7 +367,7 @@ namespace Sparrow.Compression
                     }
 
                     /* Copy Literals */
-                    WildCopy(op, anchor, (op + litLength));
+                    WildCopy8(op, anchor, (op + litLength));
                     op += litLength;
                 }
 
@@ -384,7 +456,7 @@ namespace Sparrow.Compression
                 }
 
                 LZ4_putPosition<TTableType>(ip, ctx, @base);
-                if (((typeof(TDictionaryType) == typeof(DictSmall)) ? (match >= lowRefLimit) : true) && (match + MAX_DISTANCE >= ip) && (*(uint*)(match + refDelta) == *(uint*)(ip)))
+                if (((typeof(TDictionaryIssue) == typeof(DictSmall)) ? (match >= lowRefLimit) : true) && (match + MAX_DISTANCE >= ip) && (*(uint*)(match + refDelta) == *(uint*)(ip)))
                 {
                     token = op++; *token = 0;
                     goto _next_match;
@@ -624,16 +696,14 @@ namespace Sparrow.Compression
 
             bool checkOffset = ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (dictSize < 64 * Constants.Size.Kilobyte));
 
-            // v1.8.2: Two-stage shortcut boundaries for fast path
-            // shortiend: safe input end (14 bytes max literal + 2 bytes offset)
-            // shortoend: safe output end (14 bytes max literal + 18 bytes max match)
+            // Two-stage shortcut boundaries for safe loop
             byte* shortiend = iend - (typeof(TEndCondition) == typeof(EndOnInputSize) ? 14 : 8) - 2;
             byte* shortoend = oend - (typeof(TEndCondition) == typeof(EndOnInputSize) ? 14 : 8) - 18;
 
             // Special Cases
-            if ((typeof(TEarlyEnd) == typeof(Partial)) && (oexit > oend - MFLIMIT)) oexit = oend - MFLIMIT;                          // targetOutputSize too high => decode everything
+            if ((typeof(TEarlyEnd) == typeof(Partial)) && (oexit > oend - MFLIMIT)) oexit = oend - MFLIMIT;
             if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (outputSize == 0))
-                return ((inputSize == 1) && (*ip == 0)) ? 0 : -1;  // Empty output buffer
+                return ((inputSize == 1) && (*ip == 0)) ? 0 : -1;
             if ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (outputSize == 0))
                 return (*ip == 0 ? 1 : -1);
 
@@ -642,35 +712,195 @@ namespace Sparrow.Compression
             {
                 int length;
                 byte* match;
+                byte* cpy;
+                byte token;
+                int offset;
 
-                /* get literal length */
-                byte token = *ip++;
+                /* ============================================================
+                 * FAST LOOP: decode sequences while output has >= FASTLOOP_SAFE_DISTANCE bytes remaining.
+                 * All wild copies in this path are safe because we have enough slack.
+                 * ============================================================ */
+                if ((oend - op) >= FASTLOOP_SAFE_DISTANCE &&
+                    typeof(TEndCondition) == typeof(EndOnInputSize))
+                {
+                    token = *ip++;
+                    length = token >> ML_BITS;
+
+                    /* --- fast literal copy --- */
+                    if (length == RUN_MASK)
+                    {
+                        long addl = read_variable_length(&ip, iend - RUN_MASK);
+                        if (addl < 0) goto _output_error;
+                        length += (int)addl;
+                        if ((op + length) < op) goto _output_error; /* overflow */
+                        if ((ip + length) < ip) goto _output_error; /* overflow */
+
+                        if (op + length > oend - 32 || ip + length > iend - 32)
+                            goto safe_literal_copy;
+
+                        WildCopy32(op, ip, op + length);
+                        ip += length; op += length;
+                    }
+                    else if (ip <= iend - 17)
+                    {
+                        /* Short literal (0..14): copy 16 bytes inline */
+#if NET7_0_OR_GREATER
+                        if (AdvInstructionSet.IsAcceleratedVector128)
+                        {
+                            Vector128.Load(ip).Store(op);
+                        }
+                        else
+#endif
+                        {
+                            *((ulong*)op) = *(ulong*)ip;
+                            *((ulong*)(op + 8)) = *(ulong*)(ip + 8);
+                        }
+                        ip += length; op += length;
+                    }
+                    else
+                    {
+                        goto safe_literal_copy;
+                    }
+
+                    /* --- get offset --- */
+                    offset = *((ushort*)ip); ip += 2;
+                    match = op - offset;
+
+                    if ((checkOffset) && (match + dictSize < lowPrefix))
+                        goto _output_error;
+
+                    /* --- external dictionary match (fast loop) --- */
+                    if ((typeof(TDictionaryType) == typeof(UsingExtDict)) && (match < lowPrefix))
+                    {
+                        /* get matchlength */
+                        length = token & ML_MASK;
+                        if (length == ML_MASK)
+                        {
+                            long addl = read_variable_length(&ip, iend - LASTLITERALS + 1);
+                            if (addl < 0) goto _output_error;
+                            length += (int)addl;
+                        }
+                        length += MINMATCH;
+
+                        if (op + length > oend - LASTLITERALS)
+                            goto _output_error;
+
+                        if (length <= (int)(lowPrefix - match))
+                        {
+                            match = dictEnd - (lowPrefix - match);
+                            Memory.Move(op, match, length);
+                            op += length;
+                        }
+                        else
+                        {
+                            int copySize = (int)(lowPrefix - match);
+                            Memory.Copy(op, dictEnd - copySize, (uint)copySize);
+                            op += copySize;
+
+                            copySize = length - copySize;
+                            if (copySize > (int)(op - lowPrefix))
+                            {
+                                byte* endOfMatch = op + copySize;
+                                byte* copyFrom = lowPrefix;
+                                while (op < endOfMatch)
+                                    *op++ = *copyFrom++;
+                            }
+                            else
+                            {
+                                Memory.Copy(op, lowPrefix, (uint)copySize);
+                                op += copySize;
+                            }
+                        }
+                        continue;
+                    }
+
+                    /* --- get matchlength --- */
+                    length = token & ML_MASK;
+
+                    if (length == ML_MASK)
+                    {
+                        long addl = read_variable_length(&ip, iend - LASTLITERALS + 1);
+                        if (addl < 0) goto _output_error;
+                        length += (int)addl;
+                        length += MINMATCH;
+                        if ((op + length) < op) goto _output_error; /* overflow */
+                        if (op + length >= oend - FASTLOOP_SAFE_DISTANCE)
+                            goto safe_match_copy;
+                    }
+                    else
+                    {
+                        length += MINMATCH;
+                        if (op + length >= oend - FASTLOOP_SAFE_DISTANCE)
+                            goto safe_match_copy;
+
+                        /* Fastpath check: short match with large offset */
+                        if ((typeof(TDictionaryType) == typeof(NoDict) || typeof(TDictionaryType) == typeof(WithPrefix64K)) &&
+                            match >= lowPrefix)
+                        {
+                            if (offset >= 8)
+                            {
+                                /* Copy match (up to 18 bytes: 8 + 8 + 2) */
+                                *((ulong*)op) = *(ulong*)match;
+                                *((ulong*)(op + 8)) = *(ulong*)(match + 8);
+                                *((ushort*)(op + 16)) = *(ushort*)(match + 16);
+                                op += length;
+                                continue;
+                            }
+                        }
+                    }
+
+                    /* --- copy match within block (fast loop) --- */
+                    cpy = op + length;
+
+                    if (offset < 8)
+                    {
+                        CopySmallOffset(op, match, cpy, offset);
+                    }
+                    else
+                    {
+                        WildCopy32(op, match, cpy);
+                    }
+                    op = cpy;
+                    continue;
+                }
+
+                /* ============================================================
+                 * SAFE LOOP: decode remaining sequences near end of buffers.
+                 * Uses WildCopy8 (max 7-byte overshoot) instead of WildCopy32.
+                 * ============================================================ */
+                token = *ip++;
                 length = token >> ML_BITS;
 
-                // v1.8.2: Two-stage shortcut for the most common case
-                // Fast path for literals 0..14 and matches 4..18 (most common in small data)
+                // Two-stage shortcut for the most common case
                 if (typeof(TEndCondition) == typeof(EndOnInputSize) &&
                     typeof(TDictionaryType) != typeof(UsingExtDict) &&
                     length != RUN_MASK &&
                     ip < shortiend &&
                     op <= shortoend)
                 {
-                    // Stage 1: Copy literals (up to 16 bytes, even if length is less)
-                    *((ulong*)op) = *(ulong*)ip;
-                    *((ulong*)(op + 8)) = *(ulong*)(ip + 8);
+                    // Stage 1: Copy literals (up to 16 bytes)
+#if NET7_0_OR_GREATER
+                    if (AdvInstructionSet.IsAcceleratedVector128)
+                    {
+                        Vector128.Load(ip).Store(op);
+                    }
+                    else
+#endif
+                    {
+                        *((ulong*)op) = *(ulong*)ip;
+                        *((ulong*)(op + 8)) = *(ulong*)(ip + 8);
+                    }
                     op += length;
                     ip += length;
 
                     // Stage 2: Prepare match info
                     int matchLength = token & ML_MASK;
-                    int offset = *((ushort*)ip);
+                    offset = *((ushort*)ip);
                     ip += 2;
                     match = op - offset;
 
-                    // Fast path: match length < 15 (no extended bytes) and offset >= 8 (no overlap)
                     if (matchLength != ML_MASK && offset >= 8 && match >= lowPrefix)
                     {
-                        // Copy match (up to 18 bytes: 8 + 8 + 2)
                         *((ulong*)op) = *(ulong*)match;
                         *((ulong*)(op + 8)) = *(ulong*)(match + 8);
                         *((ushort*)(op + 16)) = *(ushort*)(match + 16);
@@ -678,8 +908,6 @@ namespace Sparrow.Compression
                         continue;
                     }
 
-                    // Stage 2 failed, but we have offset and partial match info
-                    // Fall through to match length parsing
                     length = matchLength;
                     goto _copy_match;
                 }
@@ -694,45 +922,50 @@ namespace Sparrow.Compression
                     }
                     while (((typeof(TEndCondition) == typeof(EndOnInputSize)) ? ip < iend - RUN_MASK : true) && (s == 255));
 
-                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op) goto _output_error;   /* overflow detection */
-                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length) < ip) goto _output_error;   /* overflow detection */
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op) goto _output_error;
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length) < ip) goto _output_error;
                 }
 
+            safe_literal_copy:
                 // copy literals
-                byte* cpy = op + length;
+                cpy = op + length;
                 if (((typeof(TEndCondition) == typeof(EndOnInputSize)) && ((cpy > (typeof(TEarlyEnd) == typeof(Partial) ? oexit : oend - MFLIMIT)) || (ip + length > iend - (2 + 1 + LASTLITERALS))))
                     || ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (cpy > oend - COPYLENGTH)))
                 {
                     if (typeof(TEarlyEnd) == typeof(Partial))
                     {
                         if (cpy > oend)
-                            goto _output_error;                           /* Error : write attempt beyond end of output buffer */
+                            goto _output_error;
 
                         if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length > iend))
-                            goto _output_error;   /* Error : read attempt beyond end of input buffer */
+                            goto _output_error;
                     }
                     else
                     {
                         if ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (cpy != oend))
-                            goto _output_error;       /* Error : block decoding must stop exactly there */
+                            goto _output_error;
 
                         if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && ((ip + length != iend) || (cpy > oend)))
-                            goto _output_error;   /* Error : input must be consumed */
+                            goto _output_error;
                     }
 
                     Memory.Copy(op, ip, (uint)length);
                     ip += length;
                     op += length;
-                    break;     /* Necessarily EOF, due to parsing restrictions */
+                    if (typeof(TEarlyEnd) != typeof(Partial) || (cpy == oend) || (ip >= (iend - 2)))
+                        break;
+                }
+                else
+                {
+                    WildCopy8(op, ip, cpy);   /* max 7 bytes overshoot */
+                    ip += length; op = cpy;
                 }
 
-                WildCopy(op, ip, cpy);
-                ip += length; op = cpy;
-
                 /* get offset */
-                match = cpy - *((ushort*)ip); ip += sizeof(ushort);
+                offset = *((ushort*)ip); ip += sizeof(ushort);
+                match = op - offset;
                 if ((checkOffset) && (match < lowLimit))
-                    goto _output_error;   /* Error : offset outside destination buffer */
+                    goto _output_error;
 
                 /* get matchlength */
                 length = token & ML_MASK;
@@ -752,33 +985,35 @@ namespace Sparrow.Compression
                     while (s == 255);
 
                     if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op)
-                        goto _output_error;   /* overflow detection */
+                        goto _output_error;
                 }
 
                 length += MINMATCH;
 
+            safe_match_copy:
                 /* check external dictionary */
+                if ((checkOffset) && (match + dictSize < lowPrefix))
+                    goto _output_error;
+
                 if ((typeof(TDictionaryType) == typeof(UsingExtDict)) && (match < lowPrefix))
                 {
                     if (op + length > oend - LASTLITERALS)
-                        goto _output_error;   /* doesn't respect parsing restriction */
+                        goto _output_error;
 
                     if (length <= (int)(lowPrefix - match))
                     {
-                        /* match can be copied as a single segment from external dictionary */
-                        match = dictEnd - (lowPrefix - match);                        
-                        Memory.Move(op, match, length); 
+                        match = dictEnd - (lowPrefix - match);
+                        Memory.Move(op, match, length);
                         op += length;
                     }
                     else
                     {
-                        /* match encompass external dictionary and current segment */
                         int copySize = (int)(lowPrefix - match);
                         Memory.Copy(op, dictEnd - copySize, (uint)copySize);
                         op += copySize;
 
                         copySize = length - copySize;
-                        if (copySize > (int)(op - lowPrefix))   /* overlap within current segment */
+                        if (copySize > (int)(op - lowPrefix))
                         {
                             byte* endOfMatch = op + copySize;
                             byte* copyFrom = lowPrefix;
@@ -787,7 +1022,7 @@ namespace Sparrow.Compression
                         }
                         else
                         {
-                            Memory.Copy(op, lowPrefix, (uint)copySize);                            
+                            Memory.Copy(op, lowPrefix, (uint)copySize);
                             op += copySize;
                         }
                     }
@@ -796,36 +1031,63 @@ namespace Sparrow.Compression
 
                 /* copy repeated sequence */
                 cpy = op + length;
-                if ((op - match) < 8)
-                {
-                    int dec64 = dec64table[op - match];
-                    op[0] = match[0];
-                    op[1] = match[1];
-                    op[2] = match[2];
-                    op[3] = match[3];
+                int matchOffset = (int)(op - match);
 
-                    match += dec32table[op - match];
-                    *((uint*)(op + 4)) = *(uint*)match;
-                    op += 8;
-                    match -= dec64;
-                }
-                else
+                // Partial decoding near end
+                if (typeof(TEarlyEnd) == typeof(Partial) && (cpy > oend - MATCH_SAFEGUARD_DISTANCE))
                 {
-                    *((ulong*)op) = *(ulong*)match;
-                    op += sizeof(ulong);
-                    match += sizeof(ulong);
+                    int mlen = length < (int)(oend - op) ? length : (int)(oend - op);
+                    byte* matchEnd = match + mlen;
+                    byte* copyEnd = op + mlen;
+                    if (matchEnd > op)
+                    {
+                        while (op < copyEnd)
+                            *op++ = *match++;
+                    }
+                    else
+                    {
+                        Memory.Copy(op, match, (uint)mlen);
+                        op = copyEnd;
+                    }
+                    if (op == oend) break;
+                    continue;
                 }
 
-                if (cpy > oend - 12)
+                if (matchOffset < 8)
+                {
+                    // Small offsets need special handling
+                    if (cpy > oend - 12)
+                    {
+                        if (cpy > oend - LASTLITERALS)
+                            goto _output_error;
+
+                        while (op < cpy)
+                            *op++ = *match++;
+                    }
+                    else
+                    {
+                        CopySmallOffset(op, match, cpy, matchOffset);
+                        op = cpy;
+                    }
+                    continue;
+                }
+
+                // Normal offset (>= 8): no overlap concerns
+                *((ulong*)op) = *(ulong*)match;
+                op += sizeof(ulong);
+                match += sizeof(ulong);
+
+                if (cpy > oend - MATCH_SAFEGUARD_DISTANCE)
                 {
                     if (cpy > oend - LASTLITERALS)
-                        goto _output_error;    /* Error : last LASTLITERALS bytes must be literals */
+                        goto _output_error;
 
-                    if (op < oend - 8)
+                    byte* oCopyLimit = oend - (COPYLENGTH - 1);
+                    if (op < oCopyLimit)
                     {
-                        WildCopy(op, match, (oend - 8));
-                        match += (oend - 8) - op;
-                        op = oend - 8;
+                        WildCopy8(op, match, oCopyLimit);
+                        match += oCopyLimit - op;
+                        op = oCopyLimit;
                     }
 
                     while (op < cpy)
@@ -833,53 +1095,144 @@ namespace Sparrow.Compression
                 }
                 else
                 {
-                    // v1.7.3: Optimize for short matches (most common case)
-                    // Copy 8 bytes first, then only call WildCopy if length > 16
                     *((ulong*)op) = *(ulong*)match;
                     if (length > 16)
-                        WildCopy(op + 8, match + 8, cpy);
+                        WildCopy8(op + 8, match + 8, cpy);
                 }
 
-                op = cpy;   /* correction */
+                op = cpy;
             }
 
             /* end of decoding */
             if (typeof(TEndCondition) == typeof(EndOnInputSize))
-                return (int)(op - dest);     /* Nb of output bytes decoded */
+                return (int)(op - dest);
             else
-                return (int)(ip - source);   /* Nb of input bytes read */
+                return (int)(ip - source);
 
             /* Overflow error detected */
             _output_error:
             return (int)(-(ip - source)) - 1;
         }
 
+        /// <summary>
+        /// Reads a variable-length integer from the stream (used for extended literal/match lengths).
+        /// Returns the accumulated value, or -1 on error (read past limit).
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void WildCopy(byte* dest, byte* src, byte* destEnd)
-        {                  
+        private static long read_variable_length(byte** ip, byte* ilimit)
+        {
+            long length = 0;
+            byte s;
+            if (*ip >= ilimit) return -1;
             do
             {
-                ((ulong*)dest)[0] = ((ulong*)src)[0];
-                if (dest + 1 * sizeof(ulong) >= destEnd)
-                    goto Return;
+                s = *(*ip);
+                (*ip)++;
+                length += s;
+                if (*ip > ilimit) return -1;
+            }
+            while (s == 255);
+            return length;
+        }
 
-                ((ulong*)dest)[1] = ((ulong*)src)[1];
-                if (dest + 2 * sizeof(ulong) >= destEnd)
-                    goto Return;
-
-                ((ulong*)dest)[2] = ((ulong*)src)[2];
-                if (dest + 3 * sizeof(ulong) >= destEnd)
-                    goto Return;
-
-                ((ulong*)dest)[3] = ((ulong*)src)[3];
-
-                dest += 4 * sizeof(ulong);
-                src +=  4 * sizeof(ulong);
+        /// <summary>
+        /// WildCopy8 - Copy 8 bytes per iteration. Max overshoot: 7 bytes.
+        /// Used in safe-path decompression and compression literal copies.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WildCopy8(byte* dest, byte* src, byte* destEnd)
+        {
+            do
+            {
+                *((ulong*)dest) = *(ulong*)src;
+                dest += 8;
+                src += 8;
             }
             while (dest < destEnd);
+        }
 
-            Return:
-            return;
+        /// <summary>
+        /// WildCopy32 - Copy 32 bytes per iteration. Max overshoot: 31 bytes.
+        /// Used only in the fast decompression loop where FASTLOOP_SAFE_DISTANCE guarantees slack.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WildCopy32(byte* dest, byte* src, byte* destEnd)
+        {
+            do
+            {
+#if NET7_0_OR_GREATER
+                if (AdvInstructionSet.IsAcceleratedVector128)
+                {
+                    Vector128.Load(src).Store(dest);
+                    Vector128.Load(src + 16).Store(dest + 16);
+                }
+                else
+#endif
+                {
+                    *((ulong*)dest) = *(ulong*)src;
+                    *((ulong*)(dest + 8)) = *(ulong*)(src + 8);
+                    *((ulong*)(dest + 16)) = *(ulong*)(src + 16);
+                    *((ulong*)(dest + 24)) = *(ulong*)(src + 24);
+                }
+                dest += 32;
+                src += 32;
+            }
+            while (dest < destEnd);
+        }
+
+        /// <summary>
+        /// v1.9.0: Optimized copy for small offsets (1, 2, 4).
+        /// For these offsets, we build an 8-byte pattern and use pattern repetition
+        /// instead of overlapped byte-by-byte copies. This avoids load-blocked-by-store
+        /// hazards that occur when reading from recently written memory locations.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopySmallOffset(byte* op, byte* match, byte* cpy, int offset)
+        {
+            ulong pattern;
+            switch (offset)
+            {
+                case 1:
+                    // RLE - single byte repeated
+                    pattern = (ulong)(*match) * 0x0101010101010101UL;
+                    break;
+                case 2:
+                    // Two-byte pattern repeated
+                    ulong s = *(ushort*)match;
+                    pattern = s | (s << 16) | (s << 32) | (s << 48);
+                    break;
+                case 4:
+                    // Four-byte pattern repeated
+                    ulong u = *(uint*)match;
+                    pattern = u | (u << 32);
+                    break;
+                default:
+                    // For offsets 3, 5, 6, 7: use generic table-based copy
+                    // This path handles irregular patterns that don't tile evenly
+                    int dec64 = dec64table[offset];
+                    op[0] = match[0];
+                    op[1] = match[1];
+                    op[2] = match[2];
+                    op[3] = match[3];
+                    match += dec32table[offset];
+                    *((uint*)(op + 4)) = *(uint*)match;
+                    op += 8;
+                    match -= dec64;
+                    // Continue with WildCopy8 for remaining bytes
+                    if (op < cpy)
+                    {
+                        WildCopy8(op, match, cpy);
+                    }
+                    return;
+            }
+
+            // Pattern repetition loop for offsets 1, 2, 4
+            do
+            {
+                *((ulong*)op) = pattern;
+                op += 8;
+            }
+            while (op < cpy);
         }
     }
 }

--- a/src/Sparrow/Compression/LZ4.cs
+++ b/src/Sparrow/Compression/LZ4.cs
@@ -497,6 +497,10 @@ namespace Sparrow.Compression
         }
 
 
+        /// <summary>
+        /// Count matching bytes between two memory locations.
+        /// v1.10.0: Added early exit on first comparison for common short-match case.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LZ4_count(byte* pInPtr, byte* pMatchPtr, byte* pInLimitPtr)
         {
@@ -509,7 +513,19 @@ namespace Sparrow.Compression
 
             byte* pStart = pIn;
 
-            while (pIn < pInLimit - (sizeof(ulong) - 1))
+            // v1.10.0: Early exit on first comparison (most common case: short match)
+            // This avoids loop setup overhead for the frequent case where matches are short.
+            if (pIn < pInLimit - 7)
+            {
+                ulong diff = *((ulong*)pMatch) ^ *((ulong*)pIn);
+                if (diff != 0)
+                    return Bits.TrailingZeroesInBytes(diff);
+                pIn += sizeof(ulong);
+                pMatch += sizeof(ulong);
+            }
+
+            // Continue with loop for longer matches
+            while (pIn < pInLimit - 7)
             {
                 ulong diff = *((ulong*)pMatch) ^ *((ulong*)pIn);
                 if (diff == 0)
@@ -523,6 +539,7 @@ namespace Sparrow.Compression
                 return (int)(pIn - pStart);
             }
 
+            // Handle remaining bytes (less than 8)
             if ((pIn < (pInLimit - 3)) && (*((uint*)pMatch) == *((uint*)(pIn)))) { pIn += sizeof(uint); pMatch += sizeof(uint); }
             if ((pIn < (pInLimit - 1)) && (*((ushort*)pMatch) == *((ushort*)pIn))) { pIn += sizeof(ushort); pMatch += sizeof(ushort); }
             if ((pIn < pInLimit) && (*pMatch == *pIn)) pIn++;

--- a/src/Sparrow/Compression/LZ4.cs
+++ b/src/Sparrow/Compression/LZ4.cs
@@ -624,6 +624,12 @@ namespace Sparrow.Compression
 
             bool checkOffset = ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (dictSize < 64 * Constants.Size.Kilobyte));
 
+            // v1.8.2: Two-stage shortcut boundaries for fast path
+            // shortiend: safe input end (14 bytes max literal + 2 bytes offset)
+            // shortoend: safe output end (14 bytes max literal + 18 bytes max match)
+            byte* shortiend = iend - (typeof(TEndCondition) == typeof(EndOnInputSize) ? 14 : 8) - 2;
+            byte* shortoend = oend - (typeof(TEndCondition) == typeof(EndOnInputSize) ? 14 : 8) - 18;
+
             // Special Cases
             if ((typeof(TEarlyEnd) == typeof(Partial)) && (oexit > oend - MFLIMIT)) oexit = oend - MFLIMIT;                          // targetOutputSize too high => decode everything
             if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (outputSize == 0))
@@ -635,10 +641,50 @@ namespace Sparrow.Compression
             while (true)
             {
                 int length;
+                byte* match;
 
                 /* get literal length */
                 byte token = *ip++;
-                if ((length = (token >> ML_BITS)) == RUN_MASK)
+                length = token >> ML_BITS;
+
+                // v1.8.2: Two-stage shortcut for the most common case
+                // Fast path for literals 0..14 and matches 4..18 (most common in small data)
+                if (typeof(TEndCondition) == typeof(EndOnInputSize) &&
+                    typeof(TDictionaryType) != typeof(UsingExtDict) &&
+                    length != RUN_MASK &&
+                    ip < shortiend &&
+                    op <= shortoend)
+                {
+                    // Stage 1: Copy literals (up to 16 bytes, even if length is less)
+                    *((ulong*)op) = *(ulong*)ip;
+                    *((ulong*)(op + 8)) = *(ulong*)(ip + 8);
+                    op += length;
+                    ip += length;
+
+                    // Stage 2: Prepare match info
+                    int matchLength = token & ML_MASK;
+                    int offset = *((ushort*)ip);
+                    ip += 2;
+                    match = op - offset;
+
+                    // Fast path: match length < 15 (no extended bytes) and offset >= 8 (no overlap)
+                    if (matchLength != ML_MASK && offset >= 8 && match >= lowPrefix)
+                    {
+                        // Copy match (up to 18 bytes: 8 + 8 + 2)
+                        *((ulong*)op) = *(ulong*)match;
+                        *((ulong*)(op + 8)) = *(ulong*)(match + 8);
+                        *((ushort*)(op + 16)) = *(ushort*)(match + 16);
+                        op += matchLength + MINMATCH;
+                        continue;
+                    }
+
+                    // Stage 2 failed, but we have offset and partial match info
+                    // Fall through to match length parsing
+                    length = matchLength;
+                    goto _copy_match;
+                }
+
+                if (length == RUN_MASK)
                 {
                     byte s;
                     do
@@ -684,12 +730,15 @@ namespace Sparrow.Compression
                 ip += length; op = cpy;
 
                 /* get offset */
-                byte* match = cpy - *((ushort*)ip); ip += sizeof(ushort);
+                match = cpy - *((ushort*)ip); ip += sizeof(ushort);
                 if ((checkOffset) && (match < lowLimit))
                     goto _output_error;   /* Error : offset outside destination buffer */
 
                 /* get matchlength */
-                if ((length = (token & ML_MASK)) == ML_MASK)
+                length = token & ML_MASK;
+
+            _copy_match:
+                if (length == ML_MASK)
                 {
                     byte s;
                     do

--- a/src/Sparrow/Compression/LZ4.cs
+++ b/src/Sparrow/Compression/LZ4.cs
@@ -245,8 +245,8 @@ namespace Sparrow.Compression
 
                         if (typeof(TTableType) == typeof(ByU16))
                         {
-                            ulong value = *((ulong*)forwardIp) * prime5bytes >> (40 - ByU16HashLog);
-                            forwardH = (int)(value & ByU16HashMask);
+                            uint value = *((uint*)forwardIp) * prime4bytes >> ((MINMATCH * 8) - ByU16HashLog);
+                            forwardH = (int)value;
                             ((ushort*)ctx->hashTable)[h] = (ushort)(ip - @base);
                         }
                         else if (typeof(TTableType) == typeof(ByU32))
@@ -506,13 +506,16 @@ namespace Sparrow.Compression
         {
             if (typeof(TTableType) == typeof(ByU16))
             {
-                ulong value = *((ulong*)sequence) * prime5bytes >> (40 - ByU16HashLog);
-                return (int)(value & ByU16HashMask);
+                // v1.7.3: Use 4-byte read and 4-byte prime for small hash tables
+                // This is faster than 8-byte read for small data compression
+                uint value = *((uint*)sequence) * prime4bytes >> ((MINMATCH * 8) - ByU16HashLog);
+                return (int)value;
             }
             else if (typeof(TTableType) == typeof(ByU32))
             {
-                ulong value = (*((ulong*)sequence) * prime5bytes >> (40 - ByU32HashLog));
-                return (int)(value & ByU32HashMask);
+                // v1.7.3: Use 5-byte prime with improved shift calculation for 64-bit
+                ulong value = (*(ulong*)sequence << 24) * prime5bytes >> (64 - ByU32HashLog);
+                return (int)value;
             }
 
             return ThrowException<int>(new NotSupportedException("TTableType directive is not supported."));
@@ -536,6 +539,8 @@ namespace Sparrow.Compression
         private const int ByU32HashLog = LZ4_HASHLOG;
         private const ulong ByU32HashMask = (1 << ByU32HashLog) - 1;
 
+        // v1.7.3: Use 4-byte prime for ByU16 (small hash table), 5-byte prime for ByU32
+        private const uint prime4bytes = 2654435761U;
         private const ulong prime5bytes = 889523592379UL;
 
         public static long Decode64LongBuffers(
@@ -779,7 +784,11 @@ namespace Sparrow.Compression
                 }
                 else
                 {
-                    WildCopy(op, match, cpy);
+                    // v1.7.3: Optimize for short matches (most common case)
+                    // Copy 8 bytes first, then only call WildCopy if length > 16
+                    *((ulong*)op) = *(ulong*)match;
+                    if (length > 16)
+                        WildCopy(op + 8, match + 8, cpy);
                 }
 
                 op = cpy;   /* correction */

--- a/src/Sparrow/Compression/LZ4Reference.cs
+++ b/src/Sparrow/Compression/LZ4Reference.cs
@@ -1,0 +1,789 @@
+using System;
+using Sparrow.Global;
+using System.Runtime.InteropServices;
+using Sparrow.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Sparrow.Compression
+{
+    /// <summary>
+    /// Reference LZ4 implementation preserved for backward compatibility verification.
+    /// This is a copy of the original implementation before optimizations.
+    /// Used to verify that optimized code can decompress data compressed by this version and vice versa.
+    /// DO NOT MODIFY - this serves as the baseline for compatibility testing.
+    /// </summary>
+    internal sealed unsafe class LZ4Reference
+    {
+        public const int ACCELERATION_DEFAULT = 1;
+
+        private const int COPYLENGTH = 8;
+        private const int LASTLITERALS = 5;
+        private const int MINMATCH = 4;
+        private const int MFLIMIT = COPYLENGTH + MINMATCH;
+        private const int LZ4_minLength = MFLIMIT + 1;
+
+        private const int MAXD_LOG = 16;
+        private const int MAX_DISTANCE = ((1 << MAXD_LOG) - 1);
+
+        private const int LZ4_64Klimit = (64 * Constants.Size.Kilobyte) + (MFLIMIT - 1);
+        private const int LZ4_skipTrigger = 6;
+
+        private const byte ML_BITS = 4;
+        private const byte ML_MASK = ((1 << ML_BITS) - 1);
+        private const byte RUN_BITS = (8 - ML_BITS);
+        private const byte RUN_MASK = ((1 << RUN_BITS) - 1);
+
+        private const uint LZ4_MAX_INPUT_SIZE = 0x7E000000;
+
+        private const int LZ4_MEMORY_USAGE = 14;
+        private const int LZ4_HASHLOG = LZ4_MEMORY_USAGE - 2;
+        private const int HASH_SIZE_U32 = 1 << LZ4_HASHLOG;
+        private const int MAX_INPUT_LENGTH_PER_SEGMENT = int.MaxValue / 2;
+
+        private interface ILimitedOutputDirective { };
+        private struct NotLimited : ILimitedOutputDirective { };
+        private struct LimitedOutput : ILimitedOutputDirective { };
+
+        private interface IDictionaryTypeDirective { };
+        private struct NoDict : IDictionaryTypeDirective { };
+        private struct WithPrefix64K : IDictionaryTypeDirective { };
+        private struct UsingExtDict : IDictionaryTypeDirective { };
+
+        private interface IDictionaryIssueDirective { };
+        private struct NoDictIssue : IDictionaryIssueDirective { };
+        private struct DictSmall : IDictionaryIssueDirective { };
+
+        private interface ITableTypeDirective { };
+        private struct ByU32 : ITableTypeDirective { };
+        private struct ByU16 : ITableTypeDirective { };
+
+        private interface IEndConditionDirective { };
+        private struct EndOnOutputSize : IEndConditionDirective { };
+        private struct EndOnInputSize : IEndConditionDirective { };
+
+        private interface IEarlyEndDirective { };
+        private struct Full : IEarlyEndDirective { };
+        private struct Partial : IEarlyEndDirective { };
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LZ4_stream_t_internal
+        {
+            public fixed int hashTable[HASH_SIZE_U32];
+            public uint dictSize;
+            public uint currentOffset;
+            public byte* dictionary;
+            public uint initCheck;
+        }
+
+        public static long Encode64LongBuffer(
+            byte* input,
+            byte* output,
+            long inputLength,
+            long outputLength,
+            int acceleration = ACCELERATION_DEFAULT)
+        {
+            if (inputLength < MAX_INPUT_LENGTH_PER_SEGMENT && outputLength < MAX_INPUT_LENGTH_PER_SEGMENT)
+            {
+                return Encode64(input, output, (int)inputLength, (int)outputLength, acceleration);
+            }
+
+            long totalOutputSize = 0;
+            long readPosition = 0;
+            while (readPosition < inputLength)
+            {
+                int partInputLength = MAX_INPUT_LENGTH_PER_SEGMENT;
+                if (readPosition + partInputLength > inputLength)
+                    partInputLength = (int)(inputLength - readPosition);
+
+                int remaining = (outputLength - totalOutputSize) > int.MaxValue ? int.MaxValue : (int)(outputLength - totalOutputSize);
+
+                totalOutputSize += Encode64(input + readPosition, output + totalOutputSize, partInputLength, remaining, acceleration);
+
+                readPosition += partInputLength;
+            }
+
+            return totalOutputSize;
+        }
+
+        public static int Encode64(
+                byte* input,
+                byte* output,
+                int inputLength,
+                int outputLength,
+                int acceleration = ACCELERATION_DEFAULT)
+        {
+            if (acceleration < 1)
+                acceleration = ACCELERATION_DEFAULT;
+
+            LZ4_stream_t_internal ctx = new LZ4_stream_t_internal();
+
+            if (outputLength >= MaximumOutputLength(inputLength))
+            {
+                if (inputLength < LZ4_64Klimit)
+                    return LZ4_compress_generic<NotLimited, ByU16, NoDict, NoDictIssue>(&ctx, input, output, inputLength, 0, acceleration);
+                else
+                    return LZ4_compress_generic<NotLimited, ByU32, NoDict, NoDictIssue>(&ctx, input, output, inputLength, 0, acceleration);
+            }
+            else
+            {
+                if (inputLength < LZ4_64Klimit)
+                    return LZ4_compress_generic<LimitedOutput, ByU16, NoDict, NoDictIssue>(&ctx, input, output, inputLength, outputLength, acceleration);
+                else
+                    return LZ4_compress_generic<LimitedOutput, ByU32, NoDict, NoDictIssue>(&ctx, input, output, inputLength, outputLength, acceleration);
+            }
+        }
+
+        public static long MaximumOutputLength(long size)
+        {
+            return size + (size / 255) + 16;
+        }
+
+        public static int MaximumOutputLength(int size)
+        {
+            return checked(size + (size / 255) + 16);
+        }
+
+        private static int LZ4_compress_generic<TLimited, TTableType, TDictionaryType, TDictionaryIssue>(LZ4_stream_t_internal* dictPtr, byte* source, byte* dest, int inputSize, int maxOutputSize, int acceleration)
+            where TLimited : ILimitedOutputDirective
+            where TTableType : ITableTypeDirective
+            where TDictionaryType : IDictionaryTypeDirective
+            where TDictionaryIssue : IDictionaryIssueDirective
+        {
+
+            LZ4_stream_t_internal* ctx = dictPtr;
+
+            byte* op = dest;
+            byte* ip = source;
+            byte* anchor = source;
+
+            byte* dictionary = ctx->dictionary;
+            byte* dictEnd = dictionary + ctx->dictSize;
+            byte* lowRefLimit = ip - ctx->dictSize;
+
+            long dictDelta = (long)dictEnd - (long)source;
+
+            byte* iend = ip + inputSize;
+            byte* mflimit = iend - MFLIMIT;
+            byte* matchlimit = iend - LASTLITERALS;
+
+            byte* olimit = op + maxOutputSize;
+
+            if (inputSize > LZ4_MAX_INPUT_SIZE) return 0;
+
+            byte* @base;
+            byte* lowLimit;
+
+            if (typeof(TDictionaryType) == typeof(NoDict))
+            {
+                @base = source;
+                lowLimit = source;
+            }
+            else if (typeof(TDictionaryType) == typeof(WithPrefix64K))
+            {
+                @base = source - ctx->currentOffset;
+                lowLimit = source - ctx->dictSize;
+            }
+            else if (typeof(TDictionaryType) == typeof(UsingExtDict))
+            {
+                @base = source - ctx->currentOffset;
+                lowLimit = source;
+            }
+            else throw new NotSupportedException("Unsupported IDictionaryTypeDirective.");
+
+            if ((typeof(TTableType) == typeof(ByU16)) && (inputSize >= LZ4_64Klimit))
+                return 0;
+
+            if (inputSize < LZ4_minLength)
+                goto _last_literals;
+
+            LZ4_putPosition<TTableType>(ip, ctx, @base);
+            ip++;
+            int forwardH = LZ4_hashPosition<TTableType>(ip);
+
+            long refDelta = 0;
+            for (; ; )
+            {
+                byte* match;
+                {
+                    byte* forwardIp = ip;
+
+                    int step = 1;
+                    int searchMatchNb = acceleration << LZ4_skipTrigger;
+
+                    do
+                    {
+                        int h = forwardH;
+                        ip = forwardIp;
+                        forwardIp += step;
+                        step = (searchMatchNb++ >> LZ4_skipTrigger);
+
+                        if (forwardIp > mflimit)
+                            goto _last_literals;
+
+                        match = LZ4_getPositionOnHash<TTableType>(h, ctx, @base);
+                        if (typeof(TDictionaryType) == typeof(UsingExtDict))
+                        {
+                            if (match < source)
+                            {
+                                refDelta = dictDelta;
+                                lowLimit = dictionary;
+                            }
+                            else
+                            {
+                                refDelta = 0;
+                                lowLimit = source;
+                            }
+                        }
+
+                        if (typeof(TTableType) == typeof(ByU16))
+                        {
+                            ulong value = *((ulong*)forwardIp) * prime5bytes >> (40 - ByU16HashLog);
+                            forwardH = (int)(value & ByU16HashMask);
+                            ((ushort*)ctx->hashTable)[h] = (ushort)(ip - @base);
+                        }
+                        else if (typeof(TTableType) == typeof(ByU32))
+                        {
+                            ulong value = (*((ulong*)forwardIp) * prime5bytes >> (40 - ByU32HashLog));
+                            forwardH = (int)(value & ByU32HashMask);
+                            ctx->hashTable[h] = (int)(ip - @base);
+                        }
+                        else throw new NotSupportedException("TTableType directive is not supported.");
+                    }
+                    while (((typeof(TDictionaryType) == typeof(DictSmall)) ? (match < lowRefLimit) : false) ||
+                           ((typeof(TTableType) == typeof(ByU16)) ? false : (match + MAX_DISTANCE < ip)) ||
+                           (*(uint*)(match + refDelta) != *((uint*)ip)));
+                }
+
+                while ((ip > anchor) && (match + refDelta > lowLimit) && (ip[-1] == match[refDelta - 1]))
+                {
+                    ip--;
+                    match--;
+                }
+
+                byte* token;
+                {
+                    int litLength = (int)(ip - anchor);
+                    token = op++;
+
+                    if ((typeof(TLimited) == typeof(LimitedOutput)) && (op + litLength + (2 + 1 + LASTLITERALS) + (litLength / 255) > olimit))
+                        return 0;
+
+                    if (litLength >= RUN_MASK)
+                    {
+                        int len = litLength - RUN_MASK;
+                        *token = RUN_MASK << ML_BITS;
+
+                        for (; len >= 255; len -= 255)
+                            *op++ = 255;
+
+                        *op++ = (byte)len;
+                    }
+                    else
+                    {
+                        *token = (byte)(litLength << ML_BITS);
+                    }
+
+                    WildCopy(op, anchor, (op + litLength));
+                    op += litLength;
+                }
+
+            _next_match:
+
+                *((ushort*)op) = (ushort)(ip - match);
+                op += sizeof(ushort);
+
+                {
+                    int matchLength;
+
+                    if ((typeof(TDictionaryType) == typeof(UsingExtDict)) && (lowLimit == dictionary))
+                    {
+                        match += refDelta;
+
+                        byte* limit = ip + (dictEnd - match);
+                        if (limit > matchlimit) limit = matchlimit;
+                        matchLength = LZ4_count(ip + MINMATCH, match + MINMATCH, limit);
+                        ip += MINMATCH + matchLength;
+                        if (ip == limit)
+                        {
+                            int more = LZ4_count(ip, source, matchlimit);
+                            matchLength += more;
+                            ip += more;
+                        }
+                    }
+                    else
+                    {
+                        matchLength = LZ4_count(ip + MINMATCH, match + MINMATCH, matchlimit);
+                        ip += MINMATCH + matchLength;
+                    }
+
+                    if ((typeof(TLimited) == typeof(LimitedOutput)) && ((op + (1 + LASTLITERALS) + (matchLength >> 8)) > olimit))
+                        return 0;
+
+                    if (matchLength >= ML_MASK)
+                    {
+                        *token += ML_MASK;
+                        matchLength -= ML_MASK;
+
+                        for (; matchLength >= 510; matchLength -= 510)
+                        {
+                            *(ushort*)op = (255 << 8 | 255);
+                            op += sizeof(ushort);
+                        }
+
+                        if (matchLength >= 255)
+                        {
+                            matchLength -= 255;
+                            *op++ = 255;
+                        }
+
+                        *op++ = (byte)matchLength;
+                    }
+                    else
+                    {
+                        *token += (byte)(matchLength);
+                    }
+                }
+
+                anchor = ip;
+
+                if (ip > mflimit) break;
+
+                LZ4_putPosition<TTableType>(ip - 2, ctx, @base);
+
+                match = LZ4_getPosition<TTableType>(ip, ctx, @base);
+                if (typeof(TDictionaryType) == typeof(UsingExtDict))
+                {
+                    if (match < source)
+                    {
+                        refDelta = dictDelta;
+                        lowLimit = dictionary;
+                    }
+                    else
+                    {
+                        refDelta = 0;
+                        lowLimit = source;
+                    }
+                }
+
+                LZ4_putPosition<TTableType>(ip, ctx, @base);
+                if (((typeof(TDictionaryType) == typeof(DictSmall)) ? (match >= lowRefLimit) : true) && (match + MAX_DISTANCE >= ip) && (*(uint*)(match + refDelta) == *(uint*)(ip)))
+                {
+                    token = op++; *token = 0;
+                    goto _next_match;
+                }
+
+                forwardH = LZ4_hashPosition<TTableType>(++ip);
+            }
+
+        _last_literals:
+
+            {
+                int lastRun = (int)(iend - anchor);
+                if ((typeof(TLimited) == typeof(LimitedOutput)) && ((op - dest) + lastRun + 1 + ((lastRun + 255 - RUN_MASK) / 255) > maxOutputSize))
+                    return 0;
+
+                if (lastRun >= RUN_MASK)
+                {
+                    int accumulator = lastRun - RUN_MASK;
+                    *op++ = RUN_MASK << ML_BITS;
+
+                    for (; accumulator >= 255; accumulator -= 255)
+                        *op++ = 255;
+
+                    *op++ = (byte)accumulator;
+                }
+                else
+                {
+                    *op++ = (byte)(lastRun << ML_BITS);
+                }
+
+                Memory.Copy(op, anchor, (uint)lastRun);
+                op += lastRun;
+            }
+
+            return (int)(op - dest);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LZ4_count(byte* pInPtr, byte* pMatchPtr, byte* pInLimitPtr)
+        {
+            byte* pIn = pInPtr;
+            byte* pMatch = pMatchPtr;
+            byte* pInLimit = pInLimitPtr;
+
+            byte* pStart = pIn;
+
+            while (pIn < pInLimit - (sizeof(ulong) - 1))
+            {
+                ulong diff = *((ulong*)pMatch) ^ *((ulong*)pIn);
+                if (diff == 0)
+                {
+                    pIn += sizeof(ulong);
+                    pMatch += sizeof(ulong);
+                    continue;
+                }
+
+                pIn += Bits.TrailingZeroesInBytes(diff);
+                return (int)(pIn - pStart);
+            }
+
+            if ((pIn < (pInLimit - 3)) && (*((uint*)pMatch) == *((uint*)(pIn)))) { pIn += sizeof(uint); pMatch += sizeof(uint); }
+            if ((pIn < (pInLimit - 1)) && (*((ushort*)pMatch) == *((ushort*)pIn))) { pIn += sizeof(ushort); pMatch += sizeof(ushort); }
+            if ((pIn < pInLimit) && (*pMatch == *pIn)) pIn++;
+
+            return (int)(pIn - pStart);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void LZ4_putPosition<TTableType>(byte* p, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            int h = LZ4_hashPosition<TTableType>(p);
+            LZ4_putPositionOnHash<TTableType>(p, h, ctx, srcBase);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte* LZ4_getPosition<TTableType>(byte* p, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            int h = LZ4_hashPosition<TTableType>(p);
+            return LZ4_getPositionOnHash<TTableType>(h, ctx, srcBase);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void LZ4_putPositionOnHash<TTableType>(byte* p, int h, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            if (typeof(TTableType) == typeof(ByU32))
+                ctx->hashTable[h] = (int)(p - srcBase);
+            else if (typeof(TTableType) == typeof(ByU16))
+                ((ushort*)ctx->hashTable)[h] = (ushort)(p - srcBase);
+            else
+                ThrowException(new NotSupportedException("TTableType directive is not supported."));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte* LZ4_getPositionOnHash<TTableType>(int h, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            if (typeof(TTableType) == typeof(ByU32))
+                return srcBase + ctx->hashTable[h];
+            else if (typeof(TTableType) == typeof(ByU16))
+                return srcBase + ((ushort*)ctx->hashTable)[h];
+
+            ThrowException(new NotSupportedException("TTableType directive is not supported."));
+            return default(byte*);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LZ4_hashPosition<TTableType>(byte* sequence)
+            where TTableType : ITableTypeDirective
+        {
+            if (typeof(TTableType) == typeof(ByU16))
+            {
+                ulong value = *((ulong*)sequence) * prime5bytes >> (40 - ByU16HashLog);
+                return (int)(value & ByU16HashMask);
+            }
+            else if (typeof(TTableType) == typeof(ByU32))
+            {
+                ulong value = (*((ulong*)sequence) * prime5bytes >> (40 - ByU32HashLog));
+                return (int)(value & ByU32HashMask);
+            }
+
+            return ThrowException<int>(new NotSupportedException("TTableType directive is not supported."));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ThrowException(Exception e)
+        {
+            throw e;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static TResult ThrowException<TResult>(Exception e)
+        {
+            throw e;
+        }
+
+        private const int ByU16HashLog = LZ4_HASHLOG + 1;
+        private const ulong ByU16HashMask = (1 << ByU16HashLog) - 1;
+
+        private const int ByU32HashLog = LZ4_HASHLOG;
+        private const ulong ByU32HashMask = (1 << ByU32HashLog) - 1;
+
+        private const ulong prime5bytes = 889523592379UL;
+
+        public static long Decode64LongBuffers(
+            byte* input,
+            long inputLength,
+            byte* output,
+            long outputLength,
+            bool knownOutputLength)
+        {
+            if (outputLength < MAX_INPUT_LENGTH_PER_SEGMENT && inputLength < MAX_INPUT_LENGTH_PER_SEGMENT)
+            {
+                return Decode64(input, (int)inputLength, output, (int)outputLength, knownOutputLength);
+            }
+
+            long totalReadSize = 0;
+            long totalWriteSize = 0;
+            while (totalReadSize < inputLength)
+            {
+                int partInputLength = int.MaxValue;
+                if (totalReadSize + partInputLength > inputLength)
+                    partInputLength = (int)(inputLength - totalReadSize);
+
+                int partOutputLength = MAX_INPUT_LENGTH_PER_SEGMENT;
+                if (totalWriteSize + partOutputLength > outputLength)
+                {
+                    partOutputLength = checked((int)(outputLength - totalWriteSize));
+                }
+                totalReadSize += Decode64(input + totalReadSize, partInputLength, output + totalWriteSize, partOutputLength, false);
+
+                totalWriteSize += MAX_INPUT_LENGTH_PER_SEGMENT;
+            }
+
+            return totalReadSize;
+        }
+
+        public static int Decode64(
+            byte* input,
+            int inputLength,
+            byte* output,
+            int outputLength,
+            bool knownOutputLength)
+        {
+            if (knownOutputLength)
+            {
+                var length = LZ4_decompress_generic<EndOnInputSize, Full, NoDict>(input, output, inputLength, outputLength, 0, output, null, 0);
+                if (length != outputLength)
+                    ThrowException(new ArgumentException("LZ4 block is corrupted, or invalid length has been given."));
+                return outputLength;
+            }
+            else
+            {
+                var length = LZ4_decompress_generic<EndOnOutputSize, Full, WithPrefix64K>(input, output, inputLength, outputLength, 0, output - (64 * Constants.Size.Kilobyte), null, 64 * Constants.Size.Kilobyte);
+                if (length < 0)
+                    ThrowException(new ArgumentException("LZ4 block is corrupted, or invalid length has been given."));
+
+                return length;
+            }
+        }
+
+        private static readonly int[] dec32table = new int[] { 4, 1, 2, 1, 4, 4, 4, 4 };
+        private static readonly int[] dec64table = new int[] { 0, 0, 0, -1, 0, 1, 2, 3 };
+
+        private static int LZ4_decompress_generic<TEndCondition, TEarlyEnd, TDictionaryType>(byte* source, byte* dest, int inputSize, int outputSize, int targetOutputSize, byte* lowPrefix, byte* dictStart, int dictSize)
+            where TEndCondition : IEndConditionDirective
+            where TEarlyEnd : IEarlyEndDirective
+            where TDictionaryType : IDictionaryTypeDirective
+        {
+            byte* ip = source;
+            byte* iend = ip + inputSize;
+
+            byte* op = dest;
+            byte* oend = op + outputSize;
+
+            byte* oexit = op + targetOutputSize;
+            byte* lowLimit = lowPrefix - dictSize;
+
+            byte* dictEnd = dictStart + dictSize;
+
+            bool checkOffset = ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (dictSize < 64 * Constants.Size.Kilobyte));
+
+            if ((typeof(TEarlyEnd) == typeof(Partial)) && (oexit > oend - MFLIMIT)) oexit = oend - MFLIMIT;
+            if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (outputSize == 0))
+                return ((inputSize == 1) && (*ip == 0)) ? 0 : -1;
+            if ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (outputSize == 0))
+                return (*ip == 0 ? 1 : -1);
+
+            while (true)
+            {
+                int length;
+
+                byte token = *ip++;
+                if ((length = (token >> ML_BITS)) == RUN_MASK)
+                {
+                    byte s;
+                    do
+                    {
+                        s = *ip++;
+                        length += s;
+                    }
+                    while (((typeof(TEndCondition) == typeof(EndOnInputSize)) ? ip < iend - RUN_MASK : true) && (s == 255));
+
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op) goto _output_error;
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length) < ip) goto _output_error;
+                }
+
+                byte* cpy = op + length;
+                if (((typeof(TEndCondition) == typeof(EndOnInputSize)) && ((cpy > (typeof(TEarlyEnd) == typeof(Partial) ? oexit : oend - MFLIMIT)) || (ip + length > iend - (2 + 1 + LASTLITERALS))))
+                    || ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (cpy > oend - COPYLENGTH)))
+                {
+                    if (typeof(TEarlyEnd) == typeof(Partial))
+                    {
+                        if (cpy > oend)
+                            goto _output_error;
+
+                        if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length > iend))
+                            goto _output_error;
+                    }
+                    else
+                    {
+                        if ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (cpy != oend))
+                            goto _output_error;
+
+                        if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && ((ip + length != iend) || (cpy > oend)))
+                            goto _output_error;
+                    }
+
+                    Memory.Copy(op, ip, (uint)length);
+                    ip += length;
+                    op += length;
+                    break;
+                }
+
+                WildCopy(op, ip, cpy);
+                ip += length; op = cpy;
+
+                byte* match = cpy - *((ushort*)ip); ip += sizeof(ushort);
+                if ((checkOffset) && (match < lowLimit))
+                    goto _output_error;
+
+                if ((length = (token & ML_MASK)) == ML_MASK)
+                {
+                    byte s;
+                    do
+                    {
+                        if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip > iend - LASTLITERALS))
+                            goto _output_error;
+
+                        s = *ip++;
+                        length += s;
+                    }
+                    while (s == 255);
+
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op)
+                        goto _output_error;
+                }
+
+                length += MINMATCH;
+
+                if ((typeof(TDictionaryType) == typeof(UsingExtDict)) && (match < lowPrefix))
+                {
+                    if (op + length > oend - LASTLITERALS)
+                        goto _output_error;
+
+                    if (length <= (int)(lowPrefix - match))
+                    {
+                        match = dictEnd - (lowPrefix - match);
+                        Memory.Move(op, match, length);
+                        op += length;
+                    }
+                    else
+                    {
+                        int copySize = (int)(lowPrefix - match);
+                        Memory.Copy(op, dictEnd - copySize, (uint)copySize);
+                        op += copySize;
+
+                        copySize = length - copySize;
+                        if (copySize > (int)(op - lowPrefix))
+                        {
+                            byte* endOfMatch = op + copySize;
+                            byte* copyFrom = lowPrefix;
+                            while (op < endOfMatch)
+                                *op++ = *copyFrom++;
+                        }
+                        else
+                        {
+                            Memory.Copy(op, lowPrefix, (uint)copySize);
+                            op += copySize;
+                        }
+                    }
+                    continue;
+                }
+
+                cpy = op + length;
+                if ((op - match) < 8)
+                {
+                    int dec64 = dec64table[op - match];
+                    op[0] = match[0];
+                    op[1] = match[1];
+                    op[2] = match[2];
+                    op[3] = match[3];
+
+                    match += dec32table[op - match];
+                    *((uint*)(op + 4)) = *(uint*)match;
+                    op += 8;
+                    match -= dec64;
+                }
+                else
+                {
+                    *((ulong*)op) = *(ulong*)match;
+                    op += sizeof(ulong);
+                    match += sizeof(ulong);
+                }
+
+                if (cpy > oend - 12)
+                {
+                    if (cpy > oend - LASTLITERALS)
+                        goto _output_error;
+
+                    if (op < oend - 8)
+                    {
+                        WildCopy(op, match, (oend - 8));
+                        match += (oend - 8) - op;
+                        op = oend - 8;
+                    }
+
+                    while (op < cpy)
+                        *op++ = *match++;
+                }
+                else
+                {
+                    WildCopy(op, match, cpy);
+                }
+
+                op = cpy;
+            }
+
+            if (typeof(TEndCondition) == typeof(EndOnInputSize))
+                return (int)(op - dest);
+            else
+                return (int)(ip - source);
+
+        _output_error:
+            return (int)(-(ip - source)) - 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WildCopy(byte* dest, byte* src, byte* destEnd)
+        {
+            do
+            {
+                ((ulong*)dest)[0] = ((ulong*)src)[0];
+                if (dest + 1 * sizeof(ulong) >= destEnd)
+                    goto Return;
+
+                ((ulong*)dest)[1] = ((ulong*)src)[1];
+                if (dest + 2 * sizeof(ulong) >= destEnd)
+                    goto Return;
+
+                ((ulong*)dest)[2] = ((ulong*)src)[2];
+                if (dest + 3 * sizeof(ulong) >= destEnd)
+                    goto Return;
+
+                ((ulong*)dest)[3] = ((ulong*)src)[3];
+
+                dest += 4 * sizeof(ulong);
+                src += 4 * sizeof(ulong);
+            }
+            while (dest < destEnd);
+
+        Return:
+            return;
+        }
+    }
+}

--- a/test/FastTests/Sparrow/LZ4BackwardCompatibilityTests.cs
+++ b/test/FastTests/Sparrow/LZ4BackwardCompatibilityTests.cs
@@ -556,21 +556,46 @@ namespace FastTests.Sparrow
         [InlineData(15)]
         public void MatchCopy_MidRangeOffsets_InFastLoop(int offset)
         {
-            // Crafts data that forces match copies with a specific offset (8-15) and
-            // long match lengths (> 18 bytes) so the fast loop's CopySmallOffset path
-            // is exercised rather than the short-match fastpath.
-            // This catches bugs where the offset < N threshold doesn't match the
-            // lookup table sizes (dec32table/dec64table are only 8 entries).
-            const int size = 4096;
+            // Creates data with MANY moderate-length matches at the target offset,
+            // interspersed with random segments that break the pattern. This ensures
+            // individual matches are short enough to stay in the fast loop (which requires
+            // oend - op >= FASTLOOP_SAFE_DISTANCE=64), exercising the WildCopy32/CopyWithOverlap
+            // code path rather than falling through to safe_match_copy.
+            //
+            // The match lengths must be >= 19 (MINMATCH + ML_MASK) to bypass the 18-byte
+            // shortcut and reach the general copy path where the offset < 16 threshold matters.
+            const int size = 32 * 1024; // 32KB - large enough for many fast-loop iterations
             var input = new byte[size];
             var rng = new Random(42 + offset);
 
-            // Fill first `offset` bytes with random data, then repeat that block
-            // throughout the buffer. This creates matches at exactly `offset` distance.
-            for (int i = 0; i < offset; i++)
-                input[i] = (byte)rng.Next(256);
-            for (int i = offset; i < size; i++)
-                input[i] = input[i - offset];
+            int pos = 0;
+            while (pos < size)
+            {
+                // Random segment (8-32 bytes) breaks the match chain, forcing a new literal
+                int randomLen = Math.Min(8 + rng.Next(25), size - pos);
+                for (int i = 0; i < randomLen; i++)
+                    input[pos++] = (byte)rng.Next(256);
+
+                if (pos >= size) break;
+
+                // Repeating segment at target offset (20-60 bytes) creates a match
+                // that's long enough for the general copy path (>= 19) but short enough
+                // to stay in the fast loop (remaining output > 64)
+                int repeatLen = Math.Min(20 + rng.Next(41), size - pos);
+                if (repeatLen > offset && pos >= offset)
+                {
+                    // Copy from `offset` bytes back to create a match at the target distance
+                    for (int i = 0; i < repeatLen; i++)
+                        input[pos + i] = input[pos + i - offset];
+                    pos += repeatLen;
+                }
+                else
+                {
+                    // Not enough room for a meaningful repeat; fill with random
+                    for (int i = 0; i < repeatLen; i++)
+                        input[pos++] = (byte)rng.Next(256);
+                }
+            }
 
             var maxCompressedSize = LZ4.MaximumOutputLength(size);
             var guardRng = new Random(42 + offset);

--- a/test/FastTests/Sparrow/LZ4BackwardCompatibilityTests.cs
+++ b/test/FastTests/Sparrow/LZ4BackwardCompatibilityTests.cs
@@ -1,0 +1,441 @@
+using Sparrow.Compression;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    /// <summary>
+    /// Tests to verify backward compatibility between the optimized LZ4 implementation
+    /// and the reference implementation. These tests ensure that:
+    /// 1. Data compressed by the reference can be decompressed by optimized
+    /// 2. Data compressed by optimized can be decompressed by reference
+    /// 3. Both implementations produce valid output
+    /// All tests use unmanaged memory with canary guard regions to detect buffer overruns.
+    /// </summary>
+    public unsafe class LZ4BackwardCompatibilityTests : NoDisposalNeeded
+    {
+        private const int GUARD = 64;
+        private const int MAX_MISALIGN = 15;
+
+        public LZ4BackwardCompatibilityTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /// <summary>
+        /// Test sizes covering critical boundaries in LZ4 algorithm
+        /// </summary>
+        public static IEnumerable<object[]> EdgeCaseSizes
+        {
+            get
+            {
+                return new[]
+                {
+                    // Very small sizes (below MFLIMIT)
+                    new object[] { 1 },
+                    new object[] { 4 },      // MINMATCH
+                    new object[] { 8 },      // COPYLENGTH
+                    new object[] { 12 },     // MFLIMIT boundary
+                    new object[] { 13 },     // LZ4_minLength
+                    new object[] { 14 },
+                    new object[] { 15 },     // RUN_MASK
+                    new object[] { 16 },
+
+                    // Around common boundaries
+                    new object[] { 63 },
+                    new object[] { 64 },     // FASTLOOP_SAFE_DISTANCE (in newer versions)
+                    new object[] { 65 },
+
+                    // Around 128-byte threshold (BlittableWriter compression threshold)
+                    new object[] { 127 },
+                    new object[] { 128 },
+                    new object[] { 129 },
+
+                    // Around byte overflow
+                    new object[] { 254 },
+                    new object[] { 255 },
+                    new object[] { 256 },
+                    new object[] { 257 },
+
+                    // Around 1KB
+                    new object[] { 1023 },
+                    new object[] { 1024 },
+                    new object[] { 1025 },
+
+                    // Around 4KB (page size)
+                    new object[] { 4095 },
+                    new object[] { 4096 },
+                    new object[] { 4097 },
+
+                    // Around 8KB (typical Voron page)
+                    new object[] { 8191 },
+                    new object[] { 8192 },
+                    new object[] { 8193 },
+
+                    // Around 64KB (ByU16 vs ByU32 boundary)
+                    new object[] { 65534 },
+                    new object[] { 65535 },
+                    new object[] { 65536 },
+                    new object[] { 65537 },
+
+                    // Larger sizes
+                    new object[] { 100000 },
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> DataPatterns
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] { "zeros" },
+                    new object[] { "ones" },
+                    new object[] { "sequential" },
+                    new object[] { "random_seeded" },
+                    new object[] { "highly_compressible" },
+                    new object[] { "incompressible" },
+                };
+            }
+        }
+
+        /// <summary>
+        /// Allocates an unmanaged buffer with random-filled guard regions and random misalignment.
+        /// Layout: [GUARD bytes] [misalign 0-15] [usable: size bytes] [GUARD bytes]
+        /// </summary>
+        private static byte* AllocGuarded(int size, Random rng, out byte* baseAlloc, out byte[] frontSnap, out byte[] backSnap)
+        {
+            int misalign = rng.Next(0, MAX_MISALIGN + 1);
+            int total = GUARD + MAX_MISALIGN + size + GUARD;
+            baseAlloc = (byte*)NativeMemory.Alloc((nuint)total);
+
+            // Fill entire buffer with known random sequence (serves as canary AND garbage)
+            var fill = new byte[total];
+            rng.NextBytes(fill);
+            fixed (byte* fillPtr = fill)
+            {
+                Buffer.MemoryCopy(fillPtr, baseAlloc, total, total);
+            }
+
+            byte* ptr = baseAlloc + GUARD + misalign;
+
+            // Snapshot front guard: GUARD bytes before ptr
+            frontSnap = new byte[GUARD];
+            for (int i = 0; i < GUARD; i++)
+                frontSnap[i] = *(ptr - GUARD + i);
+
+            // Snapshot back guard: GUARD bytes after usable area
+            backSnap = new byte[GUARD];
+            for (int i = 0; i < GUARD; i++)
+                backSnap[i] = *(ptr + size + i);
+
+            return ptr;
+        }
+
+        /// <summary>
+        /// Verifies that the guard regions around a guarded buffer are unchanged.
+        /// </summary>
+        private static void VerifyGuards(byte* ptr, int size, byte[] frontSnap, byte[] backSnap, string ctx)
+        {
+            // Check front guard
+            for (int i = 0; i < GUARD; i++)
+            {
+                byte expected = frontSnap[i];
+                byte actual = *(ptr - GUARD + i);
+                Assert.True(expected == actual,
+                    $"Front guard corrupted at offset {i} (relative to guard start) for {ctx}. Expected 0x{expected:X2}, got 0x{actual:X2}");
+            }
+
+            // Check back guard
+            for (int i = 0; i < GUARD; i++)
+            {
+                byte expected = backSnap[i];
+                byte actual = *(ptr + size + i);
+                Assert.True(expected == actual,
+                    $"Back guard corrupted at offset {i} (relative to usable end) for {ctx}. Expected 0x{expected:X2}, got 0x{actual:X2}");
+            }
+        }
+
+        private static void FreeGuarded(byte* baseAlloc)
+        {
+            NativeMemory.Free(baseAlloc);
+        }
+
+        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        [MemberData(nameof(EdgeCaseSizes))]
+        public void ReferenceCompress_OptimizedDecompress(int size)
+        {
+            foreach (var pattern in new[] { "zeros", "sequential", "random_seeded", "highly_compressible" })
+            {
+                var input = GenerateTestData(size, pattern);
+                var maxCompressedSize = LZ4Reference.MaximumOutputLength(size);
+                var rng = new Random(42 + size + pattern.GetHashCode());
+
+                byte* compBase, decompBase;
+                byte[] compFront, compBack, decompFront, decompBack;
+
+                var compressedPtr = AllocGuarded(maxCompressedSize, rng, out compBase, out compFront, out compBack);
+                var decompressedPtr = AllocGuarded(size, rng, out decompBase, out decompFront, out decompBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        // Compress with REFERENCE
+                        int compressedSize = LZ4Reference.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                        Assert.True(compressedSize > 0, $"Reference compression failed for size={size}, pattern={pattern}");
+
+                        VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf after Reference.Encode64 size={size}, pattern={pattern}");
+
+                        // Decompress with OPTIMIZED
+                        int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                        Assert.Equal(size, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, size, decompFront, decompBack, $"decompressed buf after LZ4.Decode64 size={size}, pattern={pattern}");
+
+                        // Verify data integrity
+                        for (int i = 0; i < size; i++)
+                        {
+                            Assert.True(input[i] == decompressedPtr[i],
+                                $"Data mismatch at position {i} for size={size}, pattern={pattern}. Expected {input[i]}, got {decompressedPtr[i]}");
+                        }
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compBase);
+                    FreeGuarded(decompBase);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        [MemberData(nameof(EdgeCaseSizes))]
+        public void OptimizedCompress_ReferenceDecompress(int size)
+        {
+            foreach (var pattern in new[] { "zeros", "sequential", "random_seeded", "highly_compressible" })
+            {
+                var input = GenerateTestData(size, pattern);
+                var maxCompressedSize = LZ4.MaximumOutputLength(size);
+                var rng = new Random(42 + size + pattern.GetHashCode());
+
+                byte* compBase, decompBase;
+                byte[] compFront, compBack, decompFront, decompBack;
+
+                var compressedPtr = AllocGuarded(maxCompressedSize, rng, out compBase, out compFront, out compBack);
+                var decompressedPtr = AllocGuarded(size, rng, out decompBase, out decompFront, out decompBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        // Compress with OPTIMIZED
+                        int compressedSize = LZ4.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                        Assert.True(compressedSize > 0, $"Optimized compression failed for size={size}, pattern={pattern}");
+
+                        VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf after LZ4.Encode64 size={size}, pattern={pattern}");
+
+                        // Decompress with REFERENCE
+                        int decompressedSize = LZ4Reference.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                        Assert.Equal(size, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, size, decompFront, decompBack, $"decompressed buf after Reference.Decode64 size={size}, pattern={pattern}");
+
+                        // Verify data integrity
+                        for (int i = 0; i < size; i++)
+                        {
+                            Assert.True(input[i] == decompressedPtr[i],
+                                $"Data mismatch at position {i} for size={size}, pattern={pattern}. Expected {input[i]}, got {decompressedPtr[i]}");
+                        }
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compBase);
+                    FreeGuarded(decompBase);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        [MemberData(nameof(EdgeCaseSizes))]
+        public void OptimizedCompress_OptimizedDecompress(int size)
+        {
+            foreach (var pattern in new[] { "zeros", "sequential", "random_seeded", "highly_compressible" })
+            {
+                var input = GenerateTestData(size, pattern);
+                var maxCompressedSize = LZ4.MaximumOutputLength(size);
+                var rng = new Random(42 + size + pattern.GetHashCode());
+
+                byte* compBase, decompBase;
+                byte[] compFront, compBack, decompFront, decompBack;
+
+                var compressedPtr = AllocGuarded(maxCompressedSize, rng, out compBase, out compFront, out compBack);
+                var decompressedPtr = AllocGuarded(size, rng, out decompBase, out decompFront, out decompBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        // Compress with OPTIMIZED
+                        int compressedSize = LZ4.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                        Assert.True(compressedSize > 0, $"Optimized compression failed for size={size}, pattern={pattern}");
+
+                        VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf after LZ4.Encode64 size={size}, pattern={pattern}");
+
+                        // Decompress with OPTIMIZED
+                        int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                        Assert.Equal(size, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, size, decompFront, decompBack, $"decompressed buf after LZ4.Decode64 size={size}, pattern={pattern}");
+
+                        // Verify data integrity
+                        for (int i = 0; i < size; i++)
+                        {
+                            Assert.True(input[i] == decompressedPtr[i],
+                                $"Data mismatch at position {i} for size={size}, pattern={pattern}. Expected {input[i]}, got {decompressedPtr[i]}");
+                        }
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compBase);
+                    FreeGuarded(decompBase);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        [MemberData(nameof(EdgeCaseSizes))]
+        public void CompressionRatioShouldMatch(int size)
+        {
+            // Skip very small sizes where compression might not occur
+            if (size < 13)
+                return;
+
+            foreach (var pattern in new[] { "sequential", "highly_compressible" })
+            {
+                var input = GenerateTestData(size, pattern);
+                var maxCompressedSize = LZ4.MaximumOutputLength(size);
+                var rng = new Random(42 + size + pattern.GetHashCode());
+
+                byte* compRefBase, compOptBase;
+                byte[] compRefFront, compRefBack, compOptFront, compOptBack;
+
+                var compressedRefPtr = AllocGuarded(maxCompressedSize, rng, out compRefBase, out compRefFront, out compRefBack);
+                var compressedOptPtr = AllocGuarded(maxCompressedSize, rng, out compOptBase, out compOptFront, out compOptBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        int refSize = LZ4Reference.Encode64(inputPtr, compressedRefPtr, size, maxCompressedSize);
+                        VerifyGuards(compressedRefPtr, maxCompressedSize, compRefFront, compRefBack, $"ref compressed buf size={size}, pattern={pattern}");
+
+                        int optSize = LZ4.Encode64(inputPtr, compressedOptPtr, size, maxCompressedSize);
+                        VerifyGuards(compressedOptPtr, maxCompressedSize, compOptFront, compOptBack, $"opt compressed buf size={size}, pattern={pattern}");
+
+                        // Compression ratios should be identical or very close
+                        Assert.True(Math.Abs(refSize - optSize) <= Math.Max(1, size / 100),
+                            $"Compression ratio mismatch for size={size}, pattern={pattern}. Reference={refSize}, Optimized={optSize}");
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compRefBase);
+                    FreeGuarded(compOptBase);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        public void LimitedOutputMode()
+        {
+            // Test that limited output mode works correctly
+            var size = 10000;
+            var input = GenerateTestData(size, "highly_compressible");
+            var maxCompressedSize = LZ4.MaximumOutputLength(size);
+            var rng = new Random(42 + size);
+
+            byte* compBase, decompBase;
+            byte[] compFront, compBack, decompFront, decompBack;
+
+            var compressedPtr = AllocGuarded(maxCompressedSize, rng, out compBase, out compFront, out compBack);
+            var decompressedPtr = AllocGuarded(size, rng, out decompBase, out decompFront, out decompBack);
+            try
+            {
+                fixed (byte* inputPtr = input)
+                {
+                    // Compress with limited output (realistic scenario)
+                    int compressedSize = LZ4.Encode64(inputPtr, compressedPtr, size, size - 8);
+
+                    VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, "compressed buf after LZ4.Encode64 limited output");
+
+                    if (compressedSize > 0)
+                    {
+                        // If compression succeeded, verify round-trip
+                        int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                        Assert.Equal(size, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, size, decompFront, decompBack, "decompressed buf after LZ4.Decode64 limited output");
+
+                        for (int i = 0; i < size; i++)
+                            Assert.Equal(input[i], decompressedPtr[i]);
+                    }
+                    // If compression failed (returned 0), that's acceptable for limited output mode
+                }
+            }
+            finally
+            {
+                FreeGuarded(compBase);
+                FreeGuarded(decompBase);
+            }
+        }
+
+        private byte[] GenerateTestData(int size, string pattern)
+        {
+            var data = new byte[size];
+            var rng = new Random(42); // Seeded for reproducibility
+
+            switch (pattern)
+            {
+                case "zeros":
+                    // All zeros - highly compressible
+                    Array.Fill(data, (byte)0);
+                    break;
+
+                case "ones":
+                    // All 0xFF - highly compressible
+                    Array.Fill(data, (byte)0xFF);
+                    break;
+
+                case "sequential":
+                    // Sequential bytes 0,1,2,3... - moderately compressible
+                    for (int i = 0; i < size; i++)
+                        data[i] = (byte)(i & 0xFF);
+                    break;
+
+                case "random_seeded":
+                    // Random but reproducible
+                    rng.NextBytes(data);
+                    break;
+
+                case "highly_compressible":
+                    // Repeated patterns - very compressible
+                    for (int i = 0; i < size; i++)
+                        data[i] = (byte)(i % 4);
+                    break;
+
+                case "incompressible":
+                    // Random data - essentially incompressible
+                    new Random(size).NextBytes(data);
+                    break;
+
+                default:
+                    throw new ArgumentException($"Unknown pattern: {pattern}");
+            }
+
+            return data;
+        }
+    }
+}

--- a/test/FastTests/Sparrow/LZ4BackwardCompatibilityTests.cs
+++ b/test/FastTests/Sparrow/LZ4BackwardCompatibilityTests.cs
@@ -392,6 +392,236 @@ namespace FastTests.Sparrow
             }
         }
 
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        public void SequentialSmallCompressions_TableReuse()
+        {
+            // Compress 10 small buffers (< 4KB each) sequentially on the same thread.
+            // Each must roundtrip correctly. Tests the DictSmall + table reuse path.
+            var rng = new Random(123);
+
+            for (int iter = 0; iter < 10; iter++)
+            {
+                int size = 200 + iter * 300; // 200..2900 bytes, all < 4KB
+                var input = new byte[size];
+                rng.NextBytes(input);
+
+                var maxCompressedSize = LZ4.MaximumOutputLength(size);
+
+                byte* compBase, decompBase;
+                byte[] compFront, compBack, decompFront, decompBack;
+                var guardRng = new Random(42 + iter);
+
+                var compressedPtr = AllocGuarded(maxCompressedSize, guardRng, out compBase, out compFront, out compBack);
+                var decompressedPtr = AllocGuarded(size, guardRng, out decompBase, out decompFront, out decompBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        int compressedSize = LZ4.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                        Assert.True(compressedSize > 0, $"Compression failed for iter={iter}, size={size}");
+
+                        VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf iter={iter}");
+
+                        int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                        Assert.Equal(size, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, size, decompFront, decompBack, $"decompressed buf iter={iter}");
+
+                        for (int i = 0; i < size; i++)
+                        {
+                            Assert.True(input[i] == decompressedPtr[i],
+                                $"Data mismatch at position {i} for iter={iter}, size={size}. Expected {input[i]}, got {decompressedPtr[i]}");
+                        }
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compBase);
+                    FreeGuarded(decompBase);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        public void SmallLargeAlternation_TableClearAndReuse()
+        {
+            // Sequence: 500B -> 100KB -> 500B -> 500B
+            // Verifies table clear triggers on large input, then reuse resumes for subsequent small inputs.
+            var sizes = new[] { 500, 100_000, 500, 500 };
+            var rng = new Random(456);
+
+            for (int iter = 0; iter < sizes.Length; iter++)
+            {
+                int size = sizes[iter];
+                var input = new byte[size];
+                rng.NextBytes(input);
+
+                var maxCompressedSize = LZ4.MaximumOutputLength(size);
+                var guardRng = new Random(42 + iter);
+
+                byte* compBase, decompBase;
+                byte[] compFront, compBack, decompFront, decompBack;
+
+                var compressedPtr = AllocGuarded(maxCompressedSize, guardRng, out compBase, out compFront, out compBack);
+                var decompressedPtr = AllocGuarded(size, guardRng, out decompBase, out decompFront, out decompBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        int compressedSize = LZ4.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                        Assert.True(compressedSize > 0, $"Compression failed for iter={iter}, size={size}");
+
+                        VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf iter={iter}");
+
+                        int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                        Assert.Equal(size, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, size, decompFront, decompBack, $"decompressed buf iter={iter}");
+
+                        for (int i = 0; i < size; i++)
+                        {
+                            Assert.True(input[i] == decompressedPtr[i],
+                                $"Data mismatch at position {i} for iter={iter}, size={size}. Expected {input[i]}, got {decompressedPtr[i]}");
+                        }
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compBase);
+                    FreeGuarded(decompBase);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        public void ByU16OverflowBoundary_ForcesTableClear()
+        {
+            // Compress enough small buffers that currentOffset + inputSize >= 0xFFFF,
+            // forcing a table clear mid-sequence. Each buffer is ~3000 bytes (byU16 path,
+            // < 4KB so table reuse is attempted). After ~22 iterations the offset overflows.
+            const int bufSize = 3000;
+            int iterations = (0xFFFF / bufSize) + 5; // enough to trigger overflow
+            var rng = new Random(789);
+
+            for (int iter = 0; iter < iterations; iter++)
+            {
+                var input = new byte[bufSize];
+                rng.NextBytes(input);
+
+                var maxCompressedSize = LZ4.MaximumOutputLength(bufSize);
+                var guardRng = new Random(42 + iter);
+
+                byte* compBase, decompBase;
+                byte[] compFront, compBack, decompFront, decompBack;
+
+                var compressedPtr = AllocGuarded(maxCompressedSize, guardRng, out compBase, out compFront, out compBack);
+                var decompressedPtr = AllocGuarded(bufSize, guardRng, out decompBase, out decompFront, out decompBack);
+                try
+                {
+                    fixed (byte* inputPtr = input)
+                    {
+                        int compressedSize = LZ4.Encode64(inputPtr, compressedPtr, bufSize, maxCompressedSize);
+                        Assert.True(compressedSize > 0, $"Compression failed for iter={iter}");
+
+                        VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf iter={iter}");
+
+                        int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, bufSize, true);
+                        Assert.Equal(bufSize, decompressedSize);
+
+                        VerifyGuards(decompressedPtr, bufSize, decompFront, decompBack, $"decompressed buf iter={iter}");
+
+                        for (int i = 0; i < bufSize; i++)
+                        {
+                            Assert.True(input[i] == decompressedPtr[i],
+                                $"Data mismatch at position {i} for iter={iter}. Expected {input[i]}, got {decompressedPtr[i]}");
+                        }
+                    }
+                }
+                finally
+                {
+                    FreeGuarded(compBase);
+                    FreeGuarded(decompBase);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core | RavenTestCategory.Intrinsics)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(11)]
+        [InlineData(12)]
+        [InlineData(13)]
+        [InlineData(14)]
+        [InlineData(15)]
+        public void MatchCopy_MidRangeOffsets_InFastLoop(int offset)
+        {
+            // Crafts data that forces match copies with a specific offset (8-15) and
+            // long match lengths (> 18 bytes) so the fast loop's CopySmallOffset path
+            // is exercised rather than the short-match fastpath.
+            // This catches bugs where the offset < N threshold doesn't match the
+            // lookup table sizes (dec32table/dec64table are only 8 entries).
+            const int size = 4096;
+            var input = new byte[size];
+            var rng = new Random(42 + offset);
+
+            // Fill first `offset` bytes with random data, then repeat that block
+            // throughout the buffer. This creates matches at exactly `offset` distance.
+            for (int i = 0; i < offset; i++)
+                input[i] = (byte)rng.Next(256);
+            for (int i = offset; i < size; i++)
+                input[i] = input[i - offset];
+
+            var maxCompressedSize = LZ4.MaximumOutputLength(size);
+            var guardRng = new Random(42 + offset);
+
+            byte* compBase, decompBase;
+            byte[] compFront, compBack, decompFront, decompBack;
+
+            var compressedPtr = AllocGuarded(maxCompressedSize, guardRng, out compBase, out compFront, out compBack);
+            var decompressedPtr = AllocGuarded(size, guardRng, out decompBase, out decompFront, out decompBack);
+            try
+            {
+                fixed (byte* inputPtr = input)
+                {
+                    // Compress with reference, decompress with optimized
+                    int compressedSize = LZ4Reference.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                    Assert.True(compressedSize > 0, $"Reference compression failed for offset={offset}");
+
+                    VerifyGuards(compressedPtr, maxCompressedSize, compFront, compBack, $"compressed buf offset={offset}");
+
+                    int decompressedSize = LZ4.Decode64(compressedPtr, compressedSize, decompressedPtr, size, true);
+                    Assert.Equal(size, decompressedSize);
+
+                    VerifyGuards(decompressedPtr, size, decompFront, decompBack, $"decompressed buf offset={offset}");
+
+                    for (int i = 0; i < size; i++)
+                    {
+                        Assert.True(input[i] == decompressedPtr[i],
+                            $"Data mismatch at position {i} for offset={offset}. Expected {input[i]}, got {decompressedPtr[i]}");
+                    }
+
+                    // Also test optimized compress -> optimized decompress
+                    int optCompressedSize = LZ4.Encode64(inputPtr, compressedPtr, size, maxCompressedSize);
+                    Assert.True(optCompressedSize > 0, $"Optimized compression failed for offset={offset}");
+
+                    decompressedSize = LZ4.Decode64(compressedPtr, optCompressedSize, decompressedPtr, size, true);
+                    Assert.Equal(size, decompressedSize);
+
+                    for (int i = 0; i < size; i++)
+                    {
+                        Assert.True(input[i] == decompressedPtr[i],
+                            $"Opt roundtrip mismatch at position {i} for offset={offset}. Expected {input[i]}, got {decompressedPtr[i]}");
+                    }
+                }
+            }
+            finally
+            {
+                FreeGuarded(compBase);
+                FreeGuarded(decompBase);
+            }
+        }
+
         private byte[] GenerateTestData(int size, string pattern)
         {
             var data = new byte[size];

--- a/test/FastTests/Sparrow/LZ4Reference.cs
+++ b/test/FastTests/Sparrow/LZ4Reference.cs
@@ -1,0 +1,790 @@
+using System;
+using Sparrow;
+using Sparrow.Global;
+using System.Runtime.InteropServices;
+using Sparrow.Binary;
+using System.Runtime.CompilerServices;
+
+namespace FastTests.Sparrow
+{
+    /// <summary>
+    /// Reference LZ4 implementation preserved for backward compatibility verification.
+    /// This is a copy of the original implementation before optimizations.
+    /// Used to verify that optimized code can decompress data compressed by this version and vice versa.
+    /// DO NOT MODIFY - this serves as the baseline for compatibility testing.
+    /// </summary>
+    internal sealed unsafe class LZ4Reference
+    {
+        public const int ACCELERATION_DEFAULT = 1;
+
+        private const int COPYLENGTH = 8;
+        private const int LASTLITERALS = 5;
+        private const int MINMATCH = 4;
+        private const int MFLIMIT = COPYLENGTH + MINMATCH;
+        private const int LZ4_minLength = MFLIMIT + 1;
+
+        private const int MAXD_LOG = 16;
+        private const int MAX_DISTANCE = ((1 << MAXD_LOG) - 1);
+
+        private const int LZ4_64Klimit = (64 * Constants.Size.Kilobyte) + (MFLIMIT - 1);
+        private const int LZ4_skipTrigger = 6;
+
+        private const byte ML_BITS = 4;
+        private const byte ML_MASK = ((1 << ML_BITS) - 1);
+        private const byte RUN_BITS = (8 - ML_BITS);
+        private const byte RUN_MASK = ((1 << RUN_BITS) - 1);
+
+        private const uint LZ4_MAX_INPUT_SIZE = 0x7E000000;
+
+        private const int LZ4_MEMORY_USAGE = 14;
+        private const int LZ4_HASHLOG = LZ4_MEMORY_USAGE - 2;
+        private const int HASH_SIZE_U32 = 1 << LZ4_HASHLOG;
+        private const int MAX_INPUT_LENGTH_PER_SEGMENT = int.MaxValue / 2;
+
+        private interface ILimitedOutputDirective { };
+        private struct NotLimited : ILimitedOutputDirective { };
+        private struct LimitedOutput : ILimitedOutputDirective { };
+
+        private interface IDictionaryTypeDirective { };
+        private struct NoDict : IDictionaryTypeDirective { };
+        private struct WithPrefix64K : IDictionaryTypeDirective { };
+        private struct UsingExtDict : IDictionaryTypeDirective { };
+
+        private interface IDictionaryIssueDirective { };
+        private struct NoDictIssue : IDictionaryIssueDirective { };
+        private struct DictSmall : IDictionaryIssueDirective { };
+
+        private interface ITableTypeDirective { };
+        private struct ByU32 : ITableTypeDirective { };
+        private struct ByU16 : ITableTypeDirective { };
+
+        private interface IEndConditionDirective { };
+        private struct EndOnOutputSize : IEndConditionDirective { };
+        private struct EndOnInputSize : IEndConditionDirective { };
+
+        private interface IEarlyEndDirective { };
+        private struct Full : IEarlyEndDirective { };
+        private struct Partial : IEarlyEndDirective { };
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LZ4_stream_t_internal
+        {
+            public fixed int hashTable[HASH_SIZE_U32];
+            public uint dictSize;
+            public uint currentOffset;
+            public byte* dictionary;
+            public uint initCheck;
+        }
+
+        public static long Encode64LongBuffer(
+            byte* input,
+            byte* output,
+            long inputLength,
+            long outputLength,
+            int acceleration = ACCELERATION_DEFAULT)
+        {
+            if (inputLength < MAX_INPUT_LENGTH_PER_SEGMENT && outputLength < MAX_INPUT_LENGTH_PER_SEGMENT)
+            {
+                return Encode64(input, output, (int)inputLength, (int)outputLength, acceleration);
+            }
+
+            long totalOutputSize = 0;
+            long readPosition = 0;
+            while (readPosition < inputLength)
+            {
+                int partInputLength = MAX_INPUT_LENGTH_PER_SEGMENT;
+                if (readPosition + partInputLength > inputLength)
+                    partInputLength = (int)(inputLength - readPosition);
+
+                int remaining = (outputLength - totalOutputSize) > int.MaxValue ? int.MaxValue : (int)(outputLength - totalOutputSize);
+
+                totalOutputSize += Encode64(input + readPosition, output + totalOutputSize, partInputLength, remaining, acceleration);
+
+                readPosition += partInputLength;
+            }
+
+            return totalOutputSize;
+        }
+
+        public static int Encode64(
+                byte* input,
+                byte* output,
+                int inputLength,
+                int outputLength,
+                int acceleration = ACCELERATION_DEFAULT)
+        {
+            if (acceleration < 1)
+                acceleration = ACCELERATION_DEFAULT;
+
+            LZ4_stream_t_internal ctx = new LZ4_stream_t_internal();
+
+            if (outputLength >= MaximumOutputLength(inputLength))
+            {
+                if (inputLength < LZ4_64Klimit)
+                    return LZ4_compress_generic<NotLimited, ByU16, NoDict, NoDictIssue>(&ctx, input, output, inputLength, 0, acceleration);
+                else
+                    return LZ4_compress_generic<NotLimited, ByU32, NoDict, NoDictIssue>(&ctx, input, output, inputLength, 0, acceleration);
+            }
+            else
+            {
+                if (inputLength < LZ4_64Klimit)
+                    return LZ4_compress_generic<LimitedOutput, ByU16, NoDict, NoDictIssue>(&ctx, input, output, inputLength, outputLength, acceleration);
+                else
+                    return LZ4_compress_generic<LimitedOutput, ByU32, NoDict, NoDictIssue>(&ctx, input, output, inputLength, outputLength, acceleration);
+            }
+        }
+
+        public static long MaximumOutputLength(long size)
+        {
+            return size + (size / 255) + 16;
+        }
+
+        public static int MaximumOutputLength(int size)
+        {
+            return checked(size + (size / 255) + 16);
+        }
+
+        private static int LZ4_compress_generic<TLimited, TTableType, TDictionaryType, TDictionaryIssue>(LZ4_stream_t_internal* dictPtr, byte* source, byte* dest, int inputSize, int maxOutputSize, int acceleration)
+            where TLimited : ILimitedOutputDirective
+            where TTableType : ITableTypeDirective
+            where TDictionaryType : IDictionaryTypeDirective
+            where TDictionaryIssue : IDictionaryIssueDirective
+        {
+
+            LZ4_stream_t_internal* ctx = dictPtr;
+
+            byte* op = dest;
+            byte* ip = source;
+            byte* anchor = source;
+
+            byte* dictionary = ctx->dictionary;
+            byte* dictEnd = dictionary + ctx->dictSize;
+            byte* lowRefLimit = ip - ctx->dictSize;
+
+            long dictDelta = (long)dictEnd - (long)source;
+
+            byte* iend = ip + inputSize;
+            byte* mflimit = iend - MFLIMIT;
+            byte* matchlimit = iend - LASTLITERALS;
+
+            byte* olimit = op + maxOutputSize;
+
+            if (inputSize > LZ4_MAX_INPUT_SIZE) return 0;
+
+            byte* @base;
+            byte* lowLimit;
+
+            if (typeof(TDictionaryType) == typeof(NoDict))
+            {
+                @base = source;
+                lowLimit = source;
+            }
+            else if (typeof(TDictionaryType) == typeof(WithPrefix64K))
+            {
+                @base = source - ctx->currentOffset;
+                lowLimit = source - ctx->dictSize;
+            }
+            else if (typeof(TDictionaryType) == typeof(UsingExtDict))
+            {
+                @base = source - ctx->currentOffset;
+                lowLimit = source;
+            }
+            else throw new NotSupportedException("Unsupported IDictionaryTypeDirective.");
+
+            if ((typeof(TTableType) == typeof(ByU16)) && (inputSize >= LZ4_64Klimit))
+                return 0;
+
+            if (inputSize < LZ4_minLength)
+                goto _last_literals;
+
+            LZ4_putPosition<TTableType>(ip, ctx, @base);
+            ip++;
+            int forwardH = LZ4_hashPosition<TTableType>(ip);
+
+            long refDelta = 0;
+            for (; ; )
+            {
+                byte* match;
+                {
+                    byte* forwardIp = ip;
+
+                    int step = 1;
+                    int searchMatchNb = acceleration << LZ4_skipTrigger;
+
+                    do
+                    {
+                        int h = forwardH;
+                        ip = forwardIp;
+                        forwardIp += step;
+                        step = (searchMatchNb++ >> LZ4_skipTrigger);
+
+                        if (forwardIp > mflimit)
+                            goto _last_literals;
+
+                        match = LZ4_getPositionOnHash<TTableType>(h, ctx, @base);
+                        if (typeof(TDictionaryType) == typeof(UsingExtDict))
+                        {
+                            if (match < source)
+                            {
+                                refDelta = dictDelta;
+                                lowLimit = dictionary;
+                            }
+                            else
+                            {
+                                refDelta = 0;
+                                lowLimit = source;
+                            }
+                        }
+
+                        if (typeof(TTableType) == typeof(ByU16))
+                        {
+                            ulong value = *((ulong*)forwardIp) * prime5bytes >> (40 - ByU16HashLog);
+                            forwardH = (int)(value & ByU16HashMask);
+                            ((ushort*)ctx->hashTable)[h] = (ushort)(ip - @base);
+                        }
+                        else if (typeof(TTableType) == typeof(ByU32))
+                        {
+                            ulong value = (*((ulong*)forwardIp) * prime5bytes >> (40 - ByU32HashLog));
+                            forwardH = (int)(value & ByU32HashMask);
+                            ctx->hashTable[h] = (int)(ip - @base);
+                        }
+                        else throw new NotSupportedException("TTableType directive is not supported.");
+                    }
+                    while (((typeof(TDictionaryType) == typeof(DictSmall)) ? (match < lowRefLimit) : false) ||
+                           ((typeof(TTableType) == typeof(ByU16)) ? false : (match + MAX_DISTANCE < ip)) ||
+                           (*(uint*)(match + refDelta) != *((uint*)ip)));
+                }
+
+                while ((ip > anchor) && (match + refDelta > lowLimit) && (ip[-1] == match[refDelta - 1]))
+                {
+                    ip--;
+                    match--;
+                }
+
+                byte* token;
+                {
+                    int litLength = (int)(ip - anchor);
+                    token = op++;
+
+                    if ((typeof(TLimited) == typeof(LimitedOutput)) && (op + litLength + (2 + 1 + LASTLITERALS) + (litLength / 255) > olimit))
+                        return 0;
+
+                    if (litLength >= RUN_MASK)
+                    {
+                        int len = litLength - RUN_MASK;
+                        *token = RUN_MASK << ML_BITS;
+
+                        for (; len >= 255; len -= 255)
+                            *op++ = 255;
+
+                        *op++ = (byte)len;
+                    }
+                    else
+                    {
+                        *token = (byte)(litLength << ML_BITS);
+                    }
+
+                    WildCopy(op, anchor, (op + litLength));
+                    op += litLength;
+                }
+
+            _next_match:
+
+                *((ushort*)op) = (ushort)(ip - match);
+                op += sizeof(ushort);
+
+                {
+                    int matchLength;
+
+                    if ((typeof(TDictionaryType) == typeof(UsingExtDict)) && (lowLimit == dictionary))
+                    {
+                        match += refDelta;
+
+                        byte* limit = ip + (dictEnd - match);
+                        if (limit > matchlimit) limit = matchlimit;
+                        matchLength = LZ4_count(ip + MINMATCH, match + MINMATCH, limit);
+                        ip += MINMATCH + matchLength;
+                        if (ip == limit)
+                        {
+                            int more = LZ4_count(ip, source, matchlimit);
+                            matchLength += more;
+                            ip += more;
+                        }
+                    }
+                    else
+                    {
+                        matchLength = LZ4_count(ip + MINMATCH, match + MINMATCH, matchlimit);
+                        ip += MINMATCH + matchLength;
+                    }
+
+                    if ((typeof(TLimited) == typeof(LimitedOutput)) && ((op + (1 + LASTLITERALS) + (matchLength >> 8)) > olimit))
+                        return 0;
+
+                    if (matchLength >= ML_MASK)
+                    {
+                        *token += ML_MASK;
+                        matchLength -= ML_MASK;
+
+                        for (; matchLength >= 510; matchLength -= 510)
+                        {
+                            *(ushort*)op = (255 << 8 | 255);
+                            op += sizeof(ushort);
+                        }
+
+                        if (matchLength >= 255)
+                        {
+                            matchLength -= 255;
+                            *op++ = 255;
+                        }
+
+                        *op++ = (byte)matchLength;
+                    }
+                    else
+                    {
+                        *token += (byte)(matchLength);
+                    }
+                }
+
+                anchor = ip;
+
+                if (ip > mflimit) break;
+
+                LZ4_putPosition<TTableType>(ip - 2, ctx, @base);
+
+                match = LZ4_getPosition<TTableType>(ip, ctx, @base);
+                if (typeof(TDictionaryType) == typeof(UsingExtDict))
+                {
+                    if (match < source)
+                    {
+                        refDelta = dictDelta;
+                        lowLimit = dictionary;
+                    }
+                    else
+                    {
+                        refDelta = 0;
+                        lowLimit = source;
+                    }
+                }
+
+                LZ4_putPosition<TTableType>(ip, ctx, @base);
+                if (((typeof(TDictionaryType) == typeof(DictSmall)) ? (match >= lowRefLimit) : true) && (match + MAX_DISTANCE >= ip) && (*(uint*)(match + refDelta) == *(uint*)(ip)))
+                {
+                    token = op++; *token = 0;
+                    goto _next_match;
+                }
+
+                forwardH = LZ4_hashPosition<TTableType>(++ip);
+            }
+
+        _last_literals:
+
+            {
+                int lastRun = (int)(iend - anchor);
+                if ((typeof(TLimited) == typeof(LimitedOutput)) && ((op - dest) + lastRun + 1 + ((lastRun + 255 - RUN_MASK) / 255) > maxOutputSize))
+                    return 0;
+
+                if (lastRun >= RUN_MASK)
+                {
+                    int accumulator = lastRun - RUN_MASK;
+                    *op++ = RUN_MASK << ML_BITS;
+
+                    for (; accumulator >= 255; accumulator -= 255)
+                        *op++ = 255;
+
+                    *op++ = (byte)accumulator;
+                }
+                else
+                {
+                    *op++ = (byte)(lastRun << ML_BITS);
+                }
+
+                Memory.Copy(op, anchor, (uint)lastRun);
+                op += lastRun;
+            }
+
+            return (int)(op - dest);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LZ4_count(byte* pInPtr, byte* pMatchPtr, byte* pInLimitPtr)
+        {
+            byte* pIn = pInPtr;
+            byte* pMatch = pMatchPtr;
+            byte* pInLimit = pInLimitPtr;
+
+            byte* pStart = pIn;
+
+            while (pIn < pInLimit - (sizeof(ulong) - 1))
+            {
+                ulong diff = *((ulong*)pMatch) ^ *((ulong*)pIn);
+                if (diff == 0)
+                {
+                    pIn += sizeof(ulong);
+                    pMatch += sizeof(ulong);
+                    continue;
+                }
+
+                pIn += Bits.TrailingZeroesInBytes(diff);
+                return (int)(pIn - pStart);
+            }
+
+            if ((pIn < (pInLimit - 3)) && (*((uint*)pMatch) == *((uint*)(pIn)))) { pIn += sizeof(uint); pMatch += sizeof(uint); }
+            if ((pIn < (pInLimit - 1)) && (*((ushort*)pMatch) == *((ushort*)pIn))) { pIn += sizeof(ushort); pMatch += sizeof(ushort); }
+            if ((pIn < pInLimit) && (*pMatch == *pIn)) pIn++;
+
+            return (int)(pIn - pStart);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void LZ4_putPosition<TTableType>(byte* p, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            int h = LZ4_hashPosition<TTableType>(p);
+            LZ4_putPositionOnHash<TTableType>(p, h, ctx, srcBase);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte* LZ4_getPosition<TTableType>(byte* p, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            int h = LZ4_hashPosition<TTableType>(p);
+            return LZ4_getPositionOnHash<TTableType>(h, ctx, srcBase);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void LZ4_putPositionOnHash<TTableType>(byte* p, int h, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            if (typeof(TTableType) == typeof(ByU32))
+                ctx->hashTable[h] = (int)(p - srcBase);
+            else if (typeof(TTableType) == typeof(ByU16))
+                ((ushort*)ctx->hashTable)[h] = (ushort)(p - srcBase);
+            else
+                ThrowException(new NotSupportedException("TTableType directive is not supported."));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static byte* LZ4_getPositionOnHash<TTableType>(int h, LZ4_stream_t_internal* ctx, byte* srcBase)
+            where TTableType : ITableTypeDirective
+        {
+            if (typeof(TTableType) == typeof(ByU32))
+                return srcBase + ctx->hashTable[h];
+            else if (typeof(TTableType) == typeof(ByU16))
+                return srcBase + ((ushort*)ctx->hashTable)[h];
+
+            ThrowException(new NotSupportedException("TTableType directive is not supported."));
+            return default(byte*);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LZ4_hashPosition<TTableType>(byte* sequence)
+            where TTableType : ITableTypeDirective
+        {
+            if (typeof(TTableType) == typeof(ByU16))
+            {
+                ulong value = *((ulong*)sequence) * prime5bytes >> (40 - ByU16HashLog);
+                return (int)(value & ByU16HashMask);
+            }
+            else if (typeof(TTableType) == typeof(ByU32))
+            {
+                ulong value = (*((ulong*)sequence) * prime5bytes >> (40 - ByU32HashLog));
+                return (int)(value & ByU32HashMask);
+            }
+
+            return ThrowException<int>(new NotSupportedException("TTableType directive is not supported."));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ThrowException(Exception e)
+        {
+            throw e;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static TResult ThrowException<TResult>(Exception e)
+        {
+            throw e;
+        }
+
+        private const int ByU16HashLog = LZ4_HASHLOG + 1;
+        private const ulong ByU16HashMask = (1 << ByU16HashLog) - 1;
+
+        private const int ByU32HashLog = LZ4_HASHLOG;
+        private const ulong ByU32HashMask = (1 << ByU32HashLog) - 1;
+
+        private const ulong prime5bytes = 889523592379UL;
+
+        public static long Decode64LongBuffers(
+            byte* input,
+            long inputLength,
+            byte* output,
+            long outputLength,
+            bool knownOutputLength)
+        {
+            if (outputLength < MAX_INPUT_LENGTH_PER_SEGMENT && inputLength < MAX_INPUT_LENGTH_PER_SEGMENT)
+            {
+                return Decode64(input, (int)inputLength, output, (int)outputLength, knownOutputLength);
+            }
+
+            long totalReadSize = 0;
+            long totalWriteSize = 0;
+            while (totalReadSize < inputLength)
+            {
+                int partInputLength = int.MaxValue;
+                if (totalReadSize + partInputLength > inputLength)
+                    partInputLength = (int)(inputLength - totalReadSize);
+
+                int partOutputLength = MAX_INPUT_LENGTH_PER_SEGMENT;
+                if (totalWriteSize + partOutputLength > outputLength)
+                {
+                    partOutputLength = checked((int)(outputLength - totalWriteSize));
+                }
+                totalReadSize += Decode64(input + totalReadSize, partInputLength, output + totalWriteSize, partOutputLength, false);
+
+                totalWriteSize += MAX_INPUT_LENGTH_PER_SEGMENT;
+            }
+
+            return totalReadSize;
+        }
+
+        public static int Decode64(
+            byte* input,
+            int inputLength,
+            byte* output,
+            int outputLength,
+            bool knownOutputLength)
+        {
+            if (knownOutputLength)
+            {
+                var length = LZ4_decompress_generic<EndOnInputSize, Full, NoDict>(input, output, inputLength, outputLength, 0, output, null, 0);
+                if (length != outputLength)
+                    ThrowException(new ArgumentException("LZ4 block is corrupted, or invalid length has been given."));
+                return outputLength;
+            }
+            else
+            {
+                var length = LZ4_decompress_generic<EndOnOutputSize, Full, WithPrefix64K>(input, output, inputLength, outputLength, 0, output - (64 * Constants.Size.Kilobyte), null, 64 * Constants.Size.Kilobyte);
+                if (length < 0)
+                    ThrowException(new ArgumentException("LZ4 block is corrupted, or invalid length has been given."));
+
+                return length;
+            }
+        }
+
+        private static readonly int[] dec32table = new int[] { 4, 1, 2, 1, 4, 4, 4, 4 };
+        private static readonly int[] dec64table = new int[] { 0, 0, 0, -1, 0, 1, 2, 3 };
+
+        private static int LZ4_decompress_generic<TEndCondition, TEarlyEnd, TDictionaryType>(byte* source, byte* dest, int inputSize, int outputSize, int targetOutputSize, byte* lowPrefix, byte* dictStart, int dictSize)
+            where TEndCondition : IEndConditionDirective
+            where TEarlyEnd : IEarlyEndDirective
+            where TDictionaryType : IDictionaryTypeDirective
+        {
+            byte* ip = source;
+            byte* iend = ip + inputSize;
+
+            byte* op = dest;
+            byte* oend = op + outputSize;
+
+            byte* oexit = op + targetOutputSize;
+            byte* lowLimit = lowPrefix - dictSize;
+
+            byte* dictEnd = dictStart + dictSize;
+
+            bool checkOffset = ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (dictSize < 64 * Constants.Size.Kilobyte));
+
+            if ((typeof(TEarlyEnd) == typeof(Partial)) && (oexit > oend - MFLIMIT)) oexit = oend - MFLIMIT;
+            if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (outputSize == 0))
+                return ((inputSize == 1) && (*ip == 0)) ? 0 : -1;
+            if ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (outputSize == 0))
+                return (*ip == 0 ? 1 : -1);
+
+            while (true)
+            {
+                int length;
+
+                byte token = *ip++;
+                if ((length = (token >> ML_BITS)) == RUN_MASK)
+                {
+                    byte s;
+                    do
+                    {
+                        s = *ip++;
+                        length += s;
+                    }
+                    while (((typeof(TEndCondition) == typeof(EndOnInputSize)) ? ip < iend - RUN_MASK : true) && (s == 255));
+
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op) goto _output_error;
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length) < ip) goto _output_error;
+                }
+
+                byte* cpy = op + length;
+                if (((typeof(TEndCondition) == typeof(EndOnInputSize)) && ((cpy > (typeof(TEarlyEnd) == typeof(Partial) ? oexit : oend - MFLIMIT)) || (ip + length > iend - (2 + 1 + LASTLITERALS))))
+                    || ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (cpy > oend - COPYLENGTH)))
+                {
+                    if (typeof(TEarlyEnd) == typeof(Partial))
+                    {
+                        if (cpy > oend)
+                            goto _output_error;
+
+                        if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip + length > iend))
+                            goto _output_error;
+                    }
+                    else
+                    {
+                        if ((typeof(TEndCondition) == typeof(EndOnOutputSize)) && (cpy != oend))
+                            goto _output_error;
+
+                        if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && ((ip + length != iend) || (cpy > oend)))
+                            goto _output_error;
+                    }
+
+                    Memory.Copy(op, ip, (uint)length);
+                    ip += length;
+                    op += length;
+                    break;
+                }
+
+                WildCopy(op, ip, cpy);
+                ip += length; op = cpy;
+
+                byte* match = cpy - *((ushort*)ip); ip += sizeof(ushort);
+                if ((checkOffset) && (match < lowLimit))
+                    goto _output_error;
+
+                if ((length = (token & ML_MASK)) == ML_MASK)
+                {
+                    byte s;
+                    do
+                    {
+                        if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (ip > iend - LASTLITERALS))
+                            goto _output_error;
+
+                        s = *ip++;
+                        length += s;
+                    }
+                    while (s == 255);
+
+                    if ((typeof(TEndCondition) == typeof(EndOnInputSize)) && (op + length) < op)
+                        goto _output_error;
+                }
+
+                length += MINMATCH;
+
+                if ((typeof(TDictionaryType) == typeof(UsingExtDict)) && (match < lowPrefix))
+                {
+                    if (op + length > oend - LASTLITERALS)
+                        goto _output_error;
+
+                    if (length <= (int)(lowPrefix - match))
+                    {
+                        match = dictEnd - (lowPrefix - match);
+                        Memory.Move(op, match, length);
+                        op += length;
+                    }
+                    else
+                    {
+                        int copySize = (int)(lowPrefix - match);
+                        Memory.Copy(op, dictEnd - copySize, (uint)copySize);
+                        op += copySize;
+
+                        copySize = length - copySize;
+                        if (copySize > (int)(op - lowPrefix))
+                        {
+                            byte* endOfMatch = op + copySize;
+                            byte* copyFrom = lowPrefix;
+                            while (op < endOfMatch)
+                                *op++ = *copyFrom++;
+                        }
+                        else
+                        {
+                            Memory.Copy(op, lowPrefix, (uint)copySize);
+                            op += copySize;
+                        }
+                    }
+                    continue;
+                }
+
+                cpy = op + length;
+                if ((op - match) < 8)
+                {
+                    int dec64 = dec64table[op - match];
+                    op[0] = match[0];
+                    op[1] = match[1];
+                    op[2] = match[2];
+                    op[3] = match[3];
+
+                    match += dec32table[op - match];
+                    *((uint*)(op + 4)) = *(uint*)match;
+                    op += 8;
+                    match -= dec64;
+                }
+                else
+                {
+                    *((ulong*)op) = *(ulong*)match;
+                    op += sizeof(ulong);
+                    match += sizeof(ulong);
+                }
+
+                if (cpy > oend - 12)
+                {
+                    if (cpy > oend - LASTLITERALS)
+                        goto _output_error;
+
+                    if (op < oend - 8)
+                    {
+                        WildCopy(op, match, (oend - 8));
+                        match += (oend - 8) - op;
+                        op = oend - 8;
+                    }
+
+                    while (op < cpy)
+                        *op++ = *match++;
+                }
+                else
+                {
+                    WildCopy(op, match, cpy);
+                }
+
+                op = cpy;
+            }
+
+            if (typeof(TEndCondition) == typeof(EndOnInputSize))
+                return (int)(op - dest);
+            else
+                return (int)(ip - source);
+
+        _output_error:
+            return (int)(-(ip - source)) - 1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void WildCopy(byte* dest, byte* src, byte* destEnd)
+        {
+            do
+            {
+                ((ulong*)dest)[0] = ((ulong*)src)[0];
+                if (dest + 1 * sizeof(ulong) >= destEnd)
+                    goto Return;
+
+                ((ulong*)dest)[1] = ((ulong*)src)[1];
+                if (dest + 2 * sizeof(ulong) >= destEnd)
+                    goto Return;
+
+                ((ulong*)dest)[2] = ((ulong*)src)[2];
+                if (dest + 3 * sizeof(ulong) >= destEnd)
+                    goto Return;
+
+                ((ulong*)dest)[3] = ((ulong*)src)[3];
+
+                dest += 4 * sizeof(ulong);
+                src += 4 * sizeof(ulong);
+            }
+            while (dest < destEnd);
+
+        Return:
+            return;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-9187

### Additional description

Port LZ4 compression/decompression optimizations from upstream C reference (v131 through v1.10.0) to the C# implementation. The focus is on small data performance, which matters for BlittableWriter string compression and Voron page compression.

**Compression improvements:**
  - Hash function: ByU16 switched from 8-byte to 4-byte read with `prime4bytes`, ByU32 uses canonical shift instead of mask
  - Hash table reuse: `[ThreadStatic]` context persisted across `Encode64` calls. For repeated small inputs (< 4KB), skips zeroing the 16KB hash table — stale entries filtered via `DictSmall` pointer comparison instead.
  - Early exit in `LZ4_count`: single 8-byte XOR before the loop catches short matches (the common case) without loop setup

**Decompression improvements:**
- Two-stage shortcut (v1.8.2): for the most common token pattern (literal < 15, match < 15, offset >= 8), two unconditional 16-byte copies bypass all parsing overhead
- Fast/safe loop split (v1.9.0): fast loop uses `WildCopy32` (2x `Vector128` load/store) with 64-byte slack; safe loop uses `WildCopy8` near buffer boundaries
- Small offset pattern fill: offsets 1, 2, 4 use byte repetition to avoid load-blocked-by-store stalls
- Short match fast path: matches <= 16 bytes copy 8 bytes directly, skipping WildCopy

**Infrastructure:**
- `LZ4Reference.cs`: frozen copy of the pre-optimization implementation
- 130+ backward compatibility tests across sizes 1B–100KB with guard region overrun detection
- Comparison benchmark (`LZ4ComparisonBenchmark`) for reference vs optimized side-by-side measurement

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
