### PR TITLE
Ravendb 25990 - added fix to nodes on 7.2 don't show older nodes statistics on cluster dashboard

### DIFF
--- a/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
+++ b/src/Raven.Server/NotificationCenter/Handlers/ProxyWebSocketConnection.cs
@@ -8,10 +8,12 @@ using System.Threading.Tasks;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
 using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
 using Raven.Server.Extensions;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Smuggler.Documents.Processors;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Logging;
@@ -32,6 +34,7 @@ namespace Raven.Server.NotificationCenter.Handlers
         private Task _localToRemote;
         private Task _remoteToLocal;
         private HttpClient _httpClient;
+        private bool _remoteIsOlder;
 
         public ProxyWebSocketConnection(WebSocket localWebSocket, string nodeUrl, string websocketEndpoint, IMemoryContextPool contextPool, CancellationToken token)
         {
@@ -52,7 +55,7 @@ namespace Raven.Server.NotificationCenter.Handlers
             _remoteWebSocket = new ClientWebSocket();
         }
 
-        public Task Establish(X509Certificate2 certificate)
+        public async Task Establish(X509Certificate2 certificate)
         {
             var handler = DefaultRavenHttpClientFactory.CreateHttpMessageHandler(certificate, setSslProtocols: true, DocumentConventions.DefaultForServer.UseHttpDecompression);
 
@@ -67,7 +70,58 @@ namespace Raven.Server.NotificationCenter.Handlers
 
             _httpClient = new HttpClient(handler, disposeHandler: true).WithConventions(DocumentConventions.DefaultForServer);
 
-            return _remoteWebSocket.ConnectAsync(_remoteWebSocketUri, _httpClient, _cts.Token);
+            _remoteIsOlder = await GetRemoteVersionAndCompareAsync();
+
+            await _remoteWebSocket.ConnectAsync(_remoteWebSocketUri, _httpClient, _cts.Token);
+        }
+
+        private async Task<bool> GetRemoteVersionAndCompareAsync()
+        {
+            try
+            {
+                var operation = new GetBuildNumberOperation();
+
+                using (_contextPool.AllocateOperationContext(out JsonOperationContext context))
+                {
+                    var command = operation.GetCommand(DocumentConventions.DefaultForServer, context);
+
+                    var serverNode = new ServerNode { Url = _nodeUrl };
+
+                    using (var request = command.CreateRequest(context, serverNode, out var url))
+                    {
+                        request.RequestUri = new Uri(url);
+                        using (var response = await _httpClient.SendAsync(request, _cts.Token).ConfigureAwait(false))
+                        {
+                            response.EnsureSuccessStatusCode();
+
+                            using (var stream = await response.Content.ReadAsStreamAsync(_cts.Token).ConfigureAwait(false))
+                            using (var responseJson = await context.ReadForMemoryAsync(stream, "build/version").ConfigureAwait(false))
+                            {
+                                command.SetResponse(context, responseJson, fromCache: false);
+                            }
+                        }
+                    }
+
+                    var buildInfo = command.Result;
+                    if (buildInfo == null)
+                        return true;
+
+                    var versionType = BuildVersion.Type(buildInfo.BuildVersion);
+                    if (versionType >= BuildVersionType.V72)
+                        return false;
+
+                    if (buildInfo.BuildVersion < 71028)
+                        return true;
+
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (Logger.IsInfoEnabled)
+                    Logger.Info($"Failed to check version for {_nodeUrl}, defaulting to older.", ex);
+                return true;
+            }
         }
 
         public async Task RelayData()
@@ -99,8 +153,15 @@ namespace Raven.Server.NotificationCenter.Handlers
                             await _localWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "NORMAL_CLOSE", _cts.Token);
                             break;
                         }
-
-                        await _remoteWebSocket.SendAsync(buffer.Slice(0, receiveResult.Count), receiveResult.MessageType, receiveResult.EndOfMessage, _cts.Token);
+                        if (receiveResult.MessageType == WebSocketMessageType.Text)
+                        {
+                            var commandText = System.Text.Encoding.UTF8.GetString(buffer.Span.Slice(0, receiveResult.Count));
+                            if (_remoteIsOlder && commandText.Contains("DatabasesNotifications"))
+                            {
+                                continue; // Skip this command so the old server doesn't crash
+                            }
+                            await _remoteWebSocket.SendAsync(buffer.Slice(0, receiveResult.Count), receiveResult.MessageType, receiveResult.EndOfMessage, _cts.Token);
+                        }
                     }
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25990/In-sharded-database-upgrading-part-of-the-nodes-from-7.1-to-7.2-makes-the-nodes-of-7.2-show-the-cluster-dashboard-stats-of-the

### Additional description

In a mixed cluster, a newer node (running 7.2) acts as a proxy for the Cluster Dashboard. The 7.2 Studio sends a new command—DatabasesNotifications—to help the dashboard refresh automatically when databases are created or deleted.

Modern Nodes (7.2+): Recognize this command and process it.

Older Nodes (7.1.x and below): Do not have a handler for this text command. When they receive it they throw an unhandled exception. 
As a solution I have added a guard that checks their version and filter that command out in case they do not support it

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
