### PR TITLE
RavenDB-26011 remove obsolete SupportsAtomicClusterWrites  property

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchCommand.cs
@@ -36,8 +36,8 @@ namespace Raven.Client.Documents.Commands.Batches
 
     public class SingleNodeBatchCommand : RavenCommand<BatchCommandResult>, IDisposable
     {
+        private bool _commandsCreated;
         private readonly BlittableJsonReaderObject[] _commandsAsJson;
-        private bool? _supportsAtomicWrites;
         private HashSet<Stream> _uniqueAttachmentStreams;
         private readonly DocumentConventions _conventions;
         private readonly IList<ICommandData> _commands;
@@ -66,7 +66,7 @@ namespace Raven.Client.Documents.Commands.Batches
 
         private void HandlePutAttachmentCommandData(ICommandData command)
         {
-            if (command is not PutAttachmentCommandData putAttachmentCommandData) 
+            if (command is not PutAttachmentCommandData putAttachmentCommandData)
                 return;
 
             if (PutAttachmentCommandHelper.TryValidateStream(putAttachmentCommandData.Stream, putAttachmentCommandData.RemoteParameters) == false)
@@ -81,21 +81,18 @@ namespace Raven.Client.Documents.Commands.Batches
 
         public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
         {
-            if (_supportsAtomicWrites == null)
+            if (_commandsCreated == false)
             {
-                _supportsAtomicWrites = node.SupportsAtomicClusterWrites;
                 for (var i = 0; i < _commands.Count; i++)
                 {
                     var command = _commands[i];
 
                     var json = command.ToJson(_conventions, ctx);
 
-                    if (node.SupportsAtomicClusterWrites == false)
-                    {   // support older clients
-                        json.RemoveInMemoryPropertyByName(nameof(PutCommandData.OriginalChangeVector));
-                    }
                     _commandsAsJson[i] = ctx.ReadObject(json, "command");
                 }
+
+                _commandsCreated = true;
             }
 
             var request = new HttpRequestMessage

--- a/src/Raven.Client/Http/ServerNode.cs
+++ b/src/Raven.Client/Http/ServerNode.cs
@@ -63,20 +63,6 @@ namespace Raven.Client.Http
             }
         }
 
-        private bool? _supportsAtomicClusterWrites;
-
-        internal bool SupportsAtomicClusterWrites
-        {
-            get
-            {
-                if (_supportsAtomicClusterWrites.HasValue)
-                    return _supportsAtomicClusterWrites.Value;
-
-                UpdateServerVersion(LastServerVersion);
-                return _supportsAtomicClusterWrites.Value;
-            }
-        }
-
         public bool ShouldUpdateServerVersion()
         {
             if (LastServerVersion == null || _lastServerVersionCheck > 100)
@@ -90,16 +76,6 @@ namespace Raven.Client.Http
         {
             LastServerVersion = serverVersion;
             _lastServerVersionCheck = 0;
-            if (serverVersion != null && Version.TryParse(serverVersion, out var ver))
-            {
-                // 5.2 or higher
-                _supportsAtomicClusterWrites = ver.Major == 5 && ver.Minor >= 2 ||
-                                               ver.Major > 5;
-            }
-            else
-            {
-                _supportsAtomicClusterWrites = false;
-            }
         }
 
         public void DiscardServerVersion()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26011

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
