### PR TITLE
RavenDB-25065 Alert on possible GC contention due to high mismatch of machine cores vs licensed cores

### DIFF
--- a/src/Raven.Server/Monitoring/GcThreadContentionDetector.cs
+++ b/src/Raven.Server/Monitoring/GcThreadContentionDetector.cs
@@ -15,7 +15,7 @@ namespace Raven.Server.Monitoring
     public sealed class GcThreadContentionDetector : IDisposable
     {
         private static readonly TimeSpan InitialCheckDelay = TimeSpan.FromSeconds(30);
-        private const double CoreUtilizationThreshold = 0.5;
+        private const double MinimumContentionRatioThreshold = 0.5;
         private const int MinimumCoreDifference = 8;
 
         private readonly ServerStore _serverStore;
@@ -41,12 +41,13 @@ namespace Raven.Server.Monitoring
                 var totalCores = ProcessorInfo.ProcessorCount;
                 var utilizedCores = _serverStore.LicenseManager.GetNumberOfUtilizedCores();
                 var coreDifference = totalCores - utilizedCores;
+                var contentionRatio = (double)coreDifference / utilizedCores;
 
-                if (coreDifference < MinimumCoreDifference)
+                if (coreDifference < MinimumCoreDifference || contentionRatio < MinimumContentionRatioThreshold)
+                {
+                    DismissAlert();
                     return;
-
-                if (utilizedCores >= totalCores * CoreUtilizationThreshold)
-                    return;
+                }
 
                 IReadOnlyDictionary<string, object> gcConfig = GC.GetConfigurationVariables();
 
@@ -55,7 +56,10 @@ namespace Raven.Server.Monitoring
                     var heapCountInt64 = Convert.ToInt64(heapCount);
 
                     if (heapCountInt64 <= utilizedCores)
+                    {
+                        DismissAlert();
                         return;
+                    }
                 }
 
 
@@ -101,6 +105,12 @@ namespace Raven.Server.Monitoring
                 _logger.Operations($"GC thread contention detected: {totalCores} total cores but only {utilizedCores} utilized core(s). " +
                                   $"Consider configuring System.GC.HeapCount={utilizedCores} in Raven.Server.runtimeconfig.json or set DOTNET_GCHeapCount={utilizedCores:X} env variable");
             }
+        }
+
+
+        private void DismissAlert()
+        {
+            _notificationCenter.Dismiss(AlertRaised.GetKey(AlertType.GcThreadContention, null));
         }
 
         public void Dispose()

--- a/src/Raven.Server/Monitoring/GcThreadContentionDetector.cs
+++ b/src/Raven.Server/Monitoring/GcThreadContentionDetector.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Diagnostics;
+using System.Runtime;
+using System.Threading;
+using Raven.Server.NotificationCenter;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide;
+using Sparrow.Logging;
+using Sparrow.Utils;
+
+namespace Raven.Server.Monitoring
+{
+    public sealed class GcThreadContentionDetector : IDisposable
+    {
+        private static readonly TimeSpan InitialCheckDelay = TimeSpan.FromSeconds(30);
+        private const double CoreUtilizationThreshold = 0.5;
+        private const int MinimumCoreDifference = 8;
+
+        private readonly ServerStore _serverStore;
+        private readonly ServerNotificationCenter _notificationCenter;
+        private readonly Logger _logger = LoggingSource.Instance.GetLogger<GcThreadContentionDetector>(nameof(GcThreadContentionDetector));
+        private Timer _timer;
+
+        public GcThreadContentionDetector(ServerStore serverStore, ServerNotificationCenter notificationCenter)
+        {
+            _serverStore = serverStore;
+            _notificationCenter = notificationCenter;
+
+            _timer = new Timer(CheckGcThreadContention, null, InitialCheckDelay, Timeout.InfiniteTimeSpan);
+        }
+
+        private void CheckGcThreadContention(object state)
+        {
+            try
+            {
+                if (GCSettings.IsServerGC == false)
+                    return;
+
+                var totalCores = ProcessorInfo.ProcessorCount;
+                var utilizedCores = _serverStore.LicenseManager.GetNumberOfUtilizedCores();
+                var coreDifference = totalCores - utilizedCores;
+
+                if (coreDifference < MinimumCoreDifference)
+                    return;
+
+                if (utilizedCores >= totalCores * CoreUtilizationThreshold)
+                    return;
+
+                RaiseAlert(totalCores, utilizedCores);
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsOperationsEnabled)
+                    _logger.Operations("Failed to check if there might be GC threads contention", e);
+            }
+            finally
+            {
+                _timer?.Dispose();
+                _timer = null;
+            }
+        }
+
+        private void RaiseAlert(int totalCores, int utilizedCores)
+        {
+            var details = new GcThreadContentionDetails
+            {
+                TotalCores = totalCores,
+                UtilizedCores = utilizedCores,
+                Message = $"Your server has {totalCores} CPU cores but is limited to use only {utilizedCores} core(s) by the license. " +
+                          $"With Server GC enabled, .NET creates one GC thread per core ({totalCores} threads), but all threads are forced to run on {utilizedCores} core(s). " +
+                          $"This can cause severe GC pauses due to thread contention. " +
+                          $"To resolve this, configure the 'System.GC.HeapCount' setting in your Raven.Server.runtimeconfig.json file or set 'DOTNET_GCHeapCount' env variable to " +
+                          $"match your utilized cores ({utilizedCores})."
+            };
+
+            var alert = AlertRaised.Create(
+                null,
+                "Possible GC thread contention detected",
+                details.Message,
+                AlertType.GcThreadContention,
+                NotificationSeverity.Warning,
+                details: details);
+
+            _notificationCenter.Add(alert);
+
+            if (_logger.IsOperationsEnabled)
+            {
+                _logger.Operations($"GC thread contention detected: {totalCores} total cores but only {utilizedCores} utilized core(s). " +
+                                  $"Consider configuring System.GC.HeapCount={utilizedCores} in Raven.Server.runtimeconfig.json or set DOTNET_GCHeapCount={utilizedCores:X} env variable");
+            }
+        }
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+            _timer = null;
+        }
+    }
+}

--- a/src/Raven.Server/Monitoring/GcThreadContentionDetector.cs
+++ b/src/Raven.Server/Monitoring/GcThreadContentionDetector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime;
 using System.Threading;
@@ -46,6 +47,17 @@ namespace Raven.Server.Monitoring
 
                 if (utilizedCores >= totalCores * CoreUtilizationThreshold)
                     return;
+
+                IReadOnlyDictionary<string, object> gcConfig = GC.GetConfigurationVariables();
+
+                if (gcConfig.TryGetValue("HeapCount", out object heapCount))
+                {
+                    var heapCountInt64 = Convert.ToInt64(heapCount);
+
+                    if (heapCountInt64 <= utilizedCores)
+                        return;
+                }
+
 
                 RaiseAlert(totalCores, utilizedCores);
             }

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -95,5 +95,7 @@ namespace Raven.Server.NotificationCenter.Notifications
         ConflictRevisionsExceeded,
         
         SqlConnectionString_DeprecatedFactoryReplaced,
+
+        GcThreadContention,
     }
 }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/GcThreadContentionDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/GcThreadContentionDetails.cs
@@ -1,0 +1,23 @@
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public sealed class GcThreadContentionDetails : INotificationDetails
+    {
+        public int TotalCores { get; set; }
+
+        public int UtilizedCores { get; set; }
+
+        public string Message { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue(GetType())
+            {
+                [nameof(TotalCores)] = TotalCores,
+                [nameof(UtilizedCores)] = UtilizedCores,
+                [nameof(Message)] = Message
+            };
+        }
+    }
+}

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -139,6 +139,7 @@ namespace Raven.Server.ServerWide
         public readonly FeedbackSender FeedbackSender;
         public readonly StorageSpaceMonitor StorageSpaceMonitor;
         public readonly ServerLimitsMonitor ServerLimitsMonitor;
+        public readonly GcThreadContentionDetector GcThreadContentionDetector;
         public readonly SecretProtection Secrets;
         public readonly AsyncManualResetEvent InitializationCompleted;
         public readonly GlobalIndexingScratchSpaceMonitor GlobalIndexingScratchSpaceMonitor;
@@ -206,6 +207,8 @@ namespace Raven.Server.ServerWide
             StorageSpaceMonitor = new StorageSpaceMonitor(NotificationCenter);
 
             ServerLimitsMonitor = new ServerLimitsMonitor(this, NotificationCenter, _notificationsStorage);
+
+            GcThreadContentionDetector = new GcThreadContentionDetector(this, NotificationCenter);
 
             DatabaseInfoCache = new DatabaseInfoCache(this);
 
@@ -2717,6 +2720,7 @@ namespace Raven.Server.ServerWide
                     {
                         StorageSpaceMonitor,
                         ServerLimitsMonitor,
+                        GcThreadContentionDetector,
                         NotificationCenter,
                         LicenseManager,
                         DatabasesLandlord,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25065/GC-threads-contention-causing-long-pause-in-environments-with-license-limited-CPU-cores

### Additional description

Detection and warning about GC thread contention in license-limited deployments

<img width="431" height="368" alt="image" src="https://github.com/user-attachments/assets/d2ab04a5-4744-4971-9bb9-3f706343cbb4" />

When the alert will be shown:

| Total | Utilized | Diff | Ratio | Alert |
|------:|--------:|-----:|------:|:-----:|
| 2 | 1 | 1 | 1.00 | No |
| 4 | 2 | 2 | 1.00 | No |
| 8 | 4 | 4 | 1.00 | No |
| 16 | 4 | 12 | 3.00 | Yes |
| 16 | 8 | 8 | 1.00 | Yes |
| 16 | 12 | 4 | 0.33 | No |
| 32 | 8 | 24 | 3.00 | Yes |
| 32 | 16 | 16 | 1.00 | Yes |
| 32 | 20 | 12 | 0.60 | Yes |
| 32 | 24 | 8 | 0.33 | No |
| 64 | 16 | 48 | 3.00 | Yes |
| 64 | 32 | 32 | 1.00 | Yes |
| 64 | 42 | 22 | 0.52 | Yes |
| 128 | 32 | 96 | 3.00 | Yes |
| 128 | 64 | 64 | 1.00 | Yes |
| 128 | 85 | 43 | 0.51 | Yes |
| 128 | 96 | 32 | 0.33 | No |

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
