### PR TITLE
RavenDB-25895 Setup wizard: Inconsistent 'discard' button behavior in nodes configuration step

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -399,8 +399,17 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
                             </Button>
                         </ConditionalPopover>
                         <Button variant="secondary" onClick={handleDiscardEdit}>
-                            <Icon icon="close" />
-                            Discard
+                            {nodeData.isNewlyAdded ? (
+                                <>
+                                    <Icon icon="trash" />
+                                    Remove
+                                </>
+                            ) : (
+                                <>
+                                    <Icon icon="close" />
+                                    Discard
+                                </>
+                            )}
                         </Button>
                     </>
                 ) : (


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25895

### Additional description

<img width="1402" height="827" alt="image" src="https://github.com/user-attachments/assets/ceb75217-06f3-4455-9ffd-23cb5728638d" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
