### PR TITLE
RavenDB-26063 svgtofont: use dynamic import and normalize icons size

### DIFF
--- a/src/Raven.Studio/scripts/svgtofont.js
+++ b/src/Raven.Studio/scripts/svgtofont.js
@@ -1,4 +1,3 @@
-const svgtofont = require("svgtofont").default;
 const path = require("path");
 
 const fixedCodepoints = require("../typescript/common/helpers/view/icomoonFixedCodepoints.json");
@@ -6,36 +5,43 @@ const fixedCodepoints = require("../typescript/common/helpers/view/icomoonFixedC
 const srcDir = path.resolve(process.cwd(), "wwwroot/Content/css/fonts/icomoon");
 const distDir = path.resolve(process.cwd(), "wwwroot/Content/css/fonts/icomoon-svgtofont");
 
-svgtofont({
-    src: srcDir,
-    dist: distDir,
-    emptyDist: true,
-    excludeFormat: ["eot", "ttf", "svg", "symbol.svg"],
-    styleTemplates: path.resolve(__dirname, "svgtofont-templates"),
-    fontName: "icomoon",
-    classNamePrefix: "icon",
-    outSVGReact: false,
-    website: null,
-    addLigatures: true,
-    getIconUnicode: (iconName) => {
-        const codePointHex = fixedCodepoints[iconName];
-        if (!codePointHex) {
-            return undefined;
-        }
-
-        const codePoint = parseInt(String(codePointHex).replace(/^0x/i, ""), 16);
-        if (Number.isNaN(codePoint)) {
-            throw new Error(`Invalid fixed code point for icon '${iconName}': '${codePointHex}'`);
-        }
-
-        return [String.fromCodePoint(codePoint)];
-    },
-    css: {
-        templateVars: {
-            baseSelector: ".icon",
+// Dynamic import to support ESM in Node v20
+import("svgtofont").then(({ default: svgtofont }) => {
+    return svgtofont({
+        src: srcDir,
+        dist: distDir,
+        emptyDist: true,
+        excludeFormat: ["eot", "ttf", "svg", "symbol.svg"],
+        svgicons2svgfont: {
+            normalize: true,
+            fontHeight: 1024, // Most svg icons are designed on a 1024x1024 grid, so this ensures that all are scaled correctly
         },
-        hasTimestamp: false,
-    },
+        styleTemplates: path.resolve(__dirname, "svgtofont-templates"),
+        fontName: "icomoon",
+        classNamePrefix: "icon",
+        outSVGReact: false,
+        website: null,
+        addLigatures: true,
+        getIconUnicode: (iconName) => {
+            const codePointHex = fixedCodepoints[iconName];
+            if (!codePointHex) {
+                return undefined;
+            }
+
+            const codePoint = parseInt(String(codePointHex).replace(/^0x/i, ""), 16);
+            if (Number.isNaN(codePoint)) {
+                throw new Error(`Invalid fixed code point for icon '${iconName}': '${codePointHex}'`);
+            }
+
+            return [String.fromCodePoint(codePoint)];
+        },
+        css: {
+            templateVars: {
+                baseSelector: ".icon",
+            },
+            hasTimestamp: false,
+        },
+    });
 }).then(() => {
     console.log("Icons font generated");
 });


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26063/Missing-icons

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
