### PR TITLE
RavenDB-25494 Disable ongoing tasks during snapshot restore using DisableOngoingTasksIfNeeded

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/AbstractRestoreBackupTask.cs
@@ -189,6 +189,8 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             CreateDocumentDatabase();
 
             var databaseRecord = RestoreSettings.DatabaseRecord;
+
+            DisableOngoingTasksIfNeeded(databaseRecord);
             databaseRecord.Topology = new DatabaseTopology();
 
             // restoring to the current node only

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/Sharding/ShardedRestoreOrchestrationTask.cs
@@ -46,7 +46,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore.Sharding
             InitializeShardingConfiguration();
 
             var databaseRecord = RestoreSettings.DatabaseRecord;
-
+            DisableOngoingTasksIfNeeded(databaseRecord);
             // we are currently restoring, shouldn't try to access it
             databaseRecord.DatabaseState = DatabaseStateStatus.RestoreInProgress;
             var index = await SaveDatabaseRecordAsync(DatabaseName, databaseRecord, databaseValues: null, Result, Progress);

--- a/test/StressTests/Issues/RavenDB-25471.cs
+++ b/test/StressTests/Issues/RavenDB-25471.cs
@@ -1,131 +1,80 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Raven.Client.Documents;
+using FastTests;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.ETL.OLAP;
-using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
-using Raven.Client.Util;
-using Raven.Server;
-using Raven.Server.Commercial;
-using Raven.Server.ServerWide.Commands;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace StressTests.Issues
 {
-    public class RavenDB_25471 : ReplicationTestBase
+    public class RavenDB_25471 : RavenTestBase
     {
         public RavenDB_25471(ITestOutputHelper output) : base(output)
         {
         }
 
         [RavenTheory(RavenTestCategory.BackupExportImport)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Backup })]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { BackupType.Snapshot })]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = new object[] { BackupType.Backup })]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All, Data = new object[] { BackupType.Snapshot })]
         public async Task DisableOlapOnRestoreWithoutLicense(Options options, BackupType backupType)
         {
             DoNotReuseServer();
 
             var backupPath = NewDataPath(suffix: "BackupFolder");
 
-            using var source = GetDocumentStore();
-            await DisableRevisionCompression(Server, source);
-            SetupLocalOlapEtl(source, script: @"
-var orderDate = new Date(this.OrderedAt);
-var year = orderDate.getFullYear();
-var month = orderDate.getMonth();
-var key = new Date(year, month);
-
-loadToOrders(partitionBy(key),
-    {
-        Company : this.Company,
-        ShipVia : this.ShipVia
-    });
-", path: NewDataPath());
-
-            var backupOperation = await source.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+            using (var store = GetDocumentStore())
             {
-                BackupType = backupType,
-                LocalSettings = new LocalSettings
+                await LicenseHelper.DisableRevisionCompression(Server, store);
+
+                await store.Maintenance.SendAsync(new PutConnectionStringOperation<OlapConnectionString>(new OlapConnectionString
                 {
-                    FolderPath = backupPath
-                }
-            }));
-            await backupOperation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
-            await source.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(source.Database, hardDelete: true));
+                    Name = "olap-cs"
+                }));
 
-            await PutLicense(Server, LicenseTestBase.RL_COMM);
+                var olapEtlConfiguration = new OlapEtlConfiguration
+                {
+                    Name = "olap-test",
+                    ConnectionStringName = "olap-cs",
+                    Transforms = { new Transformation { Name = "loadAll", Collections = { "Users" }, Script = "loadToUsers(this)" } }
+                };
+                var operationResult = await store.Maintenance.SendAsync(new AddEtlOperation<OlapConnectionString>(olapEtlConfiguration));
 
-            using var store = GetDocumentStore();
+                var operation = await store.Maintenance.SendAsync(new BackupOperation(new BackupConfiguration
+                {
+                    BackupType = BackupType.Snapshot,
+                    LocalSettings = new LocalSettings
+                    {
+                        FolderPath = backupPath
+                    }
+                }));
 
-            using var destination = new DocumentStore { Urls = new[] { Server.WebUrl }, Database = source.Database + "_Restore" }.Initialize();
+                await operation.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+                olapEtlConfiguration.Disabled = true;
+                await store.Maintenance.SendAsync(new UpdateEtlOperation<OlapConnectionString>(operationResult.TaskId, olapEtlConfiguration));
 
-            using (Backup.RestoreDatabase(destination,
+                await LicenseHelper.ChangeLicense(Server, LicenseTestBase.RL_COMM);
+                var databaseName = $"restored_database-{Guid.NewGuid()}";
+
+                using (Backup.RestoreDatabase(store,
                        new RestoreBackupConfiguration
                        {
                            BackupLocation = Directory.GetDirectories(backupPath).First(),
-                           DatabaseName = destination.Database,
-                           DisableOngoingTasks = true // <<==
-                       })) // restore shouldnt throw
-            {
-                var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(destination.Database));
-                Assert.Equal(1, record.OlapEtls.Count);
-                foreach (var olap in record.OlapEtls)
+                           DatabaseName = databaseName,
+                           DisableOngoingTasks = true
+                       }))
                 {
-                    Assert.True(olap.Disabled);
+                    var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(databaseName));
+                    Assert.Equal(1, record.OlapEtls.Count);
+                    Assert.True(record.OlapEtls[0].Disabled);
                 }
             }
-        }
-
-        private void SetupLocalOlapEtl(DocumentStore store, string script, string path)
-        {
-            var connectionStringName = $"{store.Database} to local";
-            var configuration = new OlapEtlConfiguration
-            {
-                ConnectionStringName = connectionStringName,
-                RunFrequency = "* * * * *",
-                Transforms =
-            {
-                new Transformation
-                {
-                    Name = "MonthlyOrders",
-                    Collections = new List<string> {"Orders"},
-                    Script = script
-                }
-            }
-            };
-
-            var connectionString = new OlapConnectionString
-            {
-                Name = connectionStringName,
-                LocalSettings = new LocalSettings
-                {
-                    FolderPath = path
-                }
-            };
-
-            Etl.AddEtl(store, configuration, connectionString);
-        }
-
-        private static async Task PutLicense(RavenServer leader, string licenseType)
-        {
-            var license = Environment.GetEnvironmentVariable(licenseType);
-            Raven.Server.Commercial.LicenseHelper.TryDeserializeLicense(license, out License li);
-
-            await leader.ServerStore.PutLicenseAsync(li, RaftIdGenerator.NewId());
-        }
-
-        private static async Task DisableRevisionCompression(RavenServer leader, DocumentStore store)
-        {
-            var command = new EditDocumentsCompressionCommand(new DocumentsCompressionConfiguration { CompressRevisions = false, Collections = new string[] { } }, store.Database,
-                RaftIdGenerator.NewId());
-            await leader.ServerStore.SendToLeaderAsync(command);
         }
     }
 }


### PR DESCRIPTION
## Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25494

### Additional description

When restoring from a snapshot, we were not validating whether ongoing tasks needed to be disabled.
This change adds a call to DisableOngoingTasksIfNeeded after creating the new database record during snapshot restore.

In addition, the DisableOlapOnRestoreWithoutLicense test was updated to use LicenseHelper and BackupTestsBase.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
