### PR TITLE
RavenDB-25806 - Slow loading of the tombstones view

### DIFF
--- a/src/Raven.Client/Documents/Indexes/IndexProgress.cs
+++ b/src/Raven.Client/Documents/Indexes/IndexProgress.cs
@@ -22,6 +22,8 @@ namespace Raven.Client.Documents.Indexes
 
         public sealed class CollectionStats
         {
+            public bool Estimated { get; set; }
+
             public long LastProcessedItemEtag { get; set; }
 
             public long NumberOfItemsToProcess { get; set; }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -21,6 +21,7 @@ using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data;
+using Voron.Data.Fixed;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.DocumentsStorage;
@@ -1230,18 +1231,15 @@ namespace Raven.Server.Documents
             }
         }
 
-        public long GetNumberOfAttachmentsToProcess(DocumentsOperationContext context, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfAttachmentsToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
         {
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
 
             if (table == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var indexDef = AttachmentsSchema.FixedSizeIndexes[AttachmentsEtagSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
         public long GetNumberOfAttachmentTombstones(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1231,7 +1231,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfAttachmentsToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfAttachmentsToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var table = context.Transaction.InnerTransaction.OpenTable(AttachmentsSchema, AttachmentsMetadataSlice);
 
@@ -1239,7 +1239,7 @@ namespace Raven.Server.Documents
                 return new NumberOfEntriesAfterResult();
 
             var indexDef = AttachmentsSchema.FixedSizeIndexes[AttachmentsEtagSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public long GetNumberOfAttachmentTombstones(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Commands/ETL/GetEtlTaskProgressCommand.cs
+++ b/src/Raven.Server/Documents/Commands/ETL/GetEtlTaskProgressCommand.cs
@@ -10,10 +10,12 @@ namespace Raven.Server.Documents.Commands.ETL;
 internal sealed class GetEtlTaskProgressCommand : RavenCommand<EtlTaskProgress[]>
 {
     private readonly string[] _names;
+    private readonly bool _exact;
 
-    public GetEtlTaskProgressCommand(string[] names, string nodeTag)
+    public GetEtlTaskProgressCommand(string[] names, string nodeTag, bool exact = false)
     {
         _names = names;
+        _exact = exact;
         SelectedNodeTag = nodeTag;
     }
 
@@ -23,10 +25,20 @@ internal sealed class GetEtlTaskProgressCommand : RavenCommand<EtlTaskProgress[]
     {
         url = $"{node.Url}/databases/{node.Database}/etl/progress";
 
+        var separator = '?';
+
         if (_names is { Length: > 0 })
         {
             for (var i = 0; i < _names.Length; i++)
-                url += $"{(i == 0 ? "?" : "&")}name={Uri.EscapeDataString(_names[i])}";
+            {
+                url += $"{separator}name={Uri.EscapeDataString(_names[i])}";
+                separator = '&';
+            }
+        }
+
+        if (_exact)
+        {
+            url += $"{separator}exact=true";
         }
 
         return new HttpRequestMessage

--- a/src/Raven.Server/Documents/Commands/Indexes/GetIndexesProgressCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Indexes/GetIndexesProgressCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Http;
@@ -8,14 +9,27 @@ namespace Raven.Server.Documents.Commands.Indexes;
 
 internal sealed class GetIndexesProgressCommand : RavenCommand<IndexProgress[]>
 {
-    public GetIndexesProgressCommand(string nodeTag)
+    private readonly string[] _indexesWithExactProgress;
+
+    public GetIndexesProgressCommand(string nodeTag, string[] indexesWithExactProgress = null)
     {
         SelectedNodeTag = nodeTag;
+        _indexesWithExactProgress = indexesWithExactProgress;
     }
 
     public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
     {
         url = $"{node.Url}/databases/{node.Database}/indexes/progress";
+
+        if (_indexesWithExactProgress is { Length: > 0 })
+        {
+            var separator = '?';
+            for (var i = 0; i < _indexesWithExactProgress.Length; i++)
+            {
+                url += $"{separator}exact={Uri.EscapeDataString(_indexesWithExactProgress[i])}";
+                separator = '&';
+            }
+        }
 
         return new HttpRequestMessage
         {

--- a/src/Raven.Server/Documents/Commands/Indexes/GetIndexesProgressCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Indexes/GetIndexesProgressCommand.cs
@@ -9,26 +9,34 @@ namespace Raven.Server.Documents.Commands.Indexes;
 
 internal sealed class GetIndexesProgressCommand : RavenCommand<IndexProgress[]>
 {
-    private readonly string[] _indexesWithExactProgress;
+    private readonly string[] _names;
+    private readonly bool _exact;
 
-    public GetIndexesProgressCommand(string nodeTag, string[] indexesWithExactProgress = null)
+    public GetIndexesProgressCommand(string nodeTag, string[] names = null, bool exact = false)
     {
         SelectedNodeTag = nodeTag;
-        _indexesWithExactProgress = indexesWithExactProgress;
+        _names = names;
+        _exact = exact;
     }
 
     public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
     {
         url = $"{node.Url}/databases/{node.Database}/indexes/progress";
 
-        if (_indexesWithExactProgress is { Length: > 0 })
+        var separator = '?';
+
+        if (_names is { Length: > 0 })
         {
-            var separator = '?';
-            for (var i = 0; i < _indexesWithExactProgress.Length; i++)
+            for (var i = 0; i < _names.Length; i++)
             {
-                url += $"{separator}exact={Uri.EscapeDataString(_indexesWithExactProgress[i])}";
+                url += $"{separator}name={Uri.EscapeDataString(_names[i])}";
                 separator = '&';
             }
+        }
+
+        if (_exact)
+        {
+            url += $"{separator}exact=true";
         }
 
         return new HttpRequestMessage

--- a/src/Raven.Server/Documents/Commands/Replication/GetOutgoingInternalReplicationProgressCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetOutgoingInternalReplicationProgressCommand.cs
@@ -8,8 +8,11 @@ namespace Raven.Server.Documents.Commands.Replication
 {
     internal sealed class GetOutgoingInternalReplicationProgressCommand : RavenCommand<IReplicationTaskProgress[]>
     {
-        public GetOutgoingInternalReplicationProgressCommand(string nodeTag)
+        private readonly bool _exact;
+
+        public GetOutgoingInternalReplicationProgressCommand(string nodeTag, bool exact = false)
         {
+            _exact = exact;
             SelectedNodeTag = nodeTag;
         }
 
@@ -18,6 +21,11 @@ namespace Raven.Server.Documents.Commands.Replication
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
             url = $"{node.Url}/databases/{node.Database}/replication/internal/outgoing/progress";
+
+            if (_exact)
+            {
+                url += "?exact=true";
+            }
 
             return new HttpRequestMessage { Method = HttpMethod.Get };
         }

--- a/src/Raven.Server/Documents/Commands/Replication/GetReplicationOngoingTasksProgressCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Replication/GetReplicationOngoingTasksProgressCommand.cs
@@ -10,10 +10,12 @@ namespace Raven.Server.Documents.Commands.Replication
     internal sealed class GetReplicationOngoingTasksProgressCommand : RavenCommand<IReplicationTaskProgress[]>
     {
         private readonly string[] _names;
+        private readonly bool _exact;
 
-        public GetReplicationOngoingTasksProgressCommand(string[] names, string nodeTag)
+        public GetReplicationOngoingTasksProgressCommand(string[] names, string nodeTag, bool exact = false)
         {
             _names = names;
+            _exact = exact;
             SelectedNodeTag = nodeTag;
         }
 
@@ -23,10 +25,20 @@ namespace Raven.Server.Documents.Commands.Replication
         {
             url = $"{node.Url}/databases/{node.Database}/replication/progress";
 
+            var separator = '?';
+
             if (_names is { Length: > 0 })
             {
                 for (var i = 0; i < _names.Length; i++)
-                    url += $"{(i == 0 ? "?" : "&")}name={Uri.EscapeDataString(_names[i])}";
+                {
+                    url += $"{separator}name={Uri.EscapeDataString(_names[i])}";
+                    separator = '&';
+                }
+            }
+
+            if (_exact)
+            {
+                url += $"{separator}exact=true";
             }
 
             return new HttpRequestMessage

--- a/src/Raven.Server/Documents/Commands/Tombstones/GetTombstonesStateCommand.cs
+++ b/src/Raven.Server/Documents/Commands/Tombstones/GetTombstonesStateCommand.cs
@@ -74,9 +74,12 @@ internal sealed class GetTombstonesStateCommand : RavenCommand<GetTombstonesStat
         }
     }
 
-    public GetTombstonesStateCommand(string nodeTag)
+    private readonly bool _exact;
+
+    public GetTombstonesStateCommand(string nodeTag, bool exact = false)
     {
         SelectedNodeTag = nodeTag;
+        _exact = exact;
     }
 
     public override bool IsReadRequest => false;
@@ -84,6 +87,11 @@ internal sealed class GetTombstonesStateCommand : RavenCommand<GetTombstonesStat
     public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
     {
         url = $"{node.Url}/databases/{node.Database}/admin/tombstones/state";
+
+        if (_exact)
+        {
+            url += "?exact=true";
+        }
 
         return new HttpRequestMessage
         {

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -10,7 +10,6 @@ using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Exceptions.Documents.Counters;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
-using Raven.Server.Documents.Schemas;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
@@ -20,6 +19,7 @@ using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
+using Voron.Data.Fixed;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.DocumentsStorage;
@@ -211,27 +211,20 @@ namespace Raven.Server.Documents
             }
         }
 
-        public long GetNumberOfCounterGroupsToProcess(DocumentsOperationContext context, string collection, long afterEtag, out long totalCount,
-            Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfCounterGroupsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var table = GetCountersTable(context.Transaction.InnerTransaction, collectionName);
 
             if (table == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var indexDef = CountersSchema.FixedSizeIndexes[CollectionCountersEtagsSlice];
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
         public static CounterGroupDetail TableValueToCounterGroupDetail(JsonOperationContext context, ref TableValueReader tvr)
@@ -1948,14 +1941,14 @@ namespace Raven.Server.Documents
             }
         }
 
-        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
         {
             var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
             var indexDef = CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out _, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
-        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collectionName, long afterEtag)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collectionName, long afterEtag)
         {
             var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
             long count = 0;
@@ -1983,7 +1976,12 @@ namespace Raven.Server.Documents
                 }
             }
 
-            return count;
+            return new NumberOfEntriesAfterResult
+            {
+                Count = count,
+                Total = -1, // we don't use the total for tombstones count
+                Estimated = false
+            };
         }
 
         public long PurgeCountersAndCounterTombstones(DocumentsOperationContext context, string collection, long upto, long numberOfEntriesToDelete)

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -211,7 +211,7 @@ namespace Raven.Server.Documents
             }
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfCounterGroupsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfCounterGroupsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -224,7 +224,7 @@ namespace Raven.Server.Documents
 
             var indexDef = CountersSchema.FixedSizeIndexes[CollectionCountersEtagsSlice];
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public static CounterGroupDetail TableValueToCounterGroupDetail(JsonOperationContext context, ref TableValueReader tvr)
@@ -1941,11 +1941,11 @@ namespace Raven.Server.Documents
             }
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
             var indexDef = CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collectionName, long afterEtag)

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -1948,40 +1948,21 @@ namespace Raven.Server.Documents
             return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collectionName, long afterEtag)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collectionName, long afterEtag, Stopwatch overallDuration, bool exact)
         {
-            var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
-            long count = 0;
+            var collection = _documentsStorage.GetCollection(collectionName, throwIfDoesNotExist: false);
+            if (collection == null)
+                return new NumberOfEntriesAfterResult();
 
-            foreach (var result in table.SeekForwardFrom(CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice], afterEtag, 0))
-            {
-                ExtractDocIdFromCounterTombstoneKey(context, ref result.Reader, out var documentId);
+            var counterTombstonesTableName = collection.GetTableName(CollectionTableType.CounterTombstones);
+            var table = context.Transaction.InnerTransaction.OpenTable(CounterTombstonesSchema, counterTombstonesTableName);
 
-                using (documentId)
-                {
-                    var documentOrTombstone = _documentsStorage.GetDocumentOrTombstone(context, documentId, fields: DocumentFields.Data);
-                    if (documentOrTombstone.Missing)
-                        continue;
+            if (table == null)
+                return new NumberOfEntriesAfterResult();
 
-                    using (documentOrTombstone.Document)
-                    using (documentOrTombstone.Tombstone)
-                    {
-                        string collection = documentOrTombstone.Document != null ?
-                            _documentDatabase.DocumentsStorage.ExtractCollectionName(context, documentOrTombstone.Document.Data).Name :
-                            documentOrTombstone.Tombstone.Collection;
+            var indexDef = CounterTombstonesSchema.FixedSizeIndexes[CollectionCounterTombstonesEtagsSlice];
 
-                        if (collection.Equals(collectionName))
-                            count++;
-                    }
-                }
-            }
-
-            return new NumberOfEntriesAfterResult
-            {
-                Count = count,
-                Total = -1, // we don't use the total for tombstones count
-                Estimated = false
-            };
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public long PurgeCountersAndCounterTombstones(DocumentsOperationContext context, string collection, long upto, long numberOfEntriesToDelete)

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -10,6 +10,7 @@ using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Exceptions.Documents.Counters;
 using Raven.Server.Documents.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
+using Raven.Server.Documents.Schemas;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
@@ -1947,25 +1948,42 @@ namespace Raven.Server.Documents
             }
         }
 
-        public IEnumerable<CounterTombstoneDetailWithCollection> GetCounterWithCollectionTombstonesFrom(DocumentsOperationContext context, string collectionName, long etag)
+        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
         {
             var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
+            var indexDef = CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice];
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out _, overallDuration);
+        }
 
-            foreach (var result in table.SeekForwardFrom(CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice], etag, 0))
+        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collectionName, long afterEtag)
+        {
+            var table = new Table(CounterTombstonesSchema, context.Transaction.InnerTransaction);
+            long count = 0;
+
+            foreach (var result in table.SeekForwardFrom(CounterTombstonesSchema.FixedSizeIndexes[AllCounterTombstonesEtagSlice], afterEtag, 0))
             {
-                var tombstoneDetail = TableValueToCounterTombstoneDetail(context, ref result.Reader);
-                var documentOrTombstone = _documentsStorage.GetDocumentOrTombstone(context, tombstoneDetail.DocumentId);
+                ExtractDocIdFromCounterTombstoneKey(context, ref result.Reader, out var documentId);
 
-                if (documentOrTombstone.Missing)
-                    continue;
+                using (documentId)
+                {
+                    var documentOrTombstone = _documentsStorage.GetDocumentOrTombstone(context, documentId, fields: DocumentFields.Data);
+                    if (documentOrTombstone.Missing)
+                        continue;
 
-                string collection = documentOrTombstone.Document != null ?
-                    _documentDatabase.DocumentsStorage.ExtractCollectionName(context, documentOrTombstone.Document.Data).Name :
-                    documentOrTombstone.Tombstone.Collection;
+                    using (documentOrTombstone.Document)
+                    using (documentOrTombstone.Tombstone)
+                    {
+                        string collection = documentOrTombstone.Document != null ?
+                            _documentDatabase.DocumentsStorage.ExtractCollectionName(context, documentOrTombstone.Document.Data).Name :
+                            documentOrTombstone.Tombstone.Collection;
 
-                if (collection.Equals(collectionName))
-                    yield return new CounterTombstoneDetailWithCollection(tombstoneDetail, collection);
+                        if (collection.Equals(collectionName))
+                            count++;
+                    }
+                }
             }
+
+            return count;
         }
 
         public long PurgeCountersAndCounterTombstones(DocumentsOperationContext context, string collection, long upto, long numberOfEntriesToDelete)
@@ -2182,7 +2200,7 @@ namespace Raven.Server.Documents
             return context.AllocateStringValue(null, p, sizeOfDocId);
         }
 
-        public static void ExtractDocIdAndCounterNameFromCounterTombstoneKey(JsonOperationContext context, ref TableValueReader tvr, out LazyStringValue docId, out LazyStringValue counterName)
+        private static void ExtractDocIdAndCounterNameFromCounterTombstoneKey(JsonOperationContext context, ref TableValueReader tvr, out LazyStringValue docId, out LazyStringValue counterName)
         {
             var p = tvr.Read((int)CounterTombstonesTable.CounterTombstoneKey, out var size);
             int sizeOfDocId = 0;
@@ -2198,6 +2216,21 @@ namespace Raven.Server.Documents
 
             Debug.Assert(docId != null);
             Debug.Assert(counterName != null);
+        }
+
+        private static void ExtractDocIdFromCounterTombstoneKey(JsonOperationContext context, ref TableValueReader tvr, out LazyStringValue docId)
+        {
+            var p = tvr.Read((int)CounterTombstonesTable.CounterTombstoneKey, out var size);
+            int sizeOfDocId = 0;
+
+            for (; sizeOfDocId < size; sizeOfDocId++)
+            {
+                if (p[sizeOfDocId] == SpecialChars.RecordSeparator)
+                    break;
+            }
+
+            docId = context.AllocateStringValue(null, p, sizeOfDocId);
+            Debug.Assert(docId != null);
         }
 
         public string UpdateDocumentCounters(DocumentsOperationContext context, Document document, string docId,

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2288,27 +2288,27 @@ namespace Raven.Server.Documents
             return DocumentPut.PutDocument(context, id, expectedChangeVector, document, lastModifiedTicks, cv, oldChangeVectorForClusterTransactionIndexCheck, flags, nonPersistentFlags);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfDocumentsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfDocumentsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration, bool exact)
         {
-            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: false, overallDuration);
+            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: false, overallDuration, exact);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfDocumentsToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfDocumentsToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration, bool exact)
         {
-            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: false, overallDuration);
+            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: false, overallDuration, exact);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration, bool exact)
         {
-            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: true, overallDuration);
+            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: true, overallDuration, exact);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration, bool exact)
         {
-            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: true, overallDuration);
+            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: true, overallDuration, exact);
         }
 
-        private NumberOfEntriesAfterResult GetNumberOfItemsToProcess(DocumentsOperationContext context, string collection, long afterEtag, bool tombstones, Stopwatch overallDuration)
+        private NumberOfEntriesAfterResult GetNumberOfItemsToProcess(DocumentsOperationContext context, string collection, long afterEtag, bool tombstones, Stopwatch overallDuration, bool exact)
         {
             var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -2333,10 +2333,10 @@ namespace Raven.Server.Documents
             if (table == null)
                 return new NumberOfEntriesAfterResult();
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
-        private NumberOfEntriesAfterResult GetNumberOfItemsToProcess(DocumentsOperationContext context, long afterEtag, bool tombstones, Stopwatch overallDuration)
+        private NumberOfEntriesAfterResult GetNumberOfItemsToProcess(DocumentsOperationContext context, long afterEtag, bool tombstones, Stopwatch overallDuration, bool exact)
         {
             Table table;
             TableSchema.FixedSizeKeyIndexDef indexDef;
@@ -2351,7 +2351,7 @@ namespace Raven.Server.Documents
                 indexDef = DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice];
             }
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public long GetNumberOfDocuments()

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -2288,35 +2288,31 @@ namespace Raven.Server.Documents
             return DocumentPut.PutDocument(context, id, expectedChangeVector, document, lastModifiedTicks, cv, oldChangeVectorForClusterTransactionIndexCheck, flags, nonPersistentFlags);
         }
 
-        public long GetNumberOfDocumentsToProcess(DocumentsOperationContext context, string collection, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfDocumentsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
         {
-            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: false, totalCount: out totalCount, overallDuration);
+            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: false, overallDuration);
         }
 
-        public long GetNumberOfDocumentsToProcess(DocumentsOperationContext context, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfDocumentsToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
         {
-            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: false, totalCount: out totalCount, overallDuration);
+            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: false, overallDuration);
         }
 
-        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
         {
-            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: true, totalCount: out totalCount, overallDuration);
+            return GetNumberOfItemsToProcess(context, collection, afterEtag, tombstones: true, overallDuration);
         }
 
-        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
         {
-            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: true, totalCount: out totalCount, overallDuration);
+            return GetNumberOfItemsToProcess(context, afterEtag, tombstones: true, overallDuration);
         }
 
-        private long GetNumberOfItemsToProcess(DocumentsOperationContext context, string collection, long afterEtag, bool tombstones, out long totalCount,
-            Stopwatch overallDuration)
+        private NumberOfEntriesAfterResult GetNumberOfItemsToProcess(DocumentsOperationContext context, string collection, long afterEtag, bool tombstones, Stopwatch overallDuration)
         {
             var collectionName = GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             Table table;
             TableSchema.FixedSizeKeyIndexDef indexDef;
@@ -2335,16 +2331,12 @@ namespace Raven.Server.Documents
             }
 
             if (table == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
-        private long GetNumberOfItemsToProcess(DocumentsOperationContext context, long afterEtag, bool tombstones, out long totalCount,
-            Stopwatch overallDuration)
+        private NumberOfEntriesAfterResult GetNumberOfItemsToProcess(DocumentsOperationContext context, long afterEtag, bool tombstones, Stopwatch overallDuration)
         {
             Table table;
             TableSchema.FixedSizeKeyIndexDef indexDef;
@@ -2359,7 +2351,7 @@ namespace Raven.Server.Documents
                 indexDef = DocsSchema.FixedSizeIndexes[AllDocsEtagsSlice];
             }
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
         public long GetNumberOfDocuments()

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -98,7 +98,7 @@ namespace Raven.Server.Documents.ETL
 
         public abstract OngoingTaskConnectionStatus GetConnectionStatus();
 
-        public abstract EtlProcessProgress GetProgress(DocumentsOperationContext documentsContext);
+        public abstract EtlProcessProgress GetProgress(DocumentsOperationContext documentsContext, bool exact);
 
         internal abstract bool IsRunning { get; }
 
@@ -1361,7 +1361,7 @@ namespace Raven.Server.Documents.ETL
             });
         }
 
-        public override EtlProcessProgress GetProgress(DocumentsOperationContext documentsContext)
+        public override EtlProcessProgress GetProgress(DocumentsOperationContext documentsContext, bool exact)
         {
             var result = new EtlProcessProgress
             {
@@ -1379,19 +1379,19 @@ namespace Raven.Server.Documents.ETL
             var overallDuration = Stopwatch.StartNew();
             foreach (var collection in collections)
             {
-                var entriesAfter = Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                var entriesAfter = Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 result.NumberOfDocumentsToProcess += entriesAfter.Count;
                 result.TotalNumberOfDocuments += entriesAfter.Total;
                 result.Estimated |= entriesAfter.Estimated;
 
-                entriesAfter = Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                entriesAfter = Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 result.NumberOfDocumentTombstonesToProcess += entriesAfter.Count;
                 result.TotalNumberOfDocumentTombstones += entriesAfter.Total;
                 result.Estimated |= entriesAfter.Estimated;
 
                 if (ShouldTrackCounters())
                 {
-                    entriesAfter = Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                    entriesAfter = Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                     result.NumberOfCounterGroupsToProcess += entriesAfter.Count;
                     result.TotalNumberOfCounterGroups += entriesAfter.Total;
                     result.Estimated |= entriesAfter.Estimated;
@@ -1399,12 +1399,12 @@ namespace Raven.Server.Documents.ETL
 
                 if (ShouldTrackTimeSeries())
                 {
-                    entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                    entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                     result.NumberOfTimeSeriesSegmentsToProcess += entriesAfter.Count;
                     result.TotalNumberOfTimeSeriesSegments += entriesAfter.Total;
                     result.Estimated |= entriesAfter.Estimated;
 
-                    entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                    entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                     result.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
                     result.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;
                     result.Estimated |= entriesAfter.Estimated;

--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -1379,25 +1379,35 @@ namespace Raven.Server.Documents.ETL
             var overallDuration = Stopwatch.StartNew();
             foreach (var collection in collections)
             {
-                result.NumberOfDocumentsToProcess += Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, out var total, overallDuration);
-                result.TotalNumberOfDocuments += total;
+                var entriesAfter = Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                result.NumberOfDocumentsToProcess += entriesAfter.Count;
+                result.TotalNumberOfDocuments += entriesAfter.Total;
+                result.Estimated |= entriesAfter.Estimated;
 
-                result.NumberOfDocumentTombstonesToProcess += Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                result.TotalNumberOfDocumentTombstones += total;
+                entriesAfter = Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                result.NumberOfDocumentTombstonesToProcess += entriesAfter.Count;
+                result.TotalNumberOfDocumentTombstones += entriesAfter.Total;
+                result.Estimated |= entriesAfter.Estimated;
 
                 if (ShouldTrackCounters())
                 {
-                    result.NumberOfCounterGroupsToProcess += Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                    result.TotalNumberOfCounterGroups += total;
+                    entriesAfter = Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                    result.NumberOfCounterGroupsToProcess += entriesAfter.Count;
+                    result.TotalNumberOfCounterGroups += entriesAfter.Total;
+                    result.Estimated |= entriesAfter.Estimated;
                 }
 
                 if (ShouldTrackTimeSeries())
                 {
-                    result.NumberOfTimeSeriesSegmentsToProcess += Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                    result.TotalNumberOfTimeSeriesSegments += total;
+                    entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                    result.NumberOfTimeSeriesSegmentsToProcess += entriesAfter.Count;
+                    result.TotalNumberOfTimeSeriesSegments += entriesAfter.Total;
+                    result.Estimated |= entriesAfter.Estimated;
 
-                    result.NumberOfTimeSeriesDeletedRangesToProcess += Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                    result.TotalNumberOfTimeSeriesDeletedRanges += total;
+                    entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                    result.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
+                    result.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;
+                    result.Estimated |= entriesAfter.Estimated;
                 }
             }
 

--- a/src/Raven.Server/Documents/ETL/Handlers/Processors/AbstractEtlHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/Processors/AbstractEtlHandlerProcessorForProgress.cs
@@ -19,8 +19,9 @@ internal abstract class AbstractEtlHandlerProcessorForProgress<TRequestHandler, 
     protected override RavenCommand<EtlTaskProgress[]> CreateCommandForNode(string nodeTag)
     {
         var names = GetNames();
+        var exact = RequestHandler.GetBoolValueQueryString("exact", required: false) ?? false;
 
-        return new GetEtlTaskProgressCommand(names, nodeTag);
+        return new GetEtlTaskProgressCommand(names, nodeTag, exact);
     }
 
     protected StringValues GetNames() => RequestHandler.GetStringValuesQueryString("name", required: false);

--- a/src/Raven.Server/Documents/ETL/Handlers/Processors/EtlHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/Processors/EtlHandlerProcessorForProgress.cs
@@ -24,6 +24,8 @@ internal sealed class EtlHandlerProcessorForProgress : AbstractEtlHandlerProcess
 
     protected override async ValueTask HandleCurrentNodeAsync()
     {
+        var exact = RequestHandler.GetBoolValueQueryString("exact", required: false) ?? false;
+
         using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
         await using (var writer = new AsyncBlittableJsonTextWriterForDebug(context, ServerStore, RequestHandler.ResponseBodyStream()))
         using (context.OpenReadTransaction())
@@ -33,7 +35,7 @@ internal sealed class EtlHandlerProcessorForProgress : AbstractEtlHandlerProcess
             {
                 TaskName = x.Key,
                 EtlType = x.Value.First().EtlType,
-                ProcessesProgress = x.Value.Select(y => y.GetProgress(context)).ToArray(),
+                ProcessesProgress = x.Value.Select(y => y.GetProgress(context, exact)).ToArray(),
                 QueueBrokerType = x.Value.First() switch
                 {
                     RabbitMqEtl => QueueBrokerType.RabbitMq,

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/Kafka/KafkaEtl.cs
@@ -40,9 +40,9 @@ public sealed class KafkaEtl : QueueEtl<KafkaItem>
         return transactionalId.Replace("/", "_");
     }
 
-    public override EtlProcessProgress GetProgress(DocumentsOperationContext documentsContext)
+    public override EtlProcessProgress GetProgress(DocumentsOperationContext documentsContext, bool exact)
     {
-        var result = base.GetProgress(documentsContext);
+        var result = base.GetProgress(documentsContext, exact);
         result.TransactionalId = TransactionalId;
         return result;
     }

--- a/src/Raven.Server/Documents/ETL/Stats/EtlProcessProgress.cs
+++ b/src/Raven.Server/Documents/ETL/Stats/EtlProcessProgress.cs
@@ -24,6 +24,8 @@ namespace Raven.Server.Documents.ETL.Stats
 
         public bool Disabled { get; set; }
 
+        public bool Estimated { get; set; }
+
         public double AverageProcessedPerSecond { get; set; }
 
         public long NumberOfDocumentsToProcess { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -16,9 +16,7 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/tombstones/state", "GET", AuthorizationStatus.DatabaseAdmin, IsDebugInformationEndpoint = true)]
         public async Task State()
         {
-            var exact = GetBoolValueQueryString("exact", required: false) ?? false;
-
-            using (var processor = new AdminTombstoneHandlerProcessorForState(this, exact))
+            using (var processor = new AdminTombstoneHandlerProcessorForState(this))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/AdminTombstoneHandler.cs
@@ -16,7 +16,9 @@ namespace Raven.Server.Documents.Handlers.Admin
         [RavenAction("/databases/*/admin/tombstones/state", "GET", AuthorizationStatus.DatabaseAdmin, IsDebugInformationEndpoint = true)]
         public async Task State()
         {
-            using (var processor = new AdminTombstoneHandlerProcessorForState(this))
+            var exact = GetBoolValueQueryString("exact", required: false) ?? false;
+
+            using (var processor = new AdminTombstoneHandlerProcessorForState(this, exact))
                 await processor.ExecuteAsync();
         }
     }

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Tombstones/AbstractAdminTombstoneHandlerProcessorForState.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Tombstones/AbstractAdminTombstoneHandlerProcessorForState.cs
@@ -14,5 +14,11 @@ internal abstract class AbstractAdminTombstoneHandlerProcessorForState<TRequestH
     {
     }
 
-    protected override RavenCommand<GetTombstonesStateCommand.Response> CreateCommandForNode(string nodeTag) => new GetTombstonesStateCommand(nodeTag);
+    protected override RavenCommand<GetTombstonesStateCommand.Response> CreateCommandForNode(string nodeTag)
+    {
+        var exact = IsExact();
+        return new GetTombstonesStateCommand(nodeTag, exact);
+    }
+
+    protected bool IsExact() => RequestHandler.GetBoolValueQueryString("exact", required: false) ?? false;
 }

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Tombstones/AdminTombstoneHandlerProcessorForState.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Tombstones/AdminTombstoneHandlerProcessorForState.cs
@@ -11,18 +11,15 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Tombstones;
 
 internal sealed class AdminTombstoneHandlerProcessorForState : AbstractAdminTombstoneHandlerProcessorForState<DatabaseRequestHandler, DocumentsOperationContext>
 {
-    private readonly bool _exact;
-
-    public AdminTombstoneHandlerProcessorForState([NotNull] DatabaseRequestHandler requestHandler, bool exact) : base(requestHandler)
+    public AdminTombstoneHandlerProcessorForState([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
     {
-        _exact = exact;
     }
 
     protected override bool SupportsCurrentNode => true;
 
     protected override async ValueTask HandleCurrentNodeAsync()
     {
-        var state = RequestHandler.Database.TombstoneCleaner.GetState(addInfoForDebug: true, exact: _exact);
+        var state = RequestHandler.Database.TombstoneCleaner.GetState(addInfoForDebug: true, exact: IsExact());
         var response = new GetTombstonesStateCommand.Response(state);
 
         using (RequestHandler.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))
@@ -147,6 +144,9 @@ internal sealed class AdminTombstoneHandlerProcessorForState : AbstractAdminTomb
                         writer.WriteComma();
                         writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.NumberOfTombstoneLeft));
                         writer.WriteInteger(info.Value.NumberOfTombstoneLeft);
+                        writer.WriteComma();
+                        writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.Estimated));
+                        writer.WriteBool(info.Value.Estimated);
                         writer.WriteComma();
                         writer.WritePropertyName(nameof(TombstoneCleaner.TombstonesState.SubscriptionInfoExtended.Types));
                         context.Write(writer, info.Value.Types?.ToJson());

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Tombstones/AdminTombstoneHandlerProcessorForState.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Tombstones/AdminTombstoneHandlerProcessorForState.cs
@@ -11,15 +11,18 @@ namespace Raven.Server.Documents.Handlers.Admin.Processors.Tombstones;
 
 internal sealed class AdminTombstoneHandlerProcessorForState : AbstractAdminTombstoneHandlerProcessorForState<DatabaseRequestHandler, DocumentsOperationContext>
 {
-    public AdminTombstoneHandlerProcessorForState([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    private readonly bool _exact;
+
+    public AdminTombstoneHandlerProcessorForState([NotNull] DatabaseRequestHandler requestHandler, bool exact) : base(requestHandler)
     {
+        _exact = exact;
     }
 
     protected override bool SupportsCurrentNode => true;
 
     protected override async ValueTask HandleCurrentNodeAsync()
     {
-        var state = RequestHandler.Database.TombstoneCleaner.GetState(addInfoForDebug: true);
+        var state = RequestHandler.Database.TombstoneCleaner.GetState(addInfoForDebug: true, exact: _exact);
         var response = new GetTombstonesStateCommand.Response(state);
 
         using (RequestHandler.Database.DocumentsStorage.ContextPool.AllocateOperationContext(out JsonOperationContext context))

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Native.Object;
+using Microsoft.Extensions.Primitives;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Documents.Indexes;
@@ -128,7 +129,9 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/indexes/progress", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Progress()
         {
-            using (var processor = new IndexHandlerProcessorForProgress(this))
+            var indexesWithExactProgress = GetStringValuesQueryString("exact", required: false);
+
+            using (var processor = new IndexHandlerProcessorForProgress(this, indexesWithExactProgress))
                 await processor.ExecuteAsync();
         }
 

--- a/src/Raven.Server/Documents/Handlers/IndexHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/IndexHandler.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Jint.Native;
 using Jint.Native.Object;
-using Microsoft.Extensions.Primitives;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Documents.Indexes;
@@ -129,9 +128,7 @@ namespace Raven.Server.Documents.Handlers
         [RavenAction("/databases/*/indexes/progress", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task Progress()
         {
-            var indexesWithExactProgress = GetStringValuesQueryString("exact", required: false);
-
-            using (var processor = new IndexHandlerProcessorForProgress(this, indexesWithExactProgress))
+            using (var processor = new IndexHandlerProcessorForProgress(this))
                 await processor.ExecuteAsync();
         }
 

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForProgress.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using Microsoft.Extensions.Primitives;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Http;
 using Raven.Server.Documents.Commands.Indexes;
@@ -14,5 +15,11 @@ internal abstract class AbstractIndexHandlerProcessorForProgress<TRequestHandler
     {
     }
 
-    protected override RavenCommand<IndexProgress[]> CreateCommandForNode(string nodeTag) => new GetIndexesProgressCommand(nodeTag);
+    protected override RavenCommand<IndexProgress[]> CreateCommandForNode(string nodeTag)
+    {
+        var indexesWithExactProgress = GetIndexesWithExactProgress();
+        return new GetIndexesProgressCommand(nodeTag, indexesWithExactProgress);
+    }
+
+    protected StringValues GetIndexesWithExactProgress() => RequestHandler.GetStringValuesQueryString("exact", required: false);
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/AbstractIndexHandlerProcessorForProgress.cs
@@ -17,9 +17,12 @@ internal abstract class AbstractIndexHandlerProcessorForProgress<TRequestHandler
 
     protected override RavenCommand<IndexProgress[]> CreateCommandForNode(string nodeTag)
     {
-        var indexesWithExactProgress = GetIndexesWithExactProgress();
-        return new GetIndexesProgressCommand(nodeTag, indexesWithExactProgress);
+        var names = GetNames();
+        var exact = IsExact();
+        return new GetIndexesProgressCommand(nodeTag, names, exact);
     }
 
-    protected StringValues GetIndexesWithExactProgress() => RequestHandler.GetStringValuesQueryString("exact", required: false);
+    protected StringValues GetNames() => RequestHandler.GetStringValuesQueryString("name", required: false);
+
+    protected bool IsExact() => RequestHandler.GetBoolValueQueryString("exact", required: false) ?? false;
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForProgress.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Extensions.Primitives;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
@@ -16,8 +17,11 @@ namespace Raven.Server.Documents.Handlers.Processors.Indexes;
 
 internal sealed class IndexHandlerProcessorForProgress : AbstractIndexHandlerProcessorForProgress<DatabaseRequestHandler, DocumentsOperationContext>
 {
-    public IndexHandlerProcessorForProgress([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    private readonly HashSet<string> _indexesWithExactProgress;
+
+    public IndexHandlerProcessorForProgress([NotNull] DatabaseRequestHandler requestHandler, StringValues indexesWithExactProgress) : base(requestHandler)
     {
+        _indexesWithExactProgress = indexesWithExactProgress.ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     protected override bool SupportsCurrentNode => true;
@@ -46,7 +50,7 @@ internal sealed class IndexHandlerProcessorForProgress : AbstractIndexHandlerPro
                     if (index.DeployedOnAllNodes && index.IsStale(context) == false)
                         continue;
 
-                    indexProgress = index.GetProgress(context, overallDuration);
+                    indexProgress = index.GetProgress(context, overallDuration, exact: _indexesWithExactProgress.Contains(index.Name));
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Indexes/IndexHandlerProcessorForProgress.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Primitives;
 using Raven.Client.Documents.Indexes;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Json;
@@ -17,11 +16,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Indexes;
 
 internal sealed class IndexHandlerProcessorForProgress : AbstractIndexHandlerProcessorForProgress<DatabaseRequestHandler, DocumentsOperationContext>
 {
-    private readonly HashSet<string> _indexesWithExactProgress;
-
-    public IndexHandlerProcessorForProgress([NotNull] DatabaseRequestHandler requestHandler, StringValues indexesWithExactProgress) : base(requestHandler)
+    public IndexHandlerProcessorForProgress([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
     {
-        _indexesWithExactProgress = indexesWithExactProgress.ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
 
     protected override bool SupportsCurrentNode => true;
@@ -37,6 +33,9 @@ internal sealed class IndexHandlerProcessorForProgress : AbstractIndexHandlerPro
 
     private IEnumerable<IndexProgress> GetIndexesProgress()
     {
+        var names = GetNames().ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var exact = IsExact();
+
         using (var context = QueryOperationContext.Allocate(RequestHandler.Database, needsServerContext: true))
         using (context.OpenReadTransaction())
         {
@@ -44,13 +43,16 @@ internal sealed class IndexHandlerProcessorForProgress : AbstractIndexHandlerPro
 
             foreach (var index in RequestHandler.Database.IndexStore.GetIndexes())
             {
+                if (names.Count > 0 && names.Contains(index.Name) == false)
+                    continue;
+
                 IndexProgress indexProgress = null;
                 try
                 {
                     if (index.DeployedOnAllNodes && index.IsStale(context) == false)
                         continue;
 
-                    indexProgress = index.GetProgress(context, overallDuration, exact: _indexesWithExactProgress.Contains(index.Name));
+                    indexProgress = index.GetProgress(context, overallDuration, exact);
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForProgress.cs
@@ -20,11 +20,13 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
 
         protected override RavenCommand<IReplicationTaskProgress[]> CreateCommandForNode(string nodeTag)
         {
+            var exact = IsExact();
+
             if (_internalReplication)
-                return new GetOutgoingInternalReplicationProgressCommand(nodeTag);
+                return new GetOutgoingInternalReplicationProgressCommand(nodeTag, exact);
 
             var names = GetNames();
-            return new GetReplicationOngoingTasksProgressCommand(names, nodeTag);
+            return new GetReplicationOngoingTasksProgressCommand(names, nodeTag, exact);
         }
 
         protected StringValues GetNames() => RequestHandler.GetStringValuesQueryString("name", required: false);

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/AbstractReplicationHandlerProcessorForProgress.cs
@@ -28,5 +28,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         }
 
         protected StringValues GetNames() => RequestHandler.GetStringValuesQueryString("name", required: false);
+
+        protected bool IsExact() => RequestHandler.GetBoolValueQueryString("exact", required: false) ?? false;
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOngoingTasksProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOngoingTasksProgress.cs
@@ -39,6 +39,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         public IDictionary<long, ReplicationTaskProgress> GetProcessesProgress(DocumentsOperationContext context, StringValues names)
         {
             var replicationTasks = new Dictionary<long, ReplicationTaskProgress>();
+            var isExact = IsExact();
 
             foreach (var handler in RequestHandler.Database.ReplicationLoader.OutgoingHandlers)
             {
@@ -62,14 +63,14 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
                         ReplicationType = node.Type,
                         ProcessesProgress = new List<ReplicationProcessProgress>
                         {
-                            RequestHandler.Database.ReplicationLoader.GetOutgoingReplicationProgress(context, handler)
+                            RequestHandler.Database.ReplicationLoader.GetOutgoingReplicationProgress(context, handler, isExact)
                         }
                     };
 
                     continue;
                 }
 
-                taskProgress.ProcessesProgress.Add(RequestHandler.Database.ReplicationLoader.GetOutgoingReplicationProgress(context, handler));
+                taskProgress.ProcessesProgress.Add(RequestHandler.Database.ReplicationLoader.GetOutgoingReplicationProgress(context, handler, isExact));
             }
 
             return replicationTasks;

--- a/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingInternalReplicationProgress.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Replication/ReplicationHandlerProcessorForGetOutgoingInternalReplicationProgress.cs
@@ -38,6 +38,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
         {
             var replicationTasks = new List<InternalReplicationTaskProgress>();
 
+            var isExact = IsExact();
+
             foreach (var handler in RequestHandler.Database.ReplicationLoader.OutgoingHandlers)
             {
                 if (handler is not OutgoingInternalReplicationHandler || 
@@ -51,7 +53,7 @@ namespace Raven.Server.Documents.Handlers.Processors.Replication
                     DestinationNodeTag = internalReplication.NodeTag,
                     ProcessesProgress = new List<ReplicationProcessProgress>
                     {
-                        RequestHandler.Database.ReplicationLoader.GetOutgoingReplicationProgress(context, handler)
+                        RequestHandler.Database.ReplicationLoader.GetOutgoingReplicationProgress(context, handler, isExact)
                     }
                 });
             }

--- a/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Errors/FaultyInMemoryIndex.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.Indexes.Errors
             };
         }
 
-        internal override IndexProgress GetProgress(QueryOperationContext queryContext, Stopwatch overallDuration, bool? isStale = null)
+        internal override IndexProgress GetProgress(QueryOperationContext queryContext, Stopwatch overallDuration, bool exact)
         {
             return new IndexProgress
             {

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -2961,7 +2961,7 @@ namespace Raven.Server.Documents.Indexes
             _indexStorage.Rename(name);
         }
 
-        internal virtual IndexProgress GetProgress(QueryOperationContext queryContext, Stopwatch overallDuration, bool? isStale = null)
+        internal virtual IndexProgress GetProgress(QueryOperationContext queryContext, Stopwatch overallDuration, bool exact)
         {
             using (CurrentlyInUse(out var valid))
             {
@@ -2982,7 +2982,7 @@ namespace Raven.Server.Documents.Indexes
                     if (disposed)
                         return progress;
 
-                    UpdateIndexProgress(queryContext, progress, null, overallDuration);
+                    UpdateIndexProgress(queryContext, progress, null, overallDuration, exact);
                     return progress;
                 }
 
@@ -2997,21 +2997,21 @@ namespace Raven.Server.Documents.Indexes
                         Name = Name,
                         Type = Type,
                         SourceType = SourceType,
-                        IsStale = isStale ?? IsStale(queryContext, context),
+                        IsStale = IsStale(queryContext, context),
                         IndexRunningStatus = Status,
                         Collections = new Dictionary<string, IndexProgress.CollectionStats>(StringComparer.OrdinalIgnoreCase),
                     };
 
                     var stats = _indexStorage.ReadStats(tx);
 
-                    UpdateIndexProgress(queryContext, progress, stats, overallDuration);
+                    UpdateIndexProgress(queryContext, progress, stats, overallDuration, exact);
 
                     return progress;
                 }
             }
         }
 
-        private void UpdateIndexProgress(QueryOperationContext queryContext, IndexProgress progress, IndexStats stats, Stopwatch overallDuration)
+        private void UpdateIndexProgress(QueryOperationContext queryContext, IndexProgress progress, IndexStats stats, Stopwatch overallDuration, bool exact)
         {
             if (DeployedOnAllNodes == false)
             {
@@ -3047,7 +3047,7 @@ namespace Raven.Server.Documents.Indexes
                     };
                 }
 
-                UpdateProgressStats(queryContext, progressStats, collection, overallDuration);
+                UpdateProgressStats(queryContext, progressStats, collection, overallDuration, exact);
             }
 
             var referencedCollections = GetReferencedCollections();
@@ -3077,7 +3077,7 @@ namespace Raven.Server.Documents.Indexes
                                 LastProcessedTombstoneEtag = lastEtags.LastProcessedTombstoneEtag
                             };
 
-                            UpdateProgressStats(queryContext, progressStats, value.Name, overallDuration);
+                            UpdateProgressStats(queryContext, progressStats, value.Name, overallDuration, exact);
                         }
                     }
                 }
@@ -3085,13 +3085,13 @@ namespace Raven.Server.Documents.Indexes
         }
 
         internal virtual void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
-            Stopwatch overallDuration)
+            Stopwatch overallDuration, bool exact)
         {
             var entriesAfter = collectionName == Constants.Documents.Collections.AllDocumentsCollection
                 ? DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
-                    queryContext.Documents, progressStats.LastProcessedItemEtag, overallDuration)
+                    queryContext.Documents, progressStats.LastProcessedItemEtag, overallDuration, exact)
                 : DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration, exact);
 
             progressStats.NumberOfItemsToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfItems += entriesAfter.Total;
@@ -3099,9 +3099,9 @@ namespace Raven.Server.Documents.Indexes
 
             entriesAfter = collectionName == Constants.Documents.Collections.AllDocumentsCollection
                 ? DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
-                    queryContext.Documents, progressStats.LastProcessedTombstoneEtag, overallDuration)
+                    queryContext.Documents, progressStats.LastProcessedTombstoneEtag, overallDuration, exact)
                 : DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedTombstoneEtag, overallDuration);
+                    queryContext.Documents, collectionName, progressStats.LastProcessedTombstoneEtag, overallDuration, exact);
 
             progressStats.NumberOfTombstonesToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfTombstones += entriesAfter.Total;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -3087,19 +3087,25 @@ namespace Raven.Server.Documents.Indexes
         internal virtual void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
             Stopwatch overallDuration)
         {
-            progressStats.NumberOfItemsToProcess += collectionName == Constants.Documents.Collections.AllDocumentsCollection
+            var entriesAfter = collectionName == Constants.Documents.Collections.AllDocumentsCollection
                 ? DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
-                    queryContext.Documents, progressStats.LastProcessedItemEtag, out var totalCount, overallDuration)
+                    queryContext.Documents, progressStats.LastProcessedItemEtag, overallDuration)
                 : DocumentDatabase.DocumentsStorage.GetNumberOfDocumentsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out totalCount, overallDuration);
-            progressStats.TotalNumberOfItems += totalCount;
+                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
 
-            progressStats.NumberOfTombstonesToProcess += collectionName == Constants.Documents.Collections.AllDocumentsCollection
+            progressStats.NumberOfItemsToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfItems += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
+
+            entriesAfter = collectionName == Constants.Documents.Collections.AllDocumentsCollection
                 ? DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
-                    queryContext.Documents, progressStats.LastProcessedTombstoneEtag, out totalCount, overallDuration)
+                    queryContext.Documents, progressStats.LastProcessedTombstoneEtag, overallDuration)
                 : DocumentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedTombstoneEtag, out totalCount, overallDuration);
-            progressStats.TotalNumberOfTombstones += totalCount;
+                    queryContext.Documents, collectionName, progressStats.LastProcessedTombstoneEtag, overallDuration);
+
+            progressStats.NumberOfTombstonesToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfTombstones += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
         }
 
         private IEnumerable<string> GetCollections(QueryOperationContext queryContext, out bool isAllDocs)

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -256,10 +256,12 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
             Stopwatch overallDuration)
         {
-            progressStats.NumberOfItemsToProcess +=
-                DocumentDatabase.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out var totalNumberOfItems, overallDuration);
-            progressStats.TotalNumberOfItems += totalNumberOfItems;
+            var entriesAfter = DocumentDatabase.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+
+            progressStats.NumberOfItemsToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfItems += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
         }
 
         public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapCountersIndex.cs
@@ -254,10 +254,10 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
         }
 
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
-            Stopwatch overallDuration)
+            Stopwatch overallDuration, bool exact)
         {
             var entriesAfter = DocumentDatabase.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(
-                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration, exact);
 
             progressStats.NumberOfItemsToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfItems += entriesAfter.Total;

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
@@ -132,10 +132,10 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
         }
         
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
-            Stopwatch overallDuration)
+            Stopwatch overallDuration, bool exact)
         {
             var entriesAfter = DocumentDatabase.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(
-                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration, exact);
             
             progressStats.NumberOfItemsToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfItems += entriesAfter.Total;

--- a/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Counters/MapReduceCountersIndex.cs
@@ -134,10 +134,12 @@ namespace Raven.Server.Documents.Indexes.Static.Counters
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
             Stopwatch overallDuration)
         {
-            progressStats.NumberOfItemsToProcess +=
-                DocumentDatabase.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out var totalCount,overallDuration);
-            progressStats.TotalNumberOfItems += totalCount;
+            var entriesAfter = DocumentDatabase.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+            
+            progressStats.NumberOfItemsToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfItems += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
         }
 
         public override Dictionary<string, long> GetLastProcessedTombstonesPerCollection(ITombstoneAware.TombstoneType tombstoneType, Dictionary<string, LastTombstoneInfo> lastProcessedTombstonesInfo = null)

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -160,17 +160,17 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
         }
         
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
-            Stopwatch overallDuration)
+            Stopwatch overallDuration, bool exact)
         {
             var entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(
-                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration, exact);
 
             progressStats.NumberOfItemsToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfItems += entriesAfter.Total;
             progressStats.Estimated |= entriesAfter.Estimated;
 
             entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(queryContext.Documents, collectionName,
-                progressStats.LastProcessedTimeSeriesDeletedRangeEtag, overallDuration);
+                progressStats.LastProcessedTimeSeriesDeletedRangeEtag, overallDuration, exact);
 
             progressStats.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapReduceTimeSeriesIndex.cs
@@ -162,15 +162,19 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
             Stopwatch overallDuration)
         {
-            progressStats.NumberOfItemsToProcess +=
-                DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out var totalCount, overallDuration);
-            progressStats.TotalNumberOfItems += totalCount;
+            var entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
 
-            progressStats.NumberOfTimeSeriesDeletedRangesToProcess +=
-                DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(queryContext.Documents, collectionName,
-                    progressStats.LastProcessedTimeSeriesDeletedRangeEtag, out totalCount, overallDuration);
-            progressStats.TotalNumberOfTimeSeriesDeletedRanges += totalCount;
+            progressStats.NumberOfItemsToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfItems += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
+
+            entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(queryContext.Documents, collectionName,
+                progressStats.LastProcessedTimeSeriesDeletedRangeEtag, overallDuration);
+
+            progressStats.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
         }
 
         internal void HandleTimeSeriesDelete(TombstoneIndexItem tombstone, TransactionOperationContext indexContext)

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -300,17 +300,17 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
         }
 
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
-            Stopwatch overallDuration)
+            Stopwatch overallDuration, bool exact)
         {
             var entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(
-                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration, exact);
 
             progressStats.NumberOfItemsToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfItems += entriesAfter.Total;
             progressStats.Estimated |= entriesAfter.Estimated;
 
             entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(queryContext.Documents, collectionName,
-                progressStats.LastProcessedTimeSeriesDeletedRangeEtag, overallDuration);
+                progressStats.LastProcessedTimeSeriesDeletedRangeEtag, overallDuration, exact);
 
             progressStats.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
             progressStats.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;

--- a/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/TimeSeries/MapTimeSeriesIndex.cs
@@ -302,16 +302,19 @@ namespace Raven.Server.Documents.Indexes.Static.TimeSeries
         internal override void UpdateProgressStats(QueryOperationContext queryContext, IndexProgress.CollectionStats progressStats, string collectionName,
             Stopwatch overallDuration)
         {
-            progressStats.NumberOfItemsToProcess +=
-                DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(
-                    queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, out var totalCount, overallDuration);
-            progressStats.TotalNumberOfItems += totalCount;
+            var entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(
+                queryContext.Documents, collectionName, progressStats.LastProcessedItemEtag, overallDuration);
 
+            progressStats.NumberOfItemsToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfItems += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
 
-            progressStats.NumberOfTimeSeriesDeletedRangesToProcess +=
-                DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(queryContext.Documents, collectionName,
-                    progressStats.LastProcessedTimeSeriesDeletedRangeEtag, out totalCount, overallDuration);
-            progressStats.TotalNumberOfTimeSeriesDeletedRanges += totalCount;
+            entriesAfter = DocumentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(queryContext.Documents, collectionName,
+                progressStats.LastProcessedTimeSeriesDeletedRangeEtag, overallDuration);
+
+            progressStats.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
+            progressStats.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;
+            progressStats.Estimated |= entriesAfter.Estimated;
         }
     }
 }

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2048,7 +2048,7 @@ namespace Raven.Server.Documents.Replication
             var result = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentsToProcess(documentsContext, lastProcessedEtag, overallDuration, exact);
             progress.NumberOfAttachmentsToProcess = result.Count;
             progress.TotalNumberOfAttachments = result.Total;
-            progress.Estimated = result.Estimated;
+            progress.Estimated |= result.Estimated;
 
             progress.TotalNumberOfRevisionTombstones = Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionTombstones(documentsContext);
             progress.TotalNumberOfAttachmentTombstones = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentTombstones(documentsContext);

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -2010,32 +2010,46 @@ namespace Raven.Server.Documents.Replication
 
             var collections = Database.DocumentsStorage.GetCollections(documentsContext).Select(x => x.Name);
 
-            long total;
             var overallDuration = Stopwatch.StartNew();
 
             foreach (var collection in collections)
             {
-                progress.NumberOfDocumentsToProcess += Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                progress.TotalNumberOfDocuments += total;
+                var entriesAfter = Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                progress.NumberOfDocumentsToProcess += entriesAfter.Count;
+                progress.TotalNumberOfDocuments += entriesAfter.Total;
+                progress.Estimated |= entriesAfter.Estimated;
 
-                progress.NumberOfDocumentTombstonesToProcess += Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                progress.TotalNumberOfDocumentTombstones += total;
+                entriesAfter = Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                progress.NumberOfDocumentTombstonesToProcess += entriesAfter.Count;
+                progress.TotalNumberOfDocumentTombstones += entriesAfter.Total;
+                progress.Estimated |= entriesAfter.Estimated;
 
-                progress.NumberOfRevisionsToProcess += Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionsToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                progress.TotalNumberOfRevisions += total;
+                entriesAfter = Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                progress.NumberOfRevisionsToProcess += entriesAfter.Count;
+                progress.TotalNumberOfRevisions += entriesAfter.Total;
+                progress.Estimated |= entriesAfter.Estimated;
 
-                progress.NumberOfCounterGroupsToProcess += Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                progress.TotalNumberOfCounterGroups += total;
+                entriesAfter = Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                progress.NumberOfCounterGroupsToProcess += entriesAfter.Count;
+                progress.TotalNumberOfCounterGroups += entriesAfter.Total;
+                progress.Estimated |= entriesAfter.Estimated;
 
-                progress.NumberOfTimeSeriesSegmentsToProcess += Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                progress.TotalNumberOfTimeSeriesSegments += total;
+                entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                progress.NumberOfTimeSeriesSegmentsToProcess += entriesAfter.Count;
+                progress.TotalNumberOfTimeSeriesSegments += entriesAfter.Total;
+                progress.Estimated |= entriesAfter.Estimated;
 
-                progress.NumberOfTimeSeriesDeletedRangesToProcess += Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, out total, overallDuration);
-                progress.TotalNumberOfTimeSeriesDeletedRanges += total;
+                entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                progress.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
+                progress.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;
+                progress.Estimated |= entriesAfter.Estimated;
             }
 
-            progress.NumberOfAttachmentsToProcess = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentsToProcess(documentsContext, lastProcessedEtag, out total, overallDuration);
-            progress.TotalNumberOfAttachments = total;
+            var result = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentsToProcess(documentsContext, lastProcessedEtag, overallDuration);
+            progress.NumberOfAttachmentsToProcess = result.Count;
+            progress.TotalNumberOfAttachments = result.Total;
+            progress.Estimated = result.Estimated;
+
             progress.TotalNumberOfRevisionTombstones = Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionTombstones(documentsContext);
             progress.TotalNumberOfAttachmentTombstones = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentTombstones(documentsContext);
 

--- a/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationLoader.cs
@@ -1993,7 +1993,7 @@ namespace Raven.Server.Documents.Replication
             return false;
         }
 
-        internal ReplicationProcessProgress GetOutgoingReplicationProgress(DocumentsOperationContext documentsContext, DatabaseOutgoingReplicationHandler handler)
+        internal ReplicationProcessProgress GetOutgoingReplicationProgress(DocumentsOperationContext documentsContext, DatabaseOutgoingReplicationHandler handler, bool exact)
         {
             var lastProcessedEtag = handler.LastSentDocumentEtag;
 
@@ -2014,38 +2014,38 @@ namespace Raven.Server.Documents.Replication
 
             foreach (var collection in collections)
             {
-                var entriesAfter = Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                var entriesAfter = Database.DocumentsStorage.GetNumberOfDocumentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 progress.NumberOfDocumentsToProcess += entriesAfter.Count;
                 progress.TotalNumberOfDocuments += entriesAfter.Total;
                 progress.Estimated |= entriesAfter.Estimated;
 
-                entriesAfter = Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                entriesAfter = Database.DocumentsStorage.GetNumberOfTombstonesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 progress.NumberOfDocumentTombstonesToProcess += entriesAfter.Count;
                 progress.TotalNumberOfDocumentTombstones += entriesAfter.Total;
                 progress.Estimated |= entriesAfter.Estimated;
 
-                entriesAfter = Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                entriesAfter = Database.DocumentsStorage.RevisionsStorage.GetNumberOfRevisionsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 progress.NumberOfRevisionsToProcess += entriesAfter.Count;
                 progress.TotalNumberOfRevisions += entriesAfter.Total;
                 progress.Estimated |= entriesAfter.Estimated;
 
-                entriesAfter = Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                entriesAfter = Database.DocumentsStorage.CountersStorage.GetNumberOfCounterGroupsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 progress.NumberOfCounterGroupsToProcess += entriesAfter.Count;
                 progress.TotalNumberOfCounterGroups += entriesAfter.Total;
                 progress.Estimated |= entriesAfter.Estimated;
 
-                entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegmentsToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 progress.NumberOfTimeSeriesSegmentsToProcess += entriesAfter.Count;
                 progress.TotalNumberOfTimeSeriesSegments += entriesAfter.Total;
                 progress.Estimated |= entriesAfter.Estimated;
 
-                entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration);
+                entriesAfter = Database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRangesToProcess(documentsContext, collection, lastProcessedEtag, overallDuration, exact);
                 progress.NumberOfTimeSeriesDeletedRangesToProcess += entriesAfter.Count;
                 progress.TotalNumberOfTimeSeriesDeletedRanges += entriesAfter.Total;
                 progress.Estimated |= entriesAfter.Estimated;
             }
 
-            var result = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentsToProcess(documentsContext, lastProcessedEtag, overallDuration);
+            var result = Database.DocumentsStorage.AttachmentsStorage.GetNumberOfAttachmentsToProcess(documentsContext, lastProcessedEtag, overallDuration, exact);
             progress.NumberOfAttachmentsToProcess = result.Count;
             progress.TotalNumberOfAttachments = result.Total;
             progress.Estimated = result.Estimated;

--- a/src/Raven.Server/Documents/Replication/Stats/ReplicationTaskProgress.cs
+++ b/src/Raven.Server/Documents/Replication/Stats/ReplicationTaskProgress.cs
@@ -35,6 +35,8 @@ namespace Raven.Server.Documents.Replication.Stats
 
         public string SourceChangeVector { get; set; }
 
+        public bool Estimated { get; set; }
+
         public long NumberOfDocumentsToProcess { get; set; }
 
         public long TotalNumberOfDocuments { get; set; }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -26,6 +26,7 @@ using Sparrow.Platform;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Voron;
+using Voron.Data.Fixed;
 using Voron.Data.Tables;
 using Voron.Exceptions;
 using Voron.Impl;
@@ -2938,25 +2939,19 @@ namespace Raven.Server.Documents.Revisions
             return table.GetNumberOfEntriesFor(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice]);
         }
 
-        public long GetNumberOfRevisionsToProcess(DocumentsOperationContext context, string collection, long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfRevisionsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null || collectionName.IsHiLo)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var table = context.Transaction.InnerTransaction.OpenTable(RevisionsSchema, collectionName.GetTableName(CollectionTableType.Revisions));
 
             if (table == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var indexDef = RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
         public long GetNumberOfRevisionTombstones(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2939,7 +2939,7 @@ namespace Raven.Server.Documents.Revisions
             return table.GetNumberOfEntriesFor(RevisionsSchema.FixedSizeIndexes[AllRevisionsEtagsSlice]);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfRevisionsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfRevisionsToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null || collectionName.IsHiLo)
@@ -2951,7 +2951,7 @@ namespace Raven.Server.Documents.Revisions
                 return new NumberOfEntriesAfterResult();
 
             var indexDef = RevisionsSchema.FixedSizeIndexes[CollectionRevisionsEtagsSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public long GetNumberOfRevisionTombstones(DocumentsOperationContext context)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2470,6 +2470,27 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
+        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        {
+            var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
+            TableSchema.FixedSizeKeyIndexDef indexDef = DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice];
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out _, overallDuration);
+        }
+
+        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        {
+            var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
+            if (collectionName == null)
+                return 0;
+
+            var table = GetOrCreateDeleteRangesTable(context.Transaction.InnerTransaction, collectionName);
+            if (table == null)
+                return 0;
+
+            TableSchema.FixedSizeKeyIndexDef indexDef = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out _, overallDuration);
+        }
+
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesForDoc(DocumentsOperationContext context, string docId)
         {
             var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -2471,14 +2471,14 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
             TableSchema.FixedSizeKeyIndexDef indexDef = DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -2489,7 +2489,7 @@ namespace Raven.Server.Documents.TimeSeries
                 return new NumberOfEntriesAfterResult();
 
             TableSchema.FixedSizeKeyIndexDef indexDef = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesForDoc(DocumentsOperationContext context, string docId)
@@ -2975,7 +2975,7 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTimeSeriesSegmentsToProcess(DocumentsOperationContext context, string collection, in long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTimeSeriesSegmentsToProcess(DocumentsOperationContext context, string collection, in long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -2988,10 +2988,10 @@ namespace Raven.Server.Documents.TimeSeries
 
             var indexDef = TimeSeriesSchema.FixedSizeIndexes[CollectionTimeSeriesEtagsSlice];
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
-        public NumberOfEntriesAfterResult GetNumberOfTimeSeriesDeletedRangesToProcess(DocumentsOperationContext context, string collection, in long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTimeSeriesDeletedRangesToProcess(DocumentsOperationContext context, string collection, in long afterEtag, Stopwatch overallDuration, bool exact)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
@@ -3004,7 +3004,7 @@ namespace Raven.Server.Documents.TimeSeries
 
             var indexDef = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration, exact);
         }
 
         [Conditional("DEBUG")]

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -30,6 +30,7 @@ using Sparrow.Server;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
 using Voron;
+using Voron.Data.Fixed;
 using Voron.Data.Tables;
 using Voron.Impl;
 using static Raven.Server.Documents.Schemas.DeletedRanges;
@@ -2470,25 +2471,25 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, long afterEtag, Stopwatch overallDuration)
         {
             var table = new Table(DeleteRangesSchema, context.Transaction.InnerTransaction);
             TableSchema.FixedSizeKeyIndexDef indexDef = DeleteRangesSchema.FixedSizeIndexes[AllDeletedRangesEtagSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out _, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
-        public long GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTombstonesToProcess(DocumentsOperationContext context, string collection, long afterEtag, Stopwatch overallDuration)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
-                return 0;
+                return new NumberOfEntriesAfterResult();
 
             var table = GetOrCreateDeleteRangesTable(context.Transaction.InnerTransaction, collectionName);
             if (table == null)
-                return 0;
+                return new NumberOfEntriesAfterResult();
 
             TableSchema.FixedSizeKeyIndexDef indexDef = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out _, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
         public IEnumerable<TimeSeriesDeletedRangeItem> GetDeletedRangesForDoc(DocumentsOperationContext context, string docId)
@@ -2974,48 +2975,36 @@ namespace Raven.Server.Documents.TimeSeries
             }
         }
 
-        public long GetNumberOfTimeSeriesSegmentsToProcess(DocumentsOperationContext context, string collection, in long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTimeSeriesSegmentsToProcess(DocumentsOperationContext context, string collection, in long afterEtag, Stopwatch overallDuration)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var table = GetOrCreateTimeSeriesTable(context.Transaction.InnerTransaction, collectionName);
 
             if (table == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var indexDef = TimeSeriesSchema.FixedSizeIndexes[CollectionTimeSeriesEtagsSlice];
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
-        public long GetNumberOfTimeSeriesDeletedRangesToProcess(DocumentsOperationContext context, string collection, in long afterEtag, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfTimeSeriesDeletedRangesToProcess(DocumentsOperationContext context, string collection, in long afterEtag, Stopwatch overallDuration)
         {
             var collectionName = _documentsStorage.GetCollection(collection, throwIfDoesNotExist: false);
             if (collectionName == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var table = GetOrCreateDeleteRangesTable(context.Transaction.InnerTransaction, collectionName);
 
             if (table == null)
-            {
-                totalCount = 0;
-                return 0;
-            }
+                return new NumberOfEntriesAfterResult();
 
             var indexDef = DeleteRangesSchema.FixedSizeIndexes[CollectionDeletedRangesEtagsSlice];
 
-            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, out totalCount, overallDuration);
+            return table.GetNumberOfEntriesAfter(indexDef, afterEtag, overallDuration);
         }
 
         [Conditional("DEBUG")]

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -215,6 +215,8 @@ namespace Raven.Server.Documents
 
             _subscriptionsLocker.Wait();
 
+            var overallDuration = Stopwatch.StartNew();
+
             try
             {
                 foreach (var subscription in _subscriptions)
@@ -263,7 +265,7 @@ namespace Raven.Server.Documents
                         }
 
                         if (addInfoForDebug)
-                            result.AddPerSubscriptionInfoExtended(subscription, lastTombstoneInfo, tombstoneType, _documentDatabase, exact);
+                            result.AddPerSubscriptionInfoExtended(subscription, lastTombstoneInfo, tombstoneType, _documentDatabase, exact, overallDuration);
                     }
                 }
 
@@ -370,10 +372,8 @@ namespace Raven.Server.Documents
             }
 
             internal void AddPerSubscriptionInfoExtended(ITombstoneAware subscription, Dictionary<string, LastTombstoneInfo> lastTombstoneInfo, ITombstoneAware.TombstoneType type,
-                DocumentDatabase documentDatabase, bool exact)
+                DocumentDatabase documentDatabase, bool exact, Stopwatch overallDuration)
             {
-                var duration = Stopwatch.StartNew();
-
                 foreach (var tombstoneInfo in lastTombstoneInfo)
                 {
                     var collection = tombstoneInfo.Value.Collection;
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents
                         collection = string.Empty;
                     }
 
-                    var estimatedAfter = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, duration, exact);
+                    var estimatedAfter = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, overallDuration, exact);
 
                     var key = $"{subscription.TombstoneCleanerIdentifier}/{tombstoneInfo.Value.Name}/{collection}";
 

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -14,6 +14,7 @@ using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json.Parsing;
 using Sparrow.Logging;
+using Voron.Data.Fixed;
 
 namespace Raven.Server.Documents
 {
@@ -384,27 +385,29 @@ namespace Raven.Server.Documents
                         collection = string.Empty;
                     }
 
-                    long numberOfTombstonesLeft = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, duration);
+                    var estimatedAfter = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, duration);
 
                     var key = $"{subscription.TombstoneCleanerIdentifier}/{tombstoneInfo.Value.Name}/{collection}";
 
                     if (PerSubscriptionInfoExtended.TryGetValue(key, out SubscriptionInfoExtended existingSubscriptionInfo))
                     {
-                        UpdateSubscriptionInfo(existingSubscriptionInfo, type, numberOfTombstonesLeft);
+                        SetTombstoneTypes(type, existingSubscriptionInfo, estimatedAfter.Count);
+                        existingSubscriptionInfo.NumberOfTombstoneLeft += estimatedAfter.Count;
+                        existingSubscriptionInfo.Estimated |= estimatedAfter.Estimated;
                     }
                     else
                     {
-                        var newSubscriptionInfo = CreateSubscriptionInfo(type, tombstoneInfo.Value, collection, numberOfTombstonesLeft);
+                        var newSubscriptionInfo = CreateSubscriptionInfo(type, tombstoneInfo.Value, collection, estimatedAfter.Count, estimatedAfter.Estimated);
                         PerSubscriptionInfoExtended[key] = newSubscriptionInfo;
                     }
                 }
             }
 
-            private long CalculateRemainingTombstones(LastTombstoneInfo tombstoneInfo, ITombstoneAware.TombstoneType type, DocumentDatabase documentDatabase,
+            private NumberOfEntriesAfterResult CalculateRemainingTombstones(LastTombstoneInfo tombstoneInfo, ITombstoneAware.TombstoneType type, DocumentDatabase documentDatabase,
                 string collection, Stopwatch stopwatch)
             {
                 if (tombstoneInfo.Type == ITombstoneAware.TombstoneDeletionBlockerType.Index && type != ITombstoneAware.TombstoneType.Documents)
-                    return 0;
+                    return new NumberOfEntriesAfterResult();
 
                 using (documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
                 using (context.OpenReadTransaction())
@@ -412,8 +415,8 @@ namespace Raven.Server.Documents
                     return type switch
                     {
                         ITombstoneAware.TombstoneType.Documents => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, out _, stopwatch)
-                            : documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, out _, stopwatch),
+                            ? documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
+                            : documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch),
                         ITombstoneAware.TombstoneType.Counters => collection.IsNullOrEmpty()
                             ? documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
                             : documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1),
@@ -424,12 +427,6 @@ namespace Raven.Server.Documents
                     };
                 }
 
-            }
-
-            private void UpdateSubscriptionInfo(SubscriptionInfoExtended subscriptionInfo, ITombstoneAware.TombstoneType type, long remainingTombstones)
-            {
-                SetTombstoneTypes(type, subscriptionInfo, remainingTombstones);
-                subscriptionInfo.NumberOfTombstoneLeft += remainingTombstones;
             }
 
             private void SetTombstoneTypes(ITombstoneAware.TombstoneType type, SubscriptionInfoExtended subscriptionInfo, long numberOfTombstoneLeft)
@@ -469,6 +466,8 @@ namespace Raven.Server.Documents
 
                 public long NumberOfTombstoneLeft { get; set; }
 
+                public bool Estimated { get; set; }
+
                 public TombstoneTypes Types { get; set; }
             }
 
@@ -487,7 +486,7 @@ namespace Raven.Server.Documents
             }
 
             private SubscriptionInfoExtended CreateSubscriptionInfo(ITombstoneAware.TombstoneType type, LastTombstoneInfo tombstoneInfo, string collection,
-                long remainingTombstones)
+                long remainingTombstones, bool estimated)
             {
                 var newSubscriptionInfo = new SubscriptionInfoExtended
                 {
@@ -496,6 +495,7 @@ namespace Raven.Server.Documents
                     Collection = collection,
                     Etag = tombstoneInfo.Etag,
                     NumberOfTombstoneLeft = remainingTombstones,
+                    Estimated = estimated,
                     Types = new TombstoneTypes()
                 };
                 SetTombstoneTypes(type, newSubscriptionInfo, remainingTombstones);

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -419,7 +419,7 @@ namespace Raven.Server.Documents
                             : documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch, exact),
                         ITombstoneAware.TombstoneType.Counters => collection.IsNullOrEmpty()
                             ? documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch, exact)
-                            : documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1),
+                            : documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch, exact),
                         ITombstoneAware.TombstoneType.TimeSeries => collection.IsNullOrEmpty()
                             ? documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch, exact)
                             : documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch, exact), 

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -371,6 +371,8 @@ namespace Raven.Server.Documents
             internal void AddPerSubscriptionInfoExtended(ITombstoneAware subscription, Dictionary<string, LastTombstoneInfo> lastTombstoneInfo, ITombstoneAware.TombstoneType type,
                 DocumentDatabase documentDatabase)
             {
+                var duration = Stopwatch.StartNew();
+
                 foreach (var tombstoneInfo in lastTombstoneInfo)
                 {
                     var collection = tombstoneInfo.Value.Collection;
@@ -382,7 +384,7 @@ namespace Raven.Server.Documents
                         collection = string.Empty;
                     }
 
-                    long numberOfTombstonesLeft = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection);
+                    long numberOfTombstonesLeft = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, duration);
 
                     var key = $"{subscription.TombstoneCleanerIdentifier}/{tombstoneInfo.Value.Name}/{collection}";
 
@@ -399,7 +401,7 @@ namespace Raven.Server.Documents
             }
 
             private long CalculateRemainingTombstones(LastTombstoneInfo tombstoneInfo, ITombstoneAware.TombstoneType type, DocumentDatabase documentDatabase,
-                string collection)
+                string collection, Stopwatch stopwatch)
             {
                 if (tombstoneInfo.Type == ITombstoneAware.TombstoneDeletionBlockerType.Index && type != ITombstoneAware.TombstoneType.Documents)
                     return 0;
@@ -410,15 +412,14 @@ namespace Raven.Server.Documents
                     return type switch
                     {
                         ITombstoneAware.TombstoneType.Documents => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.GetTombstonesFrom(context, tombstoneInfo.Etag + 1, 0, long.MaxValue).Count()
-                            : documentDatabase.DocumentsStorage.GetTombstonesFrom(context, collection, tombstoneInfo.Etag + 1, 0, long.MaxValue).Count(),
+                            ? documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, out _, stopwatch)
+                            : documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, out _, stopwatch),
                         ITombstoneAware.TombstoneType.Counters => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.CountersStorage.GetCounterTombstonesFrom(context, tombstoneInfo.Etag + 1).Count()
-                            : documentDatabase.DocumentsStorage.CountersStorage.GetCounterWithCollectionTombstonesFrom(context, collection, tombstoneInfo.Etag + 1)
-                                .Count(),
+                            ? documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
+                            : documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1),
                         ITombstoneAware.TombstoneType.TimeSeries => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, tombstoneInfo.Etag + 1).Count()
-                            : documentDatabase.DocumentsStorage.TimeSeriesStorage.GetDeletedRangesFrom(context, collection, tombstoneInfo.Etag + 1).Count(), 
+                            ? documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
+                            : documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch), 
                         _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported tombstone type: {type}"),
                     };
                 }

--- a/src/Raven.Server/Documents/TombstoneCleaner.cs
+++ b/src/Raven.Server/Documents/TombstoneCleaner.cs
@@ -191,7 +191,7 @@ namespace Raven.Server.Documents
                 _documentDatabase.NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.BlockingTombstones, nameof(AlertType.BlockingTombstones)));
         }
 
-        internal TombstonesState GetState(bool addInfoForDebug = false)
+        internal TombstonesState GetState(bool addInfoForDebug = false, bool exact = false)
         {
             var result = new TombstonesState();
 
@@ -263,7 +263,7 @@ namespace Raven.Server.Documents
                         }
 
                         if (addInfoForDebug)
-                            result.AddPerSubscriptionInfoExtended(subscription, lastTombstoneInfo, tombstoneType, _documentDatabase);
+                            result.AddPerSubscriptionInfoExtended(subscription, lastTombstoneInfo, tombstoneType, _documentDatabase, exact);
                     }
                 }
 
@@ -370,7 +370,7 @@ namespace Raven.Server.Documents
             }
 
             internal void AddPerSubscriptionInfoExtended(ITombstoneAware subscription, Dictionary<string, LastTombstoneInfo> lastTombstoneInfo, ITombstoneAware.TombstoneType type,
-                DocumentDatabase documentDatabase)
+                DocumentDatabase documentDatabase, bool exact)
             {
                 var duration = Stopwatch.StartNew();
 
@@ -385,7 +385,7 @@ namespace Raven.Server.Documents
                         collection = string.Empty;
                     }
 
-                    var estimatedAfter = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, duration);
+                    var estimatedAfter = CalculateRemainingTombstones(tombstoneInfo.Value, type, documentDatabase, collection, duration, exact);
 
                     var key = $"{subscription.TombstoneCleanerIdentifier}/{tombstoneInfo.Value.Name}/{collection}";
 
@@ -404,7 +404,7 @@ namespace Raven.Server.Documents
             }
 
             private NumberOfEntriesAfterResult CalculateRemainingTombstones(LastTombstoneInfo tombstoneInfo, ITombstoneAware.TombstoneType type, DocumentDatabase documentDatabase,
-                string collection, Stopwatch stopwatch)
+                string collection, Stopwatch stopwatch, bool exact)
             {
                 if (tombstoneInfo.Type == ITombstoneAware.TombstoneDeletionBlockerType.Index && type != ITombstoneAware.TombstoneType.Documents)
                     return new NumberOfEntriesAfterResult();
@@ -415,14 +415,14 @@ namespace Raven.Server.Documents
                     return type switch
                     {
                         ITombstoneAware.TombstoneType.Documents => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
-                            : documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch),
+                            ? documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch, exact)
+                            : documentDatabase.DocumentsStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch, exact),
                         ITombstoneAware.TombstoneType.Counters => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
+                            ? documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch, exact)
                             : documentDatabase.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1),
                         ITombstoneAware.TombstoneType.TimeSeries => collection.IsNullOrEmpty()
-                            ? documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch)
-                            : documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch), 
+                            ? documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, tombstoneInfo.Etag + 1, stopwatch, exact)
+                            : documentDatabase.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, collection, tombstoneInfo.Etag + 1, stopwatch, exact), 
                         _ => throw new ArgumentOutOfRangeException(nameof(type), $"Unsupported tombstone type: {type}"),
                     };
                 }

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -223,6 +223,10 @@ namespace Raven.Server.Json
                     wp.WriteBool(processProgress.Disabled);
                     wp.WriteComma();
 
+                    wp.WritePropertyName(nameof(processProgress.Estimated));
+                    wp.WriteBool(processProgress.Estimated);
+                    wp.WriteComma();
+
                     wp.WritePropertyName(nameof(processProgress.AverageProcessedPerSecond));
                     wp.WriteDouble(processProgress.AverageProcessedPerSecond);
                     wp.WriteComma();
@@ -308,7 +312,11 @@ namespace Raven.Server.Json
                     w.WritePropertyName(nameof(processProgress.Completed));
                     w.WriteBool(processProgress.Completed);
                     w.WriteComma();
-                    
+
+                    w.WritePropertyName(nameof(processProgress.Estimated));
+                    w.WriteBool(processProgress.Estimated);
+                    w.WriteComma();
+
                     w.WritePropertyName(nameof(processProgress.HandlerId));
                     w.WriteString(processProgress.HandlerId);
                     w.WriteComma();
@@ -1676,6 +1684,10 @@ namespace Raven.Server.Json
                     writer.WritePropertyName(kvp.Key);
 
                     writer.WriteStartObject();
+
+                    writer.WritePropertyName(nameof(kvp.Value.Estimated));
+                    writer.WriteBool(kvp.Value.Estimated);
+                    writer.WriteComma();
 
                     writer.WritePropertyName(nameof(kvp.Value.LastProcessedItemEtag));
                     writer.WriteInteger(kvp.Value.LastProcessedItemEtag);

--- a/src/Raven.Studio/typescript/commands/database/index/getIndexesProgressCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/index/getIndexesProgressCommand.ts
@@ -8,20 +8,28 @@ class getIndexesProgressCommand extends commandBase {
 
     private location: databaseLocationSpecifier;
 
-    constructor(db: database | string, location: databaseLocationSpecifier) {
+    private indexNames: string[];
+
+    private exact: boolean;
+
+    constructor(db: database | string, location: databaseLocationSpecifier, indexNames: string[] = null, exact = false) {
         super();
         this.location = location;
         this.db = db;
+        this.indexNames = indexNames;
+        this.exact = exact;
     }
 
     execute(): JQueryPromise<Raven.Client.Documents.Indexes.IndexProgress[]> {
-        const url = endpoints.databases.index.indexesProgress;
         const args = {
-            ...this.location
-        }
+            ...this.location,
+            name: this.indexNames?.length ? this.indexNames : undefined,
+            exact: this.exact ? true : undefined,
+        };
+        const url = endpoints.databases.index.indexesProgress + this.urlEncodeArgs(args);
         const extractor = (response: resultsDto<Raven.Client.Documents.Indexes.IndexProgress>) => response.Results;
-        return this.query(url, args, this.db, extractor);
+        return this.query(url, null, this.db, extractor);
     }
-} 
+}
 
 export = getIndexesProgressCommand;

--- a/src/Raven.Studio/typescript/components/common/NamedProgress.tsx
+++ b/src/Raven.Studio/typescript/components/common/NamedProgress.tsx
@@ -23,7 +23,6 @@ export function NamedProgressItem(props: {
     const progressValue = formatPercentage(progress, incomplete);
     const completed = !incomplete && progress.total === progress.processed;
     const remaining = progress.total - progress.processed;
-    const estimatedSuffix = progress.estimated ? " — estimated" : "";
     const title = completed
         ? "Processed all items (" + progress.processed.toLocaleString() + ")"
         : "Processed " +
@@ -32,12 +31,10 @@ export function NamedProgressItem(props: {
           progress.total.toLocaleString() +
           " (" +
           remaining.toLocaleString() +
-          " left)" +
-          estimatedSuffix;
-    const displayValue = progress.estimated ? `~${progressValue}` : `${progressValue}`;
+          " left)";
     return (
         <div className="progress-item" title={title}>
-            <strong className="progress-percentage">{displayValue}%</strong>{" "}
+            <strong className="progress-percentage">{progressValue}%</strong>{" "}
             <div className="progress-label">{children}</div>
             <div className="progress">
                 <div className={classNames("progress-bar", { completed })} style={{ width: progressValue + "%" }} />

--- a/src/Raven.Studio/typescript/components/common/NamedProgress.tsx
+++ b/src/Raven.Studio/typescript/components/common/NamedProgress.tsx
@@ -20,9 +20,10 @@ export function NamedProgressItem(props: {
     incomplete?: boolean;
 }) {
     const { children, progress, incomplete } = props;
-    const progressFormatted = formatPercentage(progress, incomplete);
+    const progressValue = formatPercentage(progress, incomplete);
     const completed = !incomplete && progress.total === progress.processed;
     const remaining = progress.total - progress.processed;
+    const estimatedSuffix = progress.estimated ? " — estimated" : "";
     const title = completed
         ? "Processed all items (" + progress.processed.toLocaleString() + ")"
         : "Processed " +
@@ -31,13 +32,15 @@ export function NamedProgressItem(props: {
           progress.total.toLocaleString() +
           " (" +
           remaining.toLocaleString() +
-          " left)";
+          " left)" +
+          estimatedSuffix;
+    const displayValue = progress.estimated ? `~${progressValue}` : `${progressValue}`;
     return (
         <div className="progress-item" title={title}>
-            <strong className="progress-percentage">{progressFormatted}%</strong>{" "}
+            <strong className="progress-percentage">{displayValue}%</strong>{" "}
             <div className="progress-label">{children}</div>
             <div className="progress">
-                <div className={classNames("progress-bar", { completed })} style={{ width: progressFormatted + "%" }} />
+                <div className={classNames("progress-bar", { completed })} style={{ width: progressValue + "%" }} />
             </div>
         </div>
     );

--- a/src/Raven.Studio/typescript/components/models/indexes.ts
+++ b/src/Raven.Studio/typescript/components/models/indexes.ts
@@ -44,6 +44,7 @@ export interface IndexCollectionProgress {
     documents: IndexingProgress;
     tombstones: IndexingProgress;
     deletedTimeSeries: IndexingProgress;
+    estimated: boolean;
 }
 
 export interface IndexingProgress extends Progress {

--- a/src/Raven.Studio/typescript/components/models/tasks.ts
+++ b/src/Raven.Studio/typescript/components/models/tasks.ts
@@ -12,6 +12,7 @@ export interface OngoingTaskHubDefinitionSharedInfo extends OngoingTaskSharedInf
 interface Progress {
     total: number;
     processed: number;
+    estimated?: boolean;
 }
 
 export interface OngoingTaskNodeEtlProgressDetails {
@@ -24,6 +25,7 @@ export interface OngoingTaskNodeEtlProgressDetails {
     completed: boolean;
     processedPerSecond: number;
     transactionalId?: string;
+    estimated: boolean;
 }
 
 export interface OngoingTaskNodeReplicationProgressDetails {
@@ -36,6 +38,7 @@ export interface OngoingTaskNodeReplicationProgressDetails {
     revisions: Progress;
     timeSeriesDeletedRanges: Progress;
     timeSeries: Progress;
+    estimated: boolean;
 }
 
 export interface OngoingTaskNodeInternalReplicationProgressDetails extends OngoingTaskNodeReplicationProgressDetails {

--- a/src/Raven.Studio/typescript/components/models/tasks.ts
+++ b/src/Raven.Studio/typescript/components/models/tasks.ts
@@ -12,7 +12,6 @@ export interface OngoingTaskHubDefinitionSharedInfo extends OngoingTaskSharedInf
 interface Progress {
     total: number;
     processed: number;
-    estimated?: boolean;
 }
 
 export interface OngoingTaskNodeEtlProgressDetails {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -26,6 +26,7 @@ interface IndexDistributionProps {
     globalIndexingStatus: IndexRunningStatus;
     showStaleReason: (location: databaseLocationSpecifier) => void;
     openFaulty: (location: databaseLocationSpecifier) => void;
+    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
 }
 
 interface ItemWithTooltipProps {
@@ -33,6 +34,7 @@ interface ItemWithTooltipProps {
     globalIndexingStatus: IndexRunningStatus;
     showStaleReason: (location: databaseLocationSpecifier) => void;
     openFaulty: (location: databaseLocationSpecifier) => void;
+    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
     nodeInfo: IndexNodeInfo;
     sharded: boolean;
 }
@@ -42,7 +44,7 @@ function getFormattedTime(date: Date): string {
 }
 
 function ItemWithTooltip(props: ItemWithTooltipProps) {
-    const { nodeInfo, sharded, openFaulty, showStaleReason, globalIndexingStatus, index } = props;
+    const { nodeInfo, sharded, openFaulty, showStaleReason, fetchExactProgress, globalIndexingStatus, index } = props;
     const entriesCount = nodeInfo.details?.faulty ? "n/a" : (nodeInfo.details?.entriesCount ?? "");
 
     const shard = (
@@ -94,6 +96,7 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                     index={index}
                     globalIndexingStatus={globalIndexingStatus}
                     showStaleReason={showStaleReason}
+                    fetchExactProgress={fetchExactProgress}
                 />
             )}
         </div>
@@ -101,7 +104,7 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
 }
 
 export function IndexDistribution(props: IndexDistributionProps) {
-    const { index, globalIndexingStatus, showStaleReason, openFaulty } = props;
+    const { index, globalIndexingStatus, showStaleReason, openFaulty, fetchExactProgress } = props;
 
     const totalErrors = index.nodesInfo
         .filter((x) => x.status === "success")
@@ -130,6 +133,7 @@ export function IndexDistribution(props: IndexDistributionProps) {
                             globalIndexingStatus={globalIndexingStatus}
                             showStaleReason={showStaleReason}
                             openFaulty={openFaulty}
+                            fetchExactProgress={fetchExactProgress}
                         />
                     );
                 })}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexDistribution.tsx
@@ -26,7 +26,8 @@ interface IndexDistributionProps {
     globalIndexingStatus: IndexRunningStatus;
     showStaleReason: (location: databaseLocationSpecifier) => void;
     openFaulty: (location: databaseLocationSpecifier) => void;
-    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
+    exactProgress: boolean;
+    toggleExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
 }
 
 interface ItemWithTooltipProps {
@@ -34,7 +35,8 @@ interface ItemWithTooltipProps {
     globalIndexingStatus: IndexRunningStatus;
     showStaleReason: (location: databaseLocationSpecifier) => void;
     openFaulty: (location: databaseLocationSpecifier) => void;
-    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
+    exactProgress: boolean;
+    toggleExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
     nodeInfo: IndexNodeInfo;
     sharded: boolean;
 }
@@ -44,7 +46,16 @@ function getFormattedTime(date: Date): string {
 }
 
 function ItemWithTooltip(props: ItemWithTooltipProps) {
-    const { nodeInfo, sharded, openFaulty, showStaleReason, fetchExactProgress, globalIndexingStatus, index } = props;
+    const {
+        nodeInfo,
+        sharded,
+        openFaulty,
+        showStaleReason,
+        exactProgress,
+        toggleExactProgress,
+        globalIndexingStatus,
+        index,
+    } = props;
     const entriesCount = nodeInfo.details?.faulty ? "n/a" : (nodeInfo.details?.entriesCount ?? "");
 
     const shard = (
@@ -96,7 +107,8 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                     index={index}
                     globalIndexingStatus={globalIndexingStatus}
                     showStaleReason={showStaleReason}
-                    fetchExactProgress={fetchExactProgress}
+                    exactProgress={exactProgress}
+                    toggleExactProgress={toggleExactProgress}
                 />
             )}
         </div>
@@ -104,7 +116,7 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
 }
 
 export function IndexDistribution(props: IndexDistributionProps) {
-    const { index, globalIndexingStatus, showStaleReason, openFaulty, fetchExactProgress } = props;
+    const { index, globalIndexingStatus, showStaleReason, openFaulty, exactProgress, toggleExactProgress } = props;
 
     const totalErrors = index.nodesInfo
         .filter((x) => x.status === "success")
@@ -133,7 +145,8 @@ export function IndexDistribution(props: IndexDistributionProps) {
                             globalIndexingStatus={globalIndexingStatus}
                             showStaleReason={showStaleReason}
                             openFaulty={openFaulty}
-                            fetchExactProgress={fetchExactProgress}
+                            exactProgress={exactProgress}
+                            toggleExactProgress={toggleExactProgress}
                         />
                     );
                 })}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -53,6 +53,7 @@ export interface IndexPanelProps {
     deleteIndex: () => Promise<void>;
     resetIndex: (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
     openFaulty: (location: databaseLocationSpecifier) => Promise<void>;
+    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
     selected: boolean;
     hasReplacement?: boolean;
     toggleSelection: () => void;
@@ -504,6 +505,7 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                                 globalIndexingStatus={globalIndexingStatus}
                                 showStaleReason={(location) => showStaleReasons(index, location)}
                                 openFaulty={openFaulty}
+                                fetchExactProgress={props.fetchExactProgress}
                             />
                         </div>
                     </Collapse>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexPanel.tsx
@@ -53,7 +53,8 @@ export interface IndexPanelProps {
     deleteIndex: () => Promise<void>;
     resetIndex: (mode?: Raven.Client.Documents.Indexes.IndexResetMode) => void;
     openFaulty: (location: databaseLocationSpecifier) => Promise<void>;
-    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
+    exactProgress: boolean;
+    toggleExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
     selected: boolean;
     hasReplacement?: boolean;
     toggleSelection: () => void;
@@ -505,7 +506,8 @@ export function IndexPanelInternal(props: IndexPanelProps, ref: ForwardedRef<HTM
                                 globalIndexingStatus={globalIndexingStatus}
                                 showStaleReason={(location) => showStaleReasons(index, location)}
                                 openFaulty={openFaulty}
-                                fetchExactProgress={props.fetchExactProgress}
+                                exactProgress={props.exactProgress}
+                                toggleExactProgress={props.toggleExactProgress}
                             />
                         </div>
                     </Collapse>

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -27,26 +27,28 @@ interface IndexProgressTooltipProps {
     index: IndexSharedInfo;
     globalIndexingStatus: IndexRunningStatus;
     showStaleReason: (location: databaseLocationSpecifier) => void;
-    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
+    exactProgress: boolean;
+    toggleExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
 }
 
 export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
-    const { target, nodeInfo, index, globalIndexingStatus, showStaleReason, fetchExactProgress } = props;
+    const { target, nodeInfo, index, globalIndexingStatus, showStaleReason, exactProgress, toggleExactProgress } =
+        props;
 
-    const [loadingExactProgress, setLoadingExactProgress] = useState(false);
+    const [togglingExactProgress, setTogglingExactProgress] = useState(false);
 
-    const loadExactProgress = async () => {
-        if (loadingExactProgress) {
+    const onToggleExactProgress = async () => {
+        if (togglingExactProgress) {
             return;
         }
 
-        setLoadingExactProgress(true);
+        setTogglingExactProgress(true);
         try {
-            await fetchExactProgress(nodeInfo.location);
+            await toggleExactProgress(nodeInfo.location);
         } catch {
             // the (~) marker stays, the user can retry
         } finally {
-            setLoadingExactProgress(false);
+            setTogglingExactProgress(false);
         }
     };
 
@@ -159,15 +161,15 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
                             </NamedProgress>
                         );
                     })}
-                {nodeInfo.progress?.collections.some((x) => x.estimated) && (
+                {nodeInfo.progress && (exactProgress || nodeInfo.progress.collections.some((x) => x.estimated)) && (
                     <div className="px-3 pb-2">
-                        <a href="#" onClick={withPreventDefault(loadExactProgress)}>
-                            {loadingExactProgress ? (
+                        <a href="#" onClick={withPreventDefault(onToggleExactProgress)}>
+                            {togglingExactProgress ? (
                                 <Spinner size="sm" className="me-1" />
                             ) : (
                                 <Icon icon="refresh" margin="me-1" />
                             )}
-                            show exact counts
+                            {exactProgress ? "show estimated counts" : "show exact counts"}
                         </a>
                     </div>
                 )}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -18,6 +18,7 @@ import {
 import { NamedProgress, NamedProgressItem } from "components/common/NamedProgress";
 import { Icon } from "components/common/Icon";
 import copyToClipboard from "common/copyToClipboard";
+import messagePublisher from "common/messagePublisher";
 import Button from "react-bootstrap/Button";
 import Spinner from "react-bootstrap/Spinner";
 
@@ -45,8 +46,8 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
         setTogglingExactProgress(true);
         try {
             await toggleExactProgress(nodeInfo.location);
-        } catch {
-            // the (~) marker stays, the user can retry
+        } catch (e) {
+            messagePublisher.reportError("Failed to get index progress", e.responseText);
         } finally {
             setTogglingExactProgress(false);
         }

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -115,8 +115,21 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
 
                 {nodeInfo.progress &&
                     nodeInfo.progress.collections.map((collection) => {
+                        const collectionName = collection.estimated ? (
+                            <>
+                                {collection.name}{" "}
+                                <small
+                                    className="text-muted"
+                                    title="Estimated value. The exact count takes too long to calculate and will be skipped for performance."
+                                >
+                                    (~)
+                                </small>
+                            </>
+                        ) : (
+                            collection.name
+                        );
                         return (
-                            <NamedProgress name={collection.name} key={collection.name}>
+                            <NamedProgress name={collectionName} key={collection.name}>
                                 <NamedProgressItem progress={collection.documents}>documents</NamedProgressItem>
                                 <NamedProgressItem progress={collection.tombstones}>tombstones</NamedProgressItem>
                                 {index.sourceType === "TimeSeries" && (

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexProgressTooltip.tsx
@@ -2,7 +2,7 @@
 
 import moment = require("moment");
 
-import React from "react";
+import React, { useState } from "react";
 import { PopoverWithHover } from "components/common/PopoverWithHover";
 import classNames from "classnames";
 import IndexRunningStatus = Raven.Client.Documents.Indexes.IndexRunningStatus;
@@ -19,6 +19,7 @@ import { NamedProgress, NamedProgressItem } from "components/common/NamedProgres
 import { Icon } from "components/common/Icon";
 import copyToClipboard from "common/copyToClipboard";
 import Button from "react-bootstrap/Button";
+import Spinner from "react-bootstrap/Spinner";
 
 interface IndexProgressTooltipProps {
     target: HTMLElement;
@@ -26,10 +27,28 @@ interface IndexProgressTooltipProps {
     index: IndexSharedInfo;
     globalIndexingStatus: IndexRunningStatus;
     showStaleReason: (location: databaseLocationSpecifier) => void;
+    fetchExactProgress: (location: databaseLocationSpecifier) => Promise<void>;
 }
 
 export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
-    const { target, nodeInfo, index, globalIndexingStatus, showStaleReason } = props;
+    const { target, nodeInfo, index, globalIndexingStatus, showStaleReason, fetchExactProgress } = props;
+
+    const [loadingExactProgress, setLoadingExactProgress] = useState(false);
+
+    const loadExactProgress = async () => {
+        if (loadingExactProgress) {
+            return;
+        }
+
+        setLoadingExactProgress(true);
+        try {
+            await fetchExactProgress(nodeInfo.location);
+        } catch {
+            // the (~) marker stays, the user can retry
+        } finally {
+            setLoadingExactProgress(false);
+        }
+    };
 
     if (nodeInfo.status === "failure") {
         return (
@@ -140,6 +159,18 @@ export function IndexProgressTooltip(props: IndexProgressTooltipProps) {
                             </NamedProgress>
                         );
                     })}
+                {nodeInfo.progress?.collections.some((x) => x.estimated) && (
+                    <div className="px-3 pb-2">
+                        <a href="#" onClick={withPreventDefault(loadExactProgress)}>
+                            {loadingExactProgress ? (
+                                <Spinner size="sm" className="me-1" />
+                            ) : (
+                                <Icon icon="refresh" margin="me-1" />
+                            )}
+                            show exact counts
+                        </a>
+                    </div>
+                )}
             </LocationSpecificDetails>
         </PopoverWithHover>
     );

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -81,6 +81,7 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         openFaulty,
         getSelectedIndexes,
         confirmDeleteIndexes,
+        fetchExactProgress,
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,
@@ -163,6 +164,7 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         confirmDeleteIndexes,
         toggleSelection,
         highlightCallback,
+        fetchExactProgress,
     };
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPage.tsx
@@ -81,7 +81,8 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         openFaulty,
         getSelectedIndexes,
         confirmDeleteIndexes,
-        fetchExactProgress,
+        indexesWithExactProgress,
+        toggleExactProgress,
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,
@@ -164,7 +165,8 @@ export function IndexesPage({ queryParams }: ReactQueryParamsProps<IndexesPagePr
         confirmDeleteIndexes,
         toggleSelection,
         highlightCallback,
-        fetchExactProgress,
+        indexesWithExactProgress,
+        toggleExactProgress,
     };
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -26,7 +26,8 @@ export interface IndexesPageListProps {
     confirmDeleteIndexes: (indexes: IndexSharedInfo[]) => Promise<void>;
     toggleSelection: (index: IndexSharedInfo) => void;
     highlightCallback: (node: HTMLElement) => void;
-    fetchExactProgress: (index: IndexSharedInfo, location: databaseLocationSpecifier) => Promise<void>;
+    indexesWithExactProgress: string[];
+    toggleExactProgress: (index: IndexSharedInfo, location: databaseLocationSpecifier) => Promise<void>;
 }
 
 export default function IndexesPageList({
@@ -46,7 +47,8 @@ export default function IndexesPageList({
     confirmDeleteIndexes,
     toggleSelection,
     highlightCallback,
-    fetchExactProgress,
+    indexesWithExactProgress,
+    toggleExactProgress,
 }: IndexesPageListProps) {
     return (
         <>
@@ -62,8 +64,9 @@ export default function IndexesPageList({
                                 resetIndexData.openConfirm([index], mode)
                             }
                             openFaulty={(location: databaseLocationSpecifier) => openFaulty(index, location)}
-                            fetchExactProgress={(location: databaseLocationSpecifier) =>
-                                fetchExactProgress(index, location)
+                            exactProgress={indexesWithExactProgress.includes(index.name)}
+                            toggleExactProgress={(location: databaseLocationSpecifier) =>
+                                toggleExactProgress(index, location)
                             }
                             startIndexing={() => startIndexes([index])}
                             disableIndexing={() => disableIndexes([index])}
@@ -104,8 +107,9 @@ export default function IndexesPageList({
                                     resetIndexData.openConfirm([replacement], mode)
                                 }
                                 openFaulty={(location: databaseLocationSpecifier) => openFaulty(replacement, location)}
-                                fetchExactProgress={(location: databaseLocationSpecifier) =>
-                                    fetchExactProgress(replacement, location)
+                                exactProgress={indexesWithExactProgress.includes(replacement.name)}
+                                toggleExactProgress={(location: databaseLocationSpecifier) =>
+                                    toggleExactProgress(replacement, location)
                                 }
                                 startIndexing={() => startIndexes([replacement])}
                                 disableIndexing={() => disableIndexes([replacement])}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesPageList.tsx
@@ -26,6 +26,7 @@ export interface IndexesPageListProps {
     confirmDeleteIndexes: (indexes: IndexSharedInfo[]) => Promise<void>;
     toggleSelection: (index: IndexSharedInfo) => void;
     highlightCallback: (node: HTMLElement) => void;
+    fetchExactProgress: (index: IndexSharedInfo, location: databaseLocationSpecifier) => Promise<void>;
 }
 
 export default function IndexesPageList({
@@ -45,6 +46,7 @@ export default function IndexesPageList({
     confirmDeleteIndexes,
     toggleSelection,
     highlightCallback,
+    fetchExactProgress,
 }: IndexesPageListProps) {
     return (
         <>
@@ -60,6 +62,9 @@ export default function IndexesPageList({
                                 resetIndexData.openConfirm([index], mode)
                             }
                             openFaulty={(location: databaseLocationSpecifier) => openFaulty(index, location)}
+                            fetchExactProgress={(location: databaseLocationSpecifier) =>
+                                fetchExactProgress(index, location)
+                            }
                             startIndexing={() => startIndexes([index])}
                             disableIndexing={() => disableIndexes([index])}
                             pauseIndexing={() => pauseIndexes([index])}
@@ -99,6 +104,9 @@ export default function IndexesPageList({
                                     resetIndexData.openConfirm([replacement], mode)
                                 }
                                 openFaulty={(location: databaseLocationSpecifier) => openFaulty(replacement, location)}
+                                fetchExactProgress={(location: databaseLocationSpecifier) =>
+                                    fetchExactProgress(replacement, location)
+                                }
                                 startIndexing={() => startIndexes([replacement])}
                                 disableIndexing={() => disableIndexes([replacement])}
                                 pauseIndexing={() => pauseIndexes([replacement])}

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -26,6 +26,13 @@ interface ActionProgressLoadError {
     type: "ProgressLoadError";
 }
 
+interface ActionExactProgressLoaded {
+    location: databaseLocationSpecifier;
+    indexName: string;
+    progress: IndexProgress | undefined;
+    type: "ExactProgressLoaded";
+}
+
 interface ActionSetIndexPriority {
     indexName: string;
     priority: IndexPriority;
@@ -93,6 +100,7 @@ type IndexesStatsReducerAction =
     | ActionStatsLoaded
     | ActionProgressLoadError
     | ActionProgressLoaded
+    | ActionExactProgressLoaded
     | ActionSetIndexPriority
     | ActionSetIndexLockMode
     | ActionPauseIndexing
@@ -242,6 +250,36 @@ export const indexesStatsReducer: Reducer<IndexesStatsState, IndexesStatsReducer
                         }
                     }
                 });
+            });
+        }
+        case "ExactProgressLoaded": {
+            return produce(state, (draft) => {
+                const index = draft.indexes.find((x) => x.name === action.indexName);
+                if (!index) {
+                    return;
+                }
+
+                const itemToUpdate = index.nodesInfo.find((x) =>
+                    databaseLocationComparator(x.location, action.location)
+                );
+                if (!itemToUpdate) {
+                    return;
+                }
+
+                if (action.progress) {
+                    itemToUpdate.progress = mapProgress(action.progress);
+                    if (itemToUpdate.details) {
+                        itemToUpdate.details.stale = action.progress.IsStale;
+                    }
+                } else {
+                    // the index is no longer stale on that location
+                    if (itemToUpdate.progress) {
+                        markProgressAsCompleted(itemToUpdate.progress);
+                    }
+                    if (itemToUpdate.details) {
+                        itemToUpdate.details.stale = false;
+                    }
+                }
             });
         }
         case "ProgressLoadError": {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -178,6 +178,7 @@ function mapProgress(progress: IndexProgress): IndexProgressInfo {
         const stats = progress.Collections[name];
         return {
             name,
+            estimated: stats.Estimated,
             documents: {
                 processedPerSecond: 0,
                 total: stats.TotalNumberOfItems,

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -26,11 +26,11 @@ interface ActionProgressLoadError {
     type: "ProgressLoadError";
 }
 
-interface ActionExactProgressLoaded {
+interface ActionSingleIndexProgressLoaded {
     location: databaseLocationSpecifier;
     indexName: string;
     progress: IndexProgress | undefined;
-    type: "ExactProgressLoaded";
+    type: "SingleIndexProgressLoaded";
 }
 
 interface ActionSetIndexPriority {
@@ -100,7 +100,7 @@ type IndexesStatsReducerAction =
     | ActionStatsLoaded
     | ActionProgressLoadError
     | ActionProgressLoaded
-    | ActionExactProgressLoaded
+    | ActionSingleIndexProgressLoaded
     | ActionSetIndexPriority
     | ActionSetIndexLockMode
     | ActionPauseIndexing
@@ -252,7 +252,7 @@ export const indexesStatsReducer: Reducer<IndexesStatsState, IndexesStatsReducer
                 });
             });
         }
-        case "ExactProgressLoaded": {
+        case "SingleIndexProgressLoaded": {
             return produce(state, (draft) => {
                 const index = draft.indexes.find((x) => x.name === action.indexName);
                 if (!index) {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/IndexesStatsReducer.ts
@@ -17,6 +17,8 @@ interface ActionStatsLoaded {
 interface ActionProgressLoaded {
     location: databaseLocationSpecifier;
     progress: IndexProgress[];
+    // when set, only the listed indexes are updated (the response covers just a subset of the indexes)
+    scope?: string[];
     type: "ProgressLoaded";
 }
 
@@ -231,6 +233,10 @@ export const indexesStatsReducer: Reducer<IndexesStatsState, IndexesStatsReducer
 
             return produce(state, (draft) => {
                 draft.indexes.forEach((index) => {
+                    if (action.scope && !action.scope.includes(index.name)) {
+                        return;
+                    }
+
                     const itemToUpdate = index.nodesInfo.find((x) =>
                         databaseLocationComparator(x.location, incomingLocation)
                     );

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -147,8 +147,14 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
     const [indexesWithExactProgress, setIndexesWithExactProgress] = useState<string[]>([]);
 
     const indexNamesRef = useRef<string[]>([]);
+    const staleIndexNamesRef = useRef<string[]>([]);
     useEffect(() => {
         indexNamesRef.current = stats.indexes.map((x) => x.name);
+
+        // staleness can differ between nodes - an index counts as stale when at least one node reports it stale
+        staleIndexNamesRef.current = stats.indexes
+            .filter((x) => x.nodesInfo.some((n) => n.details?.stale))
+            .map((x) => x.name);
     }, [stats.indexes]);
 
     const fetchProgress = async (location: databaseLocationSpecifier) => {
@@ -160,8 +166,11 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
                 progress = await indexesService.getProgress(db.name, location);
             } else {
                 // split into two complementary requests so the expensive exact calculation
-                // runs only for the indexes the user asked for
-                const estimatedNames = indexNamesRef.current.filter((x) => !indexesWithExactProgressRef.current.has(x));
+                // runs only for the indexes the user asked for;
+                // the server skips non-stale indexes anyway, so only the stale ones are sent
+                const estimatedNames = staleIndexNamesRef.current.filter(
+                    (x) => !indexesWithExactProgressRef.current.has(x)
+                );
 
                 const requests = [indexesService.getProgress(db.name, location, exactNames, true)];
                 if (estimatedNames.length > 0) {

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -158,40 +158,60 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
     }, [stats.indexes]);
 
     const fetchProgress = async (location: databaseLocationSpecifier) => {
-        try {
-            const exactNames = indexNamesRef.current.filter((x) => indexesWithExactProgressRef.current.has(x));
+        const exactNames = indexNamesRef.current.filter((x) => indexesWithExactProgressRef.current.has(x));
 
-            let progress: Raven.Client.Documents.Indexes.IndexProgress[];
-            if (exactNames.length === 0) {
-                progress = await indexesService.getProgress(db.name, location);
-            } else {
-                // split into two complementary requests so the expensive exact calculation
-                // runs only for the indexes the user asked for;
-                // the server skips non-stale indexes anyway, so only the stale ones are sent
-                const estimatedNames = staleIndexNamesRef.current.filter(
-                    (x) => !indexesWithExactProgressRef.current.has(x)
-                );
+        if (exactNames.length === 0) {
+            try {
+                const progress = await indexesService.getProgress(db.name, location);
 
-                const requests = [indexesService.getProgress(db.name, location, exactNames, true)];
-                if (estimatedNames.length > 0) {
-                    requests.push(indexesService.getProgress(db.name, location, estimatedNames));
-                }
-
-                progress = (await Promise.all(requests)).flat();
+                dispatch({
+                    type: "ProgressLoaded",
+                    progress,
+                    location,
+                });
+            } catch (e) {
+                dispatch({
+                    type: "ProgressLoadError",
+                    error: e,
+                    location,
+                });
             }
+            return;
+        }
 
-            dispatch({
-                type: "ProgressLoaded",
-                progress,
-                location,
-            });
-        } catch (e) {
+        // split into two complementary requests so the expensive exact calculation
+        // runs only for the indexes the user asked for;
+        // the server skips non-stale indexes anyway, so only the stale ones are sent
+        const estimatedNames = staleIndexNamesRef.current.filter((x) => !indexesWithExactProgressRef.current.has(x));
+
+        const scopes = [{ names: exactNames, exact: true }];
+        if (estimatedNames.length > 0) {
+            scopes.push({ names: estimatedNames, exact: false });
+        }
+
+        const results = await Promise.allSettled(
+            scopes.map((x) => indexesService.getProgress(db.name, location, x.names, x.exact))
+        );
+
+        if (results.every((x) => x.status === "rejected")) {
             dispatch({
                 type: "ProgressLoadError",
-                error: e,
+                error: (results[0] as PromiseRejectedResult).reason,
                 location,
             });
+            return;
         }
+
+        results.forEach((result, i) => {
+            if (result.status === "fulfilled") {
+                dispatch({
+                    type: "ProgressLoaded",
+                    progress: result.value,
+                    location,
+                    scope: scopes[i].names,
+                });
+            }
+        });
     };
 
     const fetchSingleIndexProgress = async (

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -161,6 +161,17 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         }
     };
 
+    const fetchExactProgress = async (index: IndexSharedInfo, location: databaseLocationSpecifier) => {
+        const progress = await indexesService.getProgress(db.name, location, [index.name], true);
+
+        dispatch({
+            type: "ExactProgressLoaded",
+            progress: progress.find((x) => x.Name === index.name),
+            indexName: index.name,
+            location,
+        });
+    };
+
     const fetchStats = useCallback(
         async (location: databaseLocationSpecifier) => {
             const stats = await indexesService.getStats(db.name, location);
@@ -881,6 +892,7 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         } satisfies SwapSideBySideData,
         openFaulty,
         confirmDeleteIndexes,
+        fetchExactProgress,
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,

--- a/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/list/useIndexesPage.tsx
@@ -143,9 +143,33 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         return groupedIndexes;
     }, [filter, stats.indexes]);
 
+    const indexesWithExactProgressRef = useRef<Set<string>>(new Set());
+    const [indexesWithExactProgress, setIndexesWithExactProgress] = useState<string[]>([]);
+
+    const indexNamesRef = useRef<string[]>([]);
+    useEffect(() => {
+        indexNamesRef.current = stats.indexes.map((x) => x.name);
+    }, [stats.indexes]);
+
     const fetchProgress = async (location: databaseLocationSpecifier) => {
         try {
-            const progress = await indexesService.getProgress(db.name, location);
+            const exactNames = indexNamesRef.current.filter((x) => indexesWithExactProgressRef.current.has(x));
+
+            let progress: Raven.Client.Documents.Indexes.IndexProgress[];
+            if (exactNames.length === 0) {
+                progress = await indexesService.getProgress(db.name, location);
+            } else {
+                // split into two complementary requests so the expensive exact calculation
+                // runs only for the indexes the user asked for
+                const estimatedNames = indexNamesRef.current.filter((x) => !indexesWithExactProgressRef.current.has(x));
+
+                const requests = [indexesService.getProgress(db.name, location, exactNames, true)];
+                if (estimatedNames.length > 0) {
+                    requests.push(indexesService.getProgress(db.name, location, estimatedNames));
+                }
+
+                progress = (await Promise.all(requests)).flat();
+            }
 
             dispatch({
                 type: "ProgressLoaded",
@@ -161,15 +185,33 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         }
     };
 
-    const fetchExactProgress = async (index: IndexSharedInfo, location: databaseLocationSpecifier) => {
-        const progress = await indexesService.getProgress(db.name, location, [index.name], true);
+    const fetchSingleIndexProgress = async (
+        index: IndexSharedInfo,
+        location: databaseLocationSpecifier,
+        exact: boolean
+    ) => {
+        const progress = await indexesService.getProgress(db.name, location, [index.name], exact);
 
         dispatch({
-            type: "ExactProgressLoaded",
+            type: "SingleIndexProgressLoaded",
             progress: progress.find((x) => x.Name === index.name),
             indexName: index.name,
             location,
         });
+    };
+
+    const toggleExactProgress = async (index: IndexSharedInfo, location: databaseLocationSpecifier) => {
+        const set = indexesWithExactProgressRef.current;
+        const exact = !set.has(index.name);
+
+        if (exact) {
+            set.add(index.name);
+        } else {
+            set.delete(index.name);
+        }
+        setIndexesWithExactProgress(Array.from(set));
+
+        await fetchSingleIndexProgress(index, location, exact);
     };
 
     const fetchStats = useCallback(
@@ -892,7 +934,8 @@ export function useIndexesPage(stale: boolean, isImportOpen: boolean) {
         } satisfies SwapSideBySideData,
         openFaulty,
         confirmDeleteIndexes,
-        fetchExactProgress,
+        indexesWithExactProgress,
+        toggleExactProgress,
         globalIndexingStatus,
         isImportIndexModalOpen,
         toggleIsImportIndexModalOpen,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.spec.tsx
@@ -16,7 +16,7 @@ describe("TombstonesState", () => {
     it("shows ~ prefix for estimated tombstone counts", async () => {
         const { screen } = rtlRender(<Tombstones />);
 
-        expect(await screen.findByText("~1500")).toBeInTheDocument();
-        expect(await screen.findByText("Documents: ~1200, TimeSeries: ~200, Counters: ~100")).toBeInTheDocument();
+        expect(await screen.findByText("~1,500")).toBeInTheDocument();
+        expect(await screen.findByText("Documents: ~1,200, TimeSeries: ~200, Counters: ~100")).toBeInTheDocument();
     });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/TombstonesState.spec.tsx
@@ -12,4 +12,11 @@ describe("TombstonesState", () => {
         expect(await screen.findByRole("heading", { name: /Per Collection/ })).toBeInTheDocument();
         expect(await screen.findByRole("heading", { name: /Per Task/ })).toBeInTheDocument();
     });
+
+    it("shows ~ prefix for estimated tombstone counts", async () => {
+        const { screen } = rtlRender(<Tombstones />);
+
+        expect(await screen.findByText("~1500")).toBeInTheDocument();
+        expect(await screen.findByText("Documents: ~1200, TimeSeries: ~200, Counters: ~100")).toBeInTheDocument();
+    });
 });

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/useTombstonesStateColumns.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/useTombstonesStateColumns.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Getter, ColumnDef } from "@tanstack/react-table";
-import { CellValueWrapper } from "components/common/virtualTable/cells/CellValue";
+import CellValue, { CellValueWrapper } from "components/common/virtualTable/cells/CellValue";
 import { virtualTableUtils } from "components/common/virtualTable/utils/virtualTableUtils";
 import SubscriptionInfoExtended = Raven.Server.Documents.TombstoneCleaner.TombstonesState.SubscriptionInfoExtended;
 
@@ -126,7 +126,7 @@ function formatTombstoneTypes(
         return "";
     }
 
-    const fmt = (n: number) => (estimated ? `~${n}` : String(n));
+    const fmt = (n: number) => (estimated ? `~${n.toLocaleString()}` : n.toLocaleString());
 
     if (process === "Index") {
         return `Documents: ${fmt(types.Documents)}`;
@@ -149,7 +149,7 @@ function getEtagTitle(etagValue: number) {
 
 function CellEtagWrapper({ getValue }: { getValue: Getter<number> }) {
     const value = getValue();
-    return <CellValue value={formatEtag(value)} title={getEtagTitle(value)} />;
+    return <CellEtagValue value={formatEtag(value)} title={getEtagTitle(value)} />;
 }
 
 function CellTombstoneCountWrapper({
@@ -160,13 +160,19 @@ function CellTombstoneCountWrapper({
     row: { original: SubscriptionInfoExtended };
 }) {
     const value = getValue();
-    const estimated = row.original.Estimated;
-    const display = estimated ? `~${value}` : String(value);
-    const title = estimated ? "This value is estimated due to time constraints during calculation" : undefined;
-    return <CellValue value={display} title={title} />;
+
+    return row.original.Estimated ? (
+        <CellValue
+            value={`~${value.toLocaleString()}`}
+            className="value-number"
+            title="This value is estimated due to time constraints during calculation"
+        />
+    ) : (
+        <CellValue value={value} />
+    );
 }
 
-function CellValue({ value, title }: { value: unknown; title?: string }) {
+function CellEtagValue({ value, title }: { value: unknown; title?: string }) {
     return (
         <span title={title} className={`value-${typeof value}`}>
             {String(value)}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/useTombstonesStateColumns.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/tombstones/useTombstonesStateColumns.tsx
@@ -71,12 +71,12 @@ export function useTombstonesStateColumns(availableWidth: number) {
             {
                 header: "Number of tombstones left",
                 accessorKey: "NumberOfTombstoneLeft",
-                cell: CellValueWrapper,
+                cell: CellTombstoneCountWrapper,
                 size: getSize(10),
             },
             {
                 header: "Tombstone types",
-                accessorFn: (x) => formatTombstoneTypes(x.Types, x.Process),
+                accessorFn: (x) => formatTombstoneTypes(x.Types, x.Process, x.Estimated),
                 cell: CellValueWrapper,
                 size: getSize(25),
             },
@@ -119,17 +119,20 @@ function formatEtag(value: number) {
 }
 function formatTombstoneTypes(
     types: Raven.Server.Documents.TombstoneCleaner.TombstonesState.TombstoneTypes,
-    process: Raven.Server.Documents.ITombstoneAware.TombstoneDeletionBlockerType
+    process: Raven.Server.Documents.ITombstoneAware.TombstoneDeletionBlockerType,
+    estimated: boolean
 ) {
     if (!types) {
         return "";
     }
 
+    const fmt = (n: number) => (estimated ? `~${n}` : String(n));
+
     if (process === "Index") {
-        return `Documents: ${types.Documents}`;
+        return `Documents: ${fmt(types.Documents)}`;
     }
 
-    return `Documents: ${types.Documents}, TimeSeries: ${types.TimeSeries}, Counters: ${types.Counters}`;
+    return `Documents: ${fmt(types.Documents)}, TimeSeries: ${fmt(types.TimeSeries)}, Counters: ${fmt(types.Counters)}`;
 }
 
 function getEtagTitle(etagValue: number) {
@@ -147,6 +150,20 @@ function getEtagTitle(etagValue: number) {
 function CellEtagWrapper({ getValue }: { getValue: Getter<number> }) {
     const value = getValue();
     return <CellValue value={formatEtag(value)} title={getEtagTitle(value)} />;
+}
+
+function CellTombstoneCountWrapper({
+    getValue,
+    row,
+}: {
+    getValue: Getter<number>;
+    row: { original: SubscriptionInfoExtended };
+}) {
+    const value = getValue();
+    const estimated = row.original.Estimated;
+    const display = estimated ? `~${value}` : String(value);
+    const title = estimated ? "This value is estimated due to time constraints during calculation" : undefined;
+    return <CellValue value={display} title={title} />;
 }
 
 function CellValue({ value, title }: { value: unknown; title?: string }) {

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskProgressTooltip.tsx
@@ -49,6 +49,14 @@ export function OngoingEtlTaskProgressTooltip(props: OngoingTaskEtlProgressToolt
                         const nameNode = (
                             <div className="d-flex align-items-center justify-content-center gap-1">
                                 {transformationScriptProgress.transformationName}
+                                {transformationScriptProgress.estimated && (
+                                    <small
+                                        className="text-muted"
+                                        title="Estimated value. The exact count takes too long to calculate and will be skipped for performance."
+                                    >
+                                        (~)
+                                    </small>
+                                )}
                                 <Button
                                     variant="link"
                                     className="p-0"

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingTasksReducer.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingTasksReducer.ts
@@ -191,6 +191,7 @@ function mapEtlProgress(taskProgress: EtlProcessProgress): OngoingTaskNodeEtlPro
         disabled: taskProgress.Disabled,
         processedPerSecond: taskProgress.AverageProcessedPerSecond,
         transactionalId: taskProgress.TransactionalId,
+        estimated: taskProgress.Estimated,
     };
 }
 
@@ -248,6 +249,7 @@ function mapReplicationProgress(taskProgress: ReplicationProcessProgress): Ongoi
             processed: taskProgress.TotalNumberOfTimeSeriesSegments - taskProgress.NumberOfTimeSeriesSegmentsToProcess,
             total: taskProgress.TotalNumberOfTimeSeriesSegments,
         },
+        estimated: taskProgress.Estimated,
     };
 }
 

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/ReplicationTaskProgressTooltip.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/ReplicationTaskProgressTooltip.tsx
@@ -60,9 +60,22 @@ export function ReplicationTaskProgressTooltip(props: ReplicationTaskProgressToo
                 )}
                 {progress &&
                     progress.map((singleProgress, index) => {
+                        const replicationName = singleProgress.estimated ? (
+                            <>
+                                Replication{" "}
+                                <small
+                                    className="text-muted"
+                                    title="Estimated value. The exact count takes too long to calculate and will be skipped for performance."
+                                >
+                                    (~)
+                                </small>
+                            </>
+                        ) : (
+                            "Replication"
+                        );
                         return (
                             <div key={"progress-" + index} className="vstack">
-                                <NamedProgress name="Replication">
+                                <NamedProgress name={replicationName}>
                                     <NamedProgressItem progress={singleProgress.documents}>documents</NamedProgressItem>
                                     <NamedProgressItem progress={singleProgress.documentTombstones}>
                                         tombstones

--- a/src/Raven.Studio/typescript/components/services/IndexesService.ts
+++ b/src/Raven.Studio/typescript/components/services/IndexesService.ts
@@ -26,8 +26,13 @@ import getIndexEntriesFieldsCommand from "commands/database/index/getIndexEntrie
 import getIndexTermsCommand from "commands/database/index/getIndexTermsCommand";
 
 export default class IndexesService {
-    async getProgress(databaseName: string, location: databaseLocationSpecifier) {
-        return new getIndexesProgressCommand(databaseName, location).execute();
+    async getProgress(
+        databaseName: string,
+        location: databaseLocationSpecifier,
+        indexNames?: string[],
+        exact?: boolean
+    ) {
+        return new getIndexesProgressCommand(databaseName, location, indexNames, exact).execute();
     }
 
     async setLockMode(indexes: IndexSharedInfo[], lockMode: IndexLockMode, databaseName: string) {

--- a/src/Raven.Studio/typescript/components/services/IndexesService.ts
+++ b/src/Raven.Studio/typescript/components/services/IndexesService.ts
@@ -26,13 +26,8 @@ import getIndexEntriesFieldsCommand from "commands/database/index/getIndexEntrie
 import getIndexTermsCommand from "commands/database/index/getIndexTermsCommand";
 
 export default class IndexesService {
-    async getProgress(
-        databaseName: string,
-        location: databaseLocationSpecifier,
-        indexNames?: string[],
-        exact?: boolean
-    ) {
-        return new getIndexesProgressCommand(databaseName, location, indexNames, exact).execute();
+    async getProgress(...args: ConstructorParameters<typeof getIndexesProgressCommand>) {
+        return new getIndexesProgressCommand(...args).execute();
     }
 
     async setLockMode(indexes: IndexSharedInfo[], lockMode: IndexLockMode, databaseName: string) {

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -406,6 +406,34 @@ export class DatabasesStubs {
                     Process: "Index",
                     Estimated: false,
                 },
+                {
+                    Identifier: "ReplicationSink/Orders",
+                    Type: "Documents",
+                    Collection: "Orders",
+                    Etag: 42,
+                    NumberOfTombstoneLeft: 1500,
+                    Types: {
+                        Documents: 1200,
+                        TimeSeries: 200,
+                        Counters: 100,
+                    },
+                    Process: "InternalReplication",
+                    Estimated: true,
+                },
+                {
+                    Identifier: "ExternalReplication/Products",
+                    Type: "Documents",
+                    Collection: "Products",
+                    Etag: 42,
+                    NumberOfTombstoneLeft: 1500,
+                    Types: {
+                        Documents: 1200,
+                        TimeSeries: 200,
+                        Counters: 100,
+                    },
+                    Process: "ExternalReplication",
+                    Estimated: false,
+                },
             ],
         };
     }

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -404,6 +404,7 @@ export class DatabasesStubs {
                         Counters: 0,
                     },
                     Process: "Index",
+                    Estimated: false,
                 },
             ],
         };

--- a/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/IndexesStubs.ts
@@ -92,6 +92,7 @@ export class IndexesStubs {
                 LastProcessedTimeSeriesDeletedRangeEtag: 5,
                 NumberOfTimeSeriesDeletedRangesToProcess: 10,
                 TotalNumberOfTimeSeriesDeletedRanges: 20,
+                Estimated: true,
             },
             SecondCollection: {
                 LastProcessedItemEtag: 5,
@@ -103,6 +104,7 @@ export class IndexesStubs {
                 LastProcessedTimeSeriesDeletedRangeEtag: 5,
                 NumberOfTimeSeriesDeletedRangesToProcess: 10,
                 TotalNumberOfTimeSeriesDeletedRanges: 20,
+                Estimated: false,
             },
         };
     }

--- a/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/TasksStubs.ts
@@ -192,6 +192,7 @@ export class TasksStubs {
             FromToString: "from sink1 at C to [A/http://127.0.0.1:59690]",
             HandlerId: "hub-id",
             Completed: false,
+            Estimated: false,
         };
     }
 
@@ -562,6 +563,7 @@ export class TasksStubs {
                     NumberOfTimeSeriesSegmentsToProcess: 0,
                     TransformationName: "Script #1",
                     TransactionalId: transactionalId,
+                    Estimated: true,
                 },
             ],
             EtlType: etlType,

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1071,6 +1071,7 @@ type ReactInKnockout<T> = KnockoutComputed<ReactInKnockoutOptions<T>>;
 interface Progress {
     processed: number;
     total: number;
+    estimated?: boolean;
 }
 
 interface rawTaskItem {

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -1071,7 +1071,6 @@ type ReactInKnockout<T> = KnockoutComputed<ReactInKnockoutOptions<T>>;
 interface Progress {
     processed: number;
     total: number;
-    estimated?: boolean;
 }
 
 interface rawTaskItem {

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1674,23 +1674,28 @@ namespace Voron.Data.Fixed
             return Name.ToString();
         }
 
-        public long GetNumberOfEntriesAfter(TVal value, out long totalCount, Stopwatch overallDuration, EstimationAccuracy accuracy)
+        public NumberOfEntriesAfterResult GetNumberOfEntriesAfter(TVal value, Stopwatch overallDuration, EstimationAccuracy accuracy)
         {
-            totalCount = NumberOfEntries;
-            if (totalCount == 0)
-                return 0;
+            var result = new NumberOfEntriesAfterResult
+            {
+                Total = NumberOfEntries
+            };
+
+            if (NumberOfEntries == 0)
+                return result;
 
             if (Type.HasValue == false)
-                return 0;
+                return result;
 
             if (Type.Value == RootObjectType.EmbeddedFixedSizeTree)
             {
                 using (var it = (EmbeddedIterator)Iterate())
                 {
                     if (it.Seek(value) == false)
-                        return 0;
+                        return new NumberOfEntriesAfterResult();
 
-                    return it.NumberOfEntriesLeft;
+                    result.Count = it.NumberOfEntriesLeft;
+                    return result;
                 }
             }
 
@@ -1717,10 +1722,14 @@ namespace Voron.Data.Fixed
             if (state.EstimatedAmount && count > NumberOfEntries)
             {
                 // this can happen if the estimated amount is wildly off the actual amount 
-                return NumberOfEntries - state.NonEstimatedAmount;
+                result.Count = NumberOfEntries - state.NonEstimatedAmount;
+                result.Estimated = true;
+                return result;
             }
 
-            return count;
+            result.Count = count;
+            result.Estimated = state.EstimatedAmount;
+            return result;
         }
 
         private struct RemainingNumberOfEntriesState
@@ -1864,6 +1873,13 @@ namespace Voron.Data.Fixed
 
             _newPageAllocator = newPageAllocator;
         }
+    }
+
+    public struct NumberOfEntriesAfterResult
+    {
+        public long Count;
+        public long Total;
+        public bool Estimated;
     }
 
     public enum EstimationAccuracy

--- a/src/Voron/Data/Fixed/FixedSizeTree.cs
+++ b/src/Voron/Data/Fixed/FixedSizeTree.cs
@@ -1681,7 +1681,7 @@ namespace Voron.Data.Fixed
                 Total = NumberOfEntries
             };
 
-            if (NumberOfEntries == 0)
+            if (result.Total == 0)
                 return result;
 
             if (Type.HasValue == false)
@@ -1692,7 +1692,7 @@ namespace Voron.Data.Fixed
                 using (var it = (EmbeddedIterator)Iterate())
                 {
                     if (it.Seek(value) == false)
-                        return new NumberOfEntriesAfterResult();
+                        return result;
 
                     result.Count = it.NumberOfEntriesLeft;
                     return result;

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -1337,14 +1337,14 @@ namespace Voron.Data.Tables
         }
 
 
-        public long GetNumberOfEntriesAfter(TableSchema.FixedSizeKeyIndexDef index, long afterValue, out long totalCount, Stopwatch overallDuration)
+        public NumberOfEntriesAfterResult GetNumberOfEntriesAfter(FixedSizeKeyIndexDef index, long afterValue, Stopwatch overallDuration, bool exact)
         {
             var fst = GetFixedSizeTree(index);
 
-            return fst.GetNumberOfEntriesAfter(afterValue, out totalCount, overallDuration, EstimationAccuracy.EstimateIfLongRunning);
+            return fst.GetNumberOfEntriesAfter(afterValue, overallDuration, exact ? EstimationAccuracy.Exact : EstimationAccuracy.EstimateIfLongRunning);
         }
 
-        public long GetNumberOfEntriesFor(TableSchema.FixedSizeKeyIndexDef index)
+        public long GetNumberOfEntriesFor(FixedSizeKeyIndexDef index)
         {
             var fst = GetFixedSizeTree(index);
             return fst.NumberOfEntries;

--- a/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
+++ b/test/FastTests/Server/Documents/Indexing/Static/BasicStaticMapIndexing.cs
@@ -415,7 +415,7 @@ namespace FastTests.Server.Documents.Indexing.Static
                         IndexProgress progress;
                         using (context.OpenReadTransaction())
                         {
-                            progress = index.GetProgress(queryContext, Stopwatch.StartNew());
+                            progress = index.GetProgress(queryContext, Stopwatch.StartNew(), exact: false);
                         }
 
                         Assert.Equal(0, progress.Collections["Users"].LastProcessedItemEtag);
@@ -431,7 +431,7 @@ namespace FastTests.Server.Documents.Indexing.Static
 
                         using (context.OpenReadTransaction())
                         {
-                            progress = index.GetProgress(queryContext, Stopwatch.StartNew());
+                            progress = index.GetProgress(queryContext, Stopwatch.StartNew(), exact: false);
                         }
 
                         Assert.Equal(2, progress.Collections["Users"].LastProcessedItemEtag);
@@ -474,7 +474,7 @@ namespace FastTests.Server.Documents.Indexing.Static
 
                         using (context.OpenReadTransaction())
                         {
-                            progress = index.GetProgress(queryContext, Stopwatch.StartNew());
+                            progress = index.GetProgress(queryContext, Stopwatch.StartNew(), exact: false);
                         }
 
                         Assert.Equal(2, progress.Collections["Users"].LastProcessedItemEtag);
@@ -490,7 +490,7 @@ namespace FastTests.Server.Documents.Indexing.Static
 
                         using (context.OpenReadTransaction())
                         {
-                            progress = index.GetProgress(queryContext, Stopwatch.StartNew());
+                            progress = index.GetProgress(queryContext, Stopwatch.StartNew(), exact: false);
                         }
 
                         Assert.Equal(5, progress.Collections["Users"].LastProcessedItemEtag);

--- a/test/SlowTests/Issues/RavenDB_7281.cs
+++ b/test/SlowTests/Issues/RavenDB_7281.cs
@@ -77,12 +77,12 @@ namespace SlowTests.Issues
 
                 for (var i = 0; i < total; i++)
                 {
-                    var count = tree.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew(), EstimationAccuracy.EstimateIfLongRunning);
+                    var result = tree.GetNumberOfEntriesAfter(i, Stopwatch.StartNew(), EstimationAccuracy.EstimateIfLongRunning);
                     var expectedCount = Calculate(tree, i, out long expectedTotalCount);
 
                     Assert.Equal(inserted, expectedTotalCount);
-                    Assert.Equal(expectedTotalCount, totalCount);
-                    Assert.Equal(expectedCount, count);
+                    Assert.Equal(expectedTotalCount, result.Total);
+                    Assert.Equal(expectedCount, result.Count);
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/Indexing/RavenDB-25806.cs
+++ b/test/SlowTests/Server/Documents/Indexing/RavenDB-25806.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Server.Documents.Commands.Indexes;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.Indexing
+{
+    public class RavenDB_25806 : RavenTestBase
+    {
+        public RavenDB_25806(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public async Task Can_Filter_Indexes_Progress_By_Name_And_Request_Exact_Progress()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var usersIndex = new Users_ByName();
+                var companiesIndex = new Companies_ByName();
+                await usersIndex.ExecuteAsync(store);
+                await companiesIndex.ExecuteAsync(store);
+
+                Indexes.WaitForIndexing(store);
+
+                await store.Maintenance.SendAsync(new StopIndexingOperation());
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (var i = 1; i <= 5; i++)
+                    {
+                        await session.StoreAsync(new User { Name = $"user-{i}" }, $"users/{i}");
+                        await session.StoreAsync(new Company { Name = $"company-{i}" }, $"companies/{i}");
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Delete("users/1");
+                    session.Delete("users/2");
+                    session.Delete("companies/1");
+                    await session.SaveChangesAsync();
+                }
+
+                // no names - progress of all indexes is returned
+                var progress = await GetProgressAsync(store);
+                Assert.Equal(2, progress.Length);
+
+                // filter by index name
+                progress = await GetProgressAsync(store, names: new[] { usersIndex.IndexName });
+                var usersProgress = Assert.Single(progress);
+                Assert.Equal(usersIndex.IndexName, usersProgress.Name);
+
+                // unknown index name
+                progress = await GetProgressAsync(store, names: new[] { "Unknown/Index" });
+                Assert.Empty(progress);
+
+                // exact progress
+                progress = await GetProgressAsync(store, names: new[] { usersIndex.IndexName, companiesIndex.IndexName }, exact: true);
+                Assert.Equal(2, progress.Length);
+
+                usersProgress = progress.Single(x => x.Name == usersIndex.IndexName);
+                var collectionStats = usersProgress.Collections["Users"];
+                Assert.False(collectionStats.Estimated);
+                Assert.Equal(3, collectionStats.NumberOfItemsToProcess);
+                Assert.Equal(2, collectionStats.NumberOfTombstonesToProcess);
+
+                var companiesProgress = progress.Single(x => x.Name == companiesIndex.IndexName);
+                collectionStats = companiesProgress.Collections["Companies"];
+                Assert.False(collectionStats.Estimated);
+                Assert.Equal(4, collectionStats.NumberOfItemsToProcess);
+                Assert.Equal(1, collectionStats.NumberOfTombstonesToProcess);
+            }
+        }
+
+        private static async Task<IndexProgress[]> GetProgressAsync(IDocumentStore store, string[] names = null, bool exact = false)
+        {
+            using (var commands = store.Commands())
+            {
+                var cmd = new GetIndexesProgressCommand(nodeTag: null, names, exact);
+                await commands.ExecuteAsync(cmd);
+                return cmd.Result;
+            }
+        }
+
+        private class Users_ByName : AbstractIndexCreationTask<User>
+        {
+            public Users_ByName()
+            {
+                Map = users => from user in users
+                               select new
+                               {
+                                   user.Name
+                               };
+            }
+        }
+
+        private class Companies_ByName : AbstractIndexCreationTask<Company>
+        {
+            public Companies_ByName()
+            {
+                Map = companies => from company in companies
+                                   select new
+                                   {
+                                       company.Name
+                                   };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Tombstones/CalculateRemainingTombstonesTests.cs
+++ b/test/SlowTests/Server/Documents/Tombstones/CalculateRemainingTombstonesTests.cs
@@ -1,0 +1,435 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Raven.Server.ServerWide.Context;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Tests.Infrastructure.Entities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.Tombstones
+{
+    public class CalculateRemainingTombstonesTests : ReplicationTestBase
+    {
+        public CalculateRemainingTombstonesTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task DocumentTombstones_GlobalCount(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.Store(new User { Name = "B" }, "users/2");
+                    session.Store(new User { Name = "C" }, "users/3");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.Delete("users/2");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+                    var result = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, 0, sw, exact: true);
+                    Assert.Equal(2, result.Count);
+                    Assert.False(result.Estimated);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task DocumentTombstones_PerCollectionCount(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.Store(new User { Name = "B" }, "users/2");
+                    session.Store(new Order(), "orders/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.Delete("users/2");
+                    session.Delete("orders/1");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+
+                    var usersResult = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(2, usersResult.Count);
+
+                    var ordersResult = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, "Orders", 0, sw, exact: true);
+                    Assert.Equal(1, ordersResult.Count);
+
+                    var nonExistentResult = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, "NonExistent", 0, sw, exact: true);
+                    Assert.Equal(0, nonExistentResult.Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task DocumentTombstones_PerCollectionCount_WithAfterEtag(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.Store(new User { Name = "B" }, "users/2");
+                    session.Store(new User { Name = "C" }, "users/3");
+                    session.SaveChanges();
+                }
+
+                long firstDeleteEtag;
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/1");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var tombstones = database.DocumentsStorage.GetTombstonesFrom(context, 0, 0, int.MaxValue);
+                    firstDeleteEtag = 0;
+                    foreach (var t in tombstones)
+                    {
+                        firstDeleteEtag = t.Etag;
+                        break;
+                    }
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Delete("users/2");
+                    session.Delete("users/3");
+                    session.SaveChanges();
+                }
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+
+                    // afterEtag is exclusive — entries with etag > afterEtag are counted
+                    var result = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, "Users", firstDeleteEtag, sw, exact: true);
+                    Assert.Equal(2, result.Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Counters)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CounterTombstones_GlobalCount(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.CountersFor("users/1").Increment("Likes", 10);
+                    session.CountersFor("users/1").Increment("Dislikes", 5);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.CountersFor("users/1").Delete("Likes");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+                    var result = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, 0, sw, exact: true);
+                    Assert.Equal(1, result.Count);
+                    Assert.False(result.Estimated);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Counters)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CounterTombstones_PerCollectionCount(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.CountersFor("users/1").Increment("Likes", 10);
+                    session.CountersFor("users/1").Increment("Dislikes", 5);
+
+                    session.Store(new Order(), "orders/1");
+                    session.CountersFor("orders/1").Increment("Views", 100);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.CountersFor("users/1").Delete("Likes");
+                    session.CountersFor("users/1").Delete("Dislikes");
+                    session.CountersFor("orders/1").Delete("Views");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+
+                    var usersResult = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(2, usersResult.Count);
+
+                    var ordersResult = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Orders", 0, sw, exact: true);
+                    Assert.Equal(1, ordersResult.Count);
+
+                    var nonExistentResult = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "NonExistent", 0, sw, exact: true);
+                    Assert.Equal(0, nonExistentResult.Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Counters)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CounterTombstones_PerCollectionCount_EstimatedMode(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.CountersFor("users/1").Increment("Likes", 10);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.CountersFor("users/1").Delete("Likes");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+                    var result = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: false);
+                    // In estimated mode the count should be >= 1 (it may be exact for small datasets)
+                    Assert.True(result.Count >= 1);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task TimeSeriesDeletedRangeTombstones_GlobalCount(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var baseline = DateTime.UtcNow;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.TimeSeriesFor("users/1", "HeartRate").Append(baseline, 70);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.TimeSeriesFor("users/1", "HeartRate").Delete(baseline.AddMinutes(-1), baseline.AddMinutes(1));
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+                    var result = database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, 0, sw, exact: true);
+                    Assert.True(result.Count >= 1);
+                    Assert.False(result.Estimated);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.TimeSeries)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task TimeSeriesDeletedRangeTombstones_PerCollectionCount(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var baseline = DateTime.UtcNow;
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.TimeSeriesFor("users/1", "HeartRate").Append(baseline, 70);
+
+                    session.Store(new Order(), "orders/1");
+                    session.TimeSeriesFor("orders/1", "Temperature").Append(baseline, 22);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.TimeSeriesFor("users/1", "HeartRate").Delete(baseline.AddMinutes(-1), baseline.AddMinutes(1));
+                    session.TimeSeriesFor("orders/1", "Temperature").Delete(baseline.AddMinutes(-1), baseline.AddMinutes(1));
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+
+                    var usersResult = database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.True(usersResult.Count >= 1);
+
+                    var ordersResult = database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, "Orders", 0, sw, exact: true);
+                    Assert.True(ordersResult.Count >= 1);
+
+                    var nonExistentResult = database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, "NonExistent", 0, sw, exact: true);
+                    Assert.Equal(0, nonExistentResult.Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task DocumentTombstones_EmptyDatabase_ReturnsZero(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "any/1");
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+
+                    var globalResult = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, 0, sw, exact: true);
+                    Assert.Equal(0, globalResult.Count);
+
+                    var collectionResult = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(0, collectionResult.Count);
+
+                    var counterGlobal = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, 0, sw, exact: true);
+                    Assert.Equal(0, counterGlobal.Count);
+
+                    var counterCollection = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(0, counterCollection.Count);
+
+                    var tsGlobal = database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, 0, sw, exact: true);
+                    Assert.Equal(0, tsGlobal.Count);
+
+                    var tsCollection = database.DocumentsStorage.TimeSeriesStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(0, tsCollection.Count);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Counters)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CounterTombstones_PerCollectionCount_WithAfterEtag(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User { Name = "A" }, "users/1");
+                    session.CountersFor("users/1").Increment("Likes", 10);
+                    session.CountersFor("users/1").Increment("Dislikes", 5);
+                    session.CountersFor("users/1").Increment("Views", 20);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.CountersFor("users/1").Delete("Likes");
+                    session.SaveChanges();
+                }
+
+                var database = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
+
+                long firstTombstoneEtag;
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+                    var result = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(1, result.Count);
+
+                    // Get the etag of the first counter tombstone
+                    firstTombstoneEtag = 0;
+                    foreach (var item in database.DocumentsStorage.CountersStorage.GetCounterTombstonesFrom(context, 0))
+                    {
+                        using (item)
+                        {
+                            firstTombstoneEtag = item.Etag;
+                            break;
+                        }
+                    }
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.CountersFor("users/1").Delete("Dislikes");
+                    session.CountersFor("users/1").Delete("Views");
+                    session.SaveChanges();
+                }
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sw = Stopwatch.StartNew();
+
+                    // All counter tombstones
+                    var allResult = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Users", 0, sw, exact: true);
+                    Assert.Equal(3, allResult.Count);
+
+                    // Only tombstones after the first one
+                    var afterResult = database.DocumentsStorage.CountersStorage.GetNumberOfTombstonesToProcess(context, "Users", firstTombstoneEtag + 1, sw, exact: true);
+                    Assert.Equal(2, afterResult.Count);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/Tombstones/CalculateRemainingTombstonesTests.cs
+++ b/test/SlowTests/Server/Documents/Tombstones/CalculateRemainingTombstonesTests.cs
@@ -138,7 +138,7 @@ namespace SlowTests.Server.Documents.Tombstones
                 {
                     var sw = Stopwatch.StartNew();
 
-                    // afterEtag is exclusive — entries with etag > afterEtag are counted
+                    // afterEtag is exclusive - entries with etag > afterEtag are counted
                     var result = database.DocumentsStorage.GetNumberOfTombstonesToProcess(context, "Users", firstDeleteEtag, sw, exact: true);
                     Assert.Equal(2, result.Count);
                 }

--- a/test/SlowTests/Voron/LargeFixedSizeTrees.cs
+++ b/test/SlowTests/Voron/LargeFixedSizeTrees.cs
@@ -557,12 +557,12 @@ namespace SlowTests.Voron
 
                 for (int i = 0; i < count; i++)
                 {
-                    var actualCount = fst.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew(), accuracy);
+                    var result = fst.GetNumberOfEntriesAfter(i, Stopwatch.StartNew(), accuracy);
                     var expectedCount = CalculateExpectedEntriesAfter(fst, i, out long expectedTotalCount);
 
                     Assert.Equal(count, expectedTotalCount);
-                    Assert.Equal(expectedTotalCount, totalCount);
-                    Assert.Equal(expectedCount, actualCount);
+                    Assert.Equal(expectedTotalCount, result.Total);
+                    Assert.Equal(expectedCount, result.Count);
                 }
             }
         }
@@ -600,12 +600,12 @@ namespace SlowTests.Voron
 
                 foreach (var position in testPositions)
                 {
-                    var actualCount = fst.GetNumberOfEntriesAfter(position, out long totalCount, Stopwatch.StartNew(), accuracy);
+                    var result = fst.GetNumberOfEntriesAfter(position, Stopwatch.StartNew(), accuracy);
                     var expectedCount = CalculateExpectedEntriesAfter(fst, position, out long expectedTotalCount);
 
                     Assert.Equal(count, expectedTotalCount);
-                    Assert.Equal(expectedTotalCount, totalCount);
-                    Assert.Equal(expectedCount, actualCount);
+                    Assert.Equal(expectedTotalCount, result.Total);
+                    Assert.Equal(expectedCount, result.Count);
                 }
             }
         }
@@ -662,10 +662,10 @@ namespace SlowTests.Voron
                 var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
                 // Don't add any entries
 
-                var actualCount = fst.GetNumberOfEntriesAfter(0, out long totalCount, Stopwatch.StartNew(), accuracy);
+                var result = fst.GetNumberOfEntriesAfter(0, Stopwatch.StartNew(), accuracy);
 
-                Assert.Equal(0, totalCount);
-                Assert.Equal(0, actualCount);
+                Assert.Equal(0, result.Total);
+                Assert.Equal(0, result.Count);
             }
         }
 
@@ -690,19 +690,19 @@ namespace SlowTests.Voron
                 var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
 
                 // Query before the entry
-                var beforeCount = fst.GetNumberOfEntriesAfter(50, out long totalCount1, Stopwatch.StartNew(), accuracy);
-                Assert.Equal(1, totalCount1);
-                Assert.Equal(1, beforeCount);
+                var resultBefore = fst.GetNumberOfEntriesAfter(50, Stopwatch.StartNew(), accuracy);
+                Assert.Equal(1, resultBefore.Total);
+                Assert.Equal(1, resultBefore.Count);
 
                 // Query at the entry
-                var atCount = fst.GetNumberOfEntriesAfter(100, out long totalCount2, Stopwatch.StartNew(), accuracy);
-                Assert.Equal(1, totalCount2);
-                Assert.Equal(0, atCount);
+                var resultAt = fst.GetNumberOfEntriesAfter(100, Stopwatch.StartNew(), accuracy);
+                Assert.Equal(1, resultAt.Total);
+                Assert.Equal(0, resultAt.Count);
 
                 // Query after the entry
-                var afterCount = fst.GetNumberOfEntriesAfter(150, out long totalCount3, Stopwatch.StartNew(), accuracy);
-                Assert.Equal(1, totalCount3);
-                Assert.Equal(0, afterCount);
+                var resultAfter = fst.GetNumberOfEntriesAfter(150, Stopwatch.StartNew(), accuracy);
+                Assert.Equal(1, resultAfter.Total);
+                Assert.Equal(0, resultAfter.Count);
             }
         }
 
@@ -733,10 +733,10 @@ namespace SlowTests.Voron
                 var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
 
                 // Query way beyond the last entry
-                var actualCount = fst.GetNumberOfEntriesAfter(count + 1000, out long totalCount, Stopwatch.StartNew(), accuracy);
+                var result = fst.GetNumberOfEntriesAfter(count + 1000, Stopwatch.StartNew(), accuracy);
 
-                Assert.Equal(count, totalCount);
-                Assert.Equal(0, actualCount);
+                Assert.Equal(count, result.Total);
+                Assert.Equal(0, result.Count);
             }
         }
 
@@ -768,10 +768,10 @@ namespace SlowTests.Voron
                 var fst = tx.FixedTreeFor(treeId, valSize: sizeof(long));
 
                 // Query before all entries
-                var actualCount = fst.GetNumberOfEntriesAfter(0, out long totalCount, Stopwatch.StartNew(), accuracy);
+                var result = fst.GetNumberOfEntriesAfter(0, Stopwatch.StartNew(), accuracy);
 
-                Assert.Equal(count, totalCount);
-                Assert.Equal(count, actualCount);
+                Assert.Equal(count, result.Total);
+                Assert.Equal(count, result.Count);
             }
         }
 
@@ -810,12 +810,12 @@ namespace SlowTests.Voron
 
                 for (var i = 0; i < total; i++)
                 {
-                    var count = tree.GetNumberOfEntriesAfter(i, out long totalCount, Stopwatch.StartNew(), accuracy);
+                    var result = tree.GetNumberOfEntriesAfter(i, Stopwatch.StartNew(), accuracy);
                     var expectedCount = CalculateExpectedEntriesAfter(tree, i, out long expectedTotalCount);
 
                     Assert.Equal(inserted, expectedTotalCount);
-                    Assert.Equal(expectedTotalCount, totalCount);
-                    Assert.Equal(expectedCount, count);
+                    Assert.Equal(expectedTotalCount, result.Total);
+                    Assert.Equal(expectedCount, result.Count);
                 }
             }
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25806/Slow-loading-of-the-tombstones-view
https://issues.hibernatingrhinos.com/issue/RavenDB-26040/Display-if-the-progress-is-estimated-or-not

### Additional description

This PR addresses the slow loading time of the Tombstones view.

We now use `GetNumberOfTombstonesToProcess` instead of the previous implementation, which performed an expensive calculation and required the materialization of documents, counters, and time series.

We also output whether the result is estimated or not in order to display in the Studio.
The Studio can also send a request to calculate an accurate number.

For tombstones, ETL and replication the accurate calculation will be for everything (all collections), for indexes, it will be per index.

### Performance Benchmark
**Scenario:** 10M tombstones remaining.

| Run Type | Before | After | Improvement |
| :--- | :--- | :--- | :--- |
| **First Run** | ~3 seconds | ~191 ms | **~15x faster** |
| **Consecutive Runs** | ~2.1 seconds | ~9 ms | **~233x faster** |

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
