### PR TITLE
RavenDB-25992 - Address Multi-Agent demo comments

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentActionRequest.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentActionRequest.cs
@@ -13,7 +13,7 @@ public class AiAgentActionRequest : IDynamicJson
     internal AiAgentActionRequestType Type;
 
     [ForceJsonSerialization]
-    internal string SubConversation;
+    internal string SubConversationId;
 
     internal bool IsEqual(AiAgentActionRequest other)
     {
@@ -25,7 +25,7 @@ public class AiAgentActionRequest : IDynamicJson
             Name == other.Name &&
             Arguments == other.Arguments &&
             Type == other.Type &&
-            SubConversation == other.SubConversation;
+            SubConversationId == other.SubConversationId;
     }
 
     public override string ToString()
@@ -42,7 +42,7 @@ public class AiAgentActionRequest : IDynamicJson
             [nameof(ToolId)] = ToolId,
             [nameof(Arguments)] = Arguments,
             [nameof(Type)] = Type,
-            [nameof(SubConversation)] = SubConversation
+            [nameof(SubConversationId)] = SubConversationId
         };
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
@@ -56,7 +56,7 @@ public class AiAgentParameter : IDynamicJson
     /// <inheritdoc cref="AiAgentParameter(string, string, bool)" />
     /// <param name="policy">
     /// Policy flags for this parameter.
-    /// Use <see cref="AiAgentParameterPolicy.AllowedModelGeneration"/> to allow the parent agent to generate
+    /// Use <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> to allow the parent agent to generate
     /// a value for a sub-agent parameter with the same <paramref name="name"/>; the sub-agent will receive the parent's
     /// value as-is.
     /// </param>
@@ -71,9 +71,10 @@ public class AiAgentParameter : IDynamicJson
     /// <inheritdoc cref="AiAgentParameter(string, string)" />
     /// <param name="policy">
     /// Policy flags for this parameter.
-    /// Use <see cref="AiAgentParameterPolicy.AllowedModelGeneration"/> to allow the parent agent to generate
-    /// a value for a sub-agent parameter with the same <paramref name="name"/>; the sub-agent will receive the parent's
-    /// value as-is.
+    /// When <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> is set for a sub-agent parameter
+    /// the parent isn't allowed to generate a new value for the sub-agent;
+    /// the only option is if the parent's has a parameter with the same name and the parent's value will be sent 
+    /// to the sub-agent as-is.
     /// </param>
     public AiAgentParameter(string name, string description, AiAgentParameterPolicy policy) : this(name, description)
     {
@@ -101,8 +102,9 @@ public class AiAgentParameter : IDynamicJson
     /// with the same <see cref="Name"/>.
     /// </summary>
     /// <remarks>
-    /// When <see cref="AiAgentParameterPolicy.AllowedModelGeneration"/> is unset and a sub-agent defines a parameter
-    /// with the same name, the parent does not generate a new value for the sub-agent; the parent's value is passed
+    /// When <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> is set for a sub-agent parameter
+    /// the parent isn't allowed to generate a new value for the sub-agent;
+    /// the only option is if the parent's has a parameter with the same name and the parent's value will be sent 
     /// to the sub-agent as-is.
     /// </remarks>
     public AiAgentParameterPolicy Policy { get; set; } = AiAgentParameterPolicy.Default;
@@ -122,6 +124,6 @@ public class AiAgentParameter : IDynamicJson
     public enum AiAgentParameterPolicy
     {
         Default = 0,
-        AllowedModelGeneration = 1
+        ForbidModelGeneration = 1
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
@@ -56,9 +56,11 @@ public class AiAgentParameter : IDynamicJson
     /// <inheritdoc cref="AiAgentParameter(string, string, bool)" />
     /// <param name="policy">
     /// Policy flags for this parameter.
-    /// Use <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> to allow the parent agent to generate
-    /// a value for a sub-agent parameter with the same <paramref name="name"/>; the sub-agent will receive the parent's
-    /// value as-is.
+    /// Use <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> to prevent
+    /// the parent agent from generating a value for this parameter when the agent
+    /// is used as a sub-agent.
+    /// The value may only be inherited from the parent agent, if a parameter with
+    /// the same name exists.
     /// </param>
     public AiAgentParameter(string name, string description, bool sendToModel, AiAgentParameterPolicy policy) : this(name, description, sendToModel)
     {
@@ -71,10 +73,11 @@ public class AiAgentParameter : IDynamicJson
     /// <inheritdoc cref="AiAgentParameter(string, string)" />
     /// <param name="policy">
     /// Policy flags for this parameter.
-    /// When <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> is set for a sub-agent parameter
-    /// the parent isn't allowed to generate a new value for the sub-agent;
-    /// the only option is if the parent's has a parameter with the same name and the parent's value will be sent 
-    /// to the sub-agent as-is.
+    /// When <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> is set
+    /// and this agent is used as a sub-agent, the parent agent cannot generate
+    /// a value for this parameter.
+    /// The value may only be inherited from the parent agent's parameters,
+    /// ensuring it is not model-generated.
     /// </param>
     public AiAgentParameter(string name, string description, AiAgentParameterPolicy policy) : this(name, description)
     {
@@ -102,10 +105,10 @@ public class AiAgentParameter : IDynamicJson
     /// with the same <see cref="Name"/>.
     /// </summary>
     /// <remarks>
-    /// When <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> is set for a sub-agent parameter
-    /// the parent isn't allowed to generate a new value for the sub-agent;
-    /// the only option is if the parent's has a parameter with the same name and the parent's value will be sent 
-    /// to the sub-agent as-is.
+    /// When <see cref="AiAgentParameterPolicy.ForbidModelGeneration"/> is set and this agent is used
+    /// as a sub-agent, the parent agent isn't allowed to generate a parameter value for the sub-agent;
+    /// the parameter's value may only be inherited from the parent agent parameters.
+    /// This ensures that this is a trusted value.
     /// </remarks>
     public AiAgentParameterPolicy Policy { get; set; } = AiAgentParameterPolicy.Default;
 

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -516,7 +516,6 @@ public class ChatCompletionClient : IDisposable
         bool streaming,
         string schema)
      {
-         messages = messages.Where(m => m.TryGet("role", out string role) == false || role != Constants.RequestFields.RoleInternalValue).ToList();
 
         if (_settings.Model is null)
             throw new ArgumentNullException(nameof(_settings.Model));
@@ -531,7 +530,9 @@ public class ChatCompletionClient : IDisposable
                     return;
                 }
 
-                WriteCompletionRequestPayload(writer, ctx, messages, attachments, tools, useTools, streaming, schema);
+                WriteCompletionRequestPayload(writer, ctx, 
+                    messages.Where(IsValidMessage) // IEnumerable of valid messages
+                    , attachments, tools, useTools, streaming, schema);
             }
         }, ConventionsToUse);
 
@@ -545,6 +546,9 @@ public class ChatCompletionClient : IDisposable
         };
 
         return request;
+
+        static bool IsValidMessage(BlittableJsonReaderObject msg) 
+            => msg.TryGet("role", out string role) == false || role != Constants.RequestFields.RoleInternalValue; // isn't an internal message
     }
 
     public void WriteCompletionRequestPayload(AsyncBlittableJsonTextWriter writer, JsonOperationContext ctx, IEnumerable<BlittableJsonReaderObject> messages, List<AiAttachment> attachments, List<BlittableJsonReaderObject> tools, bool useTools, bool streaming,

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -515,7 +515,9 @@ public class ChatCompletionClient : IDisposable
         bool useTools,
         bool streaming,
         string schema)
-    {
+     {
+         messages = messages.Where(m => m.TryGet("role", out string role) == false || role != Constants.RequestFields.RoleInternalValue).ToList();
+
         if (_settings.Model is null)
             throw new ArgumentNullException(nameof(_settings.Model));
 
@@ -1048,6 +1050,7 @@ public class ChatCompletionClient : IDisposable
             public const string RoleSystemValue = "system";
             public const string RoleUserValue = "user";
             public const string RoleAssistantValue = "assistant";
+            public const string RoleInternalValue = "internal";
 
             // HTTP headers
             public const string HeaderContentType = "Content-Type";

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
@@ -36,6 +37,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
     public TimeSpan? Expires;
 
     public int RemainingToolIterations;
+
+    public HashSet<string> SubConversationIds = new (StringComparer.OrdinalIgnoreCase);
 
     public void Initialize(JsonOperationContext context, AiAgentConfiguration configuration, bool resetRemainingToolIterations, int maxModelIterationsPerCall)
     {
@@ -227,7 +230,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [nameof(CreatedAt)] = CreatedAt,
             [nameof(Expires)] = Expires,
             [nameof(CurrentUsage)] = CurrentUsage,
-            [nameof(RemainingToolIterations)] = RemainingToolIterations
+            [nameof(RemainingToolIterations)] = RemainingToolIterations,
+            [nameof(SubConversationIds)] = new DynamicJsonArray(SubConversationIds)
         };
     }
 
@@ -293,6 +297,11 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             conversation.CurrentUsage = JsonDeserializationClient.AiUsage(currentUsageBlittable);
         }
 
+        if (document.TryGet(nameof(SubConversationIds), out BlittableJsonReaderArray subConversationIds))
+        {
+            conversation.SubConversationIds = subConversationIds.Items.Select(m => ((LazyStringValue)m).ToString(CultureInfo.InvariantCulture)).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
         return conversation;
     }
 
@@ -331,7 +340,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
                     continue;
                 }
 
-                if (parameter.Policy.HasFlag(AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration))
+                if (parameter.Policy.HasFlag(AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration) == false)
                 {
                     // the parent doesn't have this parameter BUT it's allowed to be generated -> we add it to the tool schema
                     parameters[parameter.Name] = parameter.Description;
@@ -339,8 +348,9 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
                 }
 
                 throw new MissingAiAgentParameterException($"Parameter '{parameter.Name}' is missing from the parent scope." + 
-                                                           " To allow the root agent to generate this value dynamically, " + 
-                                                           "set the 'AllowedModelGeneration' flag to true in the sub-agent parameter policy.");
+                                                           " To allow the root agent to generate this value dynamically, " +
+                                                           $"unset the '{nameof(AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration)}' " +
+                                                           "flag in the sub-agent parameter policy.");
             }
 
             var argsSampleObject = DynamicJsonValue.Convert(parameters);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
@@ -84,7 +84,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                 Name = call.Name,
                 Type = AiAgentActionRequestType.SubAgent,
                 Arguments = call.Arguments,
-                SubConversation = conversationId
+                SubConversationId = conversationId
             });
         }
 
@@ -131,14 +131,14 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
 
         private static SubAgentActionResponse GetOrAddSubAgentsActionResponses(Dictionary<string, SubAgentActionResponse> subAgentsActions, AiAgentActionRequest parent, string parentToolId)
         {
-            if (subAgentsActions.TryGetValue(parent.SubConversation, out var subAgent))
+            if (subAgentsActions.TryGetValue(parent.SubConversationId, out var subAgent))
             {
                 Debug.Assert(subAgent.ParentId == parentToolId, $"subAgent.ParentId != rootToolId. subAgent.ParentId is '{subAgent.ParentId}',  rootToolId is '{parentToolId}'");
                 Debug.Assert(subAgent.Agent == parent.Name, $"subAgent.Agent != action.Name. subAgent.Agent is '{subAgent.Agent}', action.Name is '{parent.Name}'");
             }
             else
             {
-                subAgent = subAgentsActions[parent.SubConversation] = new SubAgentActionResponse()
+                subAgent = subAgentsActions[parent.SubConversationId] = new SubAgentActionResponse()
                 {
                     ParentId = parentToolId,
                     Agent = parent.Name,
@@ -150,7 +150,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         }
 
         private bool TryCloseSubAgentCall(JsonOperationContext context, string conversationId, BlittableJsonReaderObject requestResult, AiToolCall currentCall,
-    SubConversationResult result)
+            SubConversationResult result)
         {
             if (requestResult.TryGet(nameof(ConversationResult<object>.Response), out BlittableJsonReaderObject agentResult) is false)
                 throw new InvalidOperationException($"Sub-agent query output is missing the '{nameof(ConversationResult<object>.Response)}' field inside '{nameof(QueryResult.Results)}'. (Query - Id: {currentCall.Id}, Name: {currentCall.Name})");
@@ -172,6 +172,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                         Name = currentCall.Name + "/" + actionRequest.Name,
                         Type = AiAgentActionRequestType.UserAction,
                         Arguments = actionRequest.Arguments,
+                        SubConversationId = conversationId
                     };
 
                     AddChildrenUserCall(result.ChildUserCalls, actionRequest.ToolId, newActionCall);
@@ -186,7 +187,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     ["tool_call_id"] = currentCall.Id,
                     ["role"] = "tool",
                     ["content"] = agentResult.ToString(),
-                    ["subConversation"] = conversationId,
+                    ["subConversationId"] = conversationId,
                 }, "tool-call/response"));
 
             result.OpenToolCallsToRemove.Add(currentCall.Id);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -544,7 +544,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 if (_document.OpenActionCalls.TryGetValue(rootToolId, out var action) == false)
                     throw new InvalidOperationException($"{rootToolId} is an unknown action ID for conversation '{_conversationId}'");
 
-                if (action.SubConversation == null)
+                if (action.SubConversationId == null)
                 {
                     _document.OpenActionCalls.Remove(rootToolId);
                     _document.AddMessage(context, context.ReadObject(
@@ -629,6 +629,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         List<Task<SubConversationResult>> tasks = [];
         foreach (var (conversationId, conversationReqs) in reqs)
         {
+            _document.SubConversationIds.Add(conversationId);
             tasks.Add(ExecuteSingleSubConversationToolCallsAsync(conversationId, conversationReqs));
         }
 
@@ -664,6 +665,15 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                     foreach (var (key, value) in r.ChildUserCalls)
                     {
                         AddChildrenUserCall(_childUserCalls, key, value);
+                        _document.Messages.Add(context.ReadObject(
+                            new DynamicJsonValue
+                            {
+                                ["role"] = ChatCompletionClient.Constants.RequestFields.RoleInternalValue,
+                                ["type"] = "sub-agent-action-call",
+                                ["content"] = $"[sub-agent called action-tool '{value.Name}']",
+                                ["toolName"] = value.Name,
+                                ["subConversationId"] = value.SubConversationId,
+                            }, "tool-call/sub-agent-action-tool"));
                     }
                 }
             }
@@ -719,7 +729,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                                         ["tool_call_id"] = currentCall.Id,
                                         ["role"] = "tool",
                                         ["content"] = "Error has been occurred during the tool call execution: " + e.Message,
-                                        ["subConversation"] = conversationId,
+                                        ["subConversationId"] = conversationId,
                                     }, "tool-call/response"));
                             result.OpenToolCallsToRemove.Add(currentCall.Id);
                         }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887_2.cs
@@ -334,8 +334,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 },
             }
         };
-        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with", 
-            AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
 
 
@@ -353,7 +352,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        userAgent2.Parameters.Add(new AiAgentParameter("theUserId", "the id of the current user that you talk with", AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        userAgent2.Parameters.Add(new AiAgentParameter("theUserId", "the id of the current user that you talk with"));
         var userAgent2Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2, MoviesSampleObject.Instance)).Identifier;
 
 
@@ -417,8 +416,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 },
             }
         };
-        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the requested user, not his hold Name (equals to 'currentUserId')",
-            policy: AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the requested user, not his hold Name (equals to 'currentUserId')"));
         var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
 
         var userAgent1 = new AiAgentConfiguration("user-info-agent-1",
@@ -507,7 +505,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 },
             }
         };
-        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with", AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        userAgent3.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent3Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent3, MoviesSampleObject.Instance)).Identifier;
 
 
@@ -525,8 +523,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        userAgent2.Parameters.Add(new AiAgentParameter("theUserId", "the id of the current user that you talk with", 
-            AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        userAgent2.Parameters.Add(new AiAgentParameter("theUserId", "the id of the current user that you talk with"));
         var userAgent2Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent2, MoviesSampleObject.Instance)).Identifier;
 
 
@@ -544,8 +541,7 @@ public class RavenDB_24887_2(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with", 
-            AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        userAgent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var userAgent1Id = (await store.AI.CreateAgentAsync<MoviesSampleObject>(userAgent1, MoviesSampleObject.Instance)).Identifier;
 
         var chat = store.AI.Conversation(userAgent1Id, "chats/1",

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25869.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25869.cs
@@ -60,7 +60,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 }
             };
             changeUserNameAgent.Parameters.Add(new AiAgentParameter("userId", "The id of the user whose name should be changed", 
-                AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+                AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration));
             var changeUserNameAgentId = (await store.AI.CreateAgentAsync(changeUserNameAgent, MoviesSampleObject.Instance)).Identifier;
 
 
@@ -81,7 +81,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 ]
             };
             userProfileAgent.Parameters.Add(new AiAgentParameter("userId", "The current user id",
-                AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+                AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration));
             var userProfileAgentId = (await store.AI.CreateAgentAsync(userProfileAgent, MoviesSampleObject.Instance)).Identifier;
 
             var chat = store.AI.Conversation(userProfileAgentId, "chats/1",
@@ -139,8 +139,22 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             );
 
             chat2.SetUserPrompt("change my name from 'Shahar' to 'Aviv'");
-            var r2 = await chat2.RunAsync<MoviesSampleObject>();
-            Assert.Equal(AiConversationResult.Done, r2.Status);
+            await Assert.ThrowsAsync<MissingAiAgentParameterException>(() => chat2.RunAsync<MoviesSampleObject>());
+
+            changeUserNameAgent.Parameters.First(x => x.Name == "userId").Policy = AiAgentParameter.AiAgentParameterPolicy.Default;
+            await store.AI.CreateAgentAsync(changeUserNameAgent, MoviesSampleObject.Instance);
+            var chat22 = store.AI.Conversation(userProfileAgent2Id, "chats/2",
+                new AiConversationCreationOptions().AddParameter("currentUserId", "Users/1"));
+            chat22.Handle<ChangeUserNameSampleRequest>($"{changeUserNameAgentId}/ChangeUserName", r =>
+                new ActionToolResult
+                {
+                    IsSuccessful = true,
+                    Answer = $"Name of user '{r.UserId}' changed from '{r.OldUserName}' to '{r.NewUserName}'"
+                }
+            );
+            chat22.SetUserPrompt("change my name from 'Shahar' to 'Aviv'");
+            var r22 = await chat22.RunAsync<MoviesSampleObject>();
+            Assert.Equal(AiConversationResult.Done, r22.Status);
 
             using (var session = store.OpenAsyncSession())
             {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -581,8 +581,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        agent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with",
-            AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        agent1.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var identifier1 = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent1, MoviesSampleObject.Instance)).Identifier;
 
         var agent0 = new AiAgentConfiguration("movies-agent-0",
@@ -607,8 +606,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
                 }
             ]
         };
-        agent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with", 
-            AiAgentParameter.AiAgentParameterPolicy.AllowedModelGeneration));
+        agent0.Parameters.Add(new AiAgentParameter("userId", "the id of the current user that you talk with"));
         var identifier0 = (await store.AI.CreateAgentAsync<MoviesSampleObject>(agent0, MoviesSampleObject.Instance)).Identifier;
 
         var db = await GetDatabase(store.Database);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25992/Address-Multi-Agent-demo-comments

### Additional description
Address Multi-Agent demo comments:
AllowedModelGeneration => ForbidModelGeneration, subConversation  => subConversationId, add hashset of sub-comversations (ids) to conversation doc, record sub-agent action calls

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
