### PR TITLE
RavenDB-25942 - add attachments delete method to patch

### DIFF
--- a/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
@@ -17,6 +17,7 @@ namespace Raven.Server.Documents.Patch
         public readonly DynamicJsonArray IncrementTimeSeries = new DynamicJsonArray();
         public readonly DynamicJsonArray DeleteTimeSeries = new DynamicJsonArray();
         public readonly DynamicJsonArray RemoteAttachments = new DynamicJsonArray();
+        public readonly DynamicJsonArray DeleteAttachment = new DynamicJsonArray();
 
         public DynamicJsonValue GetDebugActions()
         {
@@ -34,7 +35,8 @@ namespace Raven.Server.Documents.Patch
                 [nameof(AppendTimeSeries)] = new DynamicJsonArray(AppendTimeSeries.Items),
                 [nameof(IncrementTimeSeries)] = new DynamicJsonArray(IncrementTimeSeries.Items),
                 [nameof(DeleteTimeSeries)] = new DynamicJsonArray(DeleteTimeSeries.Items),
-                [nameof(RemoteAttachments)] = new DynamicJsonArray(RemoteAttachments.Items)
+                [nameof(RemoteAttachments)] = new DynamicJsonArray(RemoteAttachments.Items),
+                [nameof(DeleteAttachment)] = new DynamicJsonArray(DeleteAttachment.Items)
             };
         }
 
@@ -53,6 +55,7 @@ namespace Raven.Server.Documents.Patch
             IncrementTimeSeries.Clear();
             DeleteTimeSeries.Clear();
             RemoteAttachments.Clear();
+            DeleteAttachment.Clear();
         }
     }
 }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -843,6 +843,7 @@ namespace Raven.Server.Documents.Patch
 
                 var obj = new JsObject(ScriptEngine);
                 obj.SetClfFunc("remote", (thisObj, values) => RemoteAttachments(thisObj.Get("doc"), thisObj.Get("name"), values));
+                obj.SetClfFunc("delete", (thisObj, values) => DeleteAttachment(thisObj.Get("doc"), thisObj.Get("name")));
                 obj.FastSetDataProperty("doc", args[0]);
                 obj.FastSetDataProperty("name", args[1]);
 
@@ -879,6 +880,27 @@ namespace Raven.Server.Documents.Patch
                         ["Identifier"] = identifier,
                         ["At"] = at,
                     });
+                }
+
+                return JsValue.Undefined;
+            }
+
+            private JsValue DeleteAttachment(JsValue document, JsValue name)
+            {
+                const string signature = "attachments(doc, name).delete";
+                AssertValidDatabaseContext(signature);
+
+                var (id, doc) = GetIdAndDocFromArg(document, signature);
+                var attachmentName = GetStringArg(name, signature, "name");
+
+                _database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(_docsCtx, id, attachmentName, null, out _, updateDocument: false);
+
+                DocumentAttachmentsToUpdate ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                DocumentAttachmentsToUpdate.Add(id);
+
+                if (DebugMode)
+                {
+                    DebugActions.DeleteAttachment.Add(attachmentName);
                 }
 
                 return JsValue.Undefined;

--- a/test/SlowTests/Server/Documents/Attachments/AttachmentsPatchSlowTests.cs
+++ b/test/SlowTests/Server/Documents/Attachments/AttachmentsPatchSlowTests.cs
@@ -1,0 +1,84 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.Attachments
+{
+    public class AttachmentsPatchSlowTests : RemoteAttachmentsS3Base
+    {
+        public AttachmentsPatchSlowTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Attachments | RavenTestCategory.Patching)]
+        public async Task CanDeleteAttachmentsInPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                const string id = "users/1";
+                const string attachmentName1 = "file1.txt";
+                const string attachmentName2 = "file2.txt";
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new User { Name = "John" }, id);
+                    await session.SaveChangesAsync();
+                }
+
+                using (var stream1 = new MemoryStream(new byte[] { 1, 2, 3 }))
+                using (var stream2 = new MemoryStream(new byte[] { 4, 5, 6 }))
+                {
+                    await store.Operations.SendAsync(new PutAttachmentOperation(id, attachmentName1, stream1, "text/plain"));
+                    await store.Operations.SendAsync(new PutAttachmentOperation(id, attachmentName2, stream2, "text/plain"));
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    var attachments = metadata.GetObjects(Constants.Documents.Metadata.Attachments);
+                    Assert.Equal(2, attachments.Length);
+                }
+
+                var patch = new PatchRequest
+                {
+                    Script = "attachments(this, args.name).delete();",
+                    Values =
+                    {
+                        { "name", attachmentName1 }
+                    }
+                };
+
+                var result = await store.Operations.SendAsync(new PatchOperation(id, null, patch));
+                Assert.Equal(PatchStatus.Patched, result);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var user = await session.LoadAsync<User>(id);
+                    var metadata = session.Advanced.GetMetadataFor(user);
+                    var attachments = metadata.GetObjects(Constants.Documents.Metadata.Attachments);
+                    Assert.Equal(1, attachments.Length);
+                    Assert.Equal(attachmentName2, attachments[0][nameof(AttachmentName.Name)].ToString());
+                }
+
+                using (var attachmentResult = await store.Operations.SendAsync(new GetAttachmentOperation(id, attachmentName1, AttachmentType.Document, null)))
+                {
+                    Assert.Null(attachmentResult);
+                }
+
+                using (var attachmentResult = await store.Operations.SendAsync(new GetAttachmentOperation(id, attachmentName2, AttachmentType.Document, null)))
+                {
+                    Assert.NotNull(attachmentResult);
+                    Assert.Equal(attachmentName2, attachmentResult.Details.Name);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25942/Add-support-for-deleting-attachment-in-Patch

### Additional description

This pull request adds support for deleting document attachments within patch scripts, enhancing the flexibility of patch operations. It introduces a new `delete` function to the `attachments` patch scripting API and provides corresponding debug and test coverage.

**Patch scripting enhancements:**

* Added a `delete` function to the `attachments(doc, name)` scripting API, allowing attachments to be deleted directly from patch scripts. [[1]](diffhunk://#diff-8c92e628a601ba577a266513e7b5b93e696940b6c97ac2d385a82217c31f9dbcR846) [[2]](diffhunk://#diff-8c92e628a601ba577a266513e7b5b93e696940b6c97ac2d385a82217c31f9dbcR888-R908)
* Updated the `PatchDebugActions` class to track deleted attachments for debugging purposes, including a new `DeleteAttachment` array and related logic in the `GetDebugActions` and `Clear` methods. [[1]](diffhunk://#diff-47d637050887530027615f98a998b66646d71b3b54df905519356819f4124a34R20) [[2]](diffhunk://#diff-47d637050887530027615f98a998b66646d71b3b54df905519356819f4124a34L37-R39) [[3]](diffhunk://#diff-47d637050887530027615f98a998b66646d71b3b54df905519356819f4124a34R58)

**Testing:**

* Added `AttachmentsPatchSlowTests.cs` to verify that attachments can be deleted via patch scripts, ensuring correct behavior and integration.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
