### PR TITLE
HRINT-4488 Run Snowflake tests only on the latest branch (7.1 skip)

### DIFF
--- a/test/Tests.Infrastructure/SnowflakeHelper.cs
+++ b/test/Tests.Infrastructure/SnowflakeHelper.cs
@@ -1,4 +1,5 @@
-﻿using Tests.Infrastructure.ConnectionString;
+﻿using System;
+using Tests.Infrastructure.ConnectionString;
 
 namespace Tests.Infrastructure;
 
@@ -14,6 +15,14 @@ public static class SnowflakeHelper
 
         if (RavenTestHelper.IsRunningOnCI)
         {
+            string snowflakeTestingBranch = Environment.GetEnvironmentVariable("RAVEN_SNOWFLAKE_TESTING_BRANCH");
+            string currentBranch = Environment.GetEnvironmentVariable("branch");
+            if (currentBranch != snowflakeTestingBranch)
+            {
+                skipMessage = $"Snowflake tests are only allowed to run on branch '{snowflakeTestingBranch}' branch. Current branch: {currentBranch}";
+                return true;
+            }
+
             skipMessage = null;
             return false;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-4488/Run-Snowflake-tests-only-on-the-latest-branch

### Additional description

We've decided to run Snowflake ETL tests (7.0 feature) against Snowflake instance only on the latest branch (cc @ppekrol). This PR skips all tests decorated with `SnowflakeRequired = true`. I've decided to push to the 7.1 branch, as 7.0 is EOL, and 7.2 is the latest.



### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
