### PR TITLE
RavenDB-25444  Testfix: limit GrowableBufferTests to x64 architectures

### DIFF
--- a/test/SlowTests/Corax/GrowableBufferTests.cs
+++ b/test/SlowTests/Corax/GrowableBufferTests.cs
@@ -11,12 +11,12 @@ namespace SlowTests.Corax;
 
 public class GrowableBufferTests(ITestOutputHelper output) : NoDisposalNoOutputNeeded(output)
 {
-    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.All)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [InlineData(4 * Sparrow.Global.Constants.Size.Megabyte)]
     [InlineData(8 * Sparrow.Global.Constants.Size.Megabyte)]
     public void CanExtendAndNotLooseAnythingSingle(int size) => CanExtendAndNotLooseAnythingBase<float>(size);
     
-    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.All)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [InlineData(4 * Sparrow.Global.Constants.Size.Megabyte)]
     [InlineData(8 * Sparrow.Global.Constants.Size.Megabyte)]
     public void CanExtendAndNotLooseAnything(int size) => CanExtendAndNotLooseAnythingBase<long>(size);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25444
### Additional description

Testfix: limit GrowableBufferTests to x64 architectures

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
