### PR TITLE
RavenDB-25916 PostingList should try to merge two pages if one of them is empty and the other is at least 75% full.

### DIFF
--- a/src/Voron/Data/PostingLists/PostingList.cs
+++ b/src/Voron/Data/PostingLists/PostingList.cs
@@ -449,10 +449,15 @@ namespace Voron.Data.PostingLists
                         continue;
 
                     var sibling = new PostingListLeafPage(siblingPage);
-                    if (sibling.SpaceUsed + leafPage.SpaceUsed > Constants.Storage.PageSize / 2 + Constants.Storage.PageSize / 4)
+                    
+                    const int page75PercentFullSize = Constants.Storage.PageSize / 2 + Constants.Storage.PageSize / 4 ;
+                    bool anyPageFree = sibling is { SpaceUsed: 0 } || leafPage is { SpaceUsed: 0 };
+                    if (sibling.SpaceUsed + leafPage.SpaceUsed > page75PercentFullSize && anyPageFree == false)
                     {
-                        // if the two pages together will be bigger than 75%, can skip merging
-                        // we do that to prevent "jumping" around between adding a page & removing that
+                        // If the two pages together are larger than 75%, we can skip merging.
+                        // We do this to prevent "jumping" around between adding a page and removing it.
+                        // However, if one side is empty, we want to free that empty space,
+                        // so we will force TryMerge in such a case.
                         continue;
                     }
 

--- a/test/SlowTests/Voron/Issues/RavenDB-25916.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB-25916.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Corax;
+using Corax.Indexing;
+using Corax.Utils;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Containers;
+using Voron.Data.PostingLists;
+using Voron.Impl;
+using Voron.Util;
+using Voron.Util.PFor;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues;
+
+public unsafe class RavenDB_25916(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CanMergeLeavesSimple()
+    {
+        ContainerId postingListContainerId;
+        long setId;
+        var currentId = 1;
+        List<long> currentElements = new();
+        using (var wTx = Env.WriteTransaction())
+        {
+            using var pForEncoder = new FastPForEncoder(wTx.Allocator);
+            using var pForDecoderDisposal = new FastPForDecoder(wTx.Allocator);
+            postingListContainerId = wTx.OpenContainer(Constants.IndexWriter.PostingListsSlice);
+
+            setId = (long)Container.Allocate(wTx.LowLevelTransaction, postingListContainerId, sizeof(PostingListState), out var setSpace);
+            ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace);
+
+
+            var currentMax = currentId + 600_000;
+            var toInsert = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+            for (; currentId < currentMax; currentId++)
+            {
+                var id = EntryIdEncodings.Encode(currentId, 1, TermIdMask.Single);
+                toInsert.Add(id);
+                currentElements.Add(id);
+            }
+
+            toInsert.Sort();
+            pForEncoder.Encode(toInsert.RawItems, toInsert.Count);
+            PostingList.Create(wTx.LowLevelTransaction, ref postingListState, pForEncoder);
+
+            wTx.Commit();
+        }
+        ValidateTree();
+
+        Remove(1, (long)EntryIdEncodings.DecodeAndDiscardFrequency(62_391_300));
+        ValidateTree();
+
+        Remove((long)EntryIdEncodings.DecodeAndDiscardFrequency(124_781_572), (long)EntryIdEncodings.DecodeAndDiscardFrequency(187_171_844));
+        ValidateTree();
+
+        Remove((long)EntryIdEncodings.DecodeAndDiscardFrequency(62_391_300), (long)EntryIdEncodings.DecodeAndDiscardFrequency(124_781_572));
+        ValidateTree();
+
+        using (var rTx = Env.ReadTransaction())
+        {
+            using var pForEncoder = new FastPForEncoder(rTx.Allocator);
+            using var pForDecoderDisposal = new FastPForDecoder(rTx.Allocator);
+            Container.Get(rTx.LowLevelTransaction, new ContainerEntryId(setId), out var setSpace);
+            ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace.ToSpan());
+            var ps = new PostingList(rTx.LowLevelTransaction, Slices.Empty, postingListState);
+
+            var it = ps.Iterate();
+            it.Seek();
+            Span<long> buffer = new long[1024];
+            while (it.Fill(buffer, out var read) && read != 0)
+            {
+                foreach (var id in buffer.Slice(0, read))
+                    currentElements.Remove(id);
+            }
+            
+            Assert.Empty(currentElements);
+        }
+
+
+        void ValidateTree()
+        {
+            using (var rTx = Env.ReadTransaction())
+            {
+                using var pForEncoder = new FastPForEncoder(rTx.Allocator);
+                using var pForDecoderDisposal = new FastPForDecoder(rTx.Allocator);
+                Container.Get(rTx.LowLevelTransaction, new ContainerEntryId(setId), out var setSpace);
+                ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace.ToSpan());
+                var ps = new PostingList(rTx.LowLevelTransaction, Slices.Empty, postingListState);
+                var startPage = rTx.LowLevelTransaction.GetPage(ps.State.RootPage);
+                AssertRecursively(rTx.LowLevelTransaction, startPage);
+
+
+                void AssertRecursively(LowLevelTransaction llt, Page page)
+                {
+                    Assert.True(RuntimeHelpers.TryEnsureSufficientExecutionStack());
+                    var header = new PostingListCursorState { Page = page };
+                    var leaf = new PostingListLeafPage(page);
+                    var branch = new PostingListBranchPage(page);
+
+                    if (header.IsLeaf)
+                    {
+                        Assert.NotEqual(0, leaf.Header->NumberOfEntries);
+                        Assert.NotEqual(0, leaf.Header->SizeUsed);
+                    }
+                    else
+                    {
+                        Assert.NotEqual(0, branch.Header->NumberOfEntries);
+                        for (int branchElementIDx = 0; branchElementIDx < branch.Header->NumberOfEntries; branchElementIDx++)
+                        {
+                            (long key, long pageNum) = branch.GetByIndex(branchElementIDx);
+                            AssertRecursively(llt, llt.GetPage(pageNum));
+                        }
+                    }
+                }
+            }
+        }
+
+        void Remove(long fromInclusive, long toExclusive)
+        {
+            using (var wTx = Env.WriteTransaction())
+            {
+                using var pForEncoder = new FastPForEncoder(wTx.Allocator);
+                using var pForDecoderDisposal = new FastPForDecoder(wTx.Allocator);
+                Container.GetMutable(wTx.LowLevelTransaction, new ContainerEntryId(setId), out var setSpace);
+                ref var postingListState = ref MemoryMarshal.AsRef<PostingListState>(setSpace.ToSpan());
+
+                var removalList = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+                for (long i = fromInclusive; i < toExclusive; i++)
+                {
+                    var id = EntryIdEncodings.Encode(i, 1, TermIdMask.Single);
+                    removalList.Add(id | 1);
+                    currentElements.Remove(id);
+                }
+
+                removalList.Sort();
+                var tmpBuffer = new ContextBoundNativeList<long>(wTx.Allocator, 1024);
+
+                var pForDecoder = pForDecoderDisposal;
+                PostingList.Update(wTx.LowLevelTransaction, ref postingListState, null, 0, removalList.RawItems, removalList.Count, pForEncoder, ref tmpBuffer, ref pForDecoder);
+                wTx.Commit();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25916

### Additional description

We want to try merge leaves when one of sibling is empty. This should remove empty leaf from the tree and release the storage for other purposes.

Result:
<img width="1796" height="1783" alt="image" src="https://github.com/user-attachments/assets/30745830-00ce-4f69-a89d-195bb8bd5600" />



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
