### PR TITLE
RavenDB-25693 - Remove newly created TermInfosReader cache entries on transaction abort

### DIFF
--- a/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronDirectory.cs
@@ -207,7 +207,14 @@ namespace Raven.Server.Indexing
             var state = s as VoronState;
             if (state == null)
                 throw new ArgumentNullException(nameof(s));
-            
+
+            if (name.EndsWith(IndexFileNames.TERMS_INDEX_EXTENSION, StringComparison.OrdinalIgnoreCase))
+            {
+                // the cache consists only of files with the TERMS_INDEX_EXTENSION.
+                // https://github.com/ravendb/lucenenet/blob/e30e8f94f6895197913d091a61e7e831398ce3fb/src/Lucene.Net/Index/TermInfosReader.cs#L107
+                state.Transaction.LowLevelTransaction.OnRollBack += _ => RemoveFromTermsIndexCache(name);
+            }
+
             return new VoronIndexOutput(_tempFileCache, name, state.Transaction, _name, _indexOutputFilesSummary);
         }
 

--- a/test/FastTests/Issues/RavenDB-8097.cs
+++ b/test/FastTests/Issues/RavenDB-8097.cs
@@ -33,7 +33,7 @@ namespace FastTests.Issues
         [Fact]
         public void ServerUrlShouldOnlyAllowHttpOrHttps()
         {
-            GetConfiguration("http://test.com");
+            GetConfiguration("http://ravendb.net");
             GetConfiguration("https://192.152.23.3:345", certPath: "certPath.pem");
 
             foreach (var serverUrl in new string[]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25693/IndexOutOfRangeException-during-ApplyDeletes

### Additional description

Port from 6.2: https://github.com/ravendb/ravendb/pull/22153

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
