### PR TITLE
RavenDB-25419 Add task input disabled reason

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/editTasks/editGenAiTask/partials/fields/EditGenAiTaskBasicFields.tsx
@@ -8,7 +8,7 @@ import EditConnectionStrings from "components/pages/database/settings/connection
 import { useAppDispatch, useAppSelector } from "components/store";
 import { sortBy } from "lodash";
 import { useAsync } from "react-async-hook";
-import { editGenAiTaskActions } from "../../store/editGenAiTaskSlice";
+import { editGenAiTaskActions, editGenAiTaskSelectors } from "../../store/editGenAiTaskSlice";
 import EditGenAiTaskNodeField from "./EditGenAiTaskNodeField";
 import InputGroup from "react-bootstrap/InputGroup";
 import { useServices } from "components/hooks/useServices";
@@ -20,6 +20,8 @@ import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { Icon } from "components/common/Icon";
 import Button from "react-bootstrap/Button";
 import { editGenAiTaskUtils } from "../../utils/editGenAiTaskUtils";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
+import tasksCommonContent from "models/database/tasks/tasksCommonContent";
 
 type OngoingTaskState = Raven.Client.Documents.Operations.OngoingTasks.OngoingTaskState;
 
@@ -28,6 +30,7 @@ export default function EditGenAiTaskBasicFields() {
 
     const isEncrypted = useAppSelector(databaseSelectors.activeDatabase)?.isEncrypted;
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
+    const isEditTask = useAppSelector(editGenAiTaskSelectors.isEditTask);
 
     const { value: isNewConnectionStringOpen, toggle: toggleIsNewConnectionStringOpen } = useBoolean(false);
 
@@ -68,17 +71,26 @@ export default function EditGenAiTaskBasicFields() {
         <>
             <FormGroup>
                 <FormLabel>Task Name</FormLabel>
-                <FormInput
-                    type="text"
-                    control={control}
-                    name="name"
-                    placeholder="My task"
-                    onBlur={() => {
-                        if (!formValues.identifier) {
-                            handleGenerateIdentifier();
-                        }
+                <ConditionalPopover
+                    conditions={{
+                        isActive: isEditTask,
+                        message: tasksCommonContent.taskNameLocked,
                     }}
-                />
+                    className="w-100"
+                >
+                    <FormInput
+                        type="text"
+                        control={control}
+                        name="name"
+                        placeholder="My task"
+                        onBlur={() => {
+                            if (!formValues.identifier) {
+                                handleGenerateIdentifier();
+                            }
+                        }}
+                        disabled={isEditTask}
+                    />
+                </ConditionalPopover>
             </FormGroup>
             <FormGroup>
                 <FormLabel>

--- a/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/tasksCommonContent.ts
@@ -69,6 +69,11 @@
 
     static readonly externalScriptNotAllowedForNonClusterAdmins =
         "Setting up the configuration via an external script is not allowed for non cluster admins.";
+
+    static readonly etlTaskNameLocked = "ETL task name cannot be changed after creation. Delete and recreate the task to use a different name.";
+
+    // Name can't be changed for any ETL task, but e.g. AI Tasks are not marked as ETL on the UI
+    static readonly taskNameLocked = "Task name cannot be changed after creation. Delete and recreate the task to use a different name.";
 }
 
 export = tasksCommonContent;

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editAmazonSqsEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editAmazonSqsEtlTask.ts
@@ -25,6 +25,7 @@ import licenseModel = require("models/auth/licenseModel");
 import ongoingTaskAmazonSqsEtlEditModel = require("models/database/tasks/ongoingTaskAmazonSqsEtlEditModel");
 import connectionStringAmazonSqsModel = require("models/database/settings/connectionStringAmazonSqsModel");
 import EditAmazonSqsEtlInfoHub = require("viewmodels/database/tasks/EditAmazonSqsEtlInfoHub");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class amazonSqsTaskTestMode {
     documentId = ko.observable<string>();
@@ -186,6 +187,8 @@ class editAmazonSqsEtlTask extends viewModelBase {
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
 
+    taskNameDisabledReason: KnockoutComputed<string>;
+
     createNewConnectionString = ko.observable<boolean>(false);
     newConnectionString = ko.observable<connectionStringAmazonSqsModel>();
 
@@ -281,6 +284,14 @@ class editAmazonSqsEtlTask extends viewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        }); 
 
         this.newConnectionString(connectionStringAmazonSqsModel.empty());
         this.newConnectionString().setNameUniquenessValidator(name => !this.etlConnectionStringsDetails().find(x => x.Name.toLocaleLowerCase() === name.toLocaleLowerCase()));

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editEmbeddingsGenerationTask.ts
@@ -27,6 +27,7 @@ import testAiConnectionStringCommand = require("commands/database/cluster/testAi
 import aiConnectionStringUtils = require("components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils");
 import eventsCollector = require("common/eventsCollector");
 import generalUtils = require("common/generalUtils");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 const minimumCommunityDeleteFrequencyInSec = TimeInSeconds.TimeInSeconds.Day * 36;
 
@@ -56,6 +57,8 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
     
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
+
+    taskNameDisabledReason: KnockoutComputed<string>;
     
     collectionNames: KnockoutComputed<string[]>;
 
@@ -273,6 +276,14 @@ class editEmbeddingsGenerationTask extends shardViewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewEtlTask()) {
+                return tasksCommonContent.taskNameLocked;
+            }
+
+            return null;
+        }); 
 
         const connectionStringName = this.editedEmbeddingsGeneration().connectionStringName();
         const connectionStringIsMissing = connectionStringName && !this.connectionStringsNames()

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editSnowflakeEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editSnowflakeEtlTask.ts
@@ -29,6 +29,7 @@ import ongoingTaskSnowflakeEtlTransformationModel = require("models/database/tas
 import ongoingTaskSnowflakeEtlTableModel = require("models/database/tasks/ongoingTaskSnowflakeEtlTableModel");
 import ongoingTaskSnowflakeEtlEditModel = require("models/database/tasks/ongoingTaskSnowflakeEtlEditModel");
 import EditSnowflakeEtlInfoHub = require("viewmodels/database/tasks/EditSnowflakeEtlInfoHub");
+import tasksCommonContent = require("models/database/tasks/tasksCommonContent");
 
 class snowflakeTaskTestMode {
     
@@ -208,6 +209,8 @@ class editSnowflakeEtlTask extends shardViewModelBase {
     fullErrorDetailsVisible = ko.observable<boolean>(false);
     shortErrorText: KnockoutObservable<string>;
 
+    taskNameDisabledReason: KnockoutComputed<string>;
+
     collections = collectionsTracker.default.collections;
     collectionNames: KnockoutComputed<string[]>;
     
@@ -322,6 +325,14 @@ class editSnowflakeEtlTask extends shardViewModelBase {
             }
             return generalUtils.trimMessage(result.Error);
         });
+
+        this.taskNameDisabledReason = ko.pureComputed(() => {
+            if (!this.isAddingNewSnowflakeEtlTask()) {
+                return tasksCommonContent.etlTaskNameLocked;
+            }
+
+            return null;
+        }); 
 
         this.collectionNames = ko.pureComputed(() => {
            return collectionsTracker.default.getCollectionNames(); 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editAmazonSqsEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editAmazonSqsEtlTask.html
@@ -26,7 +26,13 @@
                         <div class="form-group margin-top">
                             <label for="taskName" class="control-label">Task Name</label>
                             <div class="flex-grow">
-                                <input type="text" class="form-control" id="taskName" placeholder="Enter a descriptive name for the Amazon SQS ETL task (optional)" data-bind="textInput: taskName">
+                                <input
+                                    type="text"
+                                    class="form-control"
+                                    id="taskName"
+                                    placeholder="Enter a descriptive name for the Amazon SQS ETL task (optional)"
+                                    data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                >
                             </div>
                         </div>
                         <div class="form-group">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editEmbeddingsGenerationTask.html
@@ -25,8 +25,13 @@
                             <div class="form-group" data-bind="validationElement: taskName">
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
-                                    <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the AI task" data-bind="textInput: taskName, event: { blur: generateIdentifierOnNameBlur }">
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        id="taskName"
+                                        placeholder="Enter a descriptive name for the AI task"
+                                        data-bind="textInput: taskName, event: { blur: generateIdentifierOnNameBlur }, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                    >
                                 </div>
                             </div>
                             <div class="form-group" data-bind="validationElement: identifier">

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editSnowflakeEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editSnowflakeEtlTask.html
@@ -27,8 +27,13 @@
                             <div class="form-group margin-top" data-bind="validationElement: taskName">
                                 <label for="taskName" class="control-label">Task Name</label>
                                 <div class="flex-grow">
-                                    <input type="text" class="form-control" id="taskName"
-                                           placeholder="Enter a descriptive name for the Snowflake ETL task (optional)" data-bind="textInput: taskName">
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        id="taskName"
+                                        placeholder="Enter a descriptive name for the Snowflake ETL task (optional)"
+                                        data-bind="textInput: taskName, disable: !!$root.taskNameDisabledReason(), attr: { title: $root.taskNameDisabledReason() }"
+                                    >
                                 </div>
                             </div>
                             <div class="form-group">


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25419/ETL-task-name-update-behavior

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
