### PR TITLE
RavenDB-26097 Facets timings fix 

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -70,11 +70,10 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         var query = facetQuery.Query;
         Dictionary<string, Dictionary<string, FacetValues>> facetsByName = new();
         Dictionary<string, Dictionary<string, FacetValues>> facetsByRange = new();
-        var coraxPageSize = CoraxBufferSize(_indexSearcher, facetQuery.Query.PageSize, query);
-        var ids = CoraxIndexReadOperation.QueryPool.Rent(coraxPageSize);
         CreateMappingForRanges(results, facetsByRange, facetQuery);
         foreach (var result in results)
         {
+            using var facetTiming = queryTimings?.For($"{nameof(QueryTimingsScope.Names.AggregateBy)}/{result.Key}");
             var needToApplyAggregation = result.Value.Aggregations.Count > 0;
             Dictionary<string, FacetValues> facetValues;
             if (result.Value.Ranges == null || result.Value.Ranges.Count == 0)
@@ -151,7 +150,6 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         UpdateFacetResults(results, query, facetsByName);
         CompleteFacetCalculationsStage(results, query);
 
-        CoraxIndexReadOperation.QueryPool.Return(ids);
         return results.Values
             .Select(x => x.Result)
             .ToList();
@@ -217,6 +215,9 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         UpdateFacetResults(results, query, facetsByName);
 
         CompleteFacetCalculationsStage(results, query);
+        queryTimings?.SetQueryPlan(baseQuery.Inspect());
+
+        
         CoraxIndexReadOperation.QueryPool.Return(ids);
         return results.Values
             .Select(x => x.Result)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26097

### Additional description

- Exposed QueryPlan for scanned facets
- Exposed timings for indexed facets
- Removed unnecessary allocations from indexed facets


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
