### PR TITLE
RavenDB-25470 Add ToggleTaskStateCommand to license limit check

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents.Operations.Backups;
+using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Exceptions.Commercial;
 using Raven.Client.ServerWide;
@@ -24,6 +25,7 @@ using Sparrow.Json;
 using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Raven.Server.ServerWide;
 
@@ -59,7 +61,8 @@ public sealed partial class ClusterStateMachine
         nameof(AddElasticSearchEtlCommand),
         nameof(AddQueueSinkCommand),
         nameof(UpdateQueueSinkCommand),
-        nameof(EditDataArchivalCommand)
+        nameof(EditDataArchivalCommand),
+        nameof(ToggleTaskStateCommand)
     };
 
     private void AssertLicenseLimits(string type, ServerStore serverStore, DatabaseRecord databaseRecord, Table items, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand = null)
@@ -168,6 +171,9 @@ public sealed partial class ClusterStateMachine
             case nameof(PutClientConfigurationCommand):
                 if (AssertClientConfiguration(serverStore.LicenseManager.LicenseStatus, context) == false)
                     throw new LicenseLimitException(LimitType.ClientConfiguration, "Your license doesn't support adding the client configuration.");
+                break;
+            case nameof(ToggleTaskStateCommand):
+                AssertToggleTaskStateLicenseLimits(databaseRecord, serverStore.LicenseManager.LicenseStatus, context, updateDatabaseCommand);
                 break;
         }
     }
@@ -1118,6 +1124,53 @@ public sealed partial class ClusterStateMachine
         if (licenseStatus.HasSnmpMonitoring == false)
             throw new LicenseLimitException(LimitType.Snmp, message);
     }
+
+    private void AssertToggleTaskStateLicenseLimits(DatabaseRecord databaseRecord, LicenseStatus licenseStatus, ClusterOperationContext context, UpdateDatabaseCommand updateDatabaseCommand)
+    {
+        if (CanAssertLicenseLimits(context, minBuildVersion: MinBuildVersion60105) == false)
+            return;
+
+        if (updateDatabaseCommand != null && updateDatabaseCommand is ToggleTaskStateCommand ttsc)
+        {
+            switch (ttsc.TaskType)
+            {
+                case OngoingTaskType.Replication:
+                    AssertExternalReplicationLicenseLimits(databaseRecord, licenseStatus, context, updateDatabaseCommand);
+                    break;
+                case OngoingTaskType.RavenEtl:
+                    AssertRavenEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.SqlEtl:
+                    AssertSqlEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.OlapEtl:
+                    AssertOlapEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.ElasticSearchEtl:
+                    AssertElasticSearchEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.QueueEtl:
+                    AssertQueueEtlLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.Backup:
+                    AssertPeriodicBackupLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.PullReplicationAsHub:
+                    AssertPullReplicationAsHubLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.PullReplicationAsSink:
+                    AssertPullReplicationAsSinkLicenseLimits(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.QueueSink:
+                    AssertQueueSink(databaseRecord, licenseStatus, context);
+                    break;
+                default:
+                    return;
+            }
+        }
+    }
+
+
 
     private enum DatabaseRecordElementType
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25470

### Additional description

Added license limit check for ToggleTaskStateCommand 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
