### PR TITLE
RavenDB-24863 Fix startEtag type and break conditions

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -74,7 +74,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [RavenAction("/databases/*/debug/documents/scan-corrupted-ids", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
         public async Task ScanCorruptedIds()
         {
-            var startEtag = GetIntValueQueryString("startEtag", required: false) ?? 0;
+            var startEtag = GetLongQueryString("startEtag", required: false) ?? 0;
             var resultCount = GetIntValueQueryString("resultCount", required: false) ?? 1024;
             var maxBatchTimeInSec = GetIntValueQueryString("maxBatchTimeInSec", required: false) ?? 60;
 
@@ -86,19 +86,26 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
+                bool hasMore = true;
+                
                 await using (var writer = new AsyncBlittableJsonTextWriter(context, Stream.Null))
                 {
                     var timeout = Stopwatch.StartNew();
-                    while (resultCount > 0)
+                    while (resultCount > 0 && hasMore)
                     {
                         timeout.Restart();
                         using (context.OpenReadTransaction())
+                        using (var enumerator = IterateDocumentsAndRevisionsByEtag(context, lastEtag).GetEnumerator())
                         {
-                            foreach (var doc in IterateDocumentsAndRevisionsByEtag(context, lastEtag))
+                            while (true)
                             {
                                 HttpContext.RequestAborted.ThrowIfCancellationRequested();
-
-                                ++scannedDocuments;
+                                
+                                hasMore = enumerator.MoveNext();
+                                if (hasMore == false)
+                                    break;
+                                    
+                                var doc = enumerator.Current;
                                 using (doc)
                                 {
                                     unsafe
@@ -120,7 +127,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                                         AddToResult(wrongEscapedPositionsIds, doc);
                                         resultCount--;
                                     }
-
+                                    scannedDocuments++;
                                     if (resultCount <= 0 || timeout.Elapsed > maxBatchTime)
                                     {
                                         lastEtag = doc.Etag;
@@ -128,8 +135,6 @@ namespace Raven.Server.Documents.Handlers.Debugging
                                     }
                                 }
                             }
-
-                            break;
                         }
                     }
                 }
@@ -141,7 +146,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                     writer.WriteComma();
                     writer.WriteArray("UnescapedControlCharacterIds", unescapedControlCharacterIds);
                     writer.WriteComma();
-                    if (lastEtag > 0)
+                    if (hasMore)
                     {
                         writer.WritePropertyName("LastEtag");
                         writer.WriteInteger(lastEtag);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24863

### Additional description
The startEtag should be able to accept a `long` value.
Also, after the batch time, it should start another batch.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
