### PR TITLE
RavenDB-23068 JavaScript indexes should be included in unmergables.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexData.cs
@@ -37,6 +37,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
         public InvocationExpressionSyntax InvocationExpression { get; set; }
         public IndexDefinition Index => _index;
         public bool IsMapReduceOrMultiMap { get; set; }
+        public bool IsJavaScriptIndex { get; set; }
 
         public string BuildExpression(Dictionary<string, ExpressionSyntax> selectExpressions)
         {

--- a/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexMerging/IndexMerger.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
         public IndexMerger(Dictionary<string, IndexDefinition> indexDefinitions)
         {
             _indexDefinitions = indexDefinitions
-                .Where(i => i.Value.Type.IsAuto() == false && i.Value.Type.IsJavaScript() == false)
+                .Where(i => i.Value.Type.IsAuto() == false)
                 .ToDictionary(i => i.Key, i=> i.Value);
         }
 
@@ -63,6 +63,10 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
                 {
                     if (current.IsMapReduceOrMultiMap)
                         continue;
+                    
+                    if (current.IsJavaScriptIndex)
+                        continue;
+                    
                     if (mergeData.ProposedForMerge.All(other => CanMergeIndexes(other, current)) == false)
                         continue;
 
@@ -81,6 +85,12 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
         private static List<string> CheckForUnsuitableIndexForMerging(IndexData indexData)
         {
             var failComments = new List<string>();
+
+            if (indexData.Index.Type.IsJavaScript())
+            {
+                failComments.Add("Cannot merge JavaScript indexes.");
+            }
+            
             if (indexData.Index.Type == IndexType.MapReduce)
             {
                 failComments.Add("Cannot merge map/reduce indexes.");
@@ -140,6 +150,12 @@ namespace Raven.Server.Documents.Indexes.IndexMerging
 
                 indexes.Add(indexData);
 
+                if (index.Type.IsJavaScript())
+                {
+                    indexData.IsJavaScriptIndex = true;
+                    continue;
+                }
+                
                 if (index.Type == IndexType.MapReduce || index.Maps.Count > 1)
                 {
                     indexData.IsMapReduceOrMultiMap = true;

--- a/test/SlowTests/Issues/RavenDB-23068.cs
+++ b/test/SlowTests/Issues/RavenDB-23068.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Server.Documents.Indexes.IndexMerging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_23068(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task JavaScriptIndexesShouldBeIncludedInUnmergables()
+    {
+        using var store = GetDocumentStore();
+        using var session = store.OpenAsyncSession();
+        await session.StoreAsync(new TestDoc { Name = "John", SecondName = "Doe" });
+        await session.SaveChangesAsync();
+        var csharpIndex = new CsharpIndex();
+        var csharpIndex2 = new CSharpIndex2();
+        var jsIndex = new JsIndex();
+        await csharpIndex.ExecuteAsync(store);
+        await csharpIndex2.ExecuteAsync(store);
+        await jsIndex.ExecuteAsync(store);
+        
+        var definitionByIndexName = new Dictionary<string, IndexDefinition>();
+        var database = await GetDatabase(store.Database);
+
+        foreach (var index in database.IndexStore.GetIndexes())
+        {
+            definitionByIndexName[index.Name] = index.GetIndexDefinition();
+        }
+        
+        var indexMerger = new IndexMerger(definitionByIndexName);
+        var mergeSuggestions = indexMerger.ProposeIndexMergeSuggestions();
+        Assert.NotEmpty(mergeSuggestions.Unmergables);
+        Assert.Contains(jsIndex.IndexName, mergeSuggestions.Unmergables);
+        var jsIndexReason = mergeSuggestions.Unmergables[jsIndex.IndexName];
+        Assert.Equal("Cannot merge JavaScript indexes.", jsIndexReason);
+        
+        Assert.Empty(mergeSuggestions.Errors);
+        Assert.NotEmpty(mergeSuggestions.Suggestions);
+        var suggestion = mergeSuggestions.Suggestions.First();
+        Assert.Equal(2, suggestion.CanMerge.Count);
+        Assert.Contains(csharpIndex.IndexName, suggestion.CanMerge);
+        Assert.Contains(csharpIndex2.IndexName, suggestion.CanMerge);
+    }
+    
+    private class TestDoc
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string SecondName { get; set; }
+    }
+
+    private class CsharpIndex : AbstractIndexCreationTask<TestDoc>
+    {
+        public CsharpIndex()
+        {
+            Map = docs => from doc in docs
+                select new { doc.Name };
+        }
+    }
+    
+    private class CSharpIndex2 : AbstractIndexCreationTask<TestDoc>
+    {
+        public CSharpIndex2()
+        {
+            Map = docs => from doc in docs
+                select new { doc.SecondName };
+        }
+    }
+
+    private class JsIndex : AbstractJavaScriptIndexCreationTask
+    {
+        public JsIndex()
+        {
+            Maps =
+            [
+                @"map(""TestDocs"", (doc) => {
+    
+        return {
+            Name: doc.Name,
+            SecondName: doc.SecondName
+        };
+})"
+            ];
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23068
### Additional description

<img width="1796" height="1065" alt="image" src="https://github.com/user-attachments/assets/9ed79eeb-8002-4c58-b571-d97b5c477265" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
