### PR TITLE
RavenDB-25754 Testfix: Run the most exhausting test on x64 architecture to avoid OOM.

### DIFF
--- a/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
+++ b/test/StressTests/Corax/Bugs/PostingListTestsExtended.cs
@@ -10,19 +10,20 @@ namespace StressTests.Corax.Bugs;
 public class PostingListTestsExtended(ITestOutputHelper output) : NoDisposalNoOutputNeeded(output)
 {
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Voron)]
-    [InlineData(1337, 200000)]
+    [InlineData(1337, 200_000)]
     [InlineData(1064156071, 796)]
-    [InlineData(511767612, 4172)]
-    [InlineData(439188321, 502627)]
+    [InlineData(511767612, 4_172)]
     [InlineData(506431817, 2)]
     public void CanDeleteAndInsertInRandomOrder(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
 
     [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Voron, RavenArchitecture.X64)]
-    [InlineData(1828658, true, 1477187726)]
-    [InlineDataWithRandomSeed(20000000, false)]
-    [InlineDataWithRandomSeed(2000000, false)]
-    [InlineDataWithRandomSeed(200000, false)]
-    [InlineDataWithRandomSeed(20000, false)]
+    [InlineData(1_828_658, true, 1477187726)]
+    [InlineDataWithRandomSeed(20_000_000, false)]
+    [InlineDataWithRandomSeed(2_000_000, false)]
+    [InlineDataWithRandomSeed(200_000, false)]
+    [InlineDataWithRandomSeed(20_000, false)]
+    [InlineData(502_627, true, 439188321)]
+
     public void CanDeleteAndInsertInRandomOrderX64Only(int maxSize, bool maxSizeFinal, int seed)
     {
         var random = new Random(seed);
@@ -32,7 +33,7 @@ public class PostingListTestsExtended(ITestOutputHelper output) : NoDisposalNoOu
     }
 
     [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Voron, RavenPlatform.Windows, RavenArchitecture.X64)]
-    [InlineData(391060845, 31707323)]
+    [InlineData(391060845, 31_707_323)]
     public void CanDeleteAndInsertInRandomOrderWindows(int seed, int size) => CanDeleteAndInsertInRandomOrderBase(seed, size);
 
     private void CanDeleteAndInsertInRandomOrderBase(int seed, int size)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25754

### Additional description



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
