### PR TITLE
RavenDB-25880 when retrying LE request we need to recreate the message

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncryptClient.cs
+++ b/src/Raven.Server/Commercial/LetsEncryptClient.cs
@@ -213,34 +213,18 @@ namespace Raven.Server.Commercial
         {
             var hasNonce = _nonce != null;
             var retries = 3;
+
             do
             {
-                var request = new HttpRequestMessage(method, uri);
-                if (message != null)
-                {
-                    var encodedMessage = _jws.Encode(message, new JwsHeader
-                    {
-                        Nonce = _nonce,
-                        Url = uri
-                    });
-                    var json = JsonConvert.SerializeObject(encodedMessage, jsonSettings);
-
-                    request.Content = new StringContent(json, Encoding.UTF8, "application/jose+json")
-                    {
-                        Headers =
-                        {
-                            ContentType =
-                            {
-                                CharSet = string.Empty
-                            }
-                        }
-                    };
-                }
-
                 HttpResponseMessage response;
+                HttpRequestMessage lastRequest = null;
                 try
                 {
-                    response = await RetryPolicy.ExecuteAsync(t => _client.SendAsync(request, t), token, continueOnCapturedContext: false).ConfigureAwait(false);
+                    response = await RetryPolicy.ExecuteAsync(t =>
+                    {
+                        lastRequest = CreateRequest();
+                        return _client.SendAsync(lastRequest, t);
+                    }, token, continueOnCapturedContext: false).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -249,7 +233,7 @@ namespace Raven.Server.Commercial
                         continue;
                     }
 
-                    throw new InvalidOperationException($"Let's Encrypt client failed to send the request (with retries): {request}", e);
+                    throw new InvalidOperationException($"Let's Encrypt client failed to send the request (with retries): {lastRequest}", e);
                 }
 
                 if (response.Headers.TryGetValues("Replay-Nonce", out var vals))
@@ -272,7 +256,7 @@ namespace Raven.Server.Commercial
                     }
                     catch (Exception e)
                     {
-                        throw new InvalidOperationException($"Let's Encrypt client failed to send the request (with retries): {request}. Problem: {problemJson}", e);
+                        throw new InvalidOperationException($"Let's Encrypt client failed to send the request (with retries): {lastRequest}. Problem: {problemJson}", e);
                     }
                 }
 
@@ -282,6 +266,34 @@ namespace Raven.Server.Commercial
                 }
                 hasNonce = true; // we only allow it once
             } while (true);
+
+            HttpRequestMessage CreateRequest()
+            {
+                var request = new HttpRequestMessage(method, uri);
+                if (message == null) 
+                    return request;
+
+                var encodedMessage = _jws.Encode(message, new JwsHeader
+                {
+                    Nonce = _nonce,
+                    Url = uri
+                });
+
+                var json = JsonConvert.SerializeObject(encodedMessage, jsonSettings);
+
+                request.Content = new StringContent(json, Encoding.UTF8, "application/jose+json")
+                {
+                    Headers =
+                    {
+                        ContentType =
+                        {
+                            CharSet = string.Empty
+                        }
+                    }
+                };
+
+                return request;
+            }
         }
 
         public async Task<Dictionary<string, string>> NewOrder(string[] hostnames, string profile = null, CancellationToken token = default(CancellationToken))


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25880

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
