### PR TITLE
RavenDB-26049 ZstdStream should output the end frame properly

### DIFF
--- a/src/Sparrow/Utils/ZstdStream.cs
+++ b/src/Sparrow/Utils/ZstdStream.cs
@@ -258,10 +258,10 @@ namespace Sparrow.Utils
                     {
                         var (outputBytes, _, done) = CompressStep(ReadOnlySpan<byte>.Empty, ZstdLib.ZSTD_EndDirective.ZSTD_e_end);
 
+                        await _inner.WriteAsync(_tempBuffer, 0, outputBytes).ConfigureAwait(false);
+
                         if (done)
                             break;
-
-                        await _inner.WriteAsync(_tempBuffer, 0, outputBytes).ConfigureAwait(false);
                     }
                 }
 
@@ -293,10 +293,10 @@ namespace Sparrow.Utils
                     {
                         var (outputBytes, _, done) = CompressStep(ReadOnlySpan<byte>.Empty, ZstdLib.ZSTD_EndDirective.ZSTD_e_end);
 
+                        _inner.Write(_tempBuffer, 0, outputBytes);
+
                         if (done)
                             break;
-
-                        _inner.Write(_tempBuffer, 0, outputBytes);
                     }
                 }
 

--- a/test/SlowTests/Issues/RavenDB-26049.cs
+++ b/test/SlowTests/Issues/RavenDB-26049.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Sparrow.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26049(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenFact(RavenTestCategory.Compression)]
+        public void WillEmitEndFrameForZstd()
+        {
+            var buffer = "hello world"u8;
+            var outputStream = new MemoryStream();
+            using (var stream = ZstdStream.Compress(outputStream))
+            {
+                stream.Write(buffer);
+            }
+            VerifyEndFrameProperlyWritten(outputStream.ToArray());
+        }
+
+        private static unsafe void VerifyEndFrameProperlyWritten(byte[] compressed)
+        {
+            var outputBuffer = new byte[1024];
+
+            fixed (byte* pBuffer = outputBuffer, pOutput = compressed)
+            {
+                var ctx = new ZstdLib.CompressContext(0);
+                var output = new ZstdLib.ZSTD_outBuffer { Source = pBuffer, Position = UIntPtr.Zero, Size = (UIntPtr)outputBuffer.Length };
+                var input = new ZstdLib.ZSTD_inBuffer { Source = pOutput, Position = UIntPtr.Zero, Size = (UIntPtr)compressed.Length };
+                var v = ZstdLib.ZSTD_decompressStream(ctx.Decompression, &output, &input);
+                Assert.NotEqual(0ul,output.Size);
+                ZstdLib.AssertZstdSuccess(v);
+                Assert.Equal(0ul, v.ToUInt64());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Compression)]
+        public async Task WillEmitEndFrameForZstdAsync()
+        {
+            var buffer = "hello world";
+            var outputStream = new MemoryStream();
+            await using (var stream = ZstdStream.Compress(outputStream))
+            {
+                await stream.WriteAsync(Encoding.UTF8.GetBytes(buffer));
+            }
+            VerifyEndFrameProperlyWritten(outputStream.ToArray());
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26049 

### Additional description

We didn't include the end frame marker for ZSTD.
Implementations that expected is saw that we are sending truncated data.

The actual problem is that we just didn't send the data over. Added tests and verified it now works.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
