### PR TITLE
RavenDb-25803 : fixed the double deletion issue that caused the test to fail.

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -489,7 +489,19 @@ namespace Raven.Server.Documents
             {
                 removeLockAndReturn?.Dispose();
             }
-            NotifyLeaderAboutRemoval(dbName, databaseId);
+            var requestId = ComputeRemovalRequestId(dbName, databaseId, _serverStore.NodeTag);
+            NotifyLeaderAboutRemoval(dbName, databaseId, requestId);
+        }
+
+        private static string ComputeRemovalRequestId(string dbName, string databaseId, string nodeTag)
+        {
+            dbName ??= string.Empty;
+            databaseId ??= string.Empty;
+            nodeTag ??= string.Empty;
+
+            var input = string.Concat(dbName, "|", databaseId, "|", nodeTag);
+            var hash = Hashing.XXHash64.Calculate(System.Text.Encoding.UTF8.GetBytes(input));
+            return hash.ToString();
         }
 
         [DoesNotReturn]
@@ -498,9 +510,8 @@ namespace Raven.Server.Documents
             throw new InvalidOperationException($"Unknown cluster database change type: {type}");
         }
 
-        private void NotifyLeaderAboutRemoval(string dbName, string databaseId, string requestId = null)
+        private void NotifyLeaderAboutRemoval(string dbName, string databaseId, string requestId)
         {
-            requestId ??= RaftIdGenerator.NewId();
             var cmd = new RemoveNodeFromDatabaseCommand(dbName, databaseId, requestId)
             {
                 NodeTag = _serverStore.NodeTag


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25803/SlowTests.Sharding.Cluster.RavenDB25353.ReshardingSimpleMove1To0

### Additional description

HandleClusterDatabaseChanged is triggered multiple times and that register a callbacks to OnDispose to run DeleteDatabase.

and we revived it on our test, we get that specific scenrio:

in the test Resharding_Simple_Move_1_To_0 we delete and revive a node, because the node has already been revived after the first deletion, we delete it again and wait for value waits but there will be no changes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
