### PR TITLE
RavenDB-25456 - Log `ClusterObserver` decisions to the server log when `Information` level is enabled

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ObserverLogger.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ObserverLogger.cs
@@ -20,6 +20,14 @@ namespace Raven.Server.ServerWide.Maintenance
             _decisionsLog = new BlockingCollection<ClusterObserverLogEntry>();
         }
 
+        /// <summary>
+        /// Records a recurring message to the in-memory decision log and the server log.
+        /// This method throttles identical messages, logging them at most once every 30 seconds.
+        /// </summary>
+        /// <param name="message">The message to log.</param>
+        /// <param name="iteration">The current cluster observer iteration.</param>
+        /// <param name="e">An optional exception associated with the log message.</param>
+        /// <param name="database">The database name this log applies to, if any.</param>
         public void Log(string message, long iteration, Exception e = null, string database = null)
         {
             if (iteration % 10_000 == 0)
@@ -28,28 +36,34 @@ namespace Raven.Server.ServerWide.Maintenance
             if (_lastLogs.TryGetValue(message, out var last))
             {
                 if (last + 60 > iteration)
-                    // each iteration occur every 500 ms, so we update the log with the _same_ message every 30 sec (60 * 0.5s)
+                    // each iteration occurs every 500 ms, so we update the log with the _same_ message every 30 sec (60 * 0.5s)
                     return;
             }
             _lastLogs[message] = iteration;
+            
             AddToDecisionLog(database, message, iteration, e);
-
-            if (_logger.IsInfoEnabled)
-            {
-                _logger.Info(message, e);
-            }
         }
 
-        public void AddToDecisionLog(string database, string updateReason, long iteration, Exception e)
+        /// <summary>
+        /// Unconditionally records a cluster decision to the in-memory log.
+        /// If Information-level logging is enabled, the decision is also written to the server log.
+        /// </summary>
+        /// <param name="database">The database name associated with the decision.</param>
+        /// <param name="updateReason">The explanation of the decision made by the cluster.</param>
+        /// <param name="iteration">The current cluster observer iteration.</param>
+        /// <param name="e">An optional exception associated with the decision.</param>
+        public void AddToDecisionLog(string database, string updateReason, long iteration, Exception e = null)
         {
+            if (_logger.IsInfoEnabled)
+            {
+                var prefix = string.IsNullOrWhiteSpace(database) ? string.Empty : $"Database '{database}' : ";
+                var decisionPrefix = e == null ? "Decision: " : string.Empty;
+                _logger.Info($"{prefix}{decisionPrefix}{updateReason}", e);
+            }
+
             if (e != null)
                 updateReason += $"{Environment.NewLine}Error: {e}";
 
-            AddToDecisionLog(database, updateReason, iteration);
-        }
-
-        public void AddToDecisionLog(string database, string updateReason, long iteration)
-        {
             if (_decisionsLog.Count > 99)
                 _decisionsLog.Take();
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25456

### Additional description

### What this PR does

Addresses the issue where the last 100 in-memory decisions kept by the `ClusterObserver` are insufficient for troubleshooting, especially after leader changes or over long periods. 

`ClusterObserver` decisions are now unconditionally recorded to the server log whenever the `Information` log level is enabled for the node. 

Operations-level logs remain unaffected to avoid unnecessary noise.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed