### PR TITLE
RavenDB-25989 Adds `WriteCompound` to the index entry builder.

### DIFF
--- a/src/Corax/Indexing/IIndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IIndexEntryBuilder.cs
@@ -11,6 +11,7 @@ public interface IIndexEntryBuilder
     void WriteNull(int fieldId, string path);
     void WriteNonExistingMarker(int fieldId, string path);
     void Write(int fieldId, ReadOnlySpan<byte> value);
+    void WriteCompound(int fieldId, ReadOnlySpan<byte> value);
     void Write(int fieldId, string path, ReadOnlySpan<byte> value);
     void Write(int fieldId, string path, string value);
     void Write(int fieldId, ReadOnlySpan<byte> value, long longValue, double dblValue);

--- a/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
+++ b/src/Corax/Indexing/IndexWriter.IndexEntryBuilder.cs
@@ -167,9 +167,9 @@ public partial class IndexWriter
             }
         }
 
-        ref EntriesModifications ExactInsert(IndexedField field, ReadOnlySpan<byte> value, InserterMode inserterMode)
+        ref EntriesModifications ExactInsert(IndexedField field, ReadOnlySpan<byte> value, InserterMode inserterMode, bool forceExactInsert = false)
         {
-            Debug.Assert(field.FieldIndexingMode != FieldIndexingMode.No, "field.FieldIndexingMode != FieldIndexingMode.No");
+            Debug.Assert(forceExactInsert || field.FieldIndexingMode != FieldIndexingMode.No, "field.FieldIndexingMode != FieldIndexingMode.No");
 
             ByteStringContext<ByteStringMemoryCache>.InternalScope? scope = CreateNormalizedTerm(_parent._entriesAllocator, value, out var slice);
 
@@ -284,6 +284,12 @@ public partial class IndexWriter
         }
 
         public void Write(int fieldId, ReadOnlySpan<byte> value) => Write(fieldId, null, value);
+        
+        public void WriteCompound(int fieldId, ReadOnlySpan<byte> value)
+        {
+            var field = GetField(fieldId, null);
+            ExactInsert(field, value, InserterMode.ExactInsert, forceExactInsert: true);
+        }
 
         public void Write(int fieldId, string path, ReadOnlySpan<byte> value)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/AnonymousCoraxDocumentConverter.cs
@@ -124,7 +124,7 @@ public abstract class AnonymousCoraxDocumentConverterBase : CoraxDocumentConvert
                 
                 var fieldId = baseLine + i;
                 
-                builder.Write( fieldId, _compoundFieldsBuffer.AsSpan()[..totalLen]);
+                builder.WriteCompound(fieldId, _compoundFieldsBuffer.AsSpan()[..totalLen]);
             }
 
             if (_compoundFieldsBuffer.Length > 64 * 1024)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxDocumentTrainEnumerator.cs
@@ -89,6 +89,11 @@ internal class CoraxDocumentTrainEnumerator : IReadOnlySpanEnumerator
             ProcessSelectedStream(field.Analyzer ?? _lowercaseAnalyzer, value.Slice(startLocation, maxSize));
         }
 
+        public void WriteCompound(int fieldId, ReadOnlySpan<byte> value)
+        {
+            // nothing to do here
+        }
+
         public void Write(int fieldId, string path, ReadOnlySpan<byte> value)
         {
            Write(fieldId, value);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/JintCoraxDocumentConverter.cs
@@ -272,7 +272,7 @@ public abstract class CoraxJintDocumentConverterBase : CoraxDocumentConverterBas
                 
                 var fieldId = baseLine + i;
                 
-                builder.Write( fieldId, _compoundFieldsBuffer.AsSpan()[..totalLen]);
+                builder.WriteCompound(fieldId, _compoundFieldsBuffer.AsSpan()[..totalLen]);
             }
 
             if (_compoundFieldsBuffer.Length > 64 * 1024)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25989

### Additional description

We need to have an analyzer assigned to the compound field inside IndexFieldsMapping to correctly transform partial values. However, since the analysis happens during document mapping, we must skip that step in IndexEntryBuilder.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
