### PR TITLE
RavenDB-25930 Prevent marking a part of the query as matched by a compound field when it is not used, to avoid a worse query plan.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -170,7 +170,7 @@ public static class CoraxQueryBuilder
             return SkipOrderByClause;
         }
         
-        public bool TrySetAsStreamingField(Parameters builderParameters, in CoraxBooleanItem cbi)
+        public bool TrySetAsStreamingField(Parameters builderParameters, in CoraxBooleanItem cbi, IQueryMatch right)
         {
             if (OptimizationIsPossible == false)
                 return false;
@@ -183,7 +183,9 @@ public static class CoraxQueryBuilder
 
             if (cbi.Field.Equals(SortField.Field) == false)
             {
-                if ( builderParameters.Index.HasCompoundField(cbi.Field.FieldName, SortField.Field.FieldName, out var bindingId))
+                // Currently, CompoundField does not support two WHERE condition. Do not mark it as a compound field to avoid optimization that could
+                // be degradated to a worse query plan.
+                if (builderParameters.Index.HasCompoundField(cbi.Field.FieldName, SortField.Field.FieldName, out var bindingId) && right is null)
                 {
                     var indexFieldBinding = builderParameters.IndexFieldsMapping.GetByFieldId(bindingId);
                     CompoundField = FieldMetadata.Build(indexFieldBinding.FieldName, indexFieldBinding.FieldTermTotalSumField,
@@ -235,7 +237,7 @@ public static class CoraxQueryBuilder
                 source = cbq.Materialize();
                 break;
             case CoraxBooleanItem cbi:
-                streamingConfiguration.TrySetAsStreamingField(builderParameters,cbi);
+                streamingConfiguration.TrySetAsStreamingField(builderParameters, cbi, null);
                 if (streamingConfiguration.MatchedByCompoundField)
                     return cbi.OptimizeCompoundField(ref streamingConfiguration);
 
@@ -446,7 +448,7 @@ public static class CoraxQueryBuilder
                             left = ToCoraxQuery(builderParameters, @where.Left, ref leftOnlyOptimization, exact);
                             right = ToCoraxQuery(builderParameters, @where.Right, ref builderParameters.StreamingDisabled, exact);
                             // in case of AND we can materialize only TermMatches, we push streamingOptimization there only for changing order for MultiTermMatch;
-                            if (left is CoraxBooleanItem cbi && leftOnlyOptimization.TrySetAsStreamingField(builderParameters, cbi))
+                            if (left is CoraxBooleanItem cbi && leftOnlyOptimization.TrySetAsStreamingField(builderParameters, cbi, right))
                                 left = cbi.Materialize(ref leftOnlyOptimization); 
                             
                             if (TryMergeTwoNodesForAnd(indexSearcher, builderParameters, ref left, ref right, out merged, ref builderParameters.StreamingDisabled))

--- a/test/SlowTests/Corax/RavenDB-25930.cs
+++ b/test/SlowTests/Corax/RavenDB-25930.cs
@@ -1,0 +1,95 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_25930(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    public void CompoundFieldShouldNotImpactQueryBuilderPlanWhenIsNotUsed()
+    {
+        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using (var session = store.OpenSession(new SessionOptions() { NoCaching = true }))
+        {
+            session.Store(new Dto { Name = "1", Count = 1 });
+            session.Store(new Dto { Name = "1", Count = 2 });
+            session.SaveChanges();
+
+            var index = new Index();
+            index.Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        using (var session = store.OpenSession(new SessionOptions() { NoCaching = true }))
+        {
+            QueryTimings normalTimings = null;
+            _ = session.Query<Dto, Index>()
+                .Customize(x => x.Timings(out normalTimings))
+                .Where(x => x.Name == "1" && x.Count > 0)
+                .ToList();
+        
+            Assert.NotNull(normalTimings);
+            var queryPlan = (QueryInspectionNode)(normalTimings.QueryPlan);
+            Assert.True(UnaryMatchExists(queryPlan));
+        }
+
+        using (var session = store.OpenSession(new SessionOptions() { NoCaching = true }))
+        {
+            QueryTimings orderByTimings = null;
+            var result = session.Advanced.DocumentQuery<Dto, Index>()
+                .Timings(out orderByTimings)
+                .WhereEquals("Name", "1")
+                .AndAlso()
+                .WhereGreaterThan("Count", 0)
+                .OrderBy("Count", OrderingType.Long)
+                .ToList();
+
+            Assert.NotEmpty(result);
+            Assert.NotNull(orderByTimings);
+            var queryPlan = (QueryInspectionNode)(orderByTimings.QueryPlan);
+            Assert.True(UnaryMatchExists(queryPlan));
+            Assert.Equal(1, result[0].Count);
+            Assert.Equal(2, result[1].Count);
+        }
+
+
+        bool UnaryMatchExists(QueryInspectionNode current, int limit = 10)
+        {
+            Assert.True(limit >= 0); // recursive guardian 
+            var currentOperation = current.Operation;
+            if (currentOperation.Contains("UnaryMatch"))
+                return true;
+
+            foreach (var child in current.Children)
+            {
+                if (UnaryMatchExists(child, limit - 1))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    private class Dto
+    {
+        public string Name { get; set; }
+        public int Count { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = docs => from doc in docs
+                select new { doc.Name, doc.Count };
+
+            CompoundField("Name", "Count");
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25930 

### Additional description

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
