### PR TITLE
RavenDB-25988 Handle empty output from analyzer when indexing a field.

### DIFF
--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -146,6 +146,10 @@ public partial class IndexWriter
                 var word = new Span<byte>(_parent._analyzersContext.EncodingBufferHandler, token.Offset, (int)token.Length);
                 ExactInsert(field, word, InserterMode.ExactInsert);
             }
+            
+            //Analyze pipeline removed all content from our input. It means we've an empty string now.
+            if (tokens.Length == 0)
+                ExactInsert(field, Constants.EmptyStringSlice, InserterMode.ExactInsert);
         }
 
         private void AnalyzeTerm(IndexedField field, ReadOnlySpan<byte> value, Analyzer analyzer, out Span<byte> wordsBuffer, out Span<Token> tokens)

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -147,9 +147,9 @@ public partial class IndexWriter
                 ExactInsert(field, word, InserterMode.ExactInsert);
             }
             
-            //Analyze pipeline removed all content from our input. It means we've an empty string now.
+            //Analyze pipeline removed all content from our input. It means the value actually does not exist.
             if (tokens.Length == 0)
-                ExactInsert(field, Constants.EmptyStringSlice, InserterMode.ExactInsert);
+                ExactInsert(field, Constants.NonExistingValueSlice, InserterMode.ExactInsert);
         }
 
         private void AnalyzeTerm(IndexedField field, ReadOnlySpan<byte> value, Analyzer analyzer, out Span<byte> wordsBuffer, out Span<Token> tokens)

--- a/test/SlowTests/Corax/RavenDB-25988.cs
+++ b/test/SlowTests/Corax/RavenDB-25988.cs
@@ -28,6 +28,30 @@ public class RavenDB_25988(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal("London", results[1].Subnames[0].Name);
         Assert.Equal("London", results[2].Subnames[0].Name);
         Assert.Equal("Paris", results[3].Subnames[0].Name);
+
+
+        var emptySearch = session.Query<Dto, Index>().Search(x => x.Name, " ").ToList();
+        Assert.Empty(emptySearch);
+        
+        var dashSearch = session.Query<Dto, Index>().Search(x => x.Name, "-").ToList();
+        Assert.Empty(dashSearch);
+        
+        var emptySearch2 = session.Query<Dto, Index>().Search(x => x.Name, "").ToList();
+        Assert.Empty(emptySearch2);
+
+        var emptyEquals = session.Advanced.DocumentQuery<Dto, Index>().WhereEquals(x => x.Name, "").ToList();
+        Assert.Empty(emptyEquals);
+        
+        var dashEquals = session.Advanced.DocumentQuery<Dto, Index>().WhereEquals(x => x.Name, "-").ToList();
+        Assert.Empty(dashEquals);
+        
+        var emptyEquals2 = session.Advanced.DocumentQuery<Dto, Index>().WhereEquals(x => x.Name, " ").ToList();
+        Assert.Empty(emptyEquals2);
+        
+        var nonExisting = session.Advanced.DocumentQuery<Dto, Index>().Not.WhereExists(x => x.Name).ToList();
+        Assert.Single(nonExisting);
+        
+        WaitForUserToContinueTheTest(store);
     }
     
     [RavenTheory(RavenTestCategory.Querying)]

--- a/test/SlowTests/Corax/RavenDB-25988.cs
+++ b/test/SlowTests/Corax/RavenDB-25988.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_25988(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanSortAlphanumericallyOnNonExistingTerms(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store);
+        
+        using var session = store.OpenSession();
+        var results = session.Advanced.DocumentQuery<Dto, Index>()
+            .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+            .ToList();
+        
+        Assert.Equal(4, results.Count);
+        Assert.Equal(2, results[0].Subnames.Length); // doc with removed terms
+        Assert.Equal("London", results[1].Subnames[0].Name);
+        Assert.Equal("London", results[2].Subnames[0].Name);
+        Assert.Equal("Paris", results[3].Subnames[0].Name);
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanMultiSortAlphanumericallyOnNonExistingTerms(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store);
+        using var session = store.OpenSession();
+        
+        {
+            var results = session.Advanced.DocumentQuery<Dto, Index>()
+                .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+                .OrderBy(x => x.Value, OrderingType.Long)
+                .ToList();
+        
+            Assert.Equal(4, results.Count);
+            Assert.Equal(2, results[0].Subnames.Length); // doc with removed terms
+            Assert.Equal("London", results[1].Subnames[0].Name);
+            Assert.Equal(1, results[1].Value);
+            Assert.Equal("London", results[2].Subnames[0].Name);
+            Assert.Equal(2, results[2].Value);
+            Assert.Equal("Paris", results[3].Subnames[0].Name);
+        }
+
+        {
+            var results = session.Advanced.DocumentQuery<Dto, Index>()
+                .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+                .OrderByDescending(x => x.Value, OrderingType.Long)
+                .ToList();
+        
+            Assert.Equal(4, results.Count);
+            Assert.Equal(2, results[0].Subnames.Length); // doc with removed terms
+            Assert.Equal("London", results[1].Subnames[0].Name);
+            Assert.Equal(2, results[1].Value);
+            Assert.Equal("London", results[2].Subnames[0].Name);
+            Assert.Equal(1, results[2].Value);
+            Assert.Equal("Paris", results[3].Subnames[0].Name);
+        }
+    }
+
+    private void InsertDocuments(IDocumentStore store)
+    {
+        using var session = store.OpenSession();
+        
+        session.Store(new Dto()
+        {
+            Value = 2,
+            Subnames = [new(){Name = "London"}]
+        });
+        
+        session.Store(new Dto()
+        {
+            Value = 1,
+            Subnames = [new(){Name = " "}, new(){Name = "-"}]
+        });
+        
+        session.Store(new Dto()
+        {
+            Value = 2,
+            Subnames = [new(){Name = "Paris"}]
+        });
+        
+        session.Store(new Dto()
+        {
+            Value = 1,
+            Subnames = [new(){Name = "London"}]
+        });
+        
+        session.SaveChanges();
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public int Value { get; set; }
+        public Dto[] Subnames { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from dto in dtos
+                from sub in dto.Subnames
+                select new
+                {
+                    sub.Name,
+                    dto.Value,
+                };
+            
+            Index(x => x.Name, FieldIndexing.Search);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25988

### Additional description

For example, when we've FTS analyzer and our sentence contains only STOP words (or eg whitespaces), our pipeline will remove all data from input. In such case, we've to write EMPTY string as the value of the field. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
