### PR TITLE
RavenDB-26118 switched tests to x64 because ONNX is no longer support…

### DIFF
--- a/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
+++ b/src/Raven.Server/Documents/Indexes/VectorSearch/GenerateEmbeddings.cs
@@ -53,6 +53,9 @@ public static class GenerateEmbeddings
         {
             OnnxSessionOptions = new Lazy<SessionOptions>(valueFactory: () =>
             {
+                if (PlatformDetails.Is32Bits)
+                    throw new IncorrectDllException("Could not initialize 'ONNX Runtime'. The x86 architecture is not supported by the ONNX Runtime.");
+
                 if (PlatformDetails.RunningOnCortexA53)
                     throw new IncorrectDllException("Could not initialize 'ONNX Runtime'. Your CPU, the Cortex A53, is not supported by ONNX Runtime: https://github.com/microsoft/onnxruntime/issues/25472");
                 

--- a/test/FastTests/Corax/RavenDB_23695.cs
+++ b/test/FastTests/Corax/RavenDB_23695.cs
@@ -15,7 +15,7 @@ public class RavenDB_23695 : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public void CanPerformNoopUpdateOfVector()
     {
         using var store = GetDocumentStore();
@@ -44,7 +44,7 @@ public class RavenDB_23695 : RavenTestBase
         }
     }
     
-    [RavenTheory(RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(4, 5)]
     [InlineData(5, 4)]
     public void CanPerformListDegradationAndUpgrade(int from, int to)

--- a/test/FastTests/Corax/Vectors/IndexVectorExactViaStaticIndexesTests.cs
+++ b/test/FastTests/Corax/Vectors/IndexVectorExactViaStaticIndexesTests.cs
@@ -57,14 +57,14 @@ select new
         Assert.Equal(IndexDefinitionCompareDifferences.None, cmp);
     }
 
-    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(VectorEmbeddingType.Binary, 0.7f)]
     [InlineData(VectorEmbeddingType.Int8, 0.82f)]
     [InlineData(VectorEmbeddingType.Single, 0.75f)]
     public async Task CanCreateVectorIndexFromCSharp(VectorEmbeddingType vectorEmbeddingType, float similarity)
     => await CanCreateVectorIndexBase<TextVectorIndex>(vectorEmbeddingType, similarity);
     
-    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(VectorEmbeddingType.Binary, 0.7f)]
     [InlineData(VectorEmbeddingType.Int8, 0.82f)]
     [InlineData(VectorEmbeddingType.Single, 0.75f)]
@@ -229,16 +229,16 @@ select new
         public object Vector { get; set; }
     }
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void EmbeddingTextSourceTest() => StaticIndexApi<EmbeddingTextSource>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void EmbeddingTextSourceTestJs() => StaticIndexApi<EmbeddingTextSourceJs>();
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void MultiEmbeddingTextIndexTest() => StaticIndexApi<MultiEmbeddingTextIndex>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void MultiEmbeddingTextIndexTestJs() => StaticIndexApi<MultiEmbeddingTextIndexJs>();
 
     [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]

--- a/test/FastTests/Corax/Vectors/MultiVectorSearchClientAPI.cs
+++ b/test/FastTests/Corax/Vectors/MultiVectorSearchClientAPI.cs
@@ -16,7 +16,7 @@ namespace FastTests.Corax.Vectors;
 
 public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     public void CanSearchByMultipleVectorsByTexts()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -60,7 +60,7 @@ public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBas
         }
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     public void CanSearchByMultipleVectorsByEmbeddings()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -112,7 +112,7 @@ public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBas
         }
     }
 
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     public void CanSearchByMultipleVectorsByRavenVector()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -164,7 +164,7 @@ public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBas
         }
     }
     
-     [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying)]
+     [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     public void CanSearchByMultipleVectorsByBase64()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/FastTests/Corax/Vectors/RavenDB-23655.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB-23655.cs
@@ -21,7 +21,7 @@ public class RavenDB_23655 : RavenTestBase
     {
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes, LicenseRequired = true)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes, RavenArchitecture.AllX64, LicenseRequired = true)]
     [InlineData(true)]
     [InlineData(false)]
     public async Task ExactVectorSearchHasNoEffectOnIndex(bool firstIsExact)

--- a/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
+++ b/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
@@ -90,7 +90,7 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
         vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Binary, VectorEmbeddingType.Binary),
             embedding(VectorQuantizer.ToInt1([1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])), isExact: isExact), isExact);
 
-    [RavenTheory(RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(true)]
     [InlineData(false)]
     public void TextToSinglesTest(bool isExact) => AutoIndexingTestingBase(
@@ -99,7 +99,7 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
         vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text),
             value => value.ByText("test"), isExact: isExact), isExact);
 
-    [RavenTheory(RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(true)]
     [InlineData(false)]
     public void TextToInt8Test(bool isExact) => AutoIndexingTestingBase(
@@ -108,7 +108,7 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
         vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Int8),
             value => value.ByText("test"), isExact: isExact), isExact);
 
-    [RavenTheory(RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(true)]
     [InlineData(false)]
     public void TextToInt1Test(bool isExact) => AutoIndexingTestingBase(
@@ -135,7 +135,7 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
         Assert.Equal(rql, baseQuery.ToString());
     }
 
-    [RavenFact(RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public void NonExistingFieldDoesntEndWithNre()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
+++ b/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
@@ -30,7 +30,7 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         Assert.Null(result.Singles);
     }
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void CanIndexNullWhenServerGeneratesTheEmbedding()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/FastTests/Corax/Vectors/VectorJavaScriptIndexing.cs
+++ b/test/FastTests/Corax/Vectors/VectorJavaScriptIndexing.cs
@@ -19,14 +19,14 @@ public class VectorJavaScriptIndexing : RavenTestBase
     public VectorJavaScriptIndexing(ITestOutputHelper output) : base(output)
     {
     }
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void TextToSinglesTest() => JsIndexingTestingBase(nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
     
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void TextToInt8Test() => JsIndexingTestingBase(nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void TextToInt1Test() => JsIndexingTestingBase(nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
     
     

--- a/test/FastTests/Voron/Graphs/BasicGraphs.cs
+++ b/test/FastTests/Voron/Graphs/BasicGraphs.cs
@@ -252,7 +252,7 @@ public class BasicGraphs(ITestOutputHelper output) : StorageTest(output)
         }
     }
 
-    [RavenTheory(RavenTestCategory.Voron)]
+    [RavenMultiplatformTheory(RavenTestCategory.Voron, RavenArchitecture.AllX64)]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]

--- a/test/SlowTests.Issues/Issues/RavenDB-23445.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23445.cs
@@ -17,7 +17,7 @@ public class RavenDB_23445 : RavenTestBase
     {
     }
 
-    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Indexes | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
     public void TestIndexingOfNulls(Options options)
     {
@@ -45,13 +45,13 @@ public class RavenDB_23445 : RavenTestBase
         }
     }
     
-    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(VectorEmbeddingType.Binary, 0.65f)]
     [InlineData(VectorEmbeddingType.Int8, 0.80f)]
     [InlineData(VectorEmbeddingType.Single, 0.80f)]
     public void CanCreateVectorIndexFromCSharp(VectorEmbeddingType vectorEmbeddingType, float similarity) => CanCreateVectorIndexFromBase<TextVectorIndex>(vectorEmbeddingType, similarity);
     
-    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(VectorEmbeddingType.Binary, 0.65f)]
     [InlineData(VectorEmbeddingType.Int8, 0.80f)]
     [InlineData(VectorEmbeddingType.Single, 0.80f)]

--- a/test/SlowTests.Issues/Issues/RavenDB-23446.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23446.cs
@@ -131,7 +131,7 @@ public class RavenDB_23446(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanConvertTextualVectorFieldToStaticField()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests.Issues/Issues/RavenDB-23457.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23457.cs
@@ -18,12 +18,12 @@ public class RavenDB_23457 : RavenTestBase
     {
     }
 
-    [RavenTheory(RavenTestCategory.Indexes)]
+    [RavenMultiplatformTheory(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void CanShowIndexRawEntryWhenVectorSearchIsInsideWhereClause(Options options)
     => CanShowIndexRawEntryWhenVectorSearchIsInsideWhereClauseBase<DummyIndex>(options);
-    
-    [RavenTheory(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+
+    [RavenMultiplatformTheory(RavenTestCategory.Indexes | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void CanShowIndexRawEntryWhenVectorSearchIsInsideWhereClauseJs(Options options)
         => CanShowIndexRawEntryWhenVectorSearchIsInsideWhereClauseBase<DummyIndexJs>(options);

--- a/test/SlowTests.Issues/Issues/RavenDB-23473.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23473.cs
@@ -20,11 +20,11 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public void CanIndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfiguration()
     => CanIndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfigurationBase<DtoIndex>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public void CanIndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfigurationJs()
         => CanIndexVectorWhenPreviousElementsAreNullWithoutExplicitVectorFieldConfigurationBase<DtoIndexJs>();
     
@@ -56,11 +56,11 @@ public class RavenDB_23473(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Null(errors);
     }
     
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public async Task CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocument()
     => await CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocumentBase<VectorIndex>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public async Task CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocumentJs()
         => await CanUpdateNoExplicitlyConfiguredVectorFieldViaSubscriptionWithLoadDocumentBase<VectorIndexJs>();
     

--- a/test/SlowTests.Issues/Issues/RavenDB-23524.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23524.cs
@@ -9,7 +9,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23524(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task VectorSearchWillNotOverrideTheAlreadyCalculatedScore()
     {
         const string spaghetti = "spaghetti";

--- a/test/SlowTests.Issues/Issues/RavenDB-23720.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23720.cs
@@ -17,7 +17,7 @@ public class RavenDB_23720 : EmbeddingsGenerationTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task AutoIndexWithVectorSearchShouldBeConvertibleToStatic()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests.Issues/Issues/RavenDB-23909.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23909.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task Auto(Options options)
     {
@@ -47,7 +47,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
     
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task AlreadyQuantizedVectorShouldThrow(Options options)
     {
@@ -94,7 +94,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task Static(Options options)
     {
@@ -131,7 +131,7 @@ public class RavenDB_23909(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task StaticJs(Options options)
     {

--- a/test/SlowTests.Issues/Issues/RavenDB-23960.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23960.cs
@@ -8,7 +8,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23960(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task DisabledTaskDoesntImpactCreationOfOtherTasks(Options options)
     {

--- a/test/SlowTests.Issues/Issues/RavenDB-23962.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23962.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public async Task ReferencedCollectionsShouldWorkWithStalenessHandling()
     {
         const string collectionName = "Dtos";
@@ -123,7 +123,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public async Task TombstonesAreProcessed()
     {
         const string collectionName = "Dtos";
@@ -175,7 +175,7 @@ public class RavenDB_23962(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenFact(RavenTestCategory.Indexes)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes, RavenArchitecture.AllX64)]
     public async Task DeletesAreHandled()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests.Issues/Issues/RavenDB-24816.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24816.cs
@@ -17,7 +17,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
     {
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public void OverlapTokensSettingShouldWork()
     {
         const string plainTextToChunk = "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -45,7 +45,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         Assert.Equal(expectedChunks, chunks);
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public void OverlapTokensSettingForMarkdownShouldWork()
     {
         const string markdownToChunk = """
@@ -80,7 +80,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         Assert.Equal(expectedChunks, chunks);
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task OverlapTokensSettingInScriptShouldWork()
     {
         const string plainTextToChunk =
@@ -120,7 +120,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task OverlapTokensSettingViaPathShouldWork()
     {
         const string plainTextToChunk =
@@ -202,7 +202,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task UnsupportedChunkingSettingsInScriptThrowRelevantException()
     {
         const string plainTextToChunk =
@@ -231,7 +231,7 @@ public class RavenDB_24816 : EmbeddingsGenerationTestBase
         }
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task OverlapTokensShouldBeBackwardCompatible()
     {
         const string plainTextToChunk =

--- a/test/SlowTests.Issues/Issues/RavenDB-25306.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25306.cs
@@ -13,7 +13,7 @@ public class RavenDB_25306 : EmbeddingsGenerationTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task EmbeddingsGenerationTaskShouldHandleReset()
     {
         using (var store = GetDocumentStore())

--- a/test/SlowTests.Issues/Issues/RavenDB-25508.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25508.cs
@@ -7,7 +7,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_25508(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public void CanSortByScoreWhenMultiVectorSearchIsSkippedInBinaryMatch()
     {
         using var store = GetDocumentStore();
@@ -32,7 +32,7 @@ public class RavenDB_25508(ITestOutputHelper output) : RavenTestBase(output)
         Assert.NotEmpty(result);
     }
     
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public void CanSortByScoreWhenVectorSearchIsSkippedInBinaryMatch()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests.Issues/Issues/RavenDB-25698.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25698.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_25698(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task EmbeddingGenerationCreatesValueInEmbeddingCacheDocument()
     {
 

--- a/test/SlowTests.Issues/Issues/RavenDB_23448.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_23448.cs
@@ -12,11 +12,11 @@ namespace SlowTests.Issues;
 
 public class RavenDB_23448(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     public void CanQueryTextualValuesInVectorSearchWhenFieldConfigurationIsNotExplicitlySet() =>
         CanQueryTextualValuesInVectorSearchWhenFieldConfigurationIsNotExplicitlySetBase<Index>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     public void CanQueryTextualValuesInVectorSearchWhenFieldConfigurationIsNotExplicitlySetJs() =>
         CanQueryTextualValuesInVectorSearchWhenFieldConfigurationIsNotExplicitlySetBase<IndexJs>();
     

--- a/test/SlowTests.Issues/Issues/RavenDB_23792.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_23792.cs
@@ -14,7 +14,7 @@ public class RavenDB_23792 : RavenTestBase
 
     public record Item(RavenVector<float> Vector, string Name);
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void TestRqlGeneration(Options options)
     {
@@ -37,7 +37,7 @@ public class RavenDB_23792 : RavenTestBase
         }
     }
     
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void CanQueryByDocumentVector(Options options)
     {

--- a/test/SlowTests.Issues/Issues/RavenDB_24613.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_24613.cs
@@ -9,7 +9,7 @@ namespace SlowTests.Issues;
 
 public class RavenDB_24613_MultipleEmbeddingsGenerateCalls(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task MultipleEmbeddingsGenerateCallsShouldCreateAllEmbeddings()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/Corax/RavenDB-23442.cs
+++ b/test/SlowTests/Corax/RavenDB-23442.cs
@@ -27,7 +27,7 @@ public class RavenDB_23442(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
     
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [MemberData(nameof(Theory))]
     public void SingleVectorSearchWillAlwaysBeSortedByDistance(bool sortVectorSearchByScoreAutomatically, bool includeScore)
     {
@@ -45,7 +45,7 @@ public class RavenDB_23442(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal("banana", results[1].Name);
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [MemberData(nameof(Theory))]
     public void VectorSearchWillAlwaysBeSortedByDistance(bool sortVectorSearchByScoreAutomatically, bool includeScore)
     {

--- a/test/SlowTests/Corax/RavenDB-24132.cs
+++ b/test/SlowTests/Corax/RavenDB-24132.cs
@@ -12,7 +12,7 @@ namespace SlowTests.Corax;
 
 public class RavenDB_24132(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes | RavenTestCategory.Corax)]
+    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Indexes | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void CanGetVectorsFromIndex()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentBasics.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         {
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanCreateAiAgent(Options options, GenAiConfiguration config)
         {
@@ -94,7 +94,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.NotNull(chat1);
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanGetAiAgent(Options options, GenAiConfiguration config)
         {
@@ -137,7 +137,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanResumeConversation(Options options, GenAiConfiguration config)
         {
@@ -187,7 +187,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.NotNull(chat.Id);
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanRunTest(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiBasics.cs
@@ -42,7 +42,7 @@ public class AiAgentClientApiBasics : RavenTestBase
         public int Quantity;
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { true })]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = new object[] { false })]
     public async Task AiAgentClientApiBasicTest(Options options, GenAiConfiguration config, bool sendSchema)

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -51,7 +51,7 @@ public class RavenDB_24407 : RavenTestBase
         public JToken Content { get; set; }
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, false])]
     [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true], Skip = "RavenDB-24806")]

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24611.cs
@@ -106,7 +106,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.Contains("'orders/1-A' doesn't exists", ex.InnerException?.Message);
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task Concurrency_When_Resuming_Same_Conversation(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25255.cs
@@ -25,7 +25,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         {
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
         public async Task CanUseQueryToolWithSecuredServer(Options options, GenAiConfiguration config)
         {

--- a/test/SlowTests/Server/Documents/AI/AiConnectionStringsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionStringsTests.cs
@@ -196,7 +196,7 @@ public class AiConnectionStringsTests : RavenTestBase
 
     private readonly List<string> _testValuesList = ["First test value", "Second test value", "Third test value"];
 
-    [RavenTheory(RavenTestCategory.Etl | RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Etl | RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [RavenAiEmbeddingsData(IntegrationType = RavenAiIntegration.All)]
     public void SemanticKernel_WithValidConfiguration_ShouldWork(Options options, EmbeddingsGenerationConfiguration embeddingsGenerationConfiguration)
     {

--- a/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiConnectionTests.cs
@@ -37,7 +37,7 @@ namespace SlowTests.Server.Documents.AI
             }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [ClassData(typeof(IntegrationDataType<Embeddings>))]
         public void CanConnectEmbeddings(RavenAiIntegration integration)
         {
@@ -62,7 +62,7 @@ namespace SlowTests.Server.Documents.AI
             }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
         [RavenAiEmbeddingsData(IntegrationType = RavenAiIntegration.All, DatabaseMode = RavenDatabaseMode.Single)]
         public void CanTestAiEmbeddingsConnectionString(Options options, EmbeddingsGenerationConfiguration configuration)
         {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/Cache/QueryEmbeddingsCacherTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/Cache/QueryEmbeddingsCacherTests.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings.Cache;
 
 public class QueryEmbeddingsCacherTests(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task ShouldCacheEmbeddings()
     {
         var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,7 +25,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CanSingleDocumentHaveTwoEmbeddings()
     {
         using var store = GetDocumentStore();
@@ -77,7 +77,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         AssertMissingEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Names", ["Name3"], id);
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task DocumentsWithSingleValue()
     {
         using (var store = GetDocumentStore())
@@ -100,7 +100,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task DocumentsWithListOfValues()
     {
         using (var store = GetDocumentStore())
@@ -124,7 +124,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task DocumentsWithNestedPropertyPath()
     {
         using (var store = GetDocumentStore())
@@ -150,7 +150,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task DocumentsWithNestedArrayPropertyPath()
     {
         using (var store = GetDocumentStore())
@@ -176,7 +176,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task EmbeddingsMustBeGeneratedOnlyOnceInDifferentBatches()
     {
         using (var store = GetDocumentStore())
@@ -230,7 +230,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task UpdateOfDocumentsWithSingleValue()
     {
         using (var store = GetDocumentStore())
@@ -269,7 +269,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task HandlingOfNonStringValues()
     {
         using (var store = GetDocumentStore())
@@ -293,7 +293,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task FieldsToIncludeMustBeRespected()
     {
         using (var store = GetDocumentStore())
@@ -323,7 +323,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task ModificationOfNonProcessedFieldsWillTriggerTaskButWontGenerateEmbeddings()
     {
         using (var store = GetDocumentStore())
@@ -387,7 +387,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task DefaultBatchSizeMustBeRespected()
     {
         using (var store = GetDocumentStore())
@@ -417,7 +417,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CustomBatchSizeMustBeRespected()
     {
         const int batchSize = 4;
@@ -455,7 +455,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task HandlingOfDocumentDeletions()
     {
         var dto1 = new Dto { Name = "Name1" };
@@ -498,7 +498,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task WillSetExpirationOnCacheDocuments()
     {
         var dto = new Dto { Name = "Name1" };
@@ -533,7 +533,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task WillUpdateExpirationOnCacheDocuments()
     {
         var dto = new Dto { Id = "dtos/1", Name = "Name1" };
@@ -600,7 +600,7 @@ public class GenerateEmbeddingsTests(ITestOutputHelper output) : EmbeddingsGener
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task SimpleJsTransformation()
     {
         const string aiIntegrationName = "local-Onnx-AI";
@@ -634,7 +634,7 @@ embeddings.generate(
         }
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task NestedJsTransformation()
     {
         const string aiIntegrationName = "local-Onnx-AI";
@@ -666,7 +666,7 @@ embeddings.generate(
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task HashingOfTextShouldBeCaseInsensitiveAndTrimWhitespaces()
     {
         var dto = new Dto() { Name = "\n UPPERCASEVALUE\n\r " };
@@ -694,7 +694,7 @@ embeddings.generate(
 
     private record Test(string Id, DateTime? Expires);
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task TextChunkingInScript()
     {
         const string plainTextToChunk =
@@ -725,7 +725,7 @@ embeddings.generate(
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public void ChunkPlainTextShouldWork()
     {
         const string plainTextToChunk = "this is a relatively long text that should produce multiple chunks because of the chunking configuration (max tokens per chunk)";
@@ -736,7 +736,7 @@ embeddings.generate(
         Assert.Equal(expectedChunks, chunks);
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public void PlainTextSplitLinesShouldWork()
     {
         const string plainTextToChunk = "This is a relatively - long text\n that should produce multiple chunks\n\r because of the chunking configuration; (max tokens per chunk). It also contains, separators in random places.";
@@ -747,7 +747,7 @@ embeddings.generate(
         Assert.Equal(expectedChunks, chunks);
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task MarkdownChunkingInScript()
     {
         const string markdownTextToChunk =
@@ -802,7 +802,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CanUseHtmlChunkingInScript()
     {
         const string htmlTextToChunk =
@@ -850,7 +850,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CanUseHtmlChunkingInPaths()
     {
         const string htmlTextToChunk =
@@ -904,7 +904,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task TransformationWithArrayFieldOutput()
     {
         var dto = new Dto { Name = "CoolName" };
@@ -963,7 +963,7 @@ Console.WriteLine(""Hello, World!"");";
         AssertEmbeddingsForPath(store, configuration2, connectionString2, "Names", ["CoolName"], id);
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task QuantizationOfEmbeddingsInTask()
     {
         var dto = new Dto { Name = "CoolName" };
@@ -1010,7 +1010,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     [InlineData(VectorEmbeddingType.Int8)]
     [InlineData(VectorEmbeddingType.Binary)]
     [InlineData(VectorEmbeddingType.Single)]
@@ -1108,7 +1108,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CollisionOfTwoEmbeddingsInSingleTask()
     {
         using var store = GetDocumentStore();
@@ -1146,7 +1146,7 @@ Console.WriteLine(""Hello, World!"");";
         AssertEmbeddingsForPath(store, config, connection, "Names", ["Name1"], id);
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CollisionOfTwoEmbeddingsInTwoTasks()
     {
         using var store = GetDocumentStore();
@@ -1194,7 +1194,7 @@ Console.WriteLine(""Hello, World!"");";
         AssertEmbeddingsForPath(store, config2, connection2, "Names", ["Name1"], id);
     }
     
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public async Task CanUseProjectedFieldNameForQuery()
     {
         const string plainTextToChunk = "some text that should produce a single chunk";

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorQuantizationTests.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int8()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -65,7 +65,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanPerformQuantizationInIndexFromEtl()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -108,7 +108,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexAlreadyQuantizedVectorAndQueryItProperly_Int1()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
@@ -148,7 +148,7 @@ public class LoadVectorQuantizationTests(ITestOutputHelper output) : EmbeddingsG
         }
     }
     
-    [RavenFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Indexes | RavenTestCategory.Querying | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task QuantizedValuesInCacheAreSeparated()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorTests.cs
@@ -19,10 +19,10 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexSingleVectorGeneratedByEtl() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByName>();
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexSingleVectorGeneratedByEtlJs() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByNameJs>();
 
     private async Task CanIndexSingleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
@@ -106,10 +106,10 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
         AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["sdklfjklsadjkl;assdjaskll"], id);
     }
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexMultipleVectorGeneratedByEtl() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNames>();
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexMultipleVectorGeneratedByEtlJs() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesJs>();
 
     private async Task CanIndexMultipleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
@@ -189,10 +189,10 @@ public class LoadVectorTests(ITestOutputHelper output) : EmbeddingsGenerationTes
     }
 
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexVectorFromTwoDifferentEtl() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFields>();
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexVectorFromTwoDifferentEtlJs() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsJs>();
 
     private async Task CanIndexVectorFromTwoDifferentEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -17,7 +17,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void CanGenerateRqlFromLinq(Options options)
     {
@@ -37,7 +37,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task CanGenerateEmbeddingsForQuerying(Options options)
     {
@@ -90,7 +90,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task CanFetchEmbeddingFromCache(Options options)
     {
@@ -133,7 +133,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task DoesIncorrectTaskNameInQueryThrow(Options options)
     {
@@ -184,7 +184,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task CanGenerateEmbeddingsWhenQueryingStaticIndex(Options options)
     {
@@ -235,7 +235,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task CanChunkValueInQuery(Options options)
     {
@@ -282,7 +282,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task CanSearchByMultipleVectorsByTexts(Options options)
     {
@@ -346,7 +346,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task CanSearchByMultipleVectorsByTextsInParallel(Options options)
     {

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB-24620.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class RavenDB_24620(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
     [InlineData(null, null)]
     [InlineData(null, VectorEmbeddingType.Single)]
     [InlineData(null, VectorEmbeddingType.Int8)]

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RavenDB_25000.cs
@@ -15,7 +15,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class RavenDB_25000(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanUseEmbeddingGenerationTaskInIndexEntriesQuery()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/RemovalTests.cs
@@ -9,7 +9,7 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class RemovalTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Etl)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
     public async Task TaskRemoveEmbeddingsDocumentOfRemovedDocument()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/TasksManagementTests.cs
@@ -18,7 +18,7 @@ public class TasksManagementTests : RavenTestBase
     {
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public void CanDeleteTask()
     {
         using var store = GetDocumentStore();
@@ -48,7 +48,7 @@ public class TasksManagementTests : RavenTestBase
         Assert.Null(ongoingTask);
     }
 
-    [RavenFact(RavenTestCategory.Ai)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
     public void CanUpdateTask()
     {
         using var store = GetDocumentStore();

--- a/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
+++ b/test/SlowTests/Smuggler/BackupDatabaseRecordTests.cs
@@ -68,7 +68,7 @@ namespace SlowTests.Smuggler
             Assert.Equal(52, fieldNames.Count);
         }
 
-        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
+        [RavenMultiplatformFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport, RavenArchitecture.AllX64)]
         public async Task CanExportAndImportDatabaseRecord()
         {
             var file = Path.GetTempFileName();
@@ -1114,7 +1114,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport, SnowflakeRequired = true)]
+        [RavenMultiplatformFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport, RavenArchitecture.AllX64, SnowflakeRequired = true)]
         public async Task CanBackupAndRestoreDatabaseRecord()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1446,7 +1446,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.Subscriptions)]
+        [RavenMultiplatformFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport | RavenTestCategory.Subscriptions, RavenArchitecture.AllX64)]
         public async Task CanRestoreSubscriptionsFromBackup()
         {
             var backupPath = NewDataPath(suffix: "BackupFolder");
@@ -1526,7 +1526,7 @@ namespace SlowTests.Smuggler
             }
         }
 
-        [RavenTheory(RavenTestCategory.BackupExportImport)]
+        [RavenMultiplatformTheory(RavenTestCategory.BackupExportImport, RavenArchitecture.AllX64)]
         [InlineData(true)]
         [InlineData(false)]
         public async Task CanDisableTasksAfterRestore(bool disableOngoingTasks)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26118

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
