### PR TITLE
RavenDB-25673 Conditional expression support in querying.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -782,7 +782,7 @@ public static partial class CoraxQueryBuilder
     
     private static IQueryMatch HandleWhen(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization, bool exact, int? proximity)
     {
-        PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Conditional exists requires exactly 2 arguments, but got {expression.Arguments.Count}");
+        PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
         var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery((BinaryExpression)expression.Arguments[0], builderParameters.QueryParameters);
         if (constantExpressionResult == false)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -550,18 +550,27 @@ public static partial class CoraxQueryBuilder
     {
         var indexSearcher = builderParameters.IndexSearcher;
         IQueryMatch left = ToCoraxQuery(builderParameters, leftExpr, ref builderParameters.StreamingDisabled, exact);
+        
         // Corax does support internal negation of some primitives. Let's check if we can use it.
         if (TryUseNegatedQuery(builderParameters, rightExpr, out var right, exact) == false)
         {
+            if (left is CoraxWhenQuery)
+                left = builderParameters.AllEntries.Replay();
+            
             right = ToCoraxQuery(builderParameters, rightExpr.Expression, ref builderParameters.StreamingDisabled, exact);
             Materialize(builderParameters, ref left, ref right, ref builderParameters.StreamingDisabled);
-            return indexSearcher.AndNot(left, right, token: builderParameters.Token);
+            
+            return right is CoraxWhenQuery 
+                ? left 
+                : indexSearcher.AndNot(left, right, token: builderParameters.Token);
         }
 
         // We internally negated the right expression. If we find a pattern true and (NOT EXPR) we can skip the true, since it's noop. 
-        if (leftExpr is TrueExpression)
+        if (leftExpr is TrueExpression || left is CoraxWhenQuery)
             return right; // true and not... optimization
 
+        Debug.Assert(right is not CoraxWhenQuery, "TryUseNegatedQuery should not return CoraxWhenQuery as right side of the expression.");
+        
         // Materialize the query
         if (TryAndMergeOrMaterialize(builderParameters, ref left, ref right, out var merged, ref builderParameters.StreamingDisabled))
             return merged;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -508,7 +508,7 @@ public static partial class CoraxQueryBuilder
                 case MethodType.EndsWith:
                     return HandleEndsWith(builderParameters, me, exact, ref leftOnlyOptimization);
                 case MethodType.Exists:
-                    return HandleExists(builderParameters, me, ref leftOnlyOptimization);
+                    return HandleExists(builderParameters, me, ref leftOnlyOptimization, exact, proximity);
                 case MethodType.Exact:
                     return HandleExact(builderParameters, me, ref leftOnlyOptimization, proximity);
                 case MethodType.Spatial_Within:
@@ -765,7 +765,39 @@ public static partial class CoraxQueryBuilder
         }
     }
 
-    private static IQueryMatch HandleExists(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization)
+    private static IQueryMatch HandleExists(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization, bool exact, int? proximity)
+    {
+        if (expression.Arguments.Count == 1)
+            return HandleExistsField(builderParameters, expression, ref streamingOptimization);
+        
+        return HandleConditionalExists(builderParameters, expression, ref streamingOptimization, exact, proximity);
+    }
+
+
+    private static IQueryMatch HandleConditionalExists(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization, bool exact, int? proximity)
+    {
+        PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 3, $"Conditional exists requires exactly 3 arguments, but got {expression.Arguments.Count}");
+            
+        PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[0] is ValueExpression {Value: ValueTokenType.Parameter}, $"First argument to conditional exists must be a parameter, but got '{expression.Arguments[0].ToString()}'");
+
+        ValueExpression field = (ValueExpression)expression.Arguments[0];
+        var parameterName = field.Token.Value;
+        var parameterExists = builderParameters.QueryParameters.Contains(parameterName);
+
+        if (parameterExists)
+        {
+            return ToCoraxQuery(builderParameters, expression.Arguments[1], ref streamingOptimization, exact, proximity);
+        }
+
+        bool includeAll = false;
+        PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[2] is ValueExpression thirdArgument && bool.TryParse(thirdArgument.Token.Value, out includeAll), $"Third argument must be boolean. It must be 'true' or 'false'.");
+
+        return includeAll 
+            ? builderParameters.AllEntries.Replay() 
+            : builderParameters.IndexSearcher.EmptyMatch();
+    }
+    
+    private static IQueryMatch HandleExistsField(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization)
     {
         var metadata = builderParameters.Metadata;
         var queryParameters = builderParameters.QueryParameters;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -188,8 +188,10 @@ public static partial class CoraxQueryBuilder
             
             if (metadata.Query.Where is not null)
             {
-                coraxQuery = ToCoraxQuery(builderParameters, metadata.Query.Where,  ref streamingOptimization);
-                coraxQuery = MaterializeWhenNeeded(builderParameters, coraxQuery, ref streamingOptimization);
+                coraxQuery = ToCoraxQuery(builderParameters, metadata.Query.Where, ref streamingOptimization);
+                coraxQuery = coraxQuery is CoraxWhenQuery 
+                    ? builderParameters.AllEntries.Replay() 
+                    : MaterializeWhenNeeded(builderParameters, coraxQuery, ref streamingOptimization);
             }
             // We sort on known field types, we'll optimize based on the first one to get the rest
             // Non-existing posting list isn't aware of dynamic fields, so we can't use this optimization for them
@@ -342,6 +344,12 @@ public static partial class CoraxQueryBuilder
                             default:
                                 left = ToCoraxQuery(builderParameters, @where.Left, ref leftOnlyOptimization, exact);
                                 right = ToCoraxQuery(builderParameters, @where.Right, ref builderParameters.StreamingDisabled, exact);
+                                
+                                if (left is CoraxWhenQuery)
+                                    return right;
+                                if (right is CoraxWhenQuery)
+                                    return left;
+                                
                                 // in case of AND we can materialize only TermMatches, we push streamingOptimization there only for changing order for MultiTermMatch;
                             if (left is CoraxBooleanItem cbi && leftOnlyOptimization.TrySetAsStreamingField(builderParameters, cbi, right))
                                     left = cbi.Materialize(ref leftOnlyOptimization);
@@ -365,6 +373,11 @@ public static partial class CoraxQueryBuilder
                         var left = ToCoraxQuery(builderParameters, @where.Left, ref builderParameters.StreamingDisabled, exact);
                         var right = ToCoraxQuery(builderParameters, @where.Right, ref builderParameters.StreamingDisabled, exact);
 
+                        if (left is CoraxWhenQuery)
+                            return right;
+                        if (right is CoraxWhenQuery)
+                            return left;
+                        
                         builderParameters.BuildSteps?.Add(
                             $"OR operator: left - {left.GetType().FullName} ({left}) assembly: {left.GetType().Assembly.FullName} assembly location: {left.GetType().Assembly.Location} , right - {right.GetType().FullName} ({right}) assemlbly: {right.GetType().Assembly.FullName} assembly location: {right.GetType().Assembly.Location}");
 
@@ -508,7 +521,9 @@ public static partial class CoraxQueryBuilder
                 case MethodType.EndsWith:
                     return HandleEndsWith(builderParameters, me, exact, ref leftOnlyOptimization);
                 case MethodType.Exists:
-                    return HandleExists(builderParameters, me, ref leftOnlyOptimization, exact, proximity);
+                    return HandleExists(builderParameters, me, ref leftOnlyOptimization);
+                case MethodType.When:
+                    return HandleWhen(builderParameters, me, ref leftOnlyOptimization, exact, proximity);
                 case MethodType.Exact:
                     return HandleExact(builderParameters, me, ref leftOnlyOptimization, proximity);
                 case MethodType.Spatial_Within:
@@ -764,40 +779,19 @@ public static partial class CoraxQueryBuilder
             return CoraxBooleanItem.BuildBetween(builderParameters.IndexSearcher, index, fieldMetadata, valueFirstAsString, valueSecondAsString, leftSideOperation, rightSideOperation, ref builderParameters.StreamingDisabled);
         }
     }
-
-    private static IQueryMatch HandleExists(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization, bool exact, int? proximity)
-    {
-        if (expression.Arguments.Count == 1)
-            return HandleExistsField(builderParameters, expression, ref streamingOptimization);
-        
-        return HandleConditionalExists(builderParameters, expression, ref streamingOptimization, exact, proximity);
-    }
-
-
-    private static IQueryMatch HandleConditionalExists(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization, bool exact, int? proximity)
-    {
-        PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 3, $"Conditional exists requires exactly 3 arguments, but got {expression.Arguments.Count}");
-            
-        PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[0] is ValueExpression {Value: ValueTokenType.Parameter}, $"First argument to conditional exists must be a parameter, but got '{expression.Arguments[0].ToString()}'");
-
-        ValueExpression field = (ValueExpression)expression.Arguments[0];
-        var parameterName = field.Token.Value;
-        var parameterExists = builderParameters.QueryParameters.Contains(parameterName);
-
-        if (parameterExists)
-        {
-            return ToCoraxQuery(builderParameters, expression.Arguments[1], ref streamingOptimization, exact, proximity);
-        }
-
-        bool includeAll = false;
-        PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[2] is ValueExpression thirdArgument && bool.TryParse(thirdArgument.Token.Value, out includeAll), $"Third argument must be boolean. It must be 'true' or 'false'.");
-
-        return includeAll 
-            ? builderParameters.AllEntries.Replay() 
-            : builderParameters.IndexSearcher.EmptyMatch();
-    }
     
-    private static IQueryMatch HandleExistsField(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization)
+    private static IQueryMatch HandleWhen(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization, bool exact, int? proximity)
+    {
+        PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Conditional exists requires exactly 2 arguments, but got {expression.Arguments.Count}");
+
+        var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery((BinaryExpression)expression.Arguments[0], builderParameters.QueryParameters);
+        if (constantExpressionResult == false)
+            return new CoraxWhenQuery();
+            
+        return ToCoraxQuery(builderParameters, expression.Arguments[1], ref streamingOptimization, exact, proximity);
+    }
+
+    private static IQueryMatch HandleExists(Parameters builderParameters, MethodExpression expression, ref StreamingOptimization streamingOptimization)
     {
         var metadata = builderParameters.Metadata;
         var queryParameters = builderParameters.QueryParameters;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxWhenQuery.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxWhenQuery.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Corax.Querying.Matches.Meta;
+
+namespace Raven.Server.Documents.Indexes.Persistence.Corax.QueryOptimizer;
+
+public struct CoraxWhenQuery : IQueryMatch
+{
+    private const string ExceptionMessage = $"{nameof(CoraxWhenQuery)} is used for type relaxation and is not a valid struct.";
+    
+    public long Count => throw new NotSupportedException(ExceptionMessage);
+    public SkipSortingResult AttemptToSkipSorting() => throw new NotSupportedException(ExceptionMessage);
+
+    public QueryCountConfidence Confidence => throw new NotSupportedException(ExceptionMessage);
+    public bool IsBoosting => throw new NotSupportedException(ExceptionMessage);
+    public int Fill(Span<long> matches) => throw new NotSupportedException(ExceptionMessage);
+
+    public int AndWith(Span<long> buffer, int matches) => throw new NotSupportedException(ExceptionMessage);
+
+    public void Score(Span<long> matches, Span<float> scores, float boostFactor) => throw new NotSupportedException(ExceptionMessage);
+
+    public QueryInspectionNode Inspect() => throw new NotSupportedException(ExceptionMessage);
+
+    public DuplicatesOccurrence DuplicatesOccurrenceStatus => throw new NotSupportedException(ExceptionMessage);
+}

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -55,6 +55,13 @@ namespace Raven.Server.Documents.Queries
                 var luceneQuery = ToLuceneQuery(serverContext, context, metadata.Query, whereExpression, metadata, index, parameters, analyzer, factories,
                     queryTime: queryTime, buildSteps: buildSteps);
 
+                    // If the query evaluates to LuceneWhenQuery,
+                    // it means all conditions were removed; therefore, the query has no WHERE clause.
+                    if (luceneQuery is LuceneWhenQuery)
+                    {
+                        return new MatchAllDocsQuery();
+                    }
+                
                 // The parser already throws parse exception if there is a syntax error.
                 // We now return null in the case of a term query that has been fully analyzed, so we need to return a valid query.
                 return luceneQuery ?? new BooleanQuery();
@@ -249,6 +256,12 @@ namespace Raven.Server.Documents.Queries
                             var right = ToLuceneQuery(serverContext, documentsContext, query, @where.Right, metadata, index, parameters, analyzer,
                                 factories, exact, secondary: true, queryTime: queryTime, buildSteps: buildSteps);
 
+                            if (left is LuceneWhenQuery)
+                                return right;
+                            
+                            if (right is LuceneWhenQuery)
+                                return left;
+                            
                             if (left is RavenBooleanQuery rbq)
                             {
                                 if (rbq.TryAnd(right, buildSteps) == false)
@@ -272,6 +285,12 @@ namespace Raven.Server.Documents.Queries
                             buildSteps?.Add(
                                 $"OR operator: left - {left.GetType().FullName} ({left}) assembly: {left.GetType().Assembly.FullName} assemby location: {left.GetType().Assembly.Location} , right - {right.GetType().FullName} ({right}) assemlby: {right.GetType().Assembly.FullName} assemby location: {right.GetType().Assembly.Location}");
 
+                            if (left is LuceneWhenQuery)
+                                return right;
+                            
+                            if (right is LuceneWhenQuery)
+                                return left;
+                            
                             if (left is RavenBooleanQuery rbq)
                             {
                                 if (rbq.TryOr(right, buildSteps) == false)
@@ -313,6 +332,10 @@ namespace Raven.Server.Documents.Queries
 
                 var inner = ToLuceneQuery(serverContext, documentsContext, query, ne.Expression,
                     metadata, index, parameters, analyzer, factories, exact, secondary: secondary, queryTime: queryTime, buildSteps: buildSteps);
+
+                if (inner is LuceneWhenQuery)
+                    return inner;
+                
                 return new BooleanQuery { { inner, Occur.MUST_NOT }, { new MatchAllDocsQuery(), Occur.SHOULD } };
             }
 
@@ -403,7 +426,9 @@ namespace Raven.Server.Documents.Queries
                     case MethodType.Lucene:
                         return HandleLucene(query, me, metadata, parameters, analyzer, exact);
                     case MethodType.Exists:
-                        return HandleExists(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories);
+                        return HandleExists(query, me, metadata, parameters);
+                    case MethodType.When:
+                        return HandleWhen(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
                     case MethodType.Exact:
                         return HandleExact(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, queryTime);
                     case MethodType.Spatial_Within:
@@ -691,50 +716,27 @@ namespace Raven.Server.Documents.Queries
         {
             return metadata.GetIndexFieldName(new QueryFieldName(field.Token.Value, field.Value == ValueTokenType.String), parameters);
         }
-
-        private static Lucene.Net.Search.Query HandleExists(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query,
-            MethodExpression expression, QueryMetadata metadata, Index index,
+        
+        private static Lucene.Net.Search.Query HandleWhen(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query, MethodExpression expression, QueryMetadata metadata, Index index,
             BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
             List<string> buildSteps = null)
         {
-            if (expression.Arguments.Count == 1)
-                return HandleExistsField(serverContext, documentsContext, query, expression, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
+            PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Conditional exists requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
-            return HandleConditionalExists(serverContext, documentsContext, query, expression, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
-        }
-
-        private static Lucene.Net.Search.Query HandleConditionalExists(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query, MethodExpression expression, QueryMetadata metadata, Index index,
-            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
-            List<string> buildSteps = null)
-        {
-            PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 3, $"Conditional exists requires exactly 3 arguments, but got {expression.Arguments.Count}");
+            var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery((BinaryExpression)expression.Arguments[0], parameters);
+            if (constantExpressionResult == false)
+                return new LuceneWhenQuery();
             
-            PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[0] is ValueExpression {Value: ValueTokenType.Parameter}, $"First argument to conditional exists must be a parameter, but got '{expression.Arguments[0].ToString()}'");
-
-            ValueExpression field = (ValueExpression)expression.Arguments[0];
-            var parameterName = field.Token.Value;
-            var parameterExists = parameters.Contains(parameterName);
-
-            if (parameterExists)
-            {
-                return ToLuceneQuery(serverContext, documentsContext, query, expression.Arguments[1], metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
-            }
-
-            bool includeAll = false;
-            PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[2] is ValueExpression thirdArgument && bool.TryParse(thirdArgument.Token.Value, out includeAll), $"Third argument must be boolean. It must be 'true' or 'false'.");
-
-            return includeAll 
-                ? new MatchAllDocsQuery() 
-                : new BooleanQuery();
+            return ToLuceneQuery(serverContext, documentsContext, query, expression.Arguments[1], metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
         }
         
-        private static Lucene.Net.Search.Query HandleExistsField(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query,
-            MethodExpression expression, QueryMetadata metadata, Index index,
-            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
+        private static Lucene.Net.Search.Query HandleExists(Query query,
+            MethodExpression expression, QueryMetadata metadata,
+            BlittableJsonReaderObject parameters,
             List<string> buildSteps = null)
         {
             var fieldName = ExtractIndexFieldName(query, parameters, expression.Arguments[0], metadata);
-
+            buildSteps?.Add($"Exists({fieldName})");
             return LuceneQueryHelper.Term(fieldName, LuceneQueryHelper.Asterisk, LuceneTermType.WildCard);
         }
 

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -721,7 +721,7 @@ namespace Raven.Server.Documents.Queries
             BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
             List<string> buildSteps = null)
         {
-            PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Conditional exists requires exactly 2 arguments, but got {expression.Arguments.Count}");
+            PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
             var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery((BinaryExpression)expression.Arguments[0], parameters);
             if (constantExpressionResult == false)

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -403,7 +403,7 @@ namespace Raven.Server.Documents.Queries
                     case MethodType.Lucene:
                         return HandleLucene(query, me, metadata, parameters, analyzer, exact);
                     case MethodType.Exists:
-                        return HandleExists(query, parameters, me, metadata);
+                        return HandleExists(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories);
                     case MethodType.Exact:
                         return HandleExact(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, queryTime);
                     case MethodType.Spatial_Within:
@@ -692,7 +692,46 @@ namespace Raven.Server.Documents.Queries
             return metadata.GetIndexFieldName(new QueryFieldName(field.Token.Value, field.Value == ValueTokenType.String), parameters);
         }
 
-        private static Lucene.Net.Search.Query HandleExists(Query query, BlittableJsonReaderObject parameters, MethodExpression expression, QueryMetadata metadata)
+        private static Lucene.Net.Search.Query HandleExists(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query,
+            MethodExpression expression, QueryMetadata metadata, Index index,
+            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
+            List<string> buildSteps = null)
+        {
+            if (expression.Arguments.Count == 1)
+                return HandleExistsField(serverContext, documentsContext, query, expression, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
+
+            return HandleConditionalExists(serverContext, documentsContext, query, expression, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
+        }
+
+        private static Lucene.Net.Search.Query HandleConditionalExists(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query, MethodExpression expression, QueryMetadata metadata, Index index,
+            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
+            List<string> buildSteps = null)
+        {
+            PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 3, $"Conditional exists requires exactly 3 arguments, but got {expression.Arguments.Count}");
+            
+            PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[0] is ValueExpression {Value: ValueTokenType.Parameter}, $"First argument to conditional exists must be a parameter, but got '{expression.Arguments[0].ToString()}'");
+
+            ValueExpression field = (ValueExpression)expression.Arguments[0];
+            var parameterName = field.Token.Value;
+            var parameterExists = parameters.Contains(parameterName);
+
+            if (parameterExists)
+            {
+                return ToLuceneQuery(serverContext, documentsContext, query, expression.Arguments[1], metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
+            }
+
+            bool includeAll = false;
+            PortableExceptions.ThrowIfNot<ArgumentException>(expression.Arguments[2] is ValueExpression thirdArgument && bool.TryParse(thirdArgument.Token.Value, out includeAll), $"Third argument must be boolean. It must be 'true' or 'false'.");
+
+            return includeAll 
+                ? new MatchAllDocsQuery() 
+                : new BooleanQuery();
+        }
+        
+        private static Lucene.Net.Search.Query HandleExistsField(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query,
+            MethodExpression expression, QueryMetadata metadata, Index index,
+            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
+            List<string> buildSteps = null)
         {
             var fieldName = ExtractIndexFieldName(query, parameters, expression.Arguments[0], metadata);
 

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -428,7 +428,7 @@ namespace Raven.Server.Documents.Queries
                     case MethodType.Exists:
                         return HandleExists(query, me, metadata, parameters);
                     case MethodType.When:
-                        return HandleWhen(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
+                        return HandleWhen(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, exact, proximity, secondary, queryTime, buildSteps);
                     case MethodType.Exact:
                         return HandleExact(serverContext, documentsContext, query, me, metadata, index, parameters, analyzer, factories, queryTime);
                     case MethodType.Spatial_Within:
@@ -718,8 +718,7 @@ namespace Raven.Server.Documents.Queries
         }
         
         private static Lucene.Net.Search.Query HandleWhen(TransactionOperationContext serverContext, DocumentsOperationContext documentsContext, Query query, MethodExpression expression, QueryMetadata metadata, Index index,
-            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false,
-            List<string> buildSteps = null)
+            BlittableJsonReaderObject parameters, Analyzer analyzer, QueryBuilderFactories factories, bool exact = false, int? proximity = null, bool secondary = false, QueryTimeScope queryTime = null, List<string> buildSteps = null)
         {
             PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
@@ -727,7 +726,7 @@ namespace Raven.Server.Documents.Queries
             if (constantExpressionResult == false)
                 return new LuceneWhenQuery();
             
-            return ToLuceneQuery(serverContext, documentsContext, query, expression.Arguments[1], metadata, index, parameters, analyzer, factories, exact, proximity, secondary, buildSteps);
+            return ToLuceneQuery(serverContext, documentsContext, query, expression.Arguments[1], metadata, index, parameters, analyzer, factories, exact, proximity, secondary, queryTime, buildSteps);
         }
         
         private static Lucene.Net.Search.Query HandleExists(Query query,

--- a/src/Raven.Server/Documents/Queries/LuceneWhenQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneWhenQuery.cs
@@ -1,0 +1,9 @@
+﻿namespace Raven.Server.Documents.Queries;
+
+public class LuceneWhenQuery : Lucene.Net.Search.Query
+{
+    public override string ToString(string field)
+    {
+        return nameof(LuceneWhenQuery);
+    }
+}

--- a/src/Raven.Server/Documents/Queries/MethodType.cs
+++ b/src/Raven.Server/Documents/Queries/MethodType.cs
@@ -63,5 +63,6 @@
 
         Now,
         Today,
+        When
     }
 }

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -25,6 +25,7 @@ namespace Raven.Server.Documents.Queries.Parser
         private int _statePos;
 
         private bool _insideTimeSeriesBody;
+        private bool _insideWhenMethod;
         private string _fromAlias;
         public const string TimeSeries = "timeseries";
 
@@ -1286,8 +1287,11 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
 
         private bool Method(FieldExpression field, out MethodExpression op)
         {
+            
+            _insideWhenMethod = field.FieldValue.Equals("when", StringComparison.OrdinalIgnoreCase);
             var args = ReadMethodArguments();
-
+            _insideWhenMethod = false;
+            
             op = new MethodExpression(field.FieldValue, args);
             return true;
         }
@@ -1328,6 +1332,10 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
 
                     if (Scanner.TryScan(',') == false)
                         ThrowParseException("parsing method expression, expected ','");
+                    
+                    // When we're in the `when` method scope, parameter names are valid only in the first argument;
+                    // after the first comma, we prohibit using a parameter as a field identifier.
+                    _insideWhenMethod = false;
                 }
 
                 var maybeExpression = false;
@@ -1480,7 +1488,7 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
             bool quoted = false;
             while (true)
             {
-                if (Scanner.Identifier(beginning: part++ == 0) == false)
+                if (Scanner.Identifier(beginning: part++ == 0, insideWhenMethod: _insideWhenMethod) == false)
                 {
                     if (Scanner.String(out var str, fieldPath: part > 1))
                     {

--- a/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryParser.cs
@@ -1287,8 +1287,13 @@ Grouping by 'Tag' or Field is supported only as a second grouping-argument.";
 
         private bool Method(FieldExpression field, out MethodExpression op)
         {
+            if (field.FieldValue.Equals("when", StringComparison.OrdinalIgnoreCase))
+            {
+                if (_insideWhenMethod)
+                    ThrowParseException("When method cannot be nested");
+                _insideWhenMethod = true;
+            }
             
-            _insideWhenMethod = field.FieldValue.Equals("when", StringComparison.OrdinalIgnoreCase);
             var args = ReadMethodArguments();
             _insideWhenMethod = false;
             

--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -112,9 +112,9 @@ namespace Raven.Server.Documents.Queries.Parser
             if (SkipWhitespace(skipWhitespace) == false)
                 return false;
 
-            var isNotIdentifier = (Beggining: beginning, IsParameter: isParameter) switch
+            var isNotIdentifier = (Beginning: beginning, IsParameter: isParameter) switch
             {
-                (Beggining: true, IsParameter: false) => char.IsLetter(_q[_pos]) == false,
+                (Beginning: true, IsParameter: false) => char.IsLetter(_q[_pos]) == false,
                 _ => char.IsLetterOrDigit(_q[_pos]) == false
             };
             

--- a/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
+++ b/src/Raven.Server/Documents/Queries/Parser/QueryScanner.cs
@@ -107,12 +107,18 @@ namespace Raven.Server.Documents.Queries.Parser
             return result;
         }
 
-        public bool Identifier(bool skipWhitespace = true, bool beginning = true, bool isParameter = false)
+        public bool Identifier(bool skipWhitespace = true, bool beginning = true, bool isParameter = false, bool insideWhenMethod = false)
         {
             if (SkipWhitespace(skipWhitespace) == false)
                 return false;
 
-            if ((beginning && !isParameter ? char.IsLetter(_q[_pos]) == false : char.IsLetterOrDigit(_q[_pos]) == false) && _q[_pos] != '_' && _q[_pos] != '@')
+            var isNotIdentifier = (Beggining: beginning, IsParameter: isParameter) switch
+            {
+                (Beggining: true, IsParameter: false) => char.IsLetter(_q[_pos]) == false,
+                _ => char.IsLetterOrDigit(_q[_pos]) == false
+            };
+            
+            if (isNotIdentifier && _q[_pos] != '_' && _q[_pos] != '@' && (insideWhenMethod == false || _q[_pos] != '$'))
                 return false;
 
             _tokenStart = _pos;

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -859,5 +860,165 @@ public static class QueryBuilderHelper
         }
 
         return GenerateEmbeddings.FromArray(allocator, scope, memory, options, bytesRequired);
+    }
+    
+    public static bool EvaluateConstantExpressionForWhenQuery(BinaryExpression constantExpression, BlittableJsonReaderObject parameters)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+        if (constantExpression.Operator is OperatorType.And or OperatorType.Or)
+        {
+            PortableExceptions.ThrowIfNot<ArgumentException>(constantExpression.Left is BinaryExpression, $"Expected binary expression, but got: '{constantExpression.Left.ToString()}' of type '{constantExpression.Left.Type}'.");
+            PortableExceptions.ThrowIfNot<ArgumentException>(constantExpression.Right is BinaryExpression, $"Expected binary expression, but got: '{constantExpression.Right.ToString()}' of type '{constantExpression.Right.Type}'.");
+            
+            var leftResult = EvaluateConstantExpressionForWhenQuery((BinaryExpression)constantExpression.Left, parameters);
+            var rightResult = EvaluateConstantExpressionForWhenQuery((BinaryExpression)constantExpression.Right, parameters);
+            return (constantExpression.Operator) switch
+            {
+                OperatorType.And => leftResult && rightResult,
+                OperatorType.Or => leftResult || rightResult,
+                _ => throw new InvalidOperationException("Should not happen!")
+            };
+        }
+        
+        if (constantExpression.Left is not FieldExpression leftField)
+            throw new InvalidOperationException($"Expected field expression, but got: {constantExpression.Left}");
+        
+        bool paramIsMissing = false;
+        Debug.Assert(leftField.FieldValue.StartsWith('$'));
+        if (parameters.TryGet(new StringSegment(leftField.FieldValue, 1, leftField.FieldValue.Length - 1), out object paramValue) == false)
+        {
+            paramValue = null;
+            paramIsMissing = true;
+        }
+
+        var rightExpression = (ValueExpression)constantExpression.Right;
+        if ((paramIsMissing || paramValue is null) && rightExpression.Value is not ValueTokenType.Null)
+        {
+            return constantExpression.Operator switch
+            {
+                OperatorType.NotEqual => true,
+                _ => false
+            };
+        }
+
+        switch (rightExpression.Value)
+        {
+            case ValueTokenType.Null:
+            {
+                return (ParamIsMissing: paramIsMissing, ParamValue: paramValue) switch
+                {
+                    (ParamIsMissing: true, _) when constantExpression.Operator is OperatorType.Equal => true,
+                    (ParamIsMissing: _, null) when constantExpression.Operator is OperatorType.Equal => true,
+                    _ => false
+                };
+            }
+            case ValueTokenType.True:
+            case ValueTokenType.False:
+            {
+                if (paramValue is not bool paramValueAsBool)
+                    throw new InvalidOperationException($"Expected boolean value, but got: '{paramValue}' of type '{paramValue?.GetType()}'.");
+            
+                var leftSideAsBool = rightExpression.Value == ValueTokenType.True;
+
+                return constantExpression.Operator switch
+                {
+                    OperatorType.Equal => paramValueAsBool == leftSideAsBool,
+                    OperatorType.NotEqual => paramValueAsBool != leftSideAsBool,
+                    _ => throw new InvalidOperationException($"Cannot execute {constantExpression.Operator} on boolean values.")
+                };
+            }
+            case ValueTokenType.Long:
+            {
+                long leftSideValue = paramValue switch
+                {
+                    byte b => b,
+                    sbyte sb => sb,
+                    ushort us => us,
+                    short s => s,
+                    uint ui => ui,
+                    int i => i,
+                    ulong ul => checked((long)ul),
+                    long l => l,
+                    double d => checked((long)d),   
+                    float f => checked((long)f),
+                    decimal dc => checked((long)dc),
+                    LazyStringValue lsv => lsv.ToInt64(CultureInfo.InvariantCulture),
+                    LazyNumberValue lnv => lnv.ToInt64(CultureInfo.InvariantCulture),
+                    _ => throw new InvalidOperationException($"Cannot convert {paramValue!.GetType()} to long")
+                };
+            
+                if (long.TryParse(rightExpression.Token.Value, out var rightSideValue) == false)
+                    throw new InvalidOperationException($"Cannot convert {rightExpression.Token.Value} to long");
+            
+                return constantExpression.Operator switch
+                {
+                    OperatorType.Equal => leftSideValue == rightSideValue,
+                    OperatorType.NotEqual => leftSideValue != rightSideValue,
+                    OperatorType.GreaterThan => leftSideValue > rightSideValue,
+                    OperatorType.GreaterThanEqual => leftSideValue >= rightSideValue,
+                    OperatorType.LessThan => leftSideValue < rightSideValue,
+                    OperatorType.LessThanEqual => leftSideValue <= rightSideValue,
+                    _ => false
+                };
+            }
+            case ValueTokenType.Double:
+            {
+                double leftSideValue = paramValue switch
+                {
+                    byte b => b,
+                    sbyte sb => sb,
+                    ushort us => us,
+                    short s => s,
+                    uint ui => ui,
+                    int i => i,
+                    ulong ul => checked((long)ul),
+                    long l => l,
+                    double d => d,
+                    float f => f,
+                    decimal dc => checked((double)dc),
+                    LazyStringValue lsv => lsv.ToDouble(CultureInfo.InvariantCulture),
+                    LazyNumberValue lnv => lnv.ToDouble(CultureInfo.InvariantCulture),
+                    _ => throw new InvalidOperationException($"Cannot convert {paramValue!.GetType()} to long")
+                };
+            
+                if (double.TryParse(rightExpression.Token.Value, out var rightSideValue) == false)
+                    throw new InvalidOperationException($"Cannot convert {rightExpression.Token.Value} to double");
+            
+                return constantExpression.Operator switch
+                {
+                    OperatorType.Equal => leftSideValue.AlmostEquals(rightSideValue),
+                    OperatorType.NotEqual => leftSideValue.AlmostEquals(rightSideValue) == false,
+                    OperatorType.GreaterThan => leftSideValue > rightSideValue,
+                    OperatorType.GreaterThanEqual => leftSideValue >= rightSideValue,
+                    OperatorType.LessThan => leftSideValue < rightSideValue,
+                    OperatorType.LessThanEqual => leftSideValue <= rightSideValue,
+                    _ => false
+                };
+            }
+            case ValueTokenType.String:
+            {
+                var paramIsString = paramValue is string or StringSegment or LazyStringValue or LazyCompressedStringValue;
+                if (paramIsString == false)
+                    throw new InvalidOperationException($"Cannot compare string with non-string value. Parameter type is: {paramValue!.GetType().FullName}");
+                
+                var leftValueAsString = GetValueAsString(paramValue);
+                var rightValueAsString = rightExpression.Token.Value;
+
+                var comparisonResult = string.Compare(leftValueAsString, rightValueAsString, StringComparison.InvariantCulture);
+
+                return constantExpression.Operator switch
+                {
+                    OperatorType.Equal => comparisonResult == 0,
+                    OperatorType.NotEqual => comparisonResult != 0,
+                    OperatorType.GreaterThan => comparisonResult > 0,
+                    OperatorType.GreaterThanEqual => comparisonResult >= 0,
+                    OperatorType.LessThan => comparisonResult < 0,
+                    OperatorType.LessThanEqual => comparisonResult <= 0,
+                    _ => false
+                };
+            }
+            default:
+                return false;
+        }
     }
 }

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -884,8 +884,9 @@ public static class QueryBuilderHelper
             throw new InvalidOperationException($"Expected parameter field (e.g. $p0), but got: '{constantExpression.Left}'.");
         
         bool paramIsMissing = false;
-        Debug.Assert(leftField.FieldValue.StartsWith('$'));
-        if (parameters.TryGet(new StringSegment(leftField.FieldValue, 1, leftField.FieldValue.Length - 1), out object paramValue) == false)
+        PortableExceptions.ThrowIfNot<InvalidOperationException>(leftField.FieldValue.StartsWith('$'), "Expected parameter field (e.g. $p0), but got: '{constantExpression.Left}'.");
+        
+        if (parameters == null || parameters.TryGet(new StringSegment(leftField.FieldValue, 1, leftField.FieldValue.Length - 1), out object paramValue) == false)
         {
             paramValue = null;
             paramIsMissing = true;
@@ -948,9 +949,13 @@ public static class QueryBuilderHelper
                     LazyNumberValue lnv => lnv.ToInt64(CultureInfo.InvariantCulture),
                     _ => throw new InvalidOperationException($"Cannot convert {paramValue!.GetType()} to long")
                 };
-            
+
                 if (long.TryParse(rightExpression.Token.Value, out var rightSideValue) == false)
-                    throw new InvalidOperationException($"Cannot convert {rightExpression.Token.Value} to long");
+                {
+                    var rightSideTokenValue = rightExpression.Token.Value.Replace("_", string.Empty);
+                    if (long.TryParse(rightSideTokenValue, out rightSideValue) == false)
+                        throw new InvalidOperationException($"Cannot convert {rightExpression.Token.Value} to long");
+                }
             
                 return constantExpression.Operator switch
                 {
@@ -980,7 +985,7 @@ public static class QueryBuilderHelper
                     decimal dc => checked((double)dc),
                     LazyStringValue lsv => lsv.ToDouble(CultureInfo.InvariantCulture),
                     LazyNumberValue lnv => lnv.ToDouble(CultureInfo.InvariantCulture),
-                    _ => throw new InvalidOperationException($"Cannot convert {paramValue!.GetType()} to long")
+                    _ => throw new InvalidOperationException($"Cannot convert {paramValue!.GetType()} to double")
                 };
             
                 if (double.TryParse(rightExpression.Token.Value, out var rightSideValue) == false)
@@ -1006,7 +1011,7 @@ public static class QueryBuilderHelper
                 var leftValueAsString = GetValueAsString(paramValue);
                 var rightValueAsString = rightExpression.Token.Value;
 
-                var comparisonResult = string.Compare(leftValueAsString, rightValueAsString, StringComparison.InvariantCultureIgnoreCase);
+                var comparisonResult = string.Compare(leftValueAsString, rightValueAsString, StringComparison.OrdinalIgnoreCase);
 
                 return constantExpression.Operator switch
                 {

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -881,7 +881,7 @@ public static class QueryBuilderHelper
         }
         
         if (constantExpression.Left is not FieldExpression leftField)
-            throw new InvalidOperationException($"Expected field expression, but got: {constantExpression.Left}");
+            throw new InvalidOperationException($"Expected parameter field (e.g. $p0), but got: '{constantExpression.Left}'.");
         
         bool paramIsMissing = false;
         Debug.Assert(leftField.FieldValue.StartsWith('$'));
@@ -894,6 +894,8 @@ public static class QueryBuilderHelper
         var rightExpression = (ValueExpression)constantExpression.Right;
         if ((paramIsMissing || paramValue is null) && rightExpression.Value is not ValueTokenType.Null)
         {
+            //The left side is null or does not exist in parameter JSON, the right side is a non-null value. E.g.:
+            // $p0 != 1.0 // true
             return constantExpression.Operator switch
             {
                 OperatorType.NotEqual => true,

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -1006,7 +1006,7 @@ public static class QueryBuilderHelper
                 var leftValueAsString = GetValueAsString(paramValue);
                 var rightValueAsString = rightExpression.Token.Value;
 
-                var comparisonResult = string.Compare(leftValueAsString, rightValueAsString, StringComparison.InvariantCulture);
+                var comparisonResult = string.Compare(leftValueAsString, rightValueAsString, StringComparison.InvariantCultureIgnoreCase);
 
                 return constantExpression.Operator switch
                 {

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -2372,6 +2372,12 @@ function execute(doc, args){
                         break;
 
                     case MethodType.Exists:
+                        if (arguments.Count != 1)
+                        {
+                            Visit(arguments[1], parameters);
+                            break;
+                        }
+                        
                         fieldName = _metadata.ExtractFieldNameFromFirstArgument(arguments, methodName.Value, parameters);
                         _metadata.AddExistField(fieldName, parameters);
                         break;

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -2371,6 +2371,16 @@ function execute(doc, args){
                             _metadata.AddWhereField(fieldName, parameters, exact: _insideExact > 0, methodName: methodName.Value);
                         break;
 
+                    case MethodType.When:
+                        if (arguments.Count != 2)
+                        {
+                            throw new InvalidQueryException($"Method `when` requires two arguments, but got {arguments.Count}.");
+
+                        }
+
+                        Visit(arguments[1], parameters);
+                        break;
+                    
                     case MethodType.Exists:
                         if (arguments.Count != 1)
                         {

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -2382,12 +2382,6 @@ function execute(doc, args){
                         break;
                     
                     case MethodType.Exists:
-                        if (arguments.Count != 1)
-                        {
-                            Visit(arguments[1], parameters);
-                            break;
-                        }
-                        
                         fieldName = _metadata.ExtractFieldNameFromFirstArgument(arguments, methodName.Value, parameters);
                         _metadata.AddExistField(fieldName, parameters);
                         break;

--- a/src/Raven.Server/Documents/Queries/QueryMethod.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMethod.cs
@@ -146,6 +146,9 @@ namespace Raven.Server.Documents.Queries
             if (string.Equals(methodName, "today", StringComparison.OrdinalIgnoreCase))
                 return MethodType.Today;
 
+            if (string.Equals(methodName, "when", StringComparison.OrdinalIgnoreCase))
+                return MethodType.When;
+            
             if (throwIfNoMatch == false)
                 return MethodType.Unknown;
 

--- a/test/SlowTests.Issues/Issues/RavenDB-25673.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25673.cs
@@ -338,6 +338,12 @@ public class RavenDB_25673(ITestOutputHelper output) : RavenTestBase(output)
                 .AddParameter("myVar", 10L)
                 .Count();
             Assert.Equal(1, result);
+            
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1_0, Number != 1)")
+                .AddParameter("myVar", 1_0L)
+                .Count();
+            Assert.Equal(1, result);
 
             result = session.Advanced
                 .RawQuery<Dto>($"from {indexName} where when($myVar < 10, Number != 1)")
@@ -517,6 +523,20 @@ public class RavenDB_25673(ITestOutputHelper output) : RavenTestBase(output)
                 .Count();
             Assert.Equal(0, result);
 
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'BBB', Number != 1)")
+                .AddParameter("myVar", "bbb")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+            
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
+                .AddParameter("myVar", "BbB")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+            
             result = session.Advanced
                 .RawQuery<Dto>($"from {indexName} where when($myVar == 'BBB', Number != 1)")
                 .AddParameter("myVar", "bbb")

--- a/test/SlowTests.Issues/Issues/RavenDB-25673.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25673.cs
@@ -1,8 +1,7 @@
 ﻿using System.Linq;
 using FastTests;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
-using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,165 +11,1057 @@ namespace SlowTests.Issues;
 public class RavenDB_25673(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-    public void CanEvaluateConditionalExpressionAutoIndex(Options options)
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorNullTest(Options options, bool useAutoIndex)
     {
         using var store = GetDocumentStore(options);
-        InsertDocuments(store);
-        
         using var session = store.OpenSession();
-        QueryStatistics queryStatistics;
-        var conditionalNameWithoutParameter = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false)")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-
-        Assert.Empty(conditionalNameWithoutParameter);
-        Assert.Equal("Auto/Dtos/ByName", queryStatistics.IndexName);
-        
-        var conditionalNameWithoutParameterIncludeAll = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), true)")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-
-        Assert.Equal(3, conditionalNameWithoutParameterIncludeAll.Count);
-        Assert.Equal("Auto/Dtos/ByName", queryStatistics.IndexName);
-        
-        var conditionalNameWithParameter = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false)")
-            .AddParameter("p0", "te")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-        Assert.Equal(2, conditionalNameWithParameter.Count);
-        Assert.Contains("test", conditionalNameWithParameter[0].Name);
-        Assert.Contains("test", conditionalNameWithParameter[1].Name);
-        Assert.Equal("Auto/Dtos/ByName", queryStatistics.IndexName);
-
-        
-        var conditionalWithoutParameterOrStatement = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false) or Value = 2")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-        
-        Assert.Single(conditionalWithoutParameterOrStatement);
-        Assert.Contains("Maciej", conditionalWithoutParameterOrStatement[0].Name);
-        Assert.Equal("Auto/Dtos/ByNameAndValue", queryStatistics.IndexName);
-
-        
-        var conditionalWithParameterOrStatement = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false) or Value = 2")
-            .AddParameter("p0", "te")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-        
-        Assert.Equal(3, conditionalWithParameterOrStatement.Count);
-        Assert.Equal("Auto/Dtos/ByNameAndValue", queryStatistics.IndexName);
-        
-        var conditionalWithConditionInsideWithoutParameter = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-        
-        Assert.Empty(conditionalWithConditionInsideWithoutParameter);
-        
-        var conditionalWithConditionInsideWithParameter = session.Advanced
-            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
-            .AddParameter($"p0", "test")
-            .WaitForNonStaleResults()
-            .Statistics(out queryStatistics)
-            .ToList();
-
-        Assert.Single(conditionalWithConditionInsideWithParameter);
-    }
-    
-    [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
-    public void CanEvaluateConditionalExpressionStaticIndex(Options options)
-    {
-        using var store = GetDocumentStore(options);
-        InsertDocuments(store);
-        new Index().Execute(store);
-        Indexes.WaitForIndexing(store);
-        
-        using var session = store.OpenSession();
-        var conditionalNameWithoutParameter = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false)")
-            .ToList();
-
-        Assert.Empty(conditionalNameWithoutParameter);
-        
-        var conditionalNameWithoutParameterIncludeAll = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), true)")
-            .ToList();
-
-        Assert.Equal(3, conditionalNameWithoutParameterIncludeAll.Count);
-        
-        var conditionalNameWithParameter = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false)")
-            .AddParameter("p0", "te")
-            .ToList();
-        Assert.Equal(2, conditionalNameWithParameter.Count);
-        Assert.Contains("test", conditionalNameWithParameter[0].Name);
-        Assert.Contains("test", conditionalNameWithParameter[1].Name);
-
-        
-        var conditionalWithoutParameterOrStatement = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false) or Value = 2")
-            .ToList();
-        
-        Assert.Single(conditionalWithoutParameterOrStatement);
-        Assert.Contains("Maciej", conditionalWithoutParameterOrStatement[0].Name);
-
-        
-        var conditionalWithParameterOrStatement = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false) or Value = 2")
-            .AddParameter("p0", "te")
-            .ToList();
-        
-        Assert.Equal(3, conditionalWithParameterOrStatement.Count);
-
-        var conditionalWithConditionInsideWithoutParameter = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
-            .ToList();
-        
-        Assert.Empty(conditionalWithConditionInsideWithoutParameter);
-        
-        var conditionalWithConditionInsideWithParameter = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
-            .AddParameter($"p0", "test")
-            .WaitForNonStaleResults()
-            .ToList();
-
-        Assert.Single(conditionalWithConditionInsideWithParameter);
-        
-        var nonExistingFieldQuery = session.Advanced
-            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(DoNotIndexField, $p0), false)");
-        
-        var exception = Assert.Throws<Raven.Client.Exceptions.RavenException>(() => nonExistingFieldQuery.ToList());
-        Assert.Contains("The field 'DoNotIndexField' is not indexed in 'Index'", exception.Message);
-    }
-
-    private static void InsertDocuments(IDocumentStore store)
-    {
-        using var session = store.OpenSession();
-        session.Store(new Dto { Name = "test", Value = 1 });
-        session.Store(new Dto { Name = "Maciej", Value = 2 });
-        session.Store(new Dto { Name = "test2", Value = 3 });
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Attach = true, Number = 1 });
         session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+
+        int result;
+        // NotExistingParameter
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == null, Number != 1)")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != null, Number != 1)")
+                .Count();
+            Assert.Equal(1, result);
+
+            foreach (var op in new[] { ">", ">=", "<", "<=" })
+            {
+                result = session.Advanced
+                    .RawQuery<Dto>($"from {indexName} where when($myVar {op} null, Number != 1)")
+                    .Count();
+                Assert.Equal(1, result);
+            }
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1.5, Number != 1)")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1, Number != 1)")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != true, Number != 1)")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 'test', Number != 1)")
+                .Count();
+            Assert.Equal(0, result);
+
+            foreach (var value in new[] { "1.5", "1", "true", "'test'" })
+            foreach (var op in new[] { ">", ">=", "<", "<=" })
+            {
+                var query = $"from {indexName} where when($myVar {op} {value}, Number != 1)";
+                result = session.Advanced
+                    .RawQuery<Dto>(query)
+                    .Count();
+                Assert.Equal(1, result);
+            }
+        }
+
+        // Null parameter
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == null, Number != 1)")
+                .AddParameter("myVar", null)
+                .Count();
+            Assert.Equal(0, result);
+
+            foreach (var value in new[] { "1.5", "1", "true", "'test'" })
+            {
+                result = session.Advanced
+                    .RawQuery<Dto>($"from {indexName} where when($myVar != {value}, Number != 1)")
+                    .AddParameter("myVar", null)
+                    .Count();
+                Assert.Equal(0, result);
+            }
+
+            foreach (var op in new[] { "!=", ">", ">=", "<", "<=" })
+            {
+                result = session.Advanced
+                    .RawQuery<Dto>($"from {indexName} where when($myVar {op} null, Number != 1)")
+                    .AddParameter("myVar", null)
+                    .Count();
+                Assert.Equal(1, result);
+            }
+
+            foreach (var value in new[] { "1.5", "1", "true", "'test'" })
+            foreach (var op in new[] { ">", ">=", "<", "<=" })
+            {
+                result = session.Advanced
+                    .RawQuery<Dto>($"from {indexName} where when($myVar {op} {value}, Number != 1)")
+                    .AddParameter("myVar", null)
+                    .Count();
+                Assert.Equal(1, result);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void ConstantExpressionDouble(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Attach = true, Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        //double to double
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 1.5, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1.5, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 1.5, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 1.5, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 1.5, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 1.5, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        //long to double
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 2.0, Number != 1)")
+                .AddParameter("myVar", 2L)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 2.0, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1.5, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 2.0, Number != 1)")
+                .AddParameter("myVar", 2L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 1.5, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 1.5, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 1.5, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 1.5, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 1.5, Number != 1)")
+                .AddParameter("myVar", 2L)
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        //bool <-> double
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 1.5, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1.5, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 1.5, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 1.5, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 1.5, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 1.5, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+        }
+
+        //string <-> double
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 1.5, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 1.5, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 1.5, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 1.5, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 1.5, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 1.5, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void ConstantExpressionLong(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Attach = true, Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        //long to long
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 10, Number != 1)")
+                .AddParameter("myVar", 10L)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 10, Number != 1)")
+                .AddParameter("myVar", 10L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 10, Number != 1)")
+                .AddParameter("myVar", 10L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 10, Number != 1)")
+                .AddParameter("myVar", 10L)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 10, Number != 1)")
+                .AddParameter("myVar", 10L)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 10, Number != 1)")
+                .AddParameter("myVar", 10L)
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        //double to long
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 10, Number != 1)")
+                .AddParameter("myVar", 10.0)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 10, Number != 1)")
+                .AddParameter("myVar", 5.5)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 10, Number != 1)")
+                .AddParameter("myVar", 5.5)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 10, Number != 1)")
+                .AddParameter("myVar", 10.0)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 10, Number != 1)")
+                .AddParameter("myVar", 10.0)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 10, Number != 1)")
+                .AddParameter("myVar", 10.0)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 10, Number != 1)")
+                .AddParameter("myVar", 10.0)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 10, Number != 1)")
+                .AddParameter("myVar", 10.0)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 10, Number != 1)")
+                .AddParameter("myVar", 9.5)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        //bool <-> long
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 10, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 10, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 10, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 10, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 10, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 10, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+        }
+
+        //string <-> long
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 10, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 10, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 10, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 10, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 10, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 10, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void ConstantExpressionString(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Attach = true, Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        //string to string
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
+                .AddParameter("myVar", "bbb")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 'bbb', Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 'bbb', Number != 1)")
+                .AddParameter("myVar", "bbb")
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 'bbb', Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 'bbb', Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 'bbb', Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 'bbb', Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        //long <-> string
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 'bbb', Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 'bbb', Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 'bbb', Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 'bbb', Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 'bbb', Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+        }
+
+        //double <-> string
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 'bbb', Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 'bbb', Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 'bbb', Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 'bbb', Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 'bbb', Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+        }
+
+        //bool <-> string
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != 'bbb', Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < 'bbb', Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= 'bbb', Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > 'bbb', Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= 'bbb', Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void ConstantExpressionBool(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Attach = true, Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        //bool to bool
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == true, Number != 1)")
+                .AddParameter("myVar", true)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == true, Number != 1)")
+                .AddParameter("myVar", false)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != true, Number != 1)")
+                .AddParameter("myVar", false)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != true, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count();
+            Assert.Equal(1, result);
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < true, Number != 1)")
+                .AddParameter("myVar", false)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= true, Number != 1)")
+                .AddParameter("myVar", false)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > false, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= false, Number != 1)")
+                .AddParameter("myVar", true)
+                .Count());
+        }
+
+        //long <-> bool
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == true, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != true, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < true, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= true, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > true, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= true, Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count());
+        }
+
+        //double <-> bool
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == true, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != true, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < true, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= true, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > true, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= true, Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count());
+        }
+
+        //string <-> bool
+        {
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == true, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar != true, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar < true, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar <= true, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar > true, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+
+            Assert.Throws<RavenException>(() => session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar >= true, Number != 1)")
+                .AddParameter("myVar", "abc")
+                .Count());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void ConstantExpressionLogical(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Attach = true, Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a > 10 and $b < 20, Number != 1)")
+                .AddParameter("a", 15)
+                .AddParameter("b", 10)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a > 10 and $b < 20, Number != 1)")
+                .AddParameter("a", 15)
+                .AddParameter("b", 25)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a > 10 and $b < 20, Number != 1)")
+                .AddParameter("a", 5)
+                .AddParameter("b", 10)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a > 10 or $b < 20, Number != 1)")
+                .AddParameter("a", 15)
+                .AddParameter("b", 25)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a > 10 or $b < 20, Number != 1)")
+                .AddParameter("a", 5)
+                .AddParameter("b", 10)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a > 10 or $b < 20, Number != 1)")
+                .AddParameter("a", 5)
+                .AddParameter("b", 25)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 100 and $flag == true, Number != 1)")
+                .AddParameter("val", 100L)
+                .AddParameter("flag", true)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 100 and $flag == true, Number != 1)")
+                .AddParameter("val", 100L)
+                .AddParameter("flag", false)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(($a == 1 and $b == 1) or $c == true, Number != 1)")
+                .AddParameter("a", 0)
+                .AddParameter("b", 0)
+                .AddParameter("c", true)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(($a == 1 and $b == 1) or $c == true, Number != 1)")
+                .AddParameter("a", 0)
+                .AddParameter("b", 1)
+                .AddParameter("c", false)
+                .Count();
+            Assert.Equal(1, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
+    public void BinaryOperations(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+
+        session.Store(new Dto { Attach = true, Number = 1 }, "items/1");
+        session.Store(new Dto { Attach = true, Number = 2 }, "items/2");
+        session.Store(new Dto { Attach = true, Number = 3 }, "items/3");
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        // AND operation
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 1, Number == 1) and Number < 2")
+                .AddParameter("val", 1)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 2, Number == 1) and Number < 2")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 1, Number == 2) and Number < 2")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        // OR operation
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 1, Number == 1) or Number == 3")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(2, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 2, Number == 1) or Number == 3")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        // Multiple WHENs
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a == 1, Number > 1) and when($b == 1, Number < 3)")
+                .AddParameter("a", 1)
+                .AddParameter("b", 1)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($a == 2, Number > 1) and when($b == 1, Number < 3)")
+                .AddParameter("a", 1)
+                .AddParameter("b", 1)
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        // AND NOT operation
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 1, Number > 1) and not Number == 3")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 1, Number == 1) and not Number == 3")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($val == 2, Number == 1) and not Number == 3")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        // Condition AND NOT When(XYZ)
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where Number > 1 and not when($val == 1, Number == 3)")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where Number > 1 and not when($val == 2, Number == 3)")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(2, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where Number < 3 and not when($val == 1, Number == 1)")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(1, result);
+            
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where Attach == true and not when($val == 1, Number == 2)")
+                .AddParameter("val", 1)
+                .Count();
+            Assert.Equal(2, result);
+        }
     }
 
     private class Dto
     {
         public string Id { get; set; }
-        public string Name { get; set; }
-        public int Value { get; set; }
-        public string DoNotIndexField { get; set; }
+        public bool Attach { get; set; }
+        public int Number { get; set; }
     }
 
     private class Index : AbstractIndexCreationTask<Dto>
@@ -180,7 +1071,7 @@ public class RavenDB_25673(ITestOutputHelper output) : RavenTestBase(output)
             Map = dtos => from dto in dtos
                 select new
                 {
-                    dto.Name, dto.Value
+                    dto.Attach, dto.Number
                 };
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-25673.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25673.cs
@@ -1,0 +1,187 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25673(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanEvaluateConditionalExpressionAutoIndex(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store);
+        
+        using var session = store.OpenSession();
+        QueryStatistics queryStatistics;
+        var conditionalNameWithoutParameter = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false)")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+
+        Assert.Empty(conditionalNameWithoutParameter);
+        Assert.Equal("Auto/Dtos/ByName", queryStatistics.IndexName);
+        
+        var conditionalNameWithoutParameterIncludeAll = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), true)")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+
+        Assert.Equal(3, conditionalNameWithoutParameterIncludeAll.Count);
+        Assert.Equal("Auto/Dtos/ByName", queryStatistics.IndexName);
+        
+        var conditionalNameWithParameter = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false)")
+            .AddParameter("p0", "te")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+        Assert.Equal(2, conditionalNameWithParameter.Count);
+        Assert.Contains("test", conditionalNameWithParameter[0].Name);
+        Assert.Contains("test", conditionalNameWithParameter[1].Name);
+        Assert.Equal("Auto/Dtos/ByName", queryStatistics.IndexName);
+
+        
+        var conditionalWithoutParameterOrStatement = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false) or Value = 2")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+        
+        Assert.Single(conditionalWithoutParameterOrStatement);
+        Assert.Contains("Maciej", conditionalWithoutParameterOrStatement[0].Name);
+        Assert.Equal("Auto/Dtos/ByNameAndValue", queryStatistics.IndexName);
+
+        
+        var conditionalWithParameterOrStatement = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0), false) or Value = 2")
+            .AddParameter("p0", "te")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+        
+        Assert.Equal(3, conditionalWithParameterOrStatement.Count);
+        Assert.Equal("Auto/Dtos/ByNameAndValue", queryStatistics.IndexName);
+        
+        var conditionalWithConditionInsideWithoutParameter = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+        
+        Assert.Empty(conditionalWithConditionInsideWithoutParameter);
+        
+        var conditionalWithConditionInsideWithParameter = session.Advanced
+            .RawQuery<Dto>("from Dtos where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
+            .AddParameter($"p0", "test")
+            .WaitForNonStaleResults()
+            .Statistics(out queryStatistics)
+            .ToList();
+
+        Assert.Single(conditionalWithConditionInsideWithParameter);
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+    public void CanEvaluateConditionalExpressionStaticIndex(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        InsertDocuments(store);
+        new Index().Execute(store);
+        Indexes.WaitForIndexing(store);
+        
+        using var session = store.OpenSession();
+        var conditionalNameWithoutParameter = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false)")
+            .ToList();
+
+        Assert.Empty(conditionalNameWithoutParameter);
+        
+        var conditionalNameWithoutParameterIncludeAll = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), true)")
+            .ToList();
+
+        Assert.Equal(3, conditionalNameWithoutParameterIncludeAll.Count);
+        
+        var conditionalNameWithParameter = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false)")
+            .AddParameter("p0", "te")
+            .ToList();
+        Assert.Equal(2, conditionalNameWithParameter.Count);
+        Assert.Contains("test", conditionalNameWithParameter[0].Name);
+        Assert.Contains("test", conditionalNameWithParameter[1].Name);
+
+        
+        var conditionalWithoutParameterOrStatement = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false) or Value = 2")
+            .ToList();
+        
+        Assert.Single(conditionalWithoutParameterOrStatement);
+        Assert.Contains("Maciej", conditionalWithoutParameterOrStatement[0].Name);
+
+        
+        var conditionalWithParameterOrStatement = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0), false) or Value = 2")
+            .AddParameter("p0", "te")
+            .ToList();
+        
+        Assert.Equal(3, conditionalWithParameterOrStatement.Count);
+
+        var conditionalWithConditionInsideWithoutParameter = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
+            .ToList();
+        
+        Assert.Empty(conditionalWithConditionInsideWithoutParameter);
+        
+        var conditionalWithConditionInsideWithParameter = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(Name, $p0) and Value = 1, false)")
+            .AddParameter($"p0", "test")
+            .WaitForNonStaleResults()
+            .ToList();
+
+        Assert.Single(conditionalWithConditionInsideWithParameter);
+        
+        var nonExistingFieldQuery = session.Advanced
+            .RawQuery<Dto>("from index 'Index' where exists($p0, startsWith(DoNotIndexField, $p0), false)");
+        
+        var exception = Assert.Throws<Raven.Client.Exceptions.RavenException>(() => nonExistingFieldQuery.ToList());
+        Assert.Contains("The field 'DoNotIndexField' is not indexed in 'Index'", exception.Message);
+    }
+
+    private static void InsertDocuments(IDocumentStore store)
+    {
+        using var session = store.OpenSession();
+        session.Store(new Dto { Name = "test", Value = 1 });
+        session.Store(new Dto { Name = "Maciej", Value = 2 });
+        session.Store(new Dto { Name = "test2", Value = 3 });
+        session.SaveChanges();
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int Value { get; set; }
+        public string DoNotIndexField { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from dto in dtos
+                select new
+                {
+                    dto.Name, dto.Value
+                };
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB-25673.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25673.cs
@@ -4,7 +4,6 @@ using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 
@@ -518,6 +517,13 @@ public class RavenDB_25673(ITestOutputHelper output) : RavenTestBase(output)
                 .Count();
             Assert.Equal(0, result);
 
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar == 'BBB', Number != 1)")
+                .AddParameter("myVar", "bbb")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+            
             result = session.Advanced
                 .RawQuery<Dto>($"from {indexName} where when($myVar == 'bbb', Number != 1)")
                 .AddParameter("myVar", "aaa")

--- a/test/SlowTests.Issues/Issues/RavenDB-26183.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26183.cs
@@ -23,7 +23,7 @@ public class RavenDB_26183 : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single)]
     public void Now_ReturnsDocumentsWithDateBeforeCurrentTime(Options options)
     {
         using (var store = GetDocumentStore(options))
@@ -44,6 +44,13 @@ public class RavenDB_26183 : RavenTestBase
                     .ToList();
 
                 Assert.Equal(2, employees.Count);
+                
+                var employeesWithWhenOperator = session.Advanced
+                    .RawQuery<Employee>("from Employees where when($p0 > 10, HiredAt <= now())")
+                    .WaitForNonStaleResults()
+                    .AddParameter("p0", 20)
+                    .ToList();
+                Assert.Equal(2, employeesWithWhenOperator.Count);
             }
         }
     }
@@ -70,6 +77,14 @@ public class RavenDB_26183 : RavenTestBase
                     .ToList();
 
                 Assert.Equal(2, employees.Count);
+                
+                var employeesWithWhenOperator = session.Advanced
+                    .RawQuery<Employee>("from Employees where when($p0 > 10, HiredAt < today())")
+                    .AddParameter("p0", 20)
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employeesWithWhenOperator.Count);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25673

### Additional description

### General Logic
*   **Syntax:** `when(condition, filter)`
*   **Behavior:**
    *   If `condition` evaluates to **true**: The `filter` is applied to the query.
    *   If `condition` evaluates to **false**: The `filter` is **ignored** (treated as valid/no-op).
*   **Composition:** Can be combined with standard `and`, `or`, and `not` operators in the query.

### Query behaviour
* AND: `when(condition, Query1) and Query2`
 -- `Condition == true`: `Query1 and Query2`
 -- `Condition == false`: `Query2`
* OR: `when(condition, Query1) or Query2`
 -- `Condition == true`: `Query1 or Query2`
 -- `Condition == false`: `Query2`
* AND NOT: `when(condition, Query1) and not Query2`
 -- `Condition == true`: `Query1 and not Query2`
 -- `Condition == false`: `true and not Query2`
* AND NOT: `Query2 and not when(condition, Query1)`
 -- `Condition == true`: `Query2 and not Query1`
 -- `Condition == false`: `Query2`

### Parameter Handling
*   **Missing Parameters:** Treated as `null`.
*   **Null Checks:** `== null` and `!= null` work for both explicit nulls and missing parameters.

### Type Safety & Exceptions
*   **Strict Typing:** Comparing incompatible types (e.g., `String` vs `Number`, `Bool` vs `String`) throws a `RavenException`.
*   **Numerics:** Implicit conversion exists between `Long` and `Double` (e.g., `1L == 1.0` works).
*   **Booleans:**
    *   Supports `==` and `!=`.
    *   Using inequality operators (`<`, `<=`, `>`, `>=`) on booleans throws a `RavenException`.

### Logical Expressions
*   **Grouping:** Supports parentheses, `and`, and `or` within the conditional argument.
    *   *Example:* `when(($a == 1 and $b == 1) or $c == true, ...)`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
