### PR TITLE
RavenDB-22602: Optimizes Corax queries with boolean algebra rules

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -329,6 +329,18 @@ public static partial class CoraxQueryBuilder
                                 return TranslateBetweenQuery(builderParameters, bq, exact);
                         }
 
+                        // true AND X → X; skip NegatedExpression to preserve the NOT path below
+                        if (@where.Left is TrueExpression && @where.Right is not NegatedExpression)
+                        {
+                            builderParameters.BuildSteps?.Add($"BinaryExpression: {where.Type} - true AND optimization ({@where.Right})");
+                            return ToCoraxQuery(builderParameters, @where.Right, ref leftOnlyOptimization, exact);
+                        }
+                        if (@where.Right is TrueExpression && @where.Left is not NegatedExpression)
+                        {
+                            builderParameters.BuildSteps?.Add($"BinaryExpression: {where.Type} - AND true optimization ({@where.Left})");
+                            return ToCoraxQuery(builderParameters, @where.Left, ref leftOnlyOptimization, exact);
+                        }
+
                         leftOnlyOptimization.BinaryMatchTraversed();
                         switch (@where.Left, @where.Right)
                         {
@@ -342,6 +354,12 @@ public static partial class CoraxQueryBuilder
                             default:
                                 left = ToCoraxQuery(builderParameters, @where.Left, ref leftOnlyOptimization, exact);
                                 right = ToCoraxQuery(builderParameters, @where.Right, ref builderParameters.StreamingDisabled, exact);
+
+                                if (IsAllEntries(left))
+                                    return right;
+                                if (IsAllEntries(right))
+                                    return left;
+
                                 // in case of AND we can materialize only TermMatches, we push streamingOptimization there only for changing order for MultiTermMatch;
                             if (left is CoraxBooleanItem cbi && leftOnlyOptimization.TrySetAsStreamingField(builderParameters, cbi, right))
                                     left = cbi.Materialize(ref leftOnlyOptimization);
@@ -361,9 +379,20 @@ public static partial class CoraxQueryBuilder
                     }
                 case OperatorType.Or:
                     {
+                        // true OR X → AllEntries
+                        if (@where.Left is TrueExpression || @where.Right is TrueExpression)
+                        {
+                            builderParameters.BuildSteps?.Add($"BinaryExpression: {where.Type} - true OR optimization (AllEntries)");
+                            return builderParameters.AllEntries.Replay();
+                        }
+
                         leftOnlyOptimization.BinaryMatchTraversed();
                         var left = ToCoraxQuery(builderParameters, @where.Left, ref builderParameters.StreamingDisabled, exact);
                         var right = ToCoraxQuery(builderParameters, @where.Right, ref builderParameters.StreamingDisabled, exact);
+
+                        // Cascading: a sub-expression may have already resolved to AllEntries
+                        if (IsAllEntries(left) || IsAllEntries(right))
+                            return builderParameters.AllEntries.Replay();
 
                         builderParameters.BuildSteps?.Add(
                             $"OR operator: left - {left.GetType().FullName} ({left}) assembly: {left.GetType().Assembly.FullName} assembly location: {left.GetType().Assembly.Location} , right - {right.GetType().FullName} ({right}) assemlbly: {right.GetType().Assembly.FullName} assembly location: {right.GetType().Assembly.Location}");
@@ -701,12 +730,26 @@ public static partial class CoraxQueryBuilder
         return null;
     }
 
+    internal static bool IsAllEntries(IQueryMatch match)
+    {
+        if (match is AllEntriesMatch)
+            return true;
+
+        if (match is MemoizationMatch memoizationMatch)
+        {
+            memoizationMatch.InnerRetriever(out IQueryMatch inner);
+            return inner is AllEntriesMatch;
+        }
+
+        return false;
+    }
+
     private static void Materialize(Parameters builderParameters, ref IQueryMatch lhs, ref IQueryMatch rhs, ref StreamingOptimization streamingOptimization)
     {
         lhs = MaterializeWhenNeeded(builderParameters, lhs, ref streamingOptimization);
         rhs = MaterializeWhenNeeded(builderParameters, rhs, ref streamingOptimization);
     }
-    
+
     private static bool TryAndMergeOrMaterialize(Parameters parameters, ref IQueryMatch lhs, ref IQueryMatch rhs, out CoraxBooleanQueryBase merged, ref StreamingOptimization streamingOptimization, bool requiredMaterialization = false)
     {
         merged = null;

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxOrQueries.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxOrQueries.cs
@@ -30,10 +30,10 @@ public sealed class CoraxOrQueries : CoraxBooleanQueryBase
             if (right is CoraxOrQueries { HasBoosting: false } rightOr)
                 return (CoraxOrQueries)rightOr.Add(left);
         }
-        
+
         return CreateNew(parameters, left, right);
     }
-    
+
     private static CoraxOrQueries CreateNew(CoraxQueryBuilder.Parameters parameters, IQueryMatch left, IQueryMatch right)
     {
         var orClause = new CoraxOrQueries(parameters);
@@ -41,7 +41,7 @@ public sealed class CoraxOrQueries : CoraxBooleanQueryBase
         orClause.Add(right);
         return orClause;
     }
-    
+
     private static CoraxOrQueries MergeOrCreateTwoOrQueries(CoraxQueryBuilder.Parameters parameters, CoraxOrQueries left, CoraxOrQueries right)
     {
         if (left.EqualsScoreFunctions(right))
@@ -90,11 +90,11 @@ public sealed class CoraxOrQueries : CoraxBooleanQueryBase
         {
             if (VectorStack == null)
                 VectorStack = other.VectorStack;
-            else 
+            else
                 VectorStack.AddRange(other.VectorStack);
         }
     }
-    
+
     protected override void AddCoraxBooleanItem(CoraxBooleanItem itemToAdd)
     {
         if (itemToAdd.Boosting.HasValue == false && itemToAdd.Operation is not UnaryMatchOperation.Equals)
@@ -148,12 +148,12 @@ public sealed class CoraxOrQueries : CoraxBooleanQueryBase
         foreach (var complex in ComplexMatches ?? Enumerable.Empty<IQueryMatch>())
             AddToQueryTree(complex);
         ComplexMatches = null;
-        
+
         foreach (var vector in VectorStack ?? Enumerable.Empty<CoraxVectorItem>())
         {
             AddToQueryTree(vector.Materialize(null));
         }
-        
+
         VectorStack = null;
 
         if (Boosting.HasValue)

--- a/test/FastTests/Corax/RavenDB_22602.cs
+++ b/test/FastTests/Corax/RavenDB_22602.cs
@@ -1,0 +1,433 @@
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Timings;
+using ClientQueryInspectionNode = Raven.Client.Documents.Queries.Timings.QueryInspectionNode;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax;
+
+/// <summary>
+/// RavenDB-22602: Optimize true OR and true AND queries in CORAX
+///
+/// Boolean logic optimizations:
+/// - true OR X → AllEntries (matches all documents)
+/// - X OR true → AllEntries (matches all documents)
+/// - true AND X → X (simplifies to X)
+/// - X AND true → X (simplifies to X)
+/// - Cascading: (true OR X) OR Y → AllEntries (optimization propagates)
+///
+/// These patterns occur in production queries and should be simplified to avoid
+/// severe performance degradation.
+/// </summary>
+public class RavenDB_22602 : RavenTestBase
+{
+    public RavenDB_22602(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TrueAndOr_BasicCases(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 1) { Id = "items/1" });
+            session.Store(new Item("banana", "yellow", 2) { Id = "items/2" });
+            session.Store(new Item("apple", "green", 3) { Id = "items/3" });
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // Baseline plans (without true)
+            var termBaseline = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereEquals(x => x.Name, "apple")
+                .Timings(out var termTimings)
+                .ToList();
+            var termPlan = (ClientQueryInspectionNode)termTimings.QueryPlan;
+
+            var allBaseline = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .Timings(out var allTimings)
+                .ToList();
+            var allPlan = (ClientQueryInspectionNode)allTimings.QueryPlan;
+
+            // true AND X → X: plan should match Name = 'apple' baseline
+            var andResults = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where true and Name = 'apple' include timings()")
+                .Timings(out var andTimings).ToList();
+            Assert.Equal(2, andResults.Count);
+            Assert.All(andResults, r => Assert.Equal("apple", r.Name));
+            AssertSamePlan(termPlan, andTimings, "true AND X should produce same plan as X");
+
+            // X AND true → X: plan should match Name = 'apple' baseline
+            var andResults2 = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where Name = 'apple' and true include timings()")
+                .Timings(out var andTimings2).ToList();
+            Assert.Equal(2, andResults2.Count);
+            AssertSamePlan(termPlan, andTimings2, "X AND true should produce same plan as X");
+
+            // true OR X → AllEntries: plan should match no-where-clause baseline
+            var orResults = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where true or Name = 'apple' include timings()")
+                .Timings(out var orTimings).ToList();
+            Assert.Equal(3, orResults.Count);
+            AssertSamePlan(allPlan, orTimings, "true OR X should produce same plan as AllEntries");
+
+            // X OR true → AllEntries: plan should match no-where-clause baseline
+            var orResults2 = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where Name = 'apple' or true include timings()")
+                .Timings(out var orTimings2).ToList();
+            Assert.Equal(3, orResults2.Count);
+            AssertSamePlan(allPlan, orTimings2, "X OR true should produce same plan as AllEntries");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void TrueAnd_WithNegation(Options options)
+    {
+        // Guard condition: NegatedExpression takes the existing NOT path, not the true AND shortcut
+        // Correctness-only is appropriate since the optimization is intentionally not applied here
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 1));
+            session.Store(new Item("banana", "yellow", 2));
+            session.Store(new Item("cherry", "green", 3));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results1 = session.Advanced.RawQuery<Item>("from index 'ItemIndex' where true and Name != 'apple'").ToList();
+            Assert.Equal(2, results1.Count);
+            Assert.All(results1, r => Assert.NotEqual("apple", r.Name));
+
+            var results2 = session.Advanced.RawQuery<Item>("from index 'ItemIndex' where Name != 'apple' and true").ToList();
+            Assert.Equal(2, results2.Count);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void NestedExpressions(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "green", 1));
+            session.Store(new Item("banana", "red", 3));
+            session.Store(new Item("cherry", "yellow", 5));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // (true OR X) AND Y: the OR is optimized to AllEntries at the AST level,
+            // but AllEntries AND Y → Y doesn't collapse further because AllEntries is
+            // already materialized (MemoizationMatch) by the time AND is built.
+            // Correctness-only: verify the right documents are returned.
+            var r1 = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where (true or Name = 'apple') and Number > 2").ToList();
+            Assert.Equal(2, r1.Count);
+            Assert.All(r1, r => Assert.True(r.Number > 2));
+
+            // (true AND X) OR Y: the true AND collapses at AST level, so the plan
+            // should match X OR Y exactly
+            var orBaseline = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereEquals(x => x.Name, "apple")
+                .OrElse()
+                .WhereEquals(x => x.Color, "red")
+                .Timings(out var orTimings)
+                .ToList();
+            var orPlan = (ClientQueryInspectionNode)orTimings.QueryPlan;
+
+            var r2 = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where (true and Name = 'apple') or Color = 'red' include timings()")
+                .Timings(out var r2Timings).ToList();
+            Assert.Equal(2, r2.Count);
+            AssertSamePlan(orPlan, r2Timings, "(true AND X) OR Y should produce same plan as X OR Y");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CascadingOr_Optimization(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 1));
+            session.Store(new Item("banana", "yellow", 5));
+            session.Store(new Item("cherry", "green", 10));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // AllEntries baseline for r1/r2
+            _ = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .Timings(out var allTimings)
+                .ToList();
+            var allPlan = (ClientQueryInspectionNode)allTimings.QueryPlan;
+
+            // Number > 2 baseline for r3
+            _ = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereGreaterThan(x => x.Number, 2)
+                .Timings(out var numberBaselineTimings)
+                .ToList();
+            var numberBaseline = (ClientQueryInspectionNode)numberBaselineTimings.QueryPlan;
+
+            // r1: (true OR X) OR Y — the inner OR returns MemoizationMatch(AllEntries);
+            // CoraxOrQueries.TryAddItem recognises it via IsAllEntries and sets _hasAllEntries,
+            // and the OR call-site immediately replays AllEntries instead of returning CoraxOrQueries.
+            var r1 = session.Advanced.RawQuery<Item>(
+                    "from index 'ItemIndex' where true or Name = 'apple' or Color = 'red' include timings()")
+                .Timings(out var r1Timings).ToList();
+            Assert.Equal(3, r1.Count);
+            AssertSamePlan(allPlan, r1Timings, "true OR X OR Y should produce same plan as AllEntries");
+
+            // r2: X OR true OR Y — same optimisation, middle position
+            var r2 = session.Advanced.RawQuery<Item>(
+                    "from index 'ItemIndex' where Name = 'apple' or true or Color = 'yellow' include timings()")
+                .Timings(out var r2Timings).ToList();
+            Assert.Equal(3, r2.Count);
+            AssertSamePlan(allPlan, r2Timings, "X OR true OR Y should produce same plan as AllEntries");
+
+            // r3: ((true OR X) OR Y) AND Z — the OR now returns MemoizationMatch(AllEntries)
+            // instead of CoraxOrQueries, so IsAllEntries recognises it in the AND default case
+            // and the whole expression collapses to Z (Number > 2).
+            var r3 = session.Advanced.RawQuery<Item>(
+                    "from index 'ItemIndex' where ((true or Name = 'apple') or Color = 'red') and Number > 2 include timings()")
+                .Timings(out var r3Timings).ToList();
+            Assert.Equal(2, r3.Count);
+            Assert.All(r3, r => Assert.True(r.Number > 2));
+            AssertSamePlan(numberBaseline, r3Timings, "((true OR X) OR Y) AND Z should produce same plan as Z");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void CascadingOrInsideAnd_ShouldMatchBaselinePlan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 1));
+            session.Store(new Item("banana", "yellow", 5));
+            session.Store(new Item("cherry", "green", 10));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // Baseline: Number > 2
+            _ = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereGreaterThan(x => x.Number, 2)
+                .Timings(out var baselineTimings)
+                .ToList();
+            var baselinePlan = (ClientQueryInspectionNode)baselineTimings.QueryPlan;
+
+            // (true OR Name='apple') AND Number > 2 should collapse to Number > 2
+            _ = session.Advanced.RawQuery<Item>(
+                    "from index 'ItemIndex' where (true or Name = 'apple') and Number > 2 include timings()")
+                .Timings(out var optimizedTimings)
+                .ToList();
+
+            AssertSamePlan(baselinePlan, optimizedTimings,
+                "(true OR X) AND Y should produce same plan as Y");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void IntegrationWith_RavenDB22603(Options options)
+    {
+        // Verify both optimizations work together
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 1));
+            session.Store(new Item("apple", "green", 2));
+            session.Store(new Item("cherry", "yellow", 3));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // Baseline: Name = 'apple' AND Color != 'red' (without the true AND wrapper)
+            var baseline = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereEquals(x => x.Name, "apple")
+                .AndAlso()
+                .WhereNotEquals(x => x.Color, "red")
+                .Timings(out var baseTimings)
+                .ToList();
+            var basePlan = (ClientQueryInspectionNode)baseTimings.QueryPlan;
+
+            // (true AND Name = 'apple') AND Color != 'red'
+            var results = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where (true and Name = 'apple') and Color != 'red' include timings()")
+                .Timings(out var timings).ToList();
+
+            Assert.Single(results);
+            Assert.Equal("green", results[0].Color);
+            AssertSamePlan(basePlan, timings, "(true AND X) AND Y should produce same plan as X AND Y");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void StreamingOptimization_WithTrueAnd(Options options)
+    {
+        // "X AND true" should produce the same query plan as just "X"
+        // This validates that the true AND optimization preserves streaming optimization
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 10));
+            session.Store(new Item("apricot", "orange", 20));
+            session.Store(new Item("avocado", "green", 30));
+            session.Store(new Item("banana", "yellow", 40));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            // Baseline: startsWith(Name, 'a') order by Name — should use streaming
+            var baseline = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereStartsWith(x => x.Name, "a")
+                .OrderBy(x => x.Name)
+                .Timings(out var baselineTimings)
+                .ToList();
+
+            Assert.Equal(3, baseline.Count);
+            var baselinePlan = (ClientQueryInspectionNode)baselineTimings.QueryPlan;
+            Assert.NotNull(baselinePlan);
+
+            // Optimized: startsWith(Name, 'a') AND true order by Name — should produce same plan
+            var optimized = session.Advanced.RawQuery<Item>(
+                "from index 'ItemIndex' where startsWith(Name, 'a') and true order by Name include timings()")
+                .Timings(out var optimizedTimings)
+                .ToList();
+
+            Assert.Equal(3, optimized.Count);
+            AssertSamePlan(baselinePlan, optimizedTimings, "startsWith AND true ORDER BY should produce same plan as startsWith ORDER BY");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public void StreamingOptimization_WithTrueAndOnLeft_ShouldMatchBaselinePlan(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Item("apple", "red", 10));
+            session.Store(new Item("apricot", "orange", 20));
+            session.Store(new Item("avocado", "green", 30));
+            session.Store(new Item("banana", "yellow", 40));
+            session.SaveChanges();
+        }
+
+        new ItemIndex().Execute(store);
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            _ = session.Advanced.DocumentQuery<Item, ItemIndex>()
+                .WhereStartsWith(x => x.Name, "a")
+                .OrderBy(x => x.Name)
+                .Timings(out var baselineTimings)
+                .ToList();
+            var baselinePlan = (ClientQueryInspectionNode)baselineTimings.QueryPlan;
+
+            _ = session.Advanced.RawQuery<Item>(
+                    "from index 'ItemIndex' where true and startsWith(Name, 'a') order by Name include timings()")
+                .Timings(out var optimizedTimings)
+                .ToList();
+
+            AssertSamePlan(baselinePlan, optimizedTimings,
+                "true AND startsWith ORDER BY should produce same plan as startsWith ORDER BY");
+        }
+    }
+
+    private static void AssertSamePlan(ClientQueryInspectionNode expected, QueryTimings actual, string message)
+    {
+        var actualPlan = (ClientQueryInspectionNode)actual.QueryPlan;
+        Assert.NotNull(actualPlan);
+        Assert.Equal(FormatPlan(expected), FormatPlan(actualPlan));
+    }
+
+    private static string FormatPlan(ClientQueryInspectionNode node, int indent = 0)
+    {
+        if (node == null)
+            return "<null>";
+
+        var prefix = new string(' ', indent * 2);
+        var line = $"{prefix}{node.Operation}";
+        if (node.Parameters is { Count: > 0 })
+            line += $" ({string.Join(", ", node.Parameters.Select(p => $"{p.Key}={p.Value}"))})";
+
+        if (node.Children == null)
+            return line;
+
+        return line + "\n" + string.Join("\n", node.Children.Select(c => FormatPlan(c, indent + 1)));
+    }
+
+    private class Item
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Color { get; set; }
+        public int Number { get; set; }
+
+        public Item()
+        {
+        }
+
+        public Item(string name, string color, int number)
+        {
+            Name = name;
+            Color = color;
+            Number = number;
+        }
+    }
+
+    private class ItemIndex : AbstractIndexCreationTask<Item>
+    {
+        public ItemIndex()
+        {
+            Map = items => from item in items
+                select new
+                {
+                    item.Name,
+                    item.Color,
+                    item.Number
+                };
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22602

### Additional description

Implements boolean algebra identity optimizations for Corax queries:
  - true AND X → X
  - true OR X → AllEntries
 
These patterns arise in production when query conditions are dynamically composed and can cause severe performance degradation without the optimization. The optimization runs at two levels: at the AST level (before recursion) and at the runtime level when a sub-expression already materialized to `AllEntries` feeds into a parent `AND` or `OR` node. This ensures cascading cases like `((true OR X) OR Y) AND Z` also fully collapse.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
