### PR TITLE
RavenDB-25218 : Migrate AI Agent Tests from gpt-4o-mini to gpt-5-mini and resolve failures

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
@@ -124,10 +124,10 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
             "chats/123",
             new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
 
-        string query = null;
+        string[] query = null;
         chat.Handle(ProductSearch, (ProductSearchArgs args) =>
         {
-            query = args.Query[0];
+            query = args.Query;
             return "not found";
         });
 
@@ -135,7 +135,7 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
         var run = await chat.RunAsync<Sample>();
         Assert.Equal(run.Status, AiConversationResult.Done);
         Assert.NotNull(run.Answer.Answer);
-        Assert.Equal("sugar", query);
+        Assert.Contains("sugar", query);
     }
 
     [RavenTheory(RavenTestCategory.Ai)]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
@@ -131,7 +131,7 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
             return "not found";
         });
 
-        chat.SetUserPrompt("find me sugar");
+        chat.SetUserPrompt("look for 'sugar' with the tool I have provided to you");
         var run = await chat.RunAsync<Sample>();
         Assert.Equal(run.Status, AiConversationResult.Done);
         Assert.NotNull(run.Answer.Answer);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentErrors.cs
@@ -370,7 +370,7 @@ public class AiAgentErrors : RavenTestBase
             "chats/",
             creationOptions: null);
 
-        chat.SetUserPrompt("Can you answer Aviv questions?");
+        chat.SetUserPrompt("Can you answer Aviv's questions?");
         var r = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
 
         var aviv = r.Answer;
@@ -378,7 +378,7 @@ public class AiAgentErrors : RavenTestBase
         Assert.NotNull(aviv.Answer);
         Assert.False(aviv.RefusedToAnswer, aviv.ToString());
 
-        chat.SetUserPrompt("Can you answer Karmel questions?");
+        chat.SetUserPrompt("Can you answer Karmel's questions?");
         r = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
 
         var karmel = r.Answer;
@@ -386,7 +386,7 @@ public class AiAgentErrors : RavenTestBase
         Assert.NotNull(karmel.Answer);
         Assert.False(karmel.RefusedToAnswer, karmel.ToString());
 
-        chat.SetUserPrompt("Can you answer Shahar questions?");
+        chat.SetUserPrompt("Can you answer Shahar's questions?");
         r = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
 
         var shahar = r.Answer;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
@@ -162,8 +162,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var starter = store.AI.Conversation(agentId, "chats/", creationOptions: null);
             starter.OnUnhandledAction += args => Task.CompletedTask;
             starter.SetUserPrompt(
-                "Please use ProductSearch to find the top 5 cheeses, " +
-                "then use RecentOrder to fetch my last 10 orders and answer.");
+                "Please use ProductSearch Query Tool to find the top5 cheeses, " +
+                "then use RecentOrder Query Tool to fetch my last10 orders and answer.");
             var firstRun = await starter.RunAsync<OutputSchema>(CancellationToken.None);
             Assert.Equal(AiConversationResult.ActionRequired, firstRun.Status);
 
@@ -173,10 +173,44 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var staleCv = starter.ChangeVector;
             Assert.NotNull(staleCv);
 
+            // Provide plausible tool outputs to reduce model retries/loops.
+            object GetToolResult(string toolName)
+            {
+                return toolName switch
+                {
+                    "ProductSearch" => new
+                    {
+                        Products = new[]
+                        {
+                            new { Id = "products/cheddar-1", Name = "Cheddar", Score =0.98 },
+                            new { Id = "products/gouda-1", Name = "Gouda", Score =0.95 },
+                            new { Id = "products/brie-1", Name = "Brie", Score =0.93 },
+                            new { Id = "products/parmesan-1", Name = "Parmesan", Score =0.91 },
+                            new { Id = "products/blue-1", Name = "Blue cheese", Score =0.89 }
+                        }
+                    },
+                    "RecentOrder" => new
+                    {
+                        Orders = new[]
+                        {
+                            new { Id = "orders/1-A", OrderedAt = "2025-01-10T12:00:00Z", Lines = new[] { new { ProductId = "products/brie-1", Name = "Brie", Quantity =1 } } },
+                            new { Id = "orders/2-A", OrderedAt = "2025-01-09T11:00:00Z", Lines = new[] { new { ProductId = "products/cheddar-1", Name = "Cheddar", Quantity =2 } } },
+                            new { Id = "orders/3-A", OrderedAt = "2025-01-08T09:30:00Z", Lines = new[] { new { ProductId = "products/gouda-1", Name = "Gouda", Quantity =1 } } },
+                            new { Id = "orders/4-A", OrderedAt = "2025-01-07T18:15:00Z", Lines = new[] { new { ProductId = "products/parmesan-1", Name = "Parmesan", Quantity =1 } } },
+                            new { Id = "orders/5-A", OrderedAt = "2025-01-06T20:05:00Z", Lines = new[] { new { ProductId = "products/blue-1", Name = "Blue cheese", Quantity =1 } } },
+                            new { Id = "orders/6-A", OrderedAt = "2025-01-05T14:45:00Z", Lines = new[] { new { ProductId = "products/cheddar-1", Name = "Cheddar", Quantity =1 } } },
+                            new { Id = "orders/7-A", OrderedAt = "2025-01-04T08:10:00Z", Lines = new[] { new { ProductId = "products/gouda-1", Name = "Gouda", Quantity =3 } } },
+                            new { Id = "orders/8-A", OrderedAt = "2025-01-03T16:25:00Z", Lines = new[] { new { ProductId = "products/brie-1", Name = "Brie", Quantity =2 } } },
+                            new { Id = "orders/9-A", OrderedAt = "2025-01-02T10:00:00Z", Lines = new[] { new { ProductId = "products/parmesan-1", Name = "Parmesan", Quantity =1 } } },
+                            new { Id = "orders/10-A", OrderedAt = "2025-01-01T13:35:00Z", Lines = new[] { new { ProductId = "products/blue-1", Name = "Blue cheese", Quantity =2 } } }
+                        }
+                    },
+                    _ => new { }
+                };
+            }
+
             var resume1 = store.AI.Conversation(agentId, starter.Id, creationOptions: null, staleCv);
-            resume1.AddActionResponse(
-                actions[0].ToolId,
-                new { });
+            resume1.AddActionResponse(actions[0].ToolId, GetToolResult(actions[0].Name));
             resume1.OnUnhandledAction += args => Task.CompletedTask;
             var afterFirst = await resume1.RunAsync<OutputSchema>(CancellationToken.None);
 
@@ -188,18 +222,14 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var resume2 = store.AI.Conversation(agentId, starter.Id, creationOptions: null, staleCv);
             resume2.OnUnhandledAction += args => Task.CompletedTask;
 
-            resume2.AddActionResponse(
-                actions[1].ToolId,
-                new { });
+            resume2.AddActionResponse(actions[1].ToolId, GetToolResult(actions[1].Name));
 
             await Assert.ThrowsAsync<ConcurrencyException>(
                 () => resume2.RunAsync<OutputSchema>(CancellationToken.None));
 
             Assert.NotNull(resume2.ChangeVector);
 
-            resume2.AddActionResponse(
-                actions[1].ToolId,
-                new { });
+            resume2.AddActionResponse(actions[1].ToolId, GetToolResult(actions[1].Name));
             var finalResult = await resume2.RunAsync<OutputSchema>(CancellationToken.None);
             Assert.Equal(AiConversationResult.Done, finalResult.Status);
             Assert.NotNull(finalResult.Answer);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
@@ -173,42 +173,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var staleCv = starter.ChangeVector;
             Assert.NotNull(staleCv);
 
-            // Provide plausible tool outputs to reduce model retries/loops.
-            object GetToolResult(string toolName)
-            {
-                return toolName switch
-                {
-                    "ProductSearch" => new
-                    {
-                        Products = new[]
-                        {
-                            new { Id = "products/cheddar-1", Name = "Cheddar", Score =0.98 },
-                            new { Id = "products/gouda-1", Name = "Gouda", Score =0.95 },
-                            new { Id = "products/brie-1", Name = "Brie", Score =0.93 },
-                            new { Id = "products/parmesan-1", Name = "Parmesan", Score =0.91 },
-                            new { Id = "products/blue-1", Name = "Blue cheese", Score =0.89 }
-                        }
-                    },
-                    "RecentOrder" => new
-                    {
-                        Orders = new[]
-                        {
-                            new { Id = "orders/1-A", OrderedAt = "2025-01-10T12:00:00Z", Lines = new[] { new { ProductId = "products/brie-1", Name = "Brie", Quantity =1 } } },
-                            new { Id = "orders/2-A", OrderedAt = "2025-01-09T11:00:00Z", Lines = new[] { new { ProductId = "products/cheddar-1", Name = "Cheddar", Quantity =2 } } },
-                            new { Id = "orders/3-A", OrderedAt = "2025-01-08T09:30:00Z", Lines = new[] { new { ProductId = "products/gouda-1", Name = "Gouda", Quantity =1 } } },
-                            new { Id = "orders/4-A", OrderedAt = "2025-01-07T18:15:00Z", Lines = new[] { new { ProductId = "products/parmesan-1", Name = "Parmesan", Quantity =1 } } },
-                            new { Id = "orders/5-A", OrderedAt = "2025-01-06T20:05:00Z", Lines = new[] { new { ProductId = "products/blue-1", Name = "Blue cheese", Quantity =1 } } },
-                            new { Id = "orders/6-A", OrderedAt = "2025-01-05T14:45:00Z", Lines = new[] { new { ProductId = "products/cheddar-1", Name = "Cheddar", Quantity =1 } } },
-                            new { Id = "orders/7-A", OrderedAt = "2025-01-04T08:10:00Z", Lines = new[] { new { ProductId = "products/gouda-1", Name = "Gouda", Quantity =3 } } },
-                            new { Id = "orders/8-A", OrderedAt = "2025-01-03T16:25:00Z", Lines = new[] { new { ProductId = "products/brie-1", Name = "Brie", Quantity =2 } } },
-                            new { Id = "orders/9-A", OrderedAt = "2025-01-02T10:00:00Z", Lines = new[] { new { ProductId = "products/parmesan-1", Name = "Parmesan", Quantity =1 } } },
-                            new { Id = "orders/10-A", OrderedAt = "2025-01-01T13:35:00Z", Lines = new[] { new { ProductId = "products/blue-1", Name = "Blue cheese", Quantity =2 } } }
-                        }
-                    },
-                    _ => new { }
-                };
-            }
-
             var resume1 = store.AI.Conversation(agentId, starter.Id, creationOptions: null, staleCv);
             resume1.AddActionResponse(actions[0].ToolId, GetToolResult(actions[0].Name));
             resume1.OnUnhandledAction += args => Task.CompletedTask;
@@ -328,6 +292,41 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 Path = originalOptions?.Path, // keep any custom path from the framework
                 ModifyDatabaseRecord = originalOptions?.ModifyDatabaseRecord,
             });
+        }
+
+        private static object GetToolResult(string toolName)
+        {
+            return toolName switch
+            {
+                "ProductSearch" => new
+                {
+                    Products = new[]
+                    {
+                        new { Id = "products/cheddar-1", Name = "Cheddar", Score =0.98 },
+                        new { Id = "products/gouda-1", Name = "Gouda", Score =0.95 },
+                        new { Id = "products/brie-1", Name = "Brie", Score =0.93 },
+                        new { Id = "products/parmesan-1", Name = "Parmesan", Score =0.91 },
+                        new { Id = "products/blue-1", Name = "Blue cheese", Score =0.89 }
+                    }
+                },
+                "RecentOrder" => new
+                {
+                    Orders = new[]
+                    {
+                        new { Id = "orders/1-A", OrderedAt = "2025-01-10T12:00:00Z", Lines = new[] { new { ProductId = "products/brie-1", Name = "Brie", Quantity =1 } } },
+                        new { Id = "orders/2-A", OrderedAt = "2025-01-09T11:00:00Z", Lines = new[] { new { ProductId = "products/cheddar-1", Name = "Cheddar", Quantity =2 } } },
+                        new { Id = "orders/3-A", OrderedAt = "2025-01-08T09:30:00Z", Lines = new[] { new { ProductId = "products/gouda-1", Name = "Gouda", Quantity =1 } } },
+                        new { Id = "orders/4-A", OrderedAt = "2025-01-07T18:15:00Z", Lines = new[] { new { ProductId = "products/parmesan-1", Name = "Parmesan", Quantity =1 } } },
+                        new { Id = "orders/5-A", OrderedAt = "2025-01-06T20:05:00Z", Lines = new[] { new { ProductId = "products/blue-1", Name = "Blue cheese", Quantity =1 } } },
+                        new { Id = "orders/6-A", OrderedAt = "2025-01-05T14:45:00Z", Lines = new[] { new { ProductId = "products/cheddar-1", Name = "Cheddar", Quantity =1 } } },
+                        new { Id = "orders/7-A", OrderedAt = "2025-01-04T08:10:00Z", Lines = new[] { new { ProductId = "products/gouda-1", Name = "Gouda", Quantity =3 } } },
+                        new { Id = "orders/8-A", OrderedAt = "2025-01-03T16:25:00Z", Lines = new[] { new { ProductId = "products/brie-1", Name = "Brie", Quantity =2 } } },
+                        new { Id = "orders/9-A", OrderedAt = "2025-01-02T10:00:00Z", Lines = new[] { new { ProductId = "products/parmesan-1", Name = "Parmesan", Quantity =1 } } },
+                        new { Id = "orders/10-A", OrderedAt = "2025-01-01T13:35:00Z", Lines = new[] { new { ProductId = "products/blue-1", Name = "Blue cheese", Quantity =2 } } }
+                    }
+                },
+                _ => new { }
+            };
         }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24791.cs
@@ -83,7 +83,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "Chats/",
                 new AiConversationCreationOptions().AddParameter("authors", new string[] { "Aviv" }));
 
-            chat.SetUserPrompt("Can you answer the questions?");
+            chat.SetUserPrompt("answer the questions using the tool I provided you");
             var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
             Assert.True(more.Status == AiConversationResult.Done);
 
@@ -141,7 +141,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "Chats/",
                 new AiConversationCreationOptions().AddParameter("priority", priority));
 
-            chat.SetUserPrompt("Can you answer the questions?");
+            chat.SetUserPrompt("answer the questions using the tool I provided you");
             var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
             Assert.True(more.Status == AiConversationResult.Done);
 
@@ -199,7 +199,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "Chats/",
                 new AiConversationCreationOptions().AddParameter("priority", priority));
 
-            chat.SetUserPrompt("Can you answer the questions?");
+            chat.SetUserPrompt("answer the questions using the tool I provided you");
             var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
             Assert.True(more.Status == AiConversationResult.Done);
 
@@ -256,7 +256,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "Chats/",
                 new AiConversationCreationOptions().AddParameter("shouldAnswer", true));
 
-            chat.SetUserPrompt("Can you answer the questions?");
+            chat.SetUserPrompt("answer the questions using the tool I provided you");
             var more = await chat.RunAsync<QuestionOutputSchema>(CancellationToken.None);
             Assert.True(more.Status == AiConversationResult.Done);
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24883.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24883.cs
@@ -48,10 +48,10 @@ public class RavenDB_24883 : RavenTestBase
         Assert.Null(run.Answer);
         Assert.True(recentOrderCalled);
         
-        chat.AddActionResponse(toolId, "done");
+        chat.AddActionResponse(toolId, "my recent orders: Pizza, Burger");
         recentOrderCalled = false;  
         run = await chat.RunAsync<object>();
-        Assert.Equal(run.Status, AiConversationResult.Done);
+        Assert.Equal(AiConversationResult.Done, run.Status);
         Assert.NotNull(run.Answer);
         Assert.False(recentOrderCalled);
         

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24913.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24913.cs
@@ -100,7 +100,7 @@ public class RavenDB_24913(ITestOutputHelper output) : RavenTestBase(output)
             new AiConversationCreationOptions()
                 .AddParameter("username", "ayende"));
 
-        chat.SetUserPrompt("What is my name?");
+        chat.SetUserPrompt("What is my full name?");
 
         var sb = new StringBuilder();
         var result = await chat.StreamAsync<Reply>(r => r.Answer, chunk =>

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24984.cs
@@ -107,6 +107,7 @@ public class RavenDB_24984 : RavenTestBase
         Assert.Equal(AiConversationResult.Done, result.Status);
 
         var lastToolResult = lastNumber - 1;
+        Console.WriteLine(result.Answer.Answer);
         Assert.Equal(lastToolResult.ToString(), result.Answer.Answer);
         Assert.Equal(maxModelIterationsPerCall, lastToolResult);
 

--- a/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
@@ -114,7 +114,7 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
 
         try
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20)))
             {
                 return TryConnect(out logger, cts.Token);
             }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -18,7 +18,7 @@ public class EmbeddingsOpenAiConnectorForTesting : AbstractEmbeddingsConnectorFo
 
 public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<GenAiOpenAiConnectorForTesting>
 {
-    private const string Model = "gpt-4o-mini";
+    private const string Model = "gpt-5-mini";
 
     public GenAiOpenAiConnectorForTesting()
     {
@@ -41,7 +41,7 @@ internal static class OpenAiConnectorHelper
         return new AiConnectionString
         {
             ModelType = modelType,
-            OpenAiSettings = new OpenAiSettings(apiKey, Endpoint, model) { Temperature = 0 }
+            OpenAiSettings = new OpenAiSettings(apiKey, Endpoint, model) { Temperature = 1 }
         };
     }
 }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -242,7 +242,7 @@ namespace FastTests
                             [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "true",
                             [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString(),
                             [RavenConfiguration.GetKey(x => x.Queries.RegexTimeout)] = (500).ToString(),
-                            [RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = 30.ToString()
+                            [RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = 60.ToString()
                         }
                     };
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -242,7 +242,7 @@ namespace FastTests
                             [RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "true",
                             [RavenConfiguration.GetKey(x => x.Indexing.MinNumberOfMapAttemptsAfterWhichBatchWillBeCanceledIfRunningLowOnMemory)] = int.MaxValue.ToString(),
                             [RavenConfiguration.GetKey(x => x.Queries.RegexTimeout)] = (500).ToString(),
-                            [RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = 10.ToString()
+                            [RavenConfiguration.GetKey(x => x.Ai.GenAiSendToModelTimeout)] = 30.ToString()
                         }
                     };
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25218/Migrate-AI-Agent-Tests-from-gpt-4o-mini-to-gpt-5-mini-and-Resolve-Failures

### Additional description

Apparently, even though gpt-5-mini considered faster per token, it utilizes a larger volume of internal reasoning tokens to improve output accuracy. Consequently, total latency may increase. I have expanded the timeout window to accommodate this behavior while benefiting from the higher-quality responses.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
