### PR TITLE
RavenDB-26001 - Numbers of results overflow for a collection query

### DIFF
--- a/src/Raven.Server/Documents/CollectionRunner.cs
+++ b/src/Raven.Server/Documents/CollectionRunner.cs
@@ -230,12 +230,11 @@ namespace Raven.Server.Documents
             if (isAllDocs)
             {
                 var allDocsCount = Database.DocumentsStorage.GetNumberOfDocuments(context);
-                Database.DocumentsStorage.GetNumberOfDocumentsToProcess(context, CollectionName.HiLoCollection, 0, out long hiloDocsCount, Stopwatch.StartNew());
+                var hiloDocsCount = Database.DocumentsStorage.GetNumberOfDocumentsFor(CollectionName.HiLoCollection, context);
                 return allDocsCount - hiloDocsCount;
             }
 
-            Database.DocumentsStorage.GetNumberOfDocumentsToProcess(context, collectionName, 0, out long totalCount, Stopwatch.StartNew());
-            return totalCount;
+            return Database.DocumentsStorage.GetNumberOfDocumentsFor(collectionName, context);
         }
 
         protected long GetLastEtagForCollection(DocumentsOperationContext context, string collection, bool isAllDocs)

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -21,6 +21,7 @@ using Raven.Server.Documents.Refresh;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.Revisions;
+using Raven.Server.Documents.Schemas;
 using Raven.Server.Documents.Sharding;
 using Raven.Server.Documents.TimeSeries;
 using Raven.Server.ServerWide.Context;
@@ -2336,6 +2337,21 @@ namespace Raven.Server.Documents
             return fst.NumberOfEntries;
         }
 
+        public long GetNumberOfDocumentsFor(string collection, DocumentsOperationContext context)
+        {
+            var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
+            if (collectionName == null)
+                return 0;
+
+            var collectionTable = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
+                collectionName.GetTableName(CollectionTableType.Documents));
+            if (collectionTable == null)
+                return 0;
+
+            var indexDef = DocsSchema.FixedSizeIndexes[CollectionEtagsSlice];
+            return collectionTable.GetNumberOfEntriesFor(indexDef);
+        }
+
         public sealed class CollectionStats
         {
             public string Name;
@@ -2426,36 +2442,6 @@ namespace Raven.Server.Documents
             return report;
         }
 
-        public CollectionStats GetCollection(string collection, DocumentsOperationContext context)
-        {
-            var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
-            if (collectionName == null)
-            {
-                return new CollectionStats
-                {
-                    Name = collection,
-                    Count = 0
-                };
-            }
-
-            var collectionTable = context.Transaction.InnerTransaction.OpenTable(DocumentDatabase.GetDocsSchemaForCollection(collectionName),
-                collectionName.GetTableName(CollectionTableType.Documents));
-
-            if (collectionTable == null)
-            {
-                return new CollectionStats
-                {
-                    Name = collection,
-                    Count = 0
-                };
-            }
-
-            return new CollectionStats
-            {
-                Name = collectionName.Name,
-                Count = collectionTable.NumberOfEntries
-            };
-        }
 
         public long DeleteTombstonesBefore(DocumentsOperationContext context, string collection, long etag, long numberOfEntriesToDelete)
         {

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioCollectionFieldsHandlerProcessorForGetCollectionFields.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Studio
             else
             {
                 changeVector = RequestHandler.Database.DocumentsStorage.GetLastDocumentChangeVector(context.Transaction.InnerTransaction, context, collection);
-                totalResults = RequestHandler.Database.DocumentsStorage.GetCollection(collection, context).Count;
+                totalResults = RequestHandler.Database.DocumentsStorage.GetNumberOfDocumentsFor(collection, context);
 
                 if (changeVector != null)
                     etag = $"{changeVector}/{totalResults}";

--- a/src/Raven.Server/Documents/Indexes/DatabaseIndexCreateController.cs
+++ b/src/Raven.Server/Documents/Indexes/DatabaseIndexCreateController.cs
@@ -43,7 +43,7 @@ public class DatabaseIndexCreateController : AbstractIndexCreateController
     {
         using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         using (context.OpenReadTransaction())
-            return ValueTask.FromResult(_database.DocumentsStorage.GetCollection(collection, context).Count);
+            return ValueTask.FromResult(_database.DocumentsStorage.GetNumberOfDocumentsFor(collection, context));
     }
 
     protected override IEnumerable<IndexInformationHolder> GetIndexes()

--- a/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/Static/MapReduceIndex.cs
@@ -314,7 +314,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce.Static
                     {
                         using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                         using (context.OpenReadTransaction())
-                            return ValueTask.FromResult(documentDatabase.DocumentsStorage.GetCollection(collection, context).Count);
+                            return ValueTask.FromResult(documentDatabase.DocumentsStorage.GetNumberOfDocumentsFor(collection, context));
                     },
                     checkIfCollectionEmpty: isIndexReset == false)
                 .AsTask()

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -404,7 +404,7 @@ namespace Raven.Server.Documents.Queries
                     if (_filterScriptRun == null)
                     {
                         totalResultsCalculated = true;
-                        _totalResults.Value = _documents.GetCollection(_collection, _context).Count;
+                        _totalResults.Value = _documents.GetNumberOfDocumentsFor(_collection, _context);
                     }
                 }
 

--- a/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
+++ b/src/Raven.Server/Documents/Queries/CollectionQueryEnumerable.cs
@@ -395,7 +395,7 @@ namespace Raven.Server.Documents.Queries
                     if (_filterScriptRun == null)
                     {
                         totalResultsCalculated = true;
-                        _totalResults.Value = (int)_documents.GetNumberOfDocuments(_context);
+                        _totalResults.Value = _documents.GetNumberOfDocuments(_context);
                     }
                 }
                 else
@@ -404,7 +404,7 @@ namespace Raven.Server.Documents.Queries
                     if (_filterScriptRun == null)
                     {
                         totalResultsCalculated = true;
-                        _totalResults.Value = (int)_documents.GetCollection(_collection, _context).Count;
+                        _totalResults.Value = _documents.GetCollection(_collection, _context).Count;
                     }
                 }
 

--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -297,8 +297,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
                 numberOfDocuments = Database.DocumentsStorage.GetNumberOfDocuments(context.Documents);
             else
             {
-                var collectionStats = Database.DocumentsStorage.GetCollection(collection, context.Documents);
-                numberOfDocuments = collectionStats.Count;
+                numberOfDocuments = Database.DocumentsStorage.GetNumberOfDocumentsFor(collection, context.Documents);
             }
 
             // If the query has include or load, it's too difficult to check the etags for just the included collections,

--- a/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
+++ b/src/Raven.Server/Web/Studio/Processors/StudioCollectionsHandlerProcessorForPreviewCollection.cs
@@ -46,7 +46,7 @@ public sealed class StudioCollectionsHandlerProcessorForPreviewCollection : Abst
 
         _totalResults = IsAllDocsCollection
             ? _database.DocumentsStorage.GetNumberOfDocuments(_context)
-            : _database.DocumentsStorage.GetCollection(Collection, _context).Count;
+            : _database.DocumentsStorage.GetNumberOfDocumentsFor(Collection, _context);
     }
 
     protected override JsonOperationContext GetContext()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26001/Numbers-of-results-overflow-for-a-collection-query

### Additional description

- Fix overlow in the number of results for a collection query.
- Rename `GetCollection` to `GetNumberOfDocumentsFor` and simplify it.
- Use `GetNumberOfDocumentsFor` when checking for the number of documents in the collection instead of the expensive `GetNumberOfDocumentsToProces`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
