### PR TITLE
RavenDB-25492 Skip ocassionally failing tests on x86 due to failure to find nuget package DLL defined via  AdditionalAssemblies

### DIFF
--- a/test/SlowTests/Issues/RavenDB-21273.cs
+++ b/test/SlowTests/Issues/RavenDB-21273.cs
@@ -21,7 +21,7 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Smuggler | RavenTestCategory.Compression)]
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Smuggler | RavenTestCategory.Compression, Architecture = RavenArchitecture.AllX64)]
         public async Task ExceptionWhenImportingAdditionalAssembliesWithCommunityLicense()
         {
             DoNotReuseServer();

--- a/test/SlowTests/Issues/RavenDB-21427.cs
+++ b/test/SlowTests/Issues/RavenDB-21427.cs
@@ -304,7 +304,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Architecture = RavenArchitecture.AllX64)]
         public async Task Prevent_License_Downgrade_Index_Additional_Assemblies()
         {
             DoNotReuseServer();
@@ -323,7 +323,7 @@ namespace SlowTests.Issues
             }
         }
 
-        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes)]
+        [RavenMultiLicenseRequiredFact(RavenTestCategory.Licensing | RavenTestCategory.Indexes, Architecture = RavenArchitecture.AllX64)]
         public async Task Prevent_Put_Index_Additional_Assemblies()
         {
             DoNotReuseServer();

--- a/test/Tests.Infrastructure/RavenMultiLicenseRequiredFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenMultiLicenseRequiredFactAttribute.cs
@@ -35,6 +35,8 @@ namespace Tests.Infrastructure
             HasLicense = RavenLicense && RavenLicenseDeveloper && RavenLicenseCommunity && RavenLicenseProfessional;
         }
 
+        public RavenArchitecture Architecture { get; set; } = RavenArchitecture.All;
+
         public override string Skip
         {
             get
@@ -46,6 +48,11 @@ namespace Tests.Infrastructure
 
                 if (ShouldSkip(licenseRequired: true))
                     return SkipMessage;
+
+                var multiPlatformSkip = RavenMultiplatformFactAttribute.ShouldSkip(RavenPlatform.All, Architecture, RavenIntrinsics.None, false, false);
+
+                if (multiPlatformSkip != null)
+                    return multiPlatformSkip;
 
                 return null;
             }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25492
https://issues.hibernatingrhinos.com/issue/RavenDB-25493
https://issues.hibernatingrhinos.com/issue/RavenDB-25364

### Additional description

Those 3 tests fail from time to time when running on x86. 

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
