### PR TITLE
RavenDB-25419 Disable ETL task renaming

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -42,12 +42,15 @@ namespace Raven.Client.Documents.Operations.ETL
 
         public bool Disabled { get; set; }
 
-        public virtual bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+        public virtual bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, EtlConfiguration<T> existingConfiguration = null)
         {
             if (validateConnection && _initialized == false)
                 throw new InvalidOperationException("ETL configuration must be initialized");
 
             errors = new List<string>();
+            
+            if (existingConfiguration != null && existingConfiguration.Name != Name)
+                errors.Add($"Changing {nameof(Name)} of ETL is not supported.");
 
             if (validateName && string.IsNullOrEmpty(Name))
                 errors.Add($"{nameof(Name)} of ETL configuration cannot be empty");

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -18,9 +18,9 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
 
         public bool SkipAutomaticQueueDeclaration { get; set; }
 
-        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, EtlConfiguration<QueueConnectionString> existingConfiguration = null)
         {
-            var validationResult = base.Validate(out errors, validateName, validateConnection);
+            var validationResult = base.Validate(out errors, validateName, validateConnection, existingConfiguration);
             if (Connection != null && BrokerType != Connection.BrokerType)
             {
                 errors.Add("Broker type must be the same in the ETL configuration and in Connection string.");

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
@@ -26,9 +26,9 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
 
         public override EtlType EtlType => EtlType.Sql;
 
-        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true)
+        public override bool Validate(out List<string> errors, bool validateName = true, bool validateConnection = true, EtlConfiguration<SqlConnectionString> existingConfiguration = null)
         {
-            base.Validate(out errors, validateName, validateConnection);
+            base.Validate(out errors, validateName, validateConnection, existingConfiguration);
 
             if (SqlTables.Count == 0)
                 errors.Add($"{nameof(SqlTables)} cannot be empty");

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2388,8 +2388,9 @@ namespace Raven.Server.ServerWide
                 switch (EtlConfiguration<ConnectionString>.GetEtlType(etlConfiguration))
                 {
                     case EtlType.Raven:
+                        var existingRvnConfiguration = rawRecord.RavenEtls.Single(x => x.TaskId == id);
                         var rvnEtl = JsonDeserializationCluster.RavenEtlConfiguration(etlConfiguration);
-                        rvnEtl.Validate(out var rvnEtlErr, validateName: false, validateConnection: false);
+                        rvnEtl.Validate(out var rvnEtlErr, validateName: false, validateConnection: false, existingRvnConfiguration);
                         if (ValidateConnectionString(rawRecord, rvnEtl.ConnectionStringName, rvnEtl.EtlType) == false)
                             rvnEtlErr.Add($"Could not find connection string named '{rvnEtl.ConnectionStringName}'. Please supply an existing connection string.");
 
@@ -2398,8 +2399,9 @@ namespace Raven.Server.ServerWide
                         command = new UpdateRavenEtlCommand(id, rvnEtl, databaseName, raftRequestId);
                         break;
                     case EtlType.Sql:
+                        var existingSqlConfiguration = rawRecord.SqlEtls.Single(x => x.TaskId == id);
                         var sqlEtl = JsonDeserializationCluster.SqlEtlConfiguration(etlConfiguration);
-                        sqlEtl.Validate(out var sqlEtlErr, validateName: false, validateConnection: false);
+                        sqlEtl.Validate(out var sqlEtlErr, validateName: false, validateConnection: false, existingSqlConfiguration);
                         if (ValidateConnectionString(rawRecord, sqlEtl.ConnectionStringName, sqlEtl.EtlType) == false)
                             sqlEtlErr.Add($"Could not find connection string named '{sqlEtl.ConnectionStringName}'. Please supply an existing connection string.");
 
@@ -2408,8 +2410,9 @@ namespace Raven.Server.ServerWide
                         command = new UpdateSqlEtlCommand(id, sqlEtl, databaseName, raftRequestId);
                         break;
                     case EtlType.Olap:
+                        var existingOlapConfiguration = rawRecord.OlapEtls.Single(x => x.TaskId == id);
                         var olapEtl = JsonDeserializationCluster.OlapEtlConfiguration(etlConfiguration);
-                        olapEtl.Validate(out var olapEtlErr, validateName: false, validateConnection: false);
+                        olapEtl.Validate(out var olapEtlErr, validateName: false, validateConnection: false, existingOlapConfiguration);
                         if (ValidateConnectionString(rawRecord, olapEtl.ConnectionStringName, olapEtl.EtlType) == false)
                             olapEtlErr.Add($"Could not find connection string named '{olapEtl.ConnectionStringName}'. Please supply an existing connection string.");
 
@@ -2418,8 +2421,9 @@ namespace Raven.Server.ServerWide
                         command = new UpdateOlapEtlCommand(id, olapEtl, databaseName, raftRequestId);
                         break;
                     case EtlType.ElasticSearch:
+                        var existingElasticSearchConfiguration = rawRecord.ElasticSearchEtls.Single(x => x.TaskId == id);
                         var elasticSearchEtl = JsonDeserializationCluster.ElasticSearchEtlConfiguration(etlConfiguration);
-                        elasticSearchEtl.Validate(out var elasticSearchEtlErr, validateName: false, validateConnection: false);
+                        elasticSearchEtl.Validate(out var elasticSearchEtlErr, validateName: false, validateConnection: false, existingElasticSearchConfiguration);
                         if (ValidateConnectionString(rawRecord, elasticSearchEtl.ConnectionStringName, elasticSearchEtl.EtlType) == false)
                             elasticSearchEtlErr.Add($"Could not find connection string named '{elasticSearchEtl.ConnectionStringName}'. Please supply an existing connection string.");
 
@@ -2428,8 +2432,9 @@ namespace Raven.Server.ServerWide
                         command = new UpdateElasticSearchEtlCommand(id, elasticSearchEtl, databaseName, raftRequestId);
                         break;
                     case EtlType.Queue:
+                        var existingQueueConfiguration = rawRecord.QueueEtls.Single(x => x.TaskId == id);
                         var queueEtl = JsonDeserializationCluster.QueueEtlConfiguration(etlConfiguration);
-                        queueEtl.Validate(out var queueEtlErr, validateName: false, validateConnection: false);
+                        queueEtl.Validate(out var queueEtlErr, validateName: false, validateConnection: false, existingQueueConfiguration);
                         if (ValidateConnectionString(rawRecord, queueEtl.ConnectionStringName, queueEtl.EtlType) == false)
                             queueEtlErr.Add($"Could not find connection string named '{queueEtl.ConnectionStringName}'. Please supply an existing connection string.");
 

--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -69,6 +69,8 @@
 
     static readonly externalScriptNotAllowedForNonClusterAdmins =
         "Setting up the configuration via an external script is not allowed for non cluster admins.";
+
+    static readonly etlTaskNameLocked = "ETL task name cannot be changed after creation. Delete and recreate the task to use a different name.";
 }
 
 export = tasksCommonContent;

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editAzureQueueStorageEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editAzureQueueStorageEtlTask.ts
@@ -26,6 +26,7 @@ import EditAzureQueueStorageEtlInfoHub = require("viewmodels/database/tasks/Edit
 import ongoingTaskAzureQueueStorageEtlEditModel = require("models/database/tasks/ongoingTaskAzureQueueStorageEtlEditModel");
 import connectionStringAzureQueueStorageModel = require("models/database/settings/connectionStringAzureQueueStorageModel");
 import popoverUtils = require("common/popoverUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class azureQueueStorageTaskTestMode {
     documentId = ko.observable<string>();
@@ -187,6 +188,8 @@ class editAzureQueueStorageEtlTask extends viewModelBase {
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
 
+    taskNameDisabledReason: KnockoutComputed<string>;
+
     createNewConnectionString = ko.observable<boolean>(false);
     newConnectionString = ko.observable<connectionStringAzureQueueStorageModel>();
 
@@ -290,6 +293,14 @@ class editAzureQueueStorageEtlTask extends viewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        });  
 
         this.newConnectionString(connectionStringAzureQueueStorageModel.empty());
         this.newConnectionString().setNameUniquenessValidator(name => !this.etlConnectionStringsDetails().find(x => x.Name.toLocaleLowerCase() === name.toLocaleLowerCase()));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editElasticSearchEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editElasticSearchEtlTask.ts
@@ -28,6 +28,8 @@ import shardViewModelBase = require("viewmodels/shardViewModelBase");
 import licenseModel = require("models/auth/licenseModel");
 import EditElasticSearchEtlInfoHub = require("viewmodels/database/tasks/EditElasticSearchEtlInfoHub");
 import typeUtils = require("common/typeUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
+
 class elasticSearchTaskTestMode {
 
     documentId = ko.observable<string>();
@@ -200,6 +202,8 @@ class editElasticSearchEtlTask extends shardViewModelBase {
     
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
+
+    taskNameDisabledReason: KnockoutComputed<string>;
     
     collectionNames: KnockoutComputed<string[]>;
 
@@ -308,6 +312,14 @@ class editElasticSearchEtlTask extends shardViewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewElasticSearchEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        }); 
 
         this.collectionNames = ko.pureComputed(() => {
             return collectionsTracker.default.getCollectionNames();

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editKafkaEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editKafkaEtlTask.ts
@@ -27,6 +27,7 @@ import prismjs = require("prismjs");
 import licenseModel = require("models/auth/licenseModel");
 import EditKafkaEtlInfoHub = require("viewmodels/database/tasks/EditKafkaEtlInfoHub");
 import typeUtils = require("common/typeUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class kafkaTaskTestMode {
     documentId = ko.observable<string>();
@@ -193,6 +194,8 @@ class editKafkaEtlTask extends viewModelBase {
     
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
+
+    taskNameDisabledReason: KnockoutComputed<string>;
     
     createNewConnectionString = ko.observable<boolean>(false);
     newConnectionString = ko.observable<connectionStringKafkaModel>();
@@ -296,6 +299,14 @@ class editKafkaEtlTask extends viewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewKafkaEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        }); 
         
         this.newConnectionString(connectionStringKafkaModel.empty());
         this.newConnectionString().setNameUniquenessValidator(name => !this.kafkaEtlConnectionStringsDetails().find(x => x.Name.toLocaleLowerCase() === name.toLocaleLowerCase()));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editOlapEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editOlapEtlTask.ts
@@ -261,6 +261,8 @@ class editOlapEtlTask extends shardViewModelBase {
     
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
+
+    taskNameDisabledReason: KnockoutComputed<string>;
     
     collections = collectionsTracker.default.collections;
     
@@ -408,6 +410,14 @@ class editOlapEtlTask extends shardViewModelBase {
         
         this.showEditOlapTableArea = ko.pureComputed(() => !!this.editedOlapTableSandbox());
         this.showEditTransformationArea = ko.pureComputed(() => !!this.editedTransformationScriptSandbox());
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewOlapEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        }); 
 
         this.newConnectionString(connectionStringOlapEtlModel.empty());
         this.newConnectionString().setNameUniquenessValidator(name => !this.olapEtlConnectionStringsNames().find(x => x.toLocaleLowerCase() === name.toLocaleLowerCase()));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRabbitMqEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRabbitMqEtlTask.ts
@@ -27,6 +27,7 @@ import prismjs = require("prismjs");
 import licenseModel = require("models/auth/licenseModel");
 import EditRabbitMqEtlInfoHub = require("viewmodels/database/tasks/EditRabbitMqEtlInfoHub");
 import typeUtils = require("common/typeUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class rabbitMqTaskTestMode {
     documentId = ko.observable<string>();
@@ -187,6 +188,8 @@ class editRabbitMqEtlTask extends viewModelBase {
     
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
+
+    taskNameDisabledReason: KnockoutComputed<string>;
     
     createNewConnectionString = ko.observable<boolean>(false);
     newConnectionString = ko.observable<connectionStringRabbitMqEtlModel>();
@@ -291,6 +294,14 @@ class editRabbitMqEtlTask extends viewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewRabbitMqEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        });  
         
         this.newConnectionString(connectionStringRabbitMqEtlModel.empty());
         this.newConnectionString().setNameUniquenessValidator(name => !this.rabbitMqEtlConnectionStringsDetails().find(x => x.Name.toLocaleLowerCase() === name.toLocaleLowerCase()));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
@@ -26,6 +26,7 @@ import shardViewModelBase = require("viewmodels/shardViewModelBase");
 import licenseModel = require("models/auth/licenseModel");
 import EditRavenEtlInfoHub = require("viewmodels/database/tasks/EditRavenEtlInfoHub");
 import typeUtils = require("common/typeUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 type resultItem = {
     header: string;
@@ -202,6 +203,8 @@ class editRavenEtlTask extends shardViewModelBase {
     
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
+
+    taskNameDisabledReason: KnockoutComputed<string>;
     
     createNewConnectionString = ko.observable<boolean>(false);
     newConnectionString = ko.observable<connectionStringRavenEtlModel>();
@@ -295,6 +298,14 @@ class editRavenEtlTask extends shardViewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+        
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewRavenEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        });   
         
         this.newConnectionString(connectionStringRavenEtlModel.empty());
         this.newConnectionString().setNameUniquenessValidator(name => !this.ravenEtlConnectionStringsDetails().find(x => x.Name.toLocaleLowerCase() === name.toLocaleLowerCase()));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSqlEtlTask.ts
@@ -28,6 +28,7 @@ import shardViewModelBase = require("viewmodels/shardViewModelBase");
 import licenseModel = require("models/auth/licenseModel");
 import EditSqlEtlInfoHub = require("viewmodels/database/tasks/EditSqlEtlInfoHub");
 import typeUtils = require("common/typeUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class sqlTaskTestMode {
     
@@ -209,6 +210,8 @@ class editSqlEtlTask extends shardViewModelBase {
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
 
+    taskNameDisabledReason: KnockoutComputed<string>;
+
     collections = collectionsTracker.default.collections;
     collectionNames: KnockoutComputed<string[]>;
     
@@ -328,6 +331,14 @@ class editSqlEtlTask extends shardViewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewSqlEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        }); 
 
         this.collectionNames = ko.pureComputed(() => {
            return collectionsTracker.default.getCollectionNames(); 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editAzureQueueStorageEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editAzureQueueStorageEtlTask.html
@@ -26,7 +26,7 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Azure Queue Storage ETL task (optional)" data-bind="textInput: taskName">
+                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Azure Queue Storage ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewEtlTask()">
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editAzureQueueStorageEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editAzureQueueStorageEtlTask.html
@@ -26,7 +26,13 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Azure Queue Storage ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewEtlTask()">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="taskName"
+                                    placeholder="Enter a descriptive name for the Azure Queue Storage ETL task (optional)"
+                                    data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                >
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -27,8 +27,13 @@
                             <div class="form-group margin-top" data-bind="validationElement: taskName">
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
-                                    <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the Elasticsearch ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewElasticSearchEtlTask()">
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        id="taskName"
+                                        placeholder="Enter a descriptive name for the Elasticsearch ETL task (optional)"
+                                        data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                    >
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editElasticSearchEtlTask.html
@@ -28,7 +28,7 @@
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
                                     <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the Elasticsearch ETL task (optional)" data-bind="textInput: taskName">
+                                           placeholder="Enter a descriptive name for the Elasticsearch ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewElasticSearchEtlTask()">
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -26,7 +26,13 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Kafka ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewKafkaEtlTask()">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="taskName"
+                                    placeholder="Enter a descriptive name for the Kafka ETL task (optional)"
+                                    data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                >
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editKafkaEtlTask.html
@@ -26,7 +26,7 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Kafka ETL task (optional)" data-bind="textInput: taskName">
+                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Kafka ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewKafkaEtlTask()">
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -27,8 +27,13 @@
                             <div class="form-group margin-top" data-bind="validationElement: taskName">
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
-                                    <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the OLAP ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewOlapEtlTask()" />
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        id="taskName"
+                                        placeholder="Enter a descriptive name for the OLAP ETL task (optional)"
+                                        data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                    >
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editOlapEtlTask.html
@@ -28,7 +28,7 @@
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
                                     <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the OLAP ETL task (optional)" data-bind="textInput: taskName" />
+                                           placeholder="Enter a descriptive name for the OLAP ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewOlapEtlTask()" />
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -26,7 +26,13 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the RabbitMQ ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewRabbitMqEtlTask()">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="taskName"
+                                    placeholder="Enter a descriptive name for the RabbitMQ ETL task (optional)"
+                                    data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                >
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRabbitMqEtlTask.html
@@ -26,7 +26,7 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the RabbitMQ ETL task (optional)" data-bind="textInput: taskName">
+                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the RabbitMQ ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewRabbitMqEtlTask()">
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -26,7 +26,13 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the RavenDB ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewRavenEtlTask()">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="taskName"
+                                    placeholder="Enter a descriptive name for the RavenDB ETL task (optional)"
+                                    data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                >
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -26,7 +26,7 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the RavenDB ETL task (optional)" data-bind="textInput: taskName">
+                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the RavenDB ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewRavenEtlTask()">
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -28,7 +28,7 @@
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
                                     <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the SQL ETL task (optional)" data-bind="textInput: taskName">
+                                           placeholder="Enter a descriptive name for the SQL ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewSqlEtlTask()">
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSqlEtlTask.html
@@ -27,8 +27,13 @@
                             <div class="form-group margin-top" data-bind="validationElement: taskName">
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
-                                    <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the SQL ETL task (optional)" data-bind="textInput: taskName, disable: !$root.isAddingNewSqlEtlTask()">
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        id="taskName"
+                                        placeholder="Enter a descriptive name for the SQL ETL task (optional)"
+                                        data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                    >
                                 </div>
                             </div>
                             <div class="form-group">

--- a/test/SlowTests/Issues/RavenDB-25419.cs
+++ b/test/SlowTests/Issues/RavenDB-25419.cs
@@ -59,8 +59,6 @@ public class RavenDB_25419 : RavenTestBase
 
             var ex = Assert.Throws<RavenException>(() => src.Maintenance.Send(new UpdateEtlOperation<RavenConnectionString>(addEtlOperationResult.TaskId, configuration)));
             Assert.Contains("Changing Name of ETL is not supported", ex.Message);
-            
-            WaitForUserToContinueTheTest(src);
         }
     }
 }

--- a/test/SlowTests/Issues/RavenDB-25419.cs
+++ b/test/SlowTests/Issues/RavenDB-25419.cs
@@ -1,0 +1,66 @@
+using FastTests;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25419 : RavenTestBase
+{
+    public RavenDB_25419(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void RenamingEtlShouldThrow()
+    {
+        using (var src = GetDocumentStore())
+        using (var dest = GetDocumentStore())
+        {
+            var connectionString = new RavenConnectionString()
+            {
+                Name = "ConnectionString",
+                Database = dest.Database,
+                TopologyDiscoveryUrls = dest.Urls
+            };
+            
+            var transformation = new Transformation
+            {
+                Name = "Transformation1",
+                Collections = ["Users"],
+                Script = """
+                         this.Name = 'James Doe';
+                         loadToUsers(this);
+                         """,
+                ApplyToAllDocuments = false,
+                Disabled = false
+            };
+            
+            var configuration = new RavenEtlConfiguration
+            {
+                Name = "Task1",
+                ConnectionStringName = "ConnectionString",
+                Transforms =
+                {
+                    transformation
+                }
+            };
+            
+            var putConnectionStringResult = src.Maintenance.Send(new PutConnectionStringOperation<RavenConnectionString>(connectionString));
+            Assert.NotNull(putConnectionStringResult.RaftCommandIndex);
+
+            var addEtlOperationResult = src.Maintenance.Send(new AddEtlOperation<RavenConnectionString>(configuration));
+            Assert.NotNull(addEtlOperationResult.RaftCommandIndex);
+            
+            configuration.Name = "Task2";
+
+            var ex = Assert.Throws<RavenException>(() => src.Maintenance.Send(new UpdateEtlOperation<RavenConnectionString>(addEtlOperationResult.TaskId, configuration)));
+            Assert.Contains("Changing Name of ETL is not supported", ex.Message);
+            
+            WaitForUserToContinueTheTest(src);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25419/ETL-task-name-update-behavior

### Additional description

We want to disable ETL task renaming to fix task duplication issue (described in the ticket) and to avoid performing additional work (e.g. modifying table entries for ETL errors - https://issues.hibernatingrhinos.com/issue/RavenDB-21192/Redesign-ETL-error-handling)

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
