### PR TITLE
RavenDB-25995 - Calculation of DocumentsByEntity count property is wrong

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -2684,7 +2684,7 @@ more responsive application.
 
         private bool _prepareEntitiesPuts;
 
-        public int Count => _documentsByEntity.Count + _onBeforeStoreDocumentsByEntity?.Count ?? 0;
+        public int Count => _documentsByEntity.Count + (_onBeforeStoreDocumentsByEntity?.Count ?? 0);
 
         public void Remove(object entity)
         {

--- a/test/FastTests/Client/Documents/BasicDocuments.cs
+++ b/test/FastTests/Client/Documents/BasicDocuments.cs
@@ -140,5 +140,34 @@ namespace FastTests.Client.Documents
                 }
             }
         }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void CanCalculateDocumentsByEntity_Count(Options options)
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (IDocumentSession session = store.OpenSession(new SessionOptions()))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal(2, ((InMemoryDocumentSessionOperations)session).NumberOfEntitiesInUnitOfWork);
+
+                    // Evict both entities
+                    session.Advanced.Evict(jerry);
+                    session.Advanced.Evict(egor);
+
+                    Assert.Equal(0, ((InMemoryDocumentSessionOperations)session).NumberOfEntitiesInUnitOfWork);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25995/Calculation-of-DocumentsByEntity-count-property-is-wrong

### Additional description

This pull request corrects a bug in the calculation of the entity count in the `DocumentsByEntityHolder` class and adds a new test to verify this behavior. The most important changes are:

Bug fix in entity count calculation:

* Fixed the `Count` property in `DocumentsByEntityHolder` to properly account for the nullable `_onBeforeStoreDocumentsByEntity` dictionary, ensuring correct entity count calculation.

Testing improvements:

* Added a new test `CanCalculateDocumentsByEntity_Count` in `BasicDocuments.cs` to verify that the entity count is correctly updated when entities are stored and evicted in a session.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
