### PR TITLE
RavenDB-25993 - Add type property AiAgentParameter

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using Sparrow.Json.Parsing;
 
@@ -16,6 +17,8 @@ public class AiConversationCreationOptions : IDynamicJson
     }
     public AiConversationCreationOptions AddParameter(string name, object value)
     {
+        if (value is not string && value is IEnumerable ie)
+            value = new DynamicJsonArray(ie);
         Parameters ??= new Dictionary<string, object>();
         Parameters.Add(name, value);
         return this;

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiAgentParameter.cs
@@ -85,6 +85,21 @@ public class AiAgentParameter : IDynamicJson
     }
 
     /// <summary>
+    /// Initializes a new agent parameter and controls whether its value should be sent to the LLM.
+    /// Use this overload when you need to explicitly hide sensitive values (e.g. userId/tenant/company) from the model.
+    /// </summary>
+    /// <inheritdoc cref="AiAgentParameter(string, string, bool, AiAgentParameterPolicy)" />
+    /// <param name="type">
+    /// Specifies the expected <see cref="ValueType"/> for this parameter.
+    /// When set to a concrete value, the agent validates the provided value against it;
+    /// <see cref="ValueType.Default"/> disables type validation (backward compatibility).
+    /// </param>
+    public AiAgentParameter(string name, string description, bool sendToModel, AiAgentParameterPolicy policy, ValueType type) : this(name, description, sendToModel, policy)
+    {
+        Type = type;
+    }
+
+    /// <summary>
     /// Defines whether the parameter is included in the data sent to the model
     /// </summary>
     public bool? SendToModel { get; set; }
@@ -112,6 +127,21 @@ public class AiAgentParameter : IDynamicJson
     /// </remarks>
     public AiAgentParameterPolicy Policy { get; set; } = AiAgentParameterPolicy.Default;
 
+    /// <summary>
+    /// Specifies the expected JSON value type for this parameter.
+    /// </summary>
+    /// <remarks>
+    /// When set to a specific <see cref="ValueType"/>, the agent validates that
+    /// the provided value matches the declared type before execution.
+    /// 
+    /// If set to <see cref="ValueType.Default"/>, no type validation is performed
+    /// (for backward compatibility with existing agents).
+    /// 
+    /// For array types (e.g. <see cref="ValueType.ArrayOfString"/>),
+    /// all items in the array must be of the declared element type.
+    /// </remarks>
+    public ValueType Type { get; set; } = ValueType.Default;
+
     public DynamicJsonValue ToJson()
     {
         return new DynamicJsonValue
@@ -119,7 +149,8 @@ public class AiAgentParameter : IDynamicJson
             [nameof(Name)] = Name,
             [nameof(Description)] = Description,
             [nameof(SendToModel)] = SendToModel,
-            [nameof(Policy)] = Policy
+            [nameof(Policy)] = Policy,
+            [nameof(Type)] = Type,
         };
     }
 
@@ -128,5 +159,17 @@ public class AiAgentParameter : IDynamicJson
     {
         Default = 0,
         ForbidModelGeneration = 1
+    }
+
+    public enum ValueType
+    {
+        Default, // Don't care - for backward compatibility
+        String,
+        Number,
+        Boolean,
+        ArrayOfString,
+        ArrayOfNumber,
+        ArrayOfBoolean,
+        Null
     }
 }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -20,6 +20,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Exceptions;
 using Raven.Client.Http;
 using Raven.Client.Json;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -327,40 +327,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
 
         foreach (var subAgent in configuration.SubAgents ?? [])
         {
-            AiAgentConfiguration subAgentConfiguration = handler.GetAiAgentConfiguration(subAgent.Identifier);
-            var parameters = new Dictionary<string, string>();
-
-            // We only add what the sub-agent has that the root agent doesn't have
-            // the mutual params will be added to the request when we create it
-            foreach (var parameter in subAgentConfiguration.Parameters ?? [])
-            {
-                if (configuration.Parameters?.Any(p => p.Name == parameter.Name) == true)
-                {
-                    // parents has this parameter -> we copy its value from the parent later -> when we create the request to the sub-agent
-                    continue;
-                }
-
-                if (parameter.Policy.HasFlag(AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration) == false)
-                {
-                    // the parent doesn't have this parameter BUT it's allowed to be generated -> we add it to the tool schema
-                    parameters[parameter.Name] = parameter.Description;
-                    continue;
-                }
-
-                throw new MissingAiAgentParameterException($"Parameter '{parameter.Name}' is missing from the parent scope." + 
-                                                           " To allow the root agent to generate this value dynamically, " +
-                                                           $"unset the '{nameof(AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration)}' " +
-                                                           "flag in the sub-agent parameter policy.");
-            }
-
-            var argsSampleObject = DynamicJsonValue.Convert(parameters);
-
-            argsSampleObject[SubAgentUserPromptKey] = "A natural language prompt instructions for the sub-agent to do its work";
-            using var args = context.ReadObject(argsSampleObject, "args");
-            string paramsSchema = ChatCompletionClient.GetSchemaForTool(null, args.ToString());
-            var description = new StringBuilder(subAgent.Description).AppendLine();
-            subAgentConfiguration.AppendCapabilities(description);
-            var tool = GetTool(context, subAgent.Identifier, description.ToString(), paramsSchema);
+            var tool = handler.GetSubAgentTool(context, configuration, subAgent);
             tools.Add(context.ReadObject(tool, "tool"));
         }
 
@@ -375,7 +342,7 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         }
     }
 
-    private static DynamicJsonValue GetTool(JsonOperationContext context, string name, string description, string paramsSchema)
+    public static DynamicJsonValue GetTool(JsonOperationContext context, string name, string description, string paramsSchema)
     {
         var tool = new DynamicJsonValue
         {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Commands.MultiGet;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Queries;
+using Raven.Client.Exceptions;
 using Raven.Client.Json.Serialization;
 using Raven.Server.Documents.AI;
 using Raven.Server.Extensions;
@@ -209,6 +210,126 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     "The existing ActionCall does not match the newly attempted ActionCall insertion.\n" +
                     "If this mismatch is valid, ensure higher-level logic prevents conflicting ActionCalls with the same ToolId."
                 );
+            }
+        }
+
+        public DynamicJsonValue GetSubAgentTool(JsonOperationContext context, AiAgentConfiguration configuration, AiAgentToolSubAgent subAgent)
+        {
+            AiAgentConfiguration subAgentConfiguration = GetAiAgentConfiguration(subAgent.Identifier);
+            var parameters = new Dictionary<string, ParameterDefinition>();
+
+            // We only add what the sub-agent has that the root agent doesn't have
+            // the mutual params will be added to the request when we create it
+            foreach (var parameter in subAgentConfiguration.Parameters ?? [])
+            {
+                var parentParam = configuration.Parameters?.FirstOrDefault(p => p.Name == parameter.Name);
+                if (parentParam != null)
+                {
+                    // same name exists
+
+                    if (parentParam.Type != parameter.Type)
+                    {
+                        // type conflict
+                        throw new MissingAiAgentParameterException(
+                            $"Parameter '{parameter.Name}' has mismatched types between parent and sub-agent. " +
+                            $"Parent type: '{parentParam.Type}', Sub-agent type: '{parameter.Type}'. " +
+                            "Both must declare the same ValueType.");
+                    }
+
+                    // parent has this parameter with matching type
+                    continue;
+                }
+
+                if (parameter.Policy.HasFlag(AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration) == false)
+                {
+                    // the parent doesn't have this parameter BUT it's allowed to be generated -> we add it to the tool schema
+                    parameters[parameter.Name] = new ParameterDefinition(parameter.Description, parameter.Type);
+                    continue;
+                }
+
+                throw new MissingAiAgentParameterException($"Parameter '{parameter.Name}' is missing from the parent scope." +
+                                                           " To allow the root agent to generate this value dynamically, " +
+                                                           $"unset the '{nameof(AiAgentParameter.AiAgentParameterPolicy.ForbidModelGeneration)}' " +
+                                                           "flag in the sub-agent parameter policy.");
+            }
+
+            parameters[ConversationDocument.SubAgentUserPromptKey] = new ParameterDefinition("A natural language prompt instructions for the sub-agent to do its work", AiAgentParameter.ValueType.String);
+            var paramsSchema = GetSchemaForSubAgentTool(context, parameters);
+            var description = new StringBuilder(subAgent.Description).AppendLine();
+            subAgentConfiguration.AppendCapabilities(description);
+            return ConversationDocument.GetTool(context, subAgent.Identifier, description.ToString(), paramsSchema);
+        }
+
+        private static string GetSchemaForSubAgentTool(JsonOperationContext context, Dictionary<string, ParameterDefinition> parameters)
+        {
+            var properties = new DynamicJsonValue();
+            var required = new DynamicJsonArray();
+
+            foreach (var (name, value) in parameters)
+            {
+                var property = new DynamicJsonValue
+                {
+                    [ChatCompletionClient.Constants.JsonSchemaFields.Description] = value.Description
+                };
+
+                switch (value.Type)
+                {
+                    case AiAgentParameter.ValueType.Default:
+                    case AiAgentParameter.ValueType.String:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeString;
+                        break;
+
+                    case AiAgentParameter.ValueType.Number:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeNumber;
+                        break;
+
+                    case AiAgentParameter.ValueType.Boolean:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeBoolean;
+                        break;
+
+                    case AiAgentParameter.ValueType.Null:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeNull;
+                        break;
+
+                    case AiAgentParameter.ValueType.ArrayOfString:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeArray;
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Items] = new DynamicJsonValue { [ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeString };
+                        break;
+
+                    case AiAgentParameter.ValueType.ArrayOfNumber:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeArray;
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Items] = new DynamicJsonValue { [ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeNumber };
+                        break;
+
+                    case AiAgentParameter.ValueType.ArrayOfBoolean:
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeArray;
+                        property[ChatCompletionClient.Constants.JsonSchemaFields.Items] = new DynamicJsonValue { [ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeBoolean };
+                        break;
+
+                    default:
+                        throw new InvalidOperationException($"Unsupported ValueType: {value.Type}");
+                }
+                properties[name] = property;
+                required.Add(name);
+            }
+
+            return context.ReadObject(new DynamicJsonValue
+            {
+                [ChatCompletionClient.Constants.JsonSchemaFields.Type] = ChatCompletionClient.Constants.JsonSchemaFields.TypeObject,
+                [ChatCompletionClient.Constants.JsonSchemaFields.Properties] = properties,
+                [ChatCompletionClient.Constants.JsonSchemaFields.Required] = required
+            }, "tool/parameters").ToString();
+        }
+
+        private readonly struct ParameterDefinition
+        {
+            public string Description { get; }
+            public AiAgentParameter.ValueType Type { get; }
+
+            public ParameterDefinition(string description, AiAgentParameter.ValueType type)
+            {
+                Description = description;
+                Type = type;
             }
         }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -85,6 +85,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                     $"Cannot start a new conversation '{_conversationId}' without a user prompt.");
             }
 
+            ValidateParameterValues(_request.Parameters);
             _document = new ConversationDocument(agentId, _request.Parameters);
             _document.Id = await GetDocumentIdAsync();
 
@@ -125,6 +126,145 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             }
         }
     }
+
+    private void ValidateParameterValues(BlittableJsonReaderObject requestParameters)
+    {
+        // Validate that the provided parameter values match the expected types in the configuration.
+
+        if (_configuration.Parameters == null || requestParameters == null)
+            return;
+
+        foreach (var configParam in _configuration.Parameters)
+        {
+            if (requestParameters.TryGetMember(configParam.Name, out object value) == false)
+                continue;
+
+            var expectedType = configParam.Type;
+
+            if (expectedType == AiAgentParameter.ValueType.Default)
+                continue;
+
+            if (value is BlittableJsonReaderArray { Length: 0 })
+            {
+                if (expectedType is not (AiAgentParameter.ValueType.ArrayOfString or 
+                                            AiAgentParameter.ValueType.ArrayOfBoolean or 
+                                            AiAgentParameter.ValueType.ArrayOfNumber))
+                    throw new InvalidCastException(
+                        $"Parameter '{configParam.Name}' has invalid type. " +
+                        $"Expected: {expectedType}, " +
+                        $"Actual: Array (Empty), " +
+                        $"Value: {value}");
+
+                continue;
+            }
+
+            if (GetValueType(value, out var actualType, out var unsupportedType) == false)
+                throw new InvalidCastException(
+                    $"Parameter '{configParam.Name}' has unsupported type. " +
+                    $"Actual: {unsupportedType}");
+
+            if (actualType != expectedType)
+                throw new InvalidCastException(
+                    $"Parameter '{configParam.Name}' has invalid type. " +
+                    $"Expected: {expectedType}, " +
+                    $"Actual: {actualType}, " +
+                    $"Value: {value}");
+        }
+    }
+
+    private static bool GetValueType(object value, out AiAgentParameter.ValueType type, out string unsupportedType)
+    {
+        type = default;
+        unsupportedType = null;
+
+        switch (value)
+        {
+            case null:
+                type = AiAgentParameter.ValueType.Null;
+                return true;
+            case string:
+            case LazyStringValue:
+            case LazyCompressedStringValue:
+                type = AiAgentParameter.ValueType.String;
+                return true;
+
+            case int:
+            case long:
+            case float:
+            case double:
+            case decimal:
+            case LazyNumberValue:
+            case byte:
+            case short:
+            case sbyte:
+            case ushort:
+            case uint:
+            case ulong:
+                type = AiAgentParameter.ValueType.Number;
+                return true;
+
+            case bool:
+                type = AiAgentParameter.ValueType.Boolean;
+                return true;
+
+            case BlittableJsonReaderArray array:
+                bool first = true;
+                var elementType = AiAgentParameter.ValueType.Default;
+
+                // make sure all elements have the same type
+                // make sure all elements have a valid type
+                foreach (var element in array)
+                {
+                    if (GetValueType(element, out var curType, out var elementUnsupportedType) == false)
+                    {
+                        unsupportedType = $"Array contains an element of unsupported type '{elementUnsupportedType}'.";
+                        return false;
+                    }
+
+                    if (curType is AiAgentParameter.ValueType.ArrayOfBoolean or AiAgentParameter.ValueType.ArrayOfNumber or AiAgentParameter.ValueType.ArrayOfString)
+                    {
+                        unsupportedType = "Array of arrays.";
+                        return false;
+                    }
+
+                    if (first)
+                    {
+                        first = false;
+                        elementType = curType;
+                        continue;
+                    }
+
+                    if (elementType != curType)
+                    {
+                        unsupportedType = $"Array of mixed element types: '{elementType}' and '{curType}'.";
+                        return false;
+                    }
+                }
+
+                type = elementType switch
+                {
+                    AiAgentParameter.ValueType.String => AiAgentParameter.ValueType.ArrayOfString,
+                    AiAgentParameter.ValueType.Number => AiAgentParameter.ValueType.ArrayOfNumber,
+                    AiAgentParameter.ValueType.Boolean => AiAgentParameter.ValueType.ArrayOfBoolean,
+                    _ => default
+                };
+
+                if (type == default)
+                {
+                    unsupportedType = $"Array of unsupported element type '{elementType}'.";
+                    return false;
+                }
+
+                return true;
+            case BlittableJsonReaderObject:
+                unsupportedType = "Object";
+                return false;
+            default:
+                unsupportedType = value.GetType().Name;
+                return false;
+        }
+    }
+
 
     private ChatCompletionClient _client;
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
@@ -45,7 +45,8 @@ function mapFromDto(
                 name: x.Name,
                 description: x.Description,
                 isSendToModel: x.SendToModel ?? true,
-                Policy: x.Policy ?? "Default",
+                policy: x.Policy ?? "Default",
+                type: x.Type ?? "Default",
             })) ?? [],
         queries:
             dto.Queries?.map((x) => ({
@@ -115,7 +116,8 @@ function mapToDto(formData: EditAiAgentFormData): Raven.Client.Documents.Operati
                 Name: x.name,
                 Description: x.description,
                 SendToModel: x.isSendToModel,
-                Policy: x.Policy,
+                Policy: x.policy,
+                Type: x.type,
             })) ?? [],
         Queries:
             formData.queries?.map((x) => ({

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
@@ -54,7 +54,8 @@ const editSchema = yup.object({
                 ),
             description: yup.string().nullable(),
             isSendToModel: yup.boolean(),
-            Policy: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameter.AiAgentParameterPolicy>(),
+            policy: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameter.AiAgentParameterPolicy>(),
+            type: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameter.ValueType>(),
         })
     ),
 

--- a/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
@@ -55,7 +55,8 @@ export class AiAgentStubs {
                         {
                             Name: "company",
                             Description: null,
-                            Policy: "Default"
+                            Policy: "Default",
+                            Type: "Default",
                         },
                     ],
                     ChatTrimming: null,

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25993.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25993.cs
@@ -1,0 +1,379 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25993(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task AgentParameterTypeTest(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            await SeedProducts(store);
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "Find top 3 laptops within a budget and minimum RAM. and return all matching results. if you have 3 return 3, not less!"
+            )
+            {
+                Queries = new List<AiAgentToolQuery>
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "FindTopLaptops",
+                        Description = "Return top 3 laptops that match budget and min RAM. Return all of the laptops you found that will fit to the request.",
+                        Query =
+                            "from Products as p " +
+                            "where p.Category = 'Laptop' " +
+                            "and p.PriceNis <= $maxBudgetNis " +
+                            "and p.RamGb >= $minRamGb " +
+                            "order by p.PriceNis asc " +
+                            "limit 0, 3",
+                        ParametersSampleObject = "{}"
+                    }
+                }
+            };
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("maxBudgetNis", "Max budget (NIS)") { Type = AiAgentParameter.ValueType.Number });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("minRamGb", "Min RAM (GB)") { Type = AiAgentParameter.ValueType.Number });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(
+                productsSearchId,
+                "Chats/1",
+                new AiConversationCreationOptions().AddParameter("maxBudgetNis", "3500").AddParameter("minRamGb", 16)
+            );
+
+            chat.SetUserPrompt(
+                "Find laptops that'll fit to me needs."
+            );
+            var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<OutputSchema>());
+            Assert.Contains("Parameter 'maxBudgetNis' has invalid type. Expected: Number, Actual: String, Value: 3500", e.Message);
+
+            chat = store.AI.Conversation(
+                productsSearchId,
+                "Chats/2",
+                new AiConversationCreationOptions().AddParameter("maxBudgetNis", 3500).AddParameter("minRamGb", 16)
+            );
+            
+            chat.SetUserPrompt("Find laptops that'll fit to me needs.");
+            var r = await chat.RunAsync<OutputSchema>();
+        }
+
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task AgentParameterTypeTest_Primitives(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "You are a product search agent!"
+            );
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("stringParam", "some param") { Type = AiAgentParameter.ValueType.String });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("numberParam", "some param") { Type = AiAgentParameter.ValueType.Number });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("booleanParam", "some param") { Type = AiAgentParameter.ValueType.Boolean });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            var creationOptions = new AiConversationCreationOptions().AddParameter("stringParam", "abc")
+                                                                        .AddParameter("numberParam", 16)
+                                                                        .AddParameter("booleanParam", true);
+
+            await Talk("Chats/1"); // should pass
+
+            creationOptions = new AiConversationCreationOptions().AddParameter("stringParam", 1)
+                .AddParameter("numberParam", 16)
+                .AddParameter("booleanParam", true);
+            var e = await Assert.ThrowsAsync<AiException>(() => Talk("Chats/2"));
+            Assert.Contains("Parameter 'stringParam' has invalid type. Expected: String, Actual: Number, Value: 1", e.Message);
+            
+            creationOptions = new AiConversationCreationOptions().AddParameter("stringParam", "abc")
+                .AddParameter("numberParam", "16") // should throw
+                .AddParameter("booleanParam", true);
+            e = await Assert.ThrowsAsync<AiException>(() => Talk("Chats/3"));
+            Assert.Contains("Parameter 'numberParam' has invalid type. Expected: Number, Actual: String, Value: 16", e.Message);
+            
+            creationOptions = new AiConversationCreationOptions().AddParameter("stringParam", "abc")
+                .AddParameter("numberParam", 16)
+                .AddParameter("booleanParam", 5);  // should throw
+            e = await Assert.ThrowsAsync<AiException>(() => Talk("Chats/4"));
+            Assert.Contains("Parameter 'booleanParam' has invalid type. Expected: Boolean, Actual: Number, Value: 5", e.Message);
+            
+            async Task Talk(string chatId)
+            {
+                var chat = store.AI.Conversation(
+                    productsSearchId,
+                    chatId,
+                    creationOptions
+                );
+                chat.SetUserPrompt("Who are you.");
+                var r = await chat.RunAsync<OutputSchema>();
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task AgentParameterTypeTest_Array(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "You are a product search agent!"
+            );
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("arrParam", "some param") { Type = AiAgentParameter.ValueType.ArrayOfNumber });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            var creationOptions = new AiConversationCreationOptions().AddParameter("arrParam", new int[] { 1, 2, 3 }); // shouldn't throw
+            await Talk("Chats/1");
+
+            creationOptions = new AiConversationCreationOptions().AddParameter("arrParam", new OutputSchema[] { new OutputSchema() { Answer = "ans" } }); // should throw
+            var e = await Assert.ThrowsAsync<InvalidOperationException>(() => Talk("Chats/2")); // from client side, because array is not supported at all
+            Assert.Contains("Got unknown type", e.Message);
+
+            creationOptions = new AiConversationCreationOptions().AddParameter("arrParam", new object[] { 1, 2, 3 }); // shouldn't throw
+            await Talk("Chats/3");
+
+            creationOptions = new AiConversationCreationOptions().AddParameter("arrParam", new object[] { 1, 2, new OutputSchema() }); // should throw
+            var e2 = await Assert.ThrowsAsync<InvalidOperationException>(() => Talk("Chats/4")); // from client side, because array is not supported at all
+            Assert.Contains("Got unknown type", e2.Message);
+
+            creationOptions = new AiConversationCreationOptions().AddParameter("arrParam", new object[] { 1, 2, "abc" }); // should throw
+            var e3 = await Assert.ThrowsAsync<AiException>(() => Talk("Chats/5"));
+            Assert.Contains("Parameter 'arrParam' has unsupported type. Actual: Array of mixed element types: 'Number' and 'String'.", e3.Message);
+
+            creationOptions = new AiConversationCreationOptions().AddParameter("arrParam", new object[] { null }); // should throw
+            var e4 = await Assert.ThrowsAsync<AiException>(() => Talk("Chats/6"));
+            Assert.Contains("Parameter 'arrParam' has unsupported type. Actual: Array of unsupported element type 'Null'.", e4.Message);
+
+            async Task Talk(string chatId)
+            {
+                var chat = store.AI.Conversation(
+                    productsSearchId,
+                    chatId,
+                    creationOptions
+                );
+                chat.SetUserPrompt("Who are you.");
+                var r = await chat.RunAsync<OutputSchema>();
+            }
+        }
+
+        private static async Task SeedProducts(IDocumentStore store)
+        {
+            using var session = store.OpenAsyncSession();
+
+            // Matches (<=3500 & >=16GB): Products/5 (2790), Products/4 (2990), Products/1 (3290)
+            await session.StoreAsync(new Product { Id = "Products/1", Category = "Laptop", RamGb = 16, PriceNis = 3290 });
+            await session.StoreAsync(new Product { Id = "Products/4", Category = "Laptop", RamGb = 16, PriceNis = 2990 });
+            await session.StoreAsync(new Product { Id = "Products/5", Category = "Laptop", RamGb = 16, PriceNis = 2790 });
+
+            // Additional valid (<=3500 & >=16GB) for add flow
+            await session.StoreAsync(new Product { Id = "Products/6", Category = "Laptop", RamGb = 24, PriceNis = 3490 });
+
+            // Non-matching examples
+            await session.StoreAsync(new Product { Id = "Products/2", Category = "Laptop", RamGb = 32, PriceNis = 4890 }); // above budget
+            await session.StoreAsync(new Product { Id = "Products/3", Category = "Laptop", RamGb = 8, PriceNis = 1990 }); // below RAM
+
+            await session.SaveChangesAsync();
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task MultiAgentStringParametersInsteadOfNumberBug(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            await SeedProducts(store);
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "Find top 3 laptops within a budget and minimum RAM. and return all matching results. if you have 3 return 3, not less!"
+            )
+            {
+                Queries = new List<AiAgentToolQuery>
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "FindTopLaptops",
+                        Description = "Return top 3 laptops that match budget and min RAM. Return all of the laptops you found that will fit to the request.",
+                        Query =
+                            "from Products as p " +
+                            "where p.Category = 'Laptop' " +
+                            "and p.PriceNis <= $maxBudgetNis " +
+                            "and p.RamGb >= $minRamGb " +
+                            "order by p.PriceNis asc " +
+                            "limit 0, 3",
+                        ParametersSampleObject = "{}"
+                    }
+                }
+            };
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("maxBudgetNis", "Max budget (NIS)")
+            {
+                Type = AiAgentParameter.ValueType.Number
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("minRamGb", "Min RAM (GB)")
+            {
+                Type = AiAgentParameter.ValueType.Number
+            });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            // root agent
+            var root = new AiAgentConfiguration(
+                "store-clerk-agent",
+                config.ConnectionStringName,
+                "You are the store clerk (root). " +
+                "Use products-search-agent to get product ids. "
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent { Identifier = productsSearchId, Description = "Find products" },
+                ]
+            };
+
+            var rootId = (await store.AI.CreateAgentAsync(root, OutputSchema.Instance)).Identifier;
+            var chat = store.AI.Conversation(
+                rootId,
+                "Chats/1",
+                new AiConversationCreationOptions().AddParameter("customerId", "Customers/1").AddParameter("creditCardNumber", "1234-1234-1234-1234")
+            );
+            chat.SetUserPrompt(
+                "My criteria: Budget 3500 NIS, min 16GB RAM. " +
+                "Find laptops for me."
+            );
+            var r1 = await chat.RunAsync<OutputSchema>();
+            Assert.Equal(3, r1.Answer.ProductIds.Count);
+        }
+
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task MultiAgentTypeConflict(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            await SeedProducts(store);
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "Find top 3 laptops within a budget and minimum RAM. and return all matching results. if you have 3 return 3, not less!"
+            )
+            {
+                Queries = new List<AiAgentToolQuery>
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "FindTopLaptops",
+                        Description = "Return top 3 laptops that match budget and min RAM. Return all of the laptops you found that will fit to the request.",
+                        Query =
+                            "from Products as p " +
+                            "where p.Category = 'Laptop' " +
+                            "and p.PriceNis <= $maxBudgetNis " +
+                            "and p.RamGb >= $minRamGb " +
+                            "order by p.PriceNis asc " +
+                            "limit 0, 3",
+                        ParametersSampleObject = "{}"
+                    }
+                }
+            };
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("maxBudgetNis", "Max budget (NIS)")
+            {
+                Type = AiAgentParameter.ValueType.Number
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("minRamGb", "Min RAM (GB)")
+            {
+                Type = AiAgentParameter.ValueType.Number
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("customerId", "Customer Id")
+            {
+                Type = AiAgentParameter.ValueType.Number
+            });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            // root agent
+            var root = new AiAgentConfiguration(
+                "store-clerk-agent",
+                config.ConnectionStringName,
+                "You are the store clerk (root). " +
+                "Use products-search-agent to get product ids. "
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent { Identifier = productsSearchId, Description = "Find products" },
+                ]
+            };
+            root.Parameters.Add(new AiAgentParameter("customerId", "Customer Id")
+            {
+                Type = AiAgentParameter.ValueType.String
+            });
+
+            var rootId = (await store.AI.CreateAgentAsync(root, OutputSchema.Instance)).Identifier;
+            var chat = store.AI.Conversation(
+                rootId,
+                "Chats/1",
+                new AiConversationCreationOptions().AddParameter("customerId", "Customers/1").AddParameter("creditCardNumber", "1234-1234-1234-1234")
+            );
+            chat.SetUserPrompt(
+                "My criteria: Budget 3500 NIS, min 16GB RAM. " +
+                "Find laptops for me."
+            );
+            var e = await Assert.ThrowsAsync<MissingAiAgentParameterException>(() => chat.RunAsync<OutputSchema>());
+            Assert.Contains("Parameter 'customerId' has mismatched types between parent and sub-agent. Parent type: 'String', Sub-agent type: 'Number'. Both must declare the same ValueType.", e.Message);
+        }
+
+        // Entities
+        private class Product
+        {
+            public string Id { get; set; }
+            public string Category { get; set; } // "Laptop"
+            public int RamGb { get; set; }
+            public decimal PriceNis { get; set; }
+        }
+
+        // Minimal tool payloads
+        private class OutputSchema
+        {
+            public static OutputSchema Instance = new()
+            {
+                Answer = "Those are the laptops I found fitting your criteria: Products/5, Products/4, Products/1",
+                ProductIds = new List<string> { "Products/5", "Products/4", "Products/1" }
+            };
+
+            public string Answer { get; set; }
+            public List<string> ProductIds { get; set; }
+
+            public override string ToString()
+            {
+                var ids = ProductIds != null ? string.Join(", ", ProductIds) : "null";
+                return $"Answer: {Answer} | ProductIds: [{ids}]";
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25993/Add-type-property-AiAgentParameter

### Additional description

Add type property AiAgentParameter:
Add ai-agent param type validation on the server-side, Generate sub-agent params by their types


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
