### PR TITLE
RavenDB-24186 GenAI : metadata hashes should reflect deletions

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiClearMetadataHashesCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiClearMetadataHashesCommand.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
+
+internal sealed class GenAiClearMetadataHashesCommand : DocumentMergedTransactionCommand
+{
+    private readonly List<string> _docIds;
+    private readonly string _taskIdentifier;
+
+    public GenAiClearMetadataHashesCommand(List<string> docIds, string taskIdentifier)
+    {
+        _docIds = docIds ?? throw new ArgumentException(nameof(docIds));
+        _taskIdentifier = taskIdentifier ?? throw new ArgumentException(nameof(taskIdentifier));
+    }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        long updated = 0;
+
+        foreach (var id in _docIds)
+        {
+            if (string.IsNullOrEmpty(id))
+                continue;
+
+            if (TryRemoveTaskHashesFromMetadata(context, id, _taskIdentifier) == false)
+                continue;
+
+            updated++;
+        }
+
+        return updated;
+    }
+
+    private static bool TryRemoveTaskHashesFromMetadata(DocumentsOperationContext context, string id, string taskIdentifier)
+    {
+        var doc = context.DocumentDatabase.DocumentsStorage.Get(context, id);
+        if (doc == null)
+            return false;
+
+        if (doc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false ||
+            metadata == null)
+            return false;
+
+        if (metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection) == false ||
+            hashesSection == null)
+            return false;
+
+        // If there is no entry for this task, nothing to do.
+        if (hashesSection.TryGet(taskIdentifier, out object _) == false)
+            return false;
+
+        if (hashesSection.Count == 1)
+        {
+            // If this is the only entry, we can remove the entire section
+            metadata.Modifications = new DynamicJsonValue(metadata);
+            metadata.Modifications.Remove(Constants.Documents.Metadata.GenAiHashes);
+        }
+
+        else
+        {
+            // Remove the task entry from @gen-ai-hashes
+            hashesSection.Modifications = new DynamicJsonValue(hashesSection);
+            hashesSection.Modifications.Remove(taskIdentifier);
+
+            metadata.Modifications = new DynamicJsonValue(metadata)
+            {
+                [Constants.Documents.Metadata.GenAiHashes] = hashesSection
+            };
+        }
+
+        doc.Data.Modifications = new DynamicJsonValue(doc.Data)
+        {
+            [Constants.Documents.Metadata.Key] = metadata
+        };
+
+        using (var old = doc.Data)
+        {
+            doc.Data = context.ReadObject(old, id);
+        }
+
+        context.DocumentDatabase.DocumentsStorage.Put(context, id, expectedChangeVector: null, doc.Data);
+
+        return true;
+    }
+
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
+    {
+        throw new NotSupportedException($"Replay not supported for {nameof(GenAiClearMetadataHashesCommand)}");
+    }
+}
+

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiClearMetadataHashesCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiClearMetadataHashesCommand.cs
@@ -92,7 +92,23 @@ internal sealed class GenAiClearMetadataHashesCommand : DocumentMergedTransactio
 
     public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand> ToDto(DocumentsOperationContext context)
     {
-        throw new NotSupportedException($"Replay not supported for {nameof(GenAiClearMetadataHashesCommand)}");
+        return new GenAiClearMetadataHashesCommandDto
+        {
+            DocIds = _docIds,
+            TaskIdentifier = _taskIdentifier
+        };
+    }
+
+    private sealed class GenAiClearMetadataHashesCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, DocumentMergedTransactionCommand>
+    {
+        public List<string> DocIds { get; set; }
+        public string TaskIdentifier { get; set; }
+
+
+        public DocumentMergedTransactionCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new GenAiClearMetadataHashesCommand(DocIds, TaskIdentifier);
+        }
     }
 }
 

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptResult.cs
@@ -3,7 +3,7 @@ using Sparrow.Json;
 
 namespace Raven.Server.Documents.ETL.Providers.AI.GenAi;
 
-public record GenAiScriptResult(string DocumentId, BlittableJsonReaderObject Context, string AiHash, bool IsCached)
+public record GenAiScriptResult(string DocumentId, BlittableJsonReaderObject Context, string AiHash, bool IsCached, bool IsMetadataCleanupMarker = false)
 {
     public List<AiAttachment> Attachments;
 }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -167,6 +167,25 @@ var ai = new AI();
         ObjectInstance ai = DocumentScript.ScriptEngine.GetValue("ai").AsObject();
         Function retrieveContexts = ai.Prototype!.GetOwnProperty("__retrieveContexts").Value.AsFunctionInstance();
         JsArray contexts = retrieveContexts.Call(ai, []).AsArray();
+        if (contexts.Length == 0)
+        {
+            // No contexts were generated for this document.
+            // If metadata still contains GenAI hashes for this task, enqueue a marker so the load phase can remove them.
+            if (Current.Document.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) &&
+                metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection) &&
+                hashesSection.TryGet(_configuration.Identifier, out object _))
+            {
+                _currentRun.Add(new GenAiScriptResult(
+                    Current.DocumentId,
+                    Context: null,
+                    AiHash: null,
+                    IsCached: true,
+                    IsMetadataCleanupMarker: true));
+            }
+
+            return;
+        }
+
         List<string> attachmentsHashes = null;
         foreach (var ctx in contexts)
         {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -140,7 +140,13 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
 
     protected override int LoadInternal(IEnumerable<GenAiScriptResult> items, DocumentsOperationContext context, GenAiStatsScope scope)
     {
-        var results = PrepareItemsBeforeSendingToModel(items);
+        var (results, docIdsToClearTaskHashes) = PrepareItemsBeforeSendingToModel(items);
+        if (docIdsToClearTaskHashes.Count > 0)
+        {
+            var cmd = new GenAiClearMetadataHashesCommand(docIdsToClearTaskHashes, Configuration.Identifier);
+            Database.TxMerger.EnqueueSync(cmd);
+        }
+
         if (results.Count is 0)
             return 0;
 
@@ -438,7 +444,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
                 var genAiItem = new GenAiItem(document, Configuration.Collection);
                 var transformedResults = Transform([genAiItem], context, scope, new EtlProcessState());
 
-                items = PrepareItemsBeforeSendingToModel(transformedResults);
+                items = PrepareItemsBeforeSendingToModel(transformedResults).Result;
 
                 context.CloseTransaction();
 
@@ -595,14 +601,21 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         }
     }
 
-    private static List<GenAiResultItem> PrepareItemsBeforeSendingToModel(IEnumerable<GenAiScriptResult> items)
+    private static (List<GenAiResultItem> Result, List<string> DocIdsToClearTaskHashes) PrepareItemsBeforeSendingToModel(IEnumerable<GenAiScriptResult> items)
     {
         // TODO we can do this in the transform phase 
 
         var results = new List<GenAiResultItem>();
+        var docIdsToClearTaskHashes = new List<string>();
 
         foreach (var scriptResult in items)
         {
+            if (scriptResult.IsMetadataCleanupMarker)
+            {
+                docIdsToClearTaskHashes.Add(scriptResult.DocumentId);
+                continue; // this is just a marker to clear metadata, it doesn't need to be sent to the model
+            }
+
             var item = new GenAiResultItem
             {
                 DocumentId = scriptResult.DocumentId,
@@ -619,7 +632,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             results.Add(item);
         }
 
-        return results;
+        return (results, docIdsToClearTaskHashes);
     }
 
     internal ChatCompletionClient GetChatCompletionClient() => _chatCompletionClient;

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24642.cs
@@ -520,7 +520,7 @@ for(const comment of this.Comments)
         if (withNullAttachments)
             Assert.NotEqual(hash1, newHash1); // doc1 - hash of 'non-existed image.png'
         else
-            Assert.Equal(hash1, newHash1); // doc1 - hasn't changed - etl didn't process this doc
+            Assert.Null(newHash1); // doc1 produces no context objects now - metadata hashes gets cleared
         });
     }
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB-24644.cs
@@ -218,7 +218,7 @@ ai.genContext({}).withPdf(pdf);
                 if (withNullAttachments)
                     Assert.NotEqual(hash1, newHash1);
                 else
-                    Assert.Equal(hash1, newHash1);
+                    Assert.Null(newHash1); // doc1 produces no context objects now - metadata hashes gets cleared
             });
         }
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24186.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24186.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues;
+
+public class RavenDB_24186(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task ShouldReflectContextDeletionsInGenAiMetadataHashes(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+        store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var etl = Etl.WaitForEtlToComplete(store);
+
+        var taskName = config.Name.ToLower().Replace("_", "-");
+        config.Prompt = "Check if the following blog post comment is spam or not";
+        config.Collection = "Posts";
+        config.SampleObject = JsonConvert.SerializeObject(new { Blocked = true, Reason = "Concise reason for why this comment was marked as spam or ham" });
+        config.UpdateScript = "// no-op for this test";
+        config.GenAiTransformation = new GenAiTransformation
+        {
+            Script = @"
+for(const comment of this.Comments)
+{
+    ai.genContext({Text: comment.Text, Author: comment.Author, Id: comment.Id});
+}
+"
+        };
+
+        store.Maintenance.Send(new AddGenAiOperation(config));
+        
+        const string docId = "posts/1";
+
+        var post = new GenAiBasics.Post([
+            new GenAiBasics.Comment("Free crypto airdrop! Sign up now at scamcoin.fake", "evil bot") { Id = "comments/1" },
+            new GenAiBasics.Comment("Great article. Helped me understand indexing in RavenDB.", "alex") { Id = "comments/2" },
+            new GenAiBasics.Comment("Surefire investment property in caiman islands, win $$$$ for sure, qucik!", "homepage") { Id = "comments/3" }
+        ], "Understanding RavenDB Indexing", "Indexes in RavenDB are powerful...");
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(post, docId);
+            session.SaveChanges();
+        }
+
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(60)));
+
+        var db = await GetDatabase(store.Database);
+        long etag = 0;
+
+        // First run: hashes should match all extracted contexts (3 comments)
+        using (var session = store.OpenAsyncSession())
+        {
+            var postDoc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+            Assert.NotNull(postDoc);
+
+            Assert.True(postDoc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
+            Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
+            Assert.True(hashesSection.TryGet(taskName, out BlittableJsonReaderArray hashes));
+            Assert.NotNull(hashes);
+
+            // one per comment
+            Assert.Equal(3, hashes.Length);
+
+            etag = ChangeVectorUtils.GetEtagById(session.Advanced.GetChangeVectorFor(postDoc), db.DbBase64Id);
+        }
+
+        // Second run: delete one context source (remove a comment).
+        // All remaining contexts are cached (their hashes already exist), so no model call is expected.
+        // Still, @gen-ai-hashes should be updated to remove the stale hash of the deleted comment.
+        etl = Etl.WaitForEtlToComplete(store, (s, statistics) => statistics.LastProcessedEtag > etag);
+
+        using (var session = store.OpenSession())
+        {
+            post = session.Load<GenAiBasics.Post>(docId);
+
+            // remove the middle one
+            var removed = post.Comments.Single(c => c.Id == "comments/2");
+            post.Comments.Remove(removed);
+
+            session.SaveChanges();
+        }
+
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(60)));
+
+        using (var session = store.OpenAsyncSession())
+        {
+            var postDoc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+            Assert.NotNull(postDoc);
+
+            Assert.True(postDoc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
+            Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out BlittableJsonReaderObject hashesSection));
+            Assert.True(hashesSection.TryGet(taskName, out BlittableJsonReaderArray hashes));
+            Assert.NotNull(hashes);
+
+            Assert.Equal(2, hashes.Length);
+
+            etag = ChangeVectorUtils.GetEtagById(session.Advanced.GetChangeVectorFor(postDoc), db.DbBase64Id);
+        }
+
+        // Remove both of the remaining comments, which are cached.
+        // No model call expected, but @gen-ai-hashes should be cleared entirely since there are no more contexts.
+        etl = Etl.WaitForEtlToComplete(store, (s, statistics) => statistics.LastProcessedEtag > etag);
+
+        using (var session = store.OpenSession())
+        {
+            post = session.Load<GenAiBasics.Post>(docId);
+
+            // remove all remaining comments
+            post.Comments.Clear();
+            session.SaveChanges();
+        }
+
+        Assert.True(await etl.WaitAsync(TimeSpan.FromSeconds(60)));
+
+        // Verify that @gen-ai-hashes is removed entirely
+        using (var session = store.OpenAsyncSession())
+        {
+            var postDoc = await session.LoadAsync<BlittableJsonReaderObject>(docId);
+            Assert.NotNull(postDoc);
+
+            Assert.True(postDoc.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata));
+            Assert.False(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out object _));
+        }
+    }
+
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24186.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_24186.cs
@@ -18,7 +18,7 @@ public class RavenDB_24186(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Ai)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-    public async Task ShouldReflectContextDeletionsInGenAiMetadataHashes(Options options, GenAiConfiguration config)
+    public async Task GenAi_ShouldReflectContextDeletionsInMetadataHashes(Options options, GenAiConfiguration config)
     {
         using var store = GetDocumentStore(options);
         store.Maintenance.Send(new PutConnectionStringOperation<AiConnectionString>(config.Connection));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24186/GenAI-metadata-hashes-should-reflect-deletions

### Additional description

Keeps `@gen-ai-hashes` in sync with context deletions.
When remaining contexts are cached, we rewrite hashes correctly; this PR fixes the case where a document produces zero contexts by emitting a marker during transformation and clearing the task’s hash entry from metadata during the load phase.
Adds a new repro test that covers both scenarios.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
