### PR TITLE
RavenDB-26048 Setup Wizard: Mismatch between displayed domain suffix and helper text

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardDomainStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardDomainStep.tsx
@@ -81,7 +81,8 @@ export function SetupWizardDomainStep() {
         <div>
             <h2 className="mb-1">Domain</h2>
             <p className="mb-4 text-muted">
-                Enter a name for your cluster&#39;s domain. It will be available under <code>.development.run</code>.
+                Enter a name for your cluster&apos;s domain. It will be available under{" "}
+                <code>.{domainStep.rootDomain}</code>.
                 <br />
                 This domain will point to your cluster (where your databases are hosted) and will be secured with HTTPS.
             </p>
@@ -93,8 +94,8 @@ export function SetupWizardDomainStep() {
                             <>
                                 <ul className="mb-0 ps-3">
                                     <li>
-                                        The name you enter will be used to create your cluster’s domain under
-                                        <code>.development.run</code>.<br />
+                                        The name you enter will be used to create your cluster’s domain under{" "}
+                                        <code>.{domainStep.rootDomain}</code>.<br />
                                         RavenDB will use this domain to generate an HTTPS certificate for secure
                                         connections.
                                     </li>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26048/Setup-Wizard-Mismatch-between-displayed-domain-suffix-and-helper-text

### Additional description
Update the helper text to display `.development.run` or `.ravendb.run` dynamically
based on the selected domainStep.rootDomain value.

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed
 Documentation is handled in https://issues.hibernatingrhinos.com/issue/RDoc-3687/Update-the-Setup-Wizard-documentation

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
