### PR TITLE
RavenDB-25511- Throw specific `NotSupportedException` for all Include types in streaming queries

### DIFF
--- a/src/Raven.Server/Documents/Queries/QueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/QueryRunner.cs
@@ -450,8 +450,23 @@ namespace Raven.Server.Documents.Queries
 
         public static void AssertValidQuery<TQueryResult>(IndexQueryServerSide query, QueryResultServerSide<TQueryResult> result)
         {
-            if (result.SupportsInclude == false && query.Metadata.Includes != null && query.Metadata.Includes.Length > 0)
-                throw new NotSupportedException("Includes are not supported by this type of query.");
+            if (result.SupportsInclude == false)
+            {
+                if (query.Metadata.Includes is { Length: > 0 })
+                    throw new NotSupportedException("Document Includes are not supported by this type of query.");
+
+                if (query.Metadata.CounterIncludes != null)
+                    throw new NotSupportedException("Counter Includes are not supported by this type of query.");
+
+                if (query.Metadata.TimeSeriesIncludes != null)
+                    throw new NotSupportedException("TimeSeries Includes are not supported by this type of query.");
+
+                if (query.Metadata.RevisionIncludes != null)
+                    throw new NotSupportedException("Revision Includes are not supported by this type of query.");
+
+                if (query.Metadata.CompareExchangeValueIncludes != null && query.Metadata.CompareExchangeValueIncludes.Length > 0)
+                    throw new NotSupportedException("CompareExchangeValue Includes are not supported by this type of query.");
+            }
 
             if (result.SupportsHighlighting == false && query.Metadata.HasHighlightings)
                 throw new NotSupportedException("Highlighting is not supported by this type of query.");

--- a/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
+++ b/test/SlowTests/MailingList/DocumentQueryIncludeAndStreamTest.cs
@@ -89,7 +89,7 @@ namespace SlowTests.MailingList
                         }
                     }
                 });
-                Assert.Contains("Includes are not supported by this type of query.", notSupportedException.Message);
+                Assert.Contains("Document Includes are not supported by this type of query.", notSupportedException.Message);
             }
         }
         
@@ -112,7 +112,79 @@ namespace SlowTests.MailingList
                         }
                     }
                 });
-                Assert.Contains("Includes are not supported by this type of query.", notSupportedException.Message);
+                Assert.Contains("Document Includes are not supported by this type of query.", notSupportedException.Message);
+            }
+        }
+        
+        [RavenFact(RavenTestCategory.Querying)]
+        public void StreamQueryWithCounterInclude()
+        {
+            var store = GetDocumentStore();
+            Setup(store);
+            Indexes.WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.RawQuery<ProcessStep>("from ProcessSteps include counters('likes')");
+                var notSupportedException = Assert.Throws<RavenException>(() =>
+                {
+                    using var stream = session.Advanced.Stream(query);
+                    while (stream.MoveNext());
+                });
+                Assert.Contains("Counter Includes are not supported by this type of query.", notSupportedException.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void StreamQueryWithTimeSeriesInclude()
+        {
+            var store = GetDocumentStore();
+            Setup(store);
+            Indexes.WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.RawQuery<ProcessStep>("from ProcessSteps include timeseries('Heartrate', last(1, 'day'))");
+                var notSupportedException = Assert.Throws<RavenException>(() =>
+                {
+                    using var stream = session.Advanced.Stream(query);
+                    while (stream.MoveNext());
+                });
+                Assert.Contains("TimeSeries Includes are not supported by this type of query.", notSupportedException.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void StreamQueryWithRevisionInclude()
+        {
+            var store = GetDocumentStore();
+            Setup(store);
+            Indexes.WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.RawQuery<ProcessStep>("from ProcessSteps include revisions('StepExecutionsId')");
+                var notSupportedException = Assert.Throws<RavenException>(() =>
+                {
+                    using var stream = session.Advanced.Stream(query);
+                    while (stream.MoveNext());
+                });
+                Assert.Contains("Revision Includes are not supported by this type of query.", notSupportedException.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void StreamQueryWithCompareExchangeInclude()
+        {
+            var store = GetDocumentStore();
+            Setup(store);
+            Indexes.WaitForIndexing(store);
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.RawQuery<ProcessStep>("from ProcessSteps include cmpxchg('StepExecutionsId')");
+                var notSupportedException = Assert.Throws<RavenException>(() =>
+                {
+                    using var stream = session.Advanced.Stream(query);
+                    while (stream.MoveNext());
+                });
+                Assert.Contains("CompareExchangeValue Includes are not supported by this type of query.", notSupportedException.Message);
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25511

### Additional description

#### Problem
While streaming queries correctly disallowed standard document includes, they lacked validation for other include types such as Counters, Time Series, Revisions, and Compare Exchange values. This could lead to misleading results or inconsistent behavior for users attempting to use these includes with streams.

#### Fix
- Updated `QueryRunner.AssertValidQuery` to explicitly check for all supported Include types (Documents, Counters, Time Series, Revisions, and Compare Exchange).
- Implemented specific error messages for each include type to provide better clarity to developers. 
- Expanded the test suite in `DocumentQueryIncludeAndStreamTest.cs` to verify that each unsupported include type correctly triggers a specific `NotSupportedException`.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed