### PR TITLE
RavenDB-22434 - failing tests - Wait and Assert all shards have members, add debug info

### DIFF
--- a/test/SlowTests/Sharding/Encryption/ShardedEncryption.cs
+++ b/test/SlowTests/Sharding/Encryption/ShardedEncryption.cs
@@ -454,7 +454,7 @@ namespace SlowTests.Sharding.Encryption
                 }
 
                 // add shard
-                var sharding = await Sharding.GetShardingConfigurationAsync(store);
+                var sharding = await Sharding.AssertAllShardsHaveMembers(store);
                 var shardNodes = sharding.Shards.Select(kvp => kvp.Value.Members[0]);
                 var nodeNotInDbGroup = nodes.SingleOrDefault(n => shardNodes.Contains(n.ServerStore.NodeTag) == false);
                 Assert.NotNull(nodeNotInDbGroup);

--- a/test/SlowTests/Sharding/PrefixedSharding.cs
+++ b/test/SlowTests/Sharding/PrefixedSharding.cs
@@ -1839,7 +1839,7 @@ public class PrefixedSharding : ClusterTestBase
         await session.SaveChangesAsync();
 
         // add shard #2 to database
-        var sharding = await Sharding.GetShardingConfigurationAsync(store);
+        var sharding = await Sharding.AssertAllShardsHaveMembers(store);
         var shardNodes = sharding.Shards.Select(kvp => kvp.Value.Members[0]);
         var nodeNotInDbGroup = cluster.Nodes.SingleOrDefault(n => shardNodes.Contains(n.ServerStore.NodeTag) == false)?.ServerStore.NodeTag;
         Assert.NotNull(nodeNotInDbGroup);

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -24,6 +24,7 @@ using Sparrow.Server;
 using Sparrow.Threading;
 using Tests.Infrastructure;
 using Xunit;
+using Xunit.Sdk;
 
 namespace FastTests;
 
@@ -162,6 +163,40 @@ public partial class RavenTestBase
         {
             var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(database ?? store.Database));
             return record.Sharding;
+        }
+
+        public async Task<ShardingConfiguration> AssertAllShardsHaveMembers(DocumentStore store, int timeout = 15_000, int interval = 100)
+        {
+            ShardingConfiguration lastSuccessfulSharding = null;
+            var shardingDebugInfo = string.Empty;
+            try
+            {
+                await WaitAndAssertForValueAsync(act: AllHaveMember, true, timeout, interval);
+            }
+            catch (EqualException)
+            {
+                Assert.Fail(shardingDebugInfo);
+            }
+            return lastSuccessfulSharding;
+
+            async Task<bool> AllHaveMember()
+            {
+                var sharding = await GetShardingConfigurationAsync(store);
+
+                foreach (var kvp in sharding.Shards)
+                {
+                    if (kvp.Value.Members.Count == 0)
+                    {
+                        shardingDebugInfo = $"Shard: {kvp.Key} has no members." +
+                                            Environment.NewLine +
+                                            string.Join("," + Environment.NewLine, sharding.Shards.Select(kvp1 => "Shard " + kvp1.Key + ": " + kvp1.Value));
+                        return false;
+                    }
+                }
+
+                lastSuccessfulSharding = sharding;
+                return true;
+            }
         }
 
         public string GetRandomIdForShard(ShardingConfiguration config, int shardNumber)


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-22434/SlowTests.Sharding.Encryption.ShardedEncryption.CanAddAndRemoveShardFromEncryptedShardedDb

https://issues.hibernatingrhinos.com/issue/RavenDB-23242/SlowTests.Sharding.PrefixedSharding.ShouldNotAllowToRemoveShardFromDbIfItHasPrefixesSettings

### Additional description

Failing tests - Add Wait and asserts for members and debug info

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
