### PR TITLE
RavenDB-25912 - Improve the performance of `AssertNotAboutToRunOutOfMemory`

### DIFF
--- a/src/Sparrow.Server/LowMemory/MemoryInformation.EarlyOutOfMemory.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.EarlyOutOfMemory.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Sparrow.Platform;
+using Sparrow.Server.Platform.Win32;
+
+namespace Sparrow.Server.LowMemory;
+
+public static partial class MemoryInformation
+{
+    private static readonly LightWeightMemoryInfoResult FailedLightWeightMemoryResult = new()
+    {
+        AvailableMemory = new Size(256, SizeUnit.Megabytes),
+        TotalCommittableMemory = new Size(384, SizeUnit.Megabytes),
+        CurrentCommitCharge = new Size(256, SizeUnit.Megabytes),
+    };
+
+    private static LightWeightMemoryInfoResult GetEarlyOutOfMemoryInfo()
+    {
+        if (_failedToGetAvailablePhysicalMemory)
+        {
+            if (Logger.IsInfoEnabled)
+                Logger.Info("Because of a previous error in getting available memory, we are now lying and saying we have 256MB free");
+            return FailedLightWeightMemoryResult;
+        }
+
+        try
+        {
+            LightWeightMemoryInfoResult result;
+
+            if (PlatformDetails.RunningOnPosix == false)
+            {
+                result = GetEarlyOutOfMemoryInfoWindows();
+            }
+            else if (PlatformDetails.RunningOnMacOsx)
+            {
+                var info = GetMemoryInfoMacOs(process: null, extended: false);
+                result = new LightWeightMemoryInfoResult
+                {
+                    AvailableMemory = info.AvailableMemory,
+                    CurrentCommitCharge = info.CurrentCommitCharge,
+                    TotalCommittableMemory = info.TotalCommittableMemory
+                };
+            }
+            else
+            {
+                var info = GetMemoryInfoLinux(smapsReader: null, extended: false);
+                result = new LightWeightMemoryInfoResult
+                {
+                    AvailableMemory = info.AvailableMemory,
+                    CurrentCommitCharge = info.CurrentCommitCharge,
+                    TotalCommittableMemory = info.TotalCommittableMemory
+                };
+            }
+
+            return result;
+
+        }
+        catch (Exception e)
+        {
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations("Error while trying to get available memory, will stop trying and report that there is 256MB free only from now on", e);
+            _failedToGetAvailablePhysicalMemory = true;
+            return FailedLightWeightMemoryResult;
+        }
+    }
+
+    private static unsafe LightWeightMemoryInfoResult GetEarlyOutOfMemoryInfoWindows()
+    {
+        var memoryStatus = new Win32MemoryMethods.MemoryStatusEx
+        {
+            dwLength = (uint)sizeof(Win32MemoryMethods.MemoryStatusEx)
+        };
+
+        if (Win32MemoryMethods.GlobalMemoryStatusEx(&memoryStatus) == false)
+        {
+            if (Logger.IsInfoEnabled)
+                Logger.Info("Failure when trying to read memory info from Windows, error code is: " + Marshal.GetLastWin32Error());
+            return FailedLightWeightMemoryResult;
+        }
+
+        long memoryStatusUllAvailPhys = (long)memoryStatus.ullAvailPhys;
+        long totalPageFile = (long)memoryStatus.ullTotalPageFile;
+        long availPageFile = (long)(memoryStatus.ullTotalPageFile - memoryStatus.ullAvailPageFile);
+
+        if (Win32MemoryMethods.IsProcessInJob(ProcessHandle, IntPtr.Zero, out var isInJob) && isInJob)
+        {
+            Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = default;
+            if (Win32MemoryMethods.QueryInformationJobObject(IntPtr.Zero,
+                    Win32MemoryMethods.JOBOBJECTINFOCLASS.ExtendedLimitInformation, (void*)&limits,
+                    sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
+                    out int limitsOutputSize) == false ||
+                limitsOutputSize != sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
+            {
+                if (_reportedQueryJobObjectFailure == false && Logger.IsInfoEnabled)
+                {
+                    _reportedQueryJobObjectFailure = true;
+                    Logger.Info(
+                        $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
+                }
+            }
+            else
+            {
+                long maxSize = long.MaxValue;
+                if (limits.BasicLimitInformation.MaximumWorkingSetSize != UIntPtr.Zero)
+                {
+                    maxSize = (long)limits.BasicLimitInformation.MaximumWorkingSetSize;
+                }
+
+                if (limits.ProcessMemoryLimit != UIntPtr.Zero)
+                {
+                    maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
+                }
+
+                if (limits.JobMemoryLimit != UIntPtr.Zero)
+                {
+                    maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
+                }
+
+                if (maxSize != long.MaxValue)
+                {
+                    (long workingSetInBytes, long _, long? _) = GetProcessMemoryInfoForWindows();
+                    var availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSetInBytes, 0);
+                    availPageFile = Math.Max(maxSize - workingSetInBytes, 0);
+                    totalPageFile = maxSize;
+                    memoryStatusUllAvailPhys = Math.Min(availableMemoryForProcessingInBytes, memoryStatusUllAvailPhys);
+                }
+            }
+        }
+
+        return new LightWeightMemoryInfoResult
+        {
+            TotalCommittableMemory = new Size(totalPageFile, SizeUnit.Bytes),
+            CurrentCommitCharge = new Size(availPageFile, SizeUnit.Bytes),
+            AvailableMemory = new Size(memoryStatusUllAvailPhys, SizeUnit.Bytes),
+        };
+    }
+
+    public struct LightWeightMemoryInfoResult
+    {
+        public Size CurrentCommitCharge { get; set; }
+        public Size TotalCommittableMemory { get; set; }
+        public Size AvailableMemory { get; set; }
+    }
+}

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -13,11 +13,10 @@ using Sparrow.Server.Platform.Posix.macOS;
 using Sparrow.Server.Platform.Win32;
 using Sparrow.Server.Utils;
 using Sparrow.Utils;
-using NativeMemory = Sparrow.Utils.NativeMemory;
 
 namespace Sparrow.Server.LowMemory
 {
-    public static class MemoryInformation
+    public static partial class MemoryInformation
     {
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<MemoryInfoResult>("Server");
 
@@ -126,9 +125,9 @@ namespace Sparrow.Server.LowMemory
                 EnableEarlyOutOfMemoryCheck == false)   // but we want to enable this manually if needed
                 return;
 
-            var memInfo = GetMemoryInfo();
+            var memInfo = GetEarlyOutOfMemoryInfo();
             if (IsEarlyOutOfMemoryInternal(memInfo, earlyOutOfMemoryWarning: false, out _))
-                ThrowInsufficientMemory(memInfo);
+                ThrowInsufficientMemory(GetMemoryInfo());
         }
 
         internal static bool IsEarlyOutOfMemory(MemoryInfoResult memInfo, out Size commitChargeThreshold)
@@ -140,10 +139,15 @@ namespace Sparrow.Server.LowMemory
                 return false;
             }
 
-            return IsEarlyOutOfMemoryInternal(memInfo, earlyOutOfMemoryWarning: true, out commitChargeThreshold);
+            return IsEarlyOutOfMemoryInternal(new LightWeightMemoryInfoResult
+            {
+                AvailableMemory = memInfo.AvailableMemory,
+                CurrentCommitCharge = memInfo.CurrentCommitCharge,
+                TotalCommittableMemory = memInfo.TotalCommittableMemory
+            }, earlyOutOfMemoryWarning: true, out commitChargeThreshold);
         }
 
-        private static bool IsEarlyOutOfMemoryInternal(MemoryInfoResult memInfo, bool earlyOutOfMemoryWarning, out Size commitChargeThreshold)
+        private static bool IsEarlyOutOfMemoryInternal(LightWeightMemoryInfoResult memInfo, bool earlyOutOfMemoryWarning, out Size commitChargeThreshold)
         {
             // if we are about to create a new thread, might not always be a good idea:
             // https://ayende.com/blog/181537-B/production-test-run-overburdened-and-under-provisioned
@@ -156,12 +160,12 @@ namespace Sparrow.Server.LowMemory
                 // sometimes this kind of stat is shared, see:
                 // https://fabiokung.com/2014/03/13/memory-inside-linux-containers/
 
-                commitChargeThreshold = GetMinCommittedToKeep(memInfo.TotalPhysicalMemory);
+                commitChargeThreshold = GetMinCommittedToKeep(TotalPhysicalMemory);
                 overage =
                     commitChargeThreshold +                                    //extra to keep free
-                    (memInfo.TotalPhysicalMemory - memInfo.AvailableMemory);   //actually in use now
+                    (TotalPhysicalMemory - memInfo.AvailableMemory);   //actually in use now
 
-                return overage >= memInfo.TotalPhysicalMemory;
+                return overage >= TotalPhysicalMemory;
             }
 
             commitChargeThreshold = GetMinCommittedToKeep(memInfo.TotalCommittableMemory);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25912/High-CPU-usage-when-starting-the-server

### Additional description

Introduce a specialized, lightweight method `GetEarlyOutOfMemoryInfoWindow`s to replace the full `GetMemoryInfoWindows` call during early Out-Of-Memory (OOM) checks.

Motivation: The existing `GetMemoryInfoWindows` method includes a call to `GetSharedCleanInBytes`, which internally calculates `GetTotalScratchAllocatedMemoryInBytes`. Profiling indicates this operation is computationally expensive when you have a lot of environments, especially since it is called on **EACH** new allocation. This change applies exclusively to Windows, as early OOM checks are only performed on this operating system.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
