### PR TITLE
RavenDB_25808 : GenAI caching should take into account Sample Object

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -119,6 +119,14 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
         return errors.Count == 0;
     }
+    public enum GenAiHashVersion
+    {
+        None = 0, // old: no SampleObject
+        WithSampleObject = 1  // new: includes SampleObject
+    }
+
+    
+    public GenAiHashVersion HashVersion { get; internal set; }
 
     public override DynamicJsonValue ToJson()
     {
@@ -136,6 +144,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
         json[nameof(EnableTracing)] = EnableTracing;
         json[nameof(ExpirationInSec)] = ExpirationInSec;
+        json[nameof(HashVersion)] = HashVersion;
 
         return json;
     }
@@ -152,7 +161,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             SampleObject != other.SampleObject ||
             MaxConcurrency != other.MaxConcurrency ||
             ExpirationInSec != other.ExpirationInSec ||
-            EnableTracing != other.EnableTracing)
+            EnableTracing != other.EnableTracing ||
+            HashVersion != other.HashVersion)
             differences |= EtlConfigurationCompareDifferences.Other;
 
         return differences;

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -45,7 +45,6 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
     private const int DefaultMaxConcurrency = 4;
 
     internal readonly string TransformationName = "GenAi-transform-script";
-    internal const int None = 0;
     internal const int WithSampleObject = 1;
 
     [JsonDeserializationIgnore]
@@ -124,18 +123,20 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         return errors.Count == 0;
     }
 
-    internal static void ApplyHashVersionBackwardCompatibility(DatabaseRecord record, GenAiConfiguration configuration)
+    internal static void ApplyHashVersionBackwardCompatibility(DatabaseRecord record, GenAiConfiguration configuration, long taskId)
     {
-        var existing = record.GenAis?.FirstOrDefault(x => x.Name == configuration.Name);
+        var existing = record.GenAis?.FirstOrDefault(x => x.TaskId == taskId);
 
-        // Fallback for updates where the task somehow doesn't exist
         if (existing == null)
+        {
+            configuration.Version = WithSampleObject;
             return;
+        }
 
         // Existing version
         var existingVersion = existing.Version;
 
-        if (existingVersion == None)
+        if (existingVersion == null)
         {
             //did Sample object changed?
             if (string.Equals(existing.SampleObject, configuration.SampleObject, StringComparison.Ordinal) == false)
@@ -145,21 +146,21 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             else
             {
                 // If the SampleObject is IDENTICAL, and existing version is None we MUST force None.
-                configuration.Version = None;
+                configuration.Version = null;
             }
 
             return;
         }
 
         // Preserving WithSampleObject
-        if (configuration.Version == None)
+        if (configuration.Version == null)
         {
             configuration.Version = existingVersion;
         }
     }
 
     [ForceJsonSerialization]
-    internal int Version = None;
+    internal int? Version;
 
     public override DynamicJsonValue ToJson()
     {
@@ -177,7 +178,10 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
         json[nameof(EnableTracing)] = EnableTracing;
         json[nameof(ExpirationInSec)] = ExpirationInSec;
-        json[nameof(Version)] = Version;
+        if (Version.HasValue)
+        {
+            json[nameof(Version)] = Version;
+        }
 
         return json;
     }

--- a/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/AI/GenAiConfiguration.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.ServerWide;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -43,6 +45,8 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
     private const int DefaultMaxConcurrency = 4;
 
     internal readonly string TransformationName = "GenAi-transform-script";
+    internal const int None = 0;
+    internal const int WithSampleObject = 1;
 
     [JsonDeserializationIgnore]
     [JsonIgnore]
@@ -119,14 +123,43 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
 
         return errors.Count == 0;
     }
-    public enum GenAiHashVersion
+
+    internal static void ApplyHashVersionBackwardCompatibility(DatabaseRecord record, GenAiConfiguration configuration)
     {
-        None = 0, // old: no SampleObject
-        WithSampleObject = 1  // new: includes SampleObject
+        var existing = record.GenAis?.FirstOrDefault(x => x.Name == configuration.Name);
+
+        // Fallback for updates where the task somehow doesn't exist
+        if (existing == null)
+            return;
+
+        // Existing version
+        var existingVersion = existing.Version;
+
+        if (existingVersion == None)
+        {
+            //did Sample object changed?
+            if (string.Equals(existing.SampleObject, configuration.SampleObject, StringComparison.Ordinal) == false)
+            {
+                configuration.Version = WithSampleObject;
+            }
+            else
+            {
+                // If the SampleObject is IDENTICAL, and existing version is None we MUST force None.
+                configuration.Version = None;
+            }
+
+            return;
+        }
+
+        // Preserving WithSampleObject
+        if (configuration.Version == None)
+        {
+            configuration.Version = existingVersion;
+        }
     }
 
-    
-    public GenAiHashVersion HashVersion { get; internal set; }
+    [ForceJsonSerialization]
+    internal int Version = None;
 
     public override DynamicJsonValue ToJson()
     {
@@ -144,7 +177,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
         json[nameof(Queries)] = Queries != null ? new DynamicJsonArray(Queries) : null;
         json[nameof(EnableTracing)] = EnableTracing;
         json[nameof(ExpirationInSec)] = ExpirationInSec;
-        json[nameof(HashVersion)] = HashVersion;
+        json[nameof(Version)] = Version;
 
         return json;
     }
@@ -161,8 +194,7 @@ public class GenAiConfiguration : AbstractAiIntegrationConfiguration
             SampleObject != other.SampleObject ||
             MaxConcurrency != other.MaxConcurrency ||
             ExpirationInSec != other.ExpirationInSec ||
-            EnableTracing != other.EnableTracing ||
-            HashVersion != other.HashVersion)
+            EnableTracing != other.EnableTracing)
             differences |= EtlConfigurationCompareDifferences.Other;
 
         return differences;

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -334,7 +334,7 @@ var ai = new AI();
             UpdateHashString(state, cfg.JsonSchema);
             UpdateHashString(state, cfg.UpdateScript);
             UpdateHashString(state, cfg.ConnectionStringName);
-            if (cfg.HashVersion.HasFlag(GenAiConfiguration.GenAiHashVersion.WithSampleObject))
+            if (cfg.Version == (GenAiConfiguration.WithSampleObject))
             {
                 UpdateHashString(state, cfg.SampleObject);
             }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -334,6 +334,10 @@ var ai = new AI();
             UpdateHashString(state, cfg.JsonSchema);
             UpdateHashString(state, cfg.UpdateScript);
             UpdateHashString(state, cfg.ConnectionStringName);
+            if (cfg.HashVersion.HasFlag(GenAiConfiguration.GenAiHashVersion.WithSampleObject))
+            {
+                UpdateHashString(state, cfg.SampleObject);
+            }
             return result;
         }
 

--- a/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/UpdateEtlCommand.cs
@@ -36,7 +36,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
         public override void FillJson(DynamicJsonValue json)
         {
             json[nameof(TaskId)] = TaskId;
-            json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
+            json[nameof(Configuration)] = Configuration.ToJson();
             json[nameof(EtlType)] = EtlType;
         }
     }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2538,7 +2538,7 @@ namespace Raven.Server.ServerWide
 
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
                         
-                        GenAiConfiguration.ApplyHashVersionBackwardCompatibility(rawRecord, genAi);
+                        GenAiConfiguration.ApplyHashVersionBackwardCompatibility(rawRecord, genAi, id);
 
                         command = new UpdateGenAiCommand(id, genAi, databaseName, changeVector, raftRequestId);
                         break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2299,6 +2299,8 @@ namespace Raven.Server.ServerWide
                             genAiErr.Add($"Could not find connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
 
+                        genAi.HashVersion = GenAiConfiguration.GenAiHashVersion.WithSampleObject;
+
                         command = new AddGenAiCommand(genAi, databaseName, changeVector, raftRequestId);
                     }
                         break;
@@ -2309,6 +2311,40 @@ namespace Raven.Server.ServerWide
             }
 
             return await SendToLeaderAsync(command);
+        }
+
+        private void ApplyHashVersionBackwardCompatibility(DatabaseRecord record, GenAiConfiguration configuration)
+        {
+            var existing = record.GenAis?.FirstOrDefault(x => x.Name == configuration.Name);
+
+            // Fallback for updates where the task somehow doesn't exist
+            if (existing == null)
+                return;
+
+            // Existing version
+            var existingVersion = existing.HashVersion;
+
+            if (existingVersion == GenAiConfiguration.GenAiHashVersion.None)
+            {
+                //did Sample object changed?
+                if (string.Equals(existing.SampleObject, configuration.SampleObject, StringComparison.Ordinal) == false)
+                {
+                    configuration.HashVersion = GenAiConfiguration.GenAiHashVersion.WithSampleObject;
+                }
+                else
+                {
+                    // If the SampleObject is IDENTICAL, and existing version is None we MUST force None.
+                    configuration.HashVersion = GenAiConfiguration.GenAiHashVersion.None;
+                }
+
+                return;
+            }
+
+            // Preserving WithSampleObject
+            if (configuration.HashVersion == GenAiConfiguration.GenAiHashVersion.None)
+            {
+                configuration.HashVersion = existingVersion;
+            }
         }
 
         public async Task<(long, object)> AddQueueSink(TransactionOperationContext context,
@@ -2535,6 +2571,8 @@ namespace Raven.Server.ServerWide
                             genAiErr.Add($"Could not find AI connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
 
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
+
+                        ApplyHashVersionBackwardCompatibility(rawRecord, genAi);
 
                         command = new UpdateGenAiCommand(id, genAi, databaseName, changeVector, raftRequestId);
                         break;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2299,7 +2299,7 @@ namespace Raven.Server.ServerWide
                             genAiErr.Add($"Could not find connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
 
-                        genAi.HashVersion = GenAiConfiguration.GenAiHashVersion.WithSampleObject;
+                        genAi.Version = GenAiConfiguration.WithSampleObject;
 
                         command = new AddGenAiCommand(genAi, databaseName, changeVector, raftRequestId);
                     }
@@ -2311,40 +2311,6 @@ namespace Raven.Server.ServerWide
             }
 
             return await SendToLeaderAsync(command);
-        }
-
-        private void ApplyHashVersionBackwardCompatibility(DatabaseRecord record, GenAiConfiguration configuration)
-        {
-            var existing = record.GenAis?.FirstOrDefault(x => x.Name == configuration.Name);
-
-            // Fallback for updates where the task somehow doesn't exist
-            if (existing == null)
-                return;
-
-            // Existing version
-            var existingVersion = existing.HashVersion;
-
-            if (existingVersion == GenAiConfiguration.GenAiHashVersion.None)
-            {
-                //did Sample object changed?
-                if (string.Equals(existing.SampleObject, configuration.SampleObject, StringComparison.Ordinal) == false)
-                {
-                    configuration.HashVersion = GenAiConfiguration.GenAiHashVersion.WithSampleObject;
-                }
-                else
-                {
-                    // If the SampleObject is IDENTICAL, and existing version is None we MUST force None.
-                    configuration.HashVersion = GenAiConfiguration.GenAiHashVersion.None;
-                }
-
-                return;
-            }
-
-            // Preserving WithSampleObject
-            if (configuration.HashVersion == GenAiConfiguration.GenAiHashVersion.None)
-            {
-                configuration.HashVersion = existingVersion;
-            }
         }
 
         public async Task<(long, object)> AddQueueSink(TransactionOperationContext context,
@@ -2571,8 +2537,8 @@ namespace Raven.Server.ServerWide
                             genAiErr.Add($"Could not find AI connection string named '{genAi.ConnectionStringName}'. Please supply an existing connection string.");
 
                         ThrowInvalidConfigurationIfNecessary(etlConfiguration, genAiErr);
-
-                        ApplyHashVersionBackwardCompatibility(rawRecord, genAi);
+                        
+                        GenAiConfiguration.ApplyHashVersionBackwardCompatibility(rawRecord, genAi);
 
                         command = new UpdateGenAiCommand(id, genAi, databaseName, changeVector, raftRequestId);
                         break;

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
@@ -175,7 +175,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             config.Collection = "Posts";
             config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
             config.Identifier = "posts-translation-v1-stays-v1";
-            config.Version = GenAiConfiguration.None;
+            config.Version = null;
             config.SampleObject = sampleObjectV1;
 
             var command = new Raven.Server.ServerWide.Commands.AI.AddGenAiCommand(
@@ -276,7 +276,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
                 var finalGenAiTaskInfo = finalTaskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
 
                 Assert.NotNull(finalGenAiTaskInfo);
-                Assert.Equal(GenAiConfiguration.None, finalGenAiTaskInfo.Configuration.Version);
+                Assert.Equal(null, finalGenAiTaskInfo.Configuration.Version);
             }
         }
     }

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi;
+using Raven.Server.Documents.ETL.Providers.AI.GenAi.Stats;
+using Raven.Server.Documents.ETL.Stats;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.GenAi.Issues
+{
+    public class RavenDB_25808 : RavenTestBase
+    {
+        public RavenDB_25808(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldResendWhenExistingTaskIsV1AndSampleObjectChangedBumpsToV2(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            // ---- Task config (V1) ----
+            var sampleObjectV1 = JsonConvert.SerializeObject(new { Translation = "translated text" });
+            var schema = ChatCompletionClient.GetSchemaFromSampleObject(sampleObjectV1);
+
+            config.Prompt = "Translate this text to Polish";
+            config.JsonSchema = schema;
+            config.UpdateScript = "this.TextInPolish = $output.Translation;";
+            config.Collection = "Posts";
+            config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
+            config.Identifier = "posts-translation-v1-to-v2";
+            config.HashVersion = GenAiConfiguration.GenAiHashVersion.None;
+            config.SampleObject = sampleObjectV1;
+
+
+            var command = new Raven.Server.ServerWide.Commands.AI.AddGenAiCommand(
+                config,
+                store.Database,
+                changeVector: null,
+                uniqueRequestId: Guid.NewGuid().ToString());
+
+            await Server.ServerStore.SendToLeaderAsync(command);
+
+            // ---- Run once (stores V1 hash) ----
+            var etlDone = Etl.WaitForEtlToComplete(store);
+            const string docId = "posts/1";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new GenAiBasics.Post([new GenAiBasics.Comment("c1", "a1")], "t", "Hello World"), docId);
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+            string originalHash;
+            int originalCount;
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Sparrow.Json.BlittableJsonReaderObject>(docId);
+                Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out Sparrow.Json.BlittableJsonReaderObject metadata));
+                Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out Sparrow.Json.BlittableJsonReaderObject hashesSection));
+                Assert.True(hashesSection.TryGet(config.Identifier, out Sparrow.Json.BlittableJsonReaderArray hashesArray));
+
+                originalHash = hashesArray.Last().ToString();
+            }
+
+            // get taskId + process
+            var db = await GetDatabase(store.Database);
+            var etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;
+            Assert.NotNull(etlProcess);
+            var taskId = etlProcess.TaskId;
+
+            // disable task
+            await store.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.GenAi, disable: true));
+            await AssertWaitForTrueAsync(() => Task.FromResult(etlProcess.IsRunning == false));
+
+            // ---- Change SampleObject -> should bump task to V2 inside AddGenAiCommand ----
+            var sampleObjectV2 = JsonConvert.SerializeObject(new
+            {
+                Translation = "translated text",
+                Extra = "new field to force SampleObject change"
+            });
+
+            config.SampleObject = sampleObjectV2;
+
+            //simulating older client cause the HashVersion is configured to None.
+            store.Maintenance.Send(new UpdateGenAiOperation(taskId, config)); // task will be re-enabled
+
+            // ---- DIAGNOSTIC ASSERTION ----
+            // Verify the server actually bumped the version to WithSampleObject BEFORE waiting for ETL.
+            var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
+            var genAiTaskInfo = taskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
+            Assert.NotNull(genAiTaskInfo);
+            Assert.Equal(GenAiConfiguration.GenAiHashVersion.WithSampleObject, genAiTaskInfo.Configuration.HashVersion);
+
+            // ---- Touch doc without changing context (Body stays same) ----
+            var baselineUtc = DateTime.UtcNow;
+            etlDone = Etl.WaitForEtlToComplete(store);
+
+            using (var session = store.OpenSession())
+            {
+                var post = session.Load<GenAiBasics.Post>(docId);
+                post.Comments.Add(new GenAiBasics.Comment("new comment", "bot")); // context is Body only -> unchanged
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+            // Update process reference
+            etlProcess = db.EtlLoader.Processes.OfType<GenAiTask>().FirstOrDefault();
+            Assert.NotNull(etlProcess);
+
+            // ---- Assert it resent (hash mismatch due to including SampleObject) ----
+            EtlPerformanceStats[] stats = null;
+            var ok = await WaitForValueAsync(() =>
+            {
+                stats = etlProcess.GetPerformanceStats()
+                    .Where(x => x != null && x.Started >= baselineUtc && x.NumberOfLoadedItems > 0)
+                    .ToArray();
+
+                return stats.Length > 0;
+            }, expectedVal: true, timeout: 60_000);
+
+            Assert.True(ok, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+
+            var resent = stats.Any(s =>
+            {
+                var load = s.Details.Operations[^1];
+                var op = load.Operations.FirstOrDefault(x => x.Name == GenAiOperations.LoadToModel)
+                    as GenAiPerformanceOperation;
+
+                return op is { NumberOfContextObjects: 1, TotalSentToModel: 1, TotalCachedContexts: 0 };
+            });
+
+            Assert.True(resent, "Expected the context to be resent after SampleObject change (V1 -> V2).");
+
+            // ---- Hash should change and count should increase ----
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Sparrow.Json.BlittableJsonReaderObject>(docId);
+                Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out Sparrow.Json.BlittableJsonReaderObject metadata));
+                Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out Sparrow.Json.BlittableJsonReaderObject hashesSection));
+                Assert.True(hashesSection.TryGet(config.Identifier, out Sparrow.Json.BlittableJsonReaderArray hashesArray));
+
+                var newHash = hashesArray.Last().ToString();
+                Assert.NotEqual(originalHash, newHash);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldNotResend_WhenExistingTaskIsV1_AndSampleObjectIsUnchanged_StaysV1(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            // ---- Task config (V1) ----
+            var sampleObjectV1 = JsonConvert.SerializeObject(new { Translation = "translated text" });
+            var schema = ChatCompletionClient.GetSchemaFromSampleObject(sampleObjectV1);
+
+            config.Prompt = "Translate this text to Polish";
+            config.JsonSchema = schema;
+            config.UpdateScript = "this.TextInPolish = $output.Translation;";
+            config.Collection = "Posts";
+            config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
+            config.Identifier = "posts-translation-v1-stays-v1";
+            config.HashVersion = GenAiConfiguration.GenAiHashVersion.None;
+            config.SampleObject = sampleObjectV1;
+
+            var command = new Raven.Server.ServerWide.Commands.AI.AddGenAiCommand(
+                config,
+                store.Database,
+                changeVector: null,
+                uniqueRequestId: Guid.NewGuid().ToString());
+
+            await Server.ServerStore.SendToLeaderAsync(command);
+
+            // ---- Run once (stores V1 hash) ----
+            var etlDone = Etl.WaitForEtlToComplete(store);
+            const string docId = "posts/2";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new GenAiBasics.Post([new GenAiBasics.Comment("c1", "a1")], "t", "Hello World"), docId);
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+            string originalHash;
+            int originalCount;
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Sparrow.Json.BlittableJsonReaderObject>(docId);
+                Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out Sparrow.Json.BlittableJsonReaderObject metadata));
+                Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out Sparrow.Json.BlittableJsonReaderObject hashesSection));
+                Assert.True(hashesSection.TryGet(config.Identifier, out Sparrow.Json.BlittableJsonReaderArray hashesArray));
+
+                originalHash = hashesArray.Last().ToString();
+            }
+
+            // get taskId + process
+            var db = await GetDatabase(store.Database);
+            var etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;
+            Assert.NotNull(etlProcess);
+            var taskId = etlProcess.TaskId;
+
+            // disable task
+            await store.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.GenAi, disable: true));
+            await AssertWaitForTrueAsync(() => Task.FromResult(etlProcess.IsRunning == false));
+
+            store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
+
+            // ---- Touch doc without changing context (Body stays same) ----
+            var baselineUtc = DateTime.UtcNow;
+            etlDone = Etl.WaitForEtlToComplete(store);
+
+            using (var session = store.OpenSession())
+            {
+                var post = session.Load<GenAiBasics.Post>(docId);
+                post.Comments.Add(new GenAiBasics.Comment("new comment", "bot")); // context is Body only -> unchanged
+                session.SaveChanges();
+            }
+
+            Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
+
+            // Update process reference
+            etlProcess = db.EtlLoader.Processes.OfType<GenAiTask>().FirstOrDefault();
+            Assert.NotNull(etlProcess);
+
+            // ---- Assert it was CACHED (did not resend, because hash algorithm remained V1) ----
+            EtlPerformanceStats[] stats = null;
+            var ok = await WaitForValueAsync(() =>
+            {
+                stats = etlProcess.GetPerformanceStats()
+                    .Where(x => x != null && x.Started >= baselineUtc && x.NumberOfLoadedItems > 0)
+                    .ToArray();
+
+                return stats.Length > 0;
+            }, expectedVal: true, timeout: 60_000);
+
+            Assert.True(ok, await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+
+            var usedCache = stats.Any(s =>
+            {
+                var load = s.Details.Operations[^1];
+                var op = load.Operations.FirstOrDefault(x => x.Name == GenAiOperations.LoadToModel)
+                    as GenAiPerformanceOperation;
+
+                return op is { NumberOfContextObjects: 1, TotalSentToModel: 0, TotalCachedContexts: 1 };
+            });
+
+            Assert.True(usedCache, "Expected the context to be cached since SampleObject was unchanged and task stayed V1.");
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Sparrow.Json.BlittableJsonReaderObject>(docId);
+                Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out Sparrow.Json.BlittableJsonReaderObject metadata));
+                Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out Sparrow.Json.BlittableJsonReaderObject hashesSection));
+                Assert.True(hashesSection.TryGet(config.Identifier, out Sparrow.Json.BlittableJsonReaderArray hashesArray));
+
+                var newHash = hashesArray.Last().ToString();
+                Assert.Equal(originalHash, newHash);
+
+                var finalTaskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
+                var finalGenAiTaskInfo = finalTaskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
+
+                Assert.NotNull(finalGenAiTaskInfo);
+                Assert.Equal(GenAiConfiguration.GenAiHashVersion.None, finalGenAiTaskInfo.Configuration.HashVersion);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             config.Collection = "Posts";
             config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
             config.Identifier = "posts-translation-v1-to-v2";
-            config.HashVersion = GenAiConfiguration.GenAiHashVersion.None;
+            config.Version = 0;
             config.SampleObject = sampleObjectV1;
 
 
@@ -65,7 +65,6 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
             string originalHash;
-            int originalCount;
             using (var session = store.OpenAsyncSession())
             {
                 var doc = await session.LoadAsync<Sparrow.Json.BlittableJsonReaderObject>(docId);
@@ -103,7 +102,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
             var genAiTaskInfo = taskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
             Assert.NotNull(genAiTaskInfo);
-            Assert.Equal(GenAiConfiguration.GenAiHashVersion.WithSampleObject, genAiTaskInfo.Configuration.HashVersion);
+            Assert.Equal(GenAiConfiguration.WithSampleObject, genAiTaskInfo.Configuration.Version);
 
             // ---- Touch doc without changing context (Body stays same) ----
             var baselineUtc = DateTime.UtcNow;
@@ -176,7 +175,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             config.Collection = "Posts";
             config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
             config.Identifier = "posts-translation-v1-stays-v1";
-            config.HashVersion = GenAiConfiguration.GenAiHashVersion.None;
+            config.Version = GenAiConfiguration.None;
             config.SampleObject = sampleObjectV1;
 
             var command = new Raven.Server.ServerWide.Commands.AI.AddGenAiCommand(
@@ -200,7 +199,6 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
             string originalHash;
-            int originalCount;
             using (var session = store.OpenAsyncSession())
             {
                 var doc = await session.LoadAsync<Sparrow.Json.BlittableJsonReaderObject>(docId);
@@ -278,7 +276,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
                 var finalGenAiTaskInfo = finalTaskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
 
                 Assert.NotNull(finalGenAiTaskInfo);
-                Assert.Equal(GenAiConfiguration.GenAiHashVersion.None, finalGenAiTaskInfo.Configuration.HashVersion);
+                Assert.Equal(GenAiConfiguration.None, finalGenAiTaskInfo.Configuration.Version);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25808/GenAI-caching-doesnt-take-into-account-Sample-Object

### Additional description
GenAi caching now take into account Sample Object.
backward compatibility logic:

- New Tasks: Always start with the New Version.

- Updates (Sample Object Unchanged): Task stays on the Old Version to save costs.

- Updates (Sample Object Changed): Task moves to the New Version to force an AI update.

- Existing New Tasks: Stay on the New Version (no downgrades).

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
