### PR TITLE
RavenDB-25762  Ignore errors on specific index compaction to allow entire compaction operation to continue

### DIFF
--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1203,6 +1203,12 @@ namespace Raven.Server.Web.System
                                                 indexCompactionResult.AddInfo(
                                                     $"Skipping data compaction of '{indexName}' index because data compaction of Corax indexes isn't supported.");
                                             }
+                                            catch (Exception e)
+                                            {
+                                                indexCompactionResult.Skipped = true;
+                                                indexCompactionResult.AddInfo(
+                                                    $"Skipping data compaction of '{indexName}' index because of encountered error: {e.Message}. Stacktrace: {e.StackTrace}");
+                                            }
                                             
                                             indexCompactionResult.Processed = true;
                                         }

--- a/test/SlowTests/Issues/RavenDB_25762.cs
+++ b/test/SlowTests/Issues/RavenDB_25762.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.ServerWide;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Config;
+using Raven.Server.Utils;
+using SlowTests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Voron.Global;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25762 : RavenTestBase
+{
+    public RavenDB_25762(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Indexes)]
+    public async Task Compaction_should_ignore_errored_index()
+    {
+        using (var store = GetDocumentStore(new Options
+               {
+                   RunInMemory = false,
+                   ModifyDatabaseRecord = databaseRecord =>
+                   {
+                       databaseRecord.Settings[RavenConfiguration.GetKey(x => x.Core.ThrowIfAnyIndexCannotBeOpened)] = "false";
+                   }
+        }))
+        {
+            var index1 = new Users_ByLastName();
+            await store.ExecuteIndexAsync(index1);
+
+            var index2 = new Users_ByName();
+            await store.ExecuteIndexAsync(index2);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    await session.StoreAsync(new User{ Name = "abc" + i});
+                }
+
+                await session.SaveChangesAsync();
+            }
+
+            await Indexes.WaitForIndexingAsync(store, allowErrors: true);
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var index1Path = database.IndexStore.GetIndex(index1.IndexName)._environment.Options.BasePath;
+
+            Server.ServerStore.DatabasesLandlord.UnloadDirectly(store.Database);
+
+            // corrupting index data so we won't be able to open index hence compaction should skip it without erroring whole operation
+            IOExtensions.DeleteFile(index1Path.Combine(Constants.DatabaseFilename).FullPath);
+            IOExtensions.DeleteDirectory(index1Path.Combine("Journals").FullPath);
+
+            var compactOperation = store.Maintenance.Server.Send(new CompactDatabaseOperation(new CompactSettings
+            {
+                DatabaseName = store.Database,
+                Documents = true,
+                Indexes = new[] { index1.IndexName, index2.IndexName }
+            }));
+
+            var result = await compactOperation.WaitForCompletionAsync<CompactionResult>(TimeSpan.FromSeconds(60));
+
+            Assert.True(result.IndexesResults[index1.IndexName].Skipped);
+            Assert.Contains($"Skipping data compaction of '{index1.IndexName}' index because of encountered error", result.IndexesResults[index1.IndexName].Message);
+        }
+    }
+
+    private class Users_ByLastName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByLastName()
+        {
+            Map = users => from user in users
+                select new
+                {
+                    user.LastName
+                };
+        }
+    }
+
+    private class Users_ByName : AbstractIndexCreationTask<User>
+    {
+        public Users_ByName()
+        {
+            Map = users => from user in users
+                select new
+                {
+                    Name = user.Name
+                };
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25762

### Additional description

It ensures  compaction continues despite individual index errors

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
