### PR TITLE
RavenDB-26124 - heartbeat was not sent under high document write rate

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -70,6 +70,7 @@ using Constants = Raven.Client.Constants;
 using MountPointUsage = Raven.Client.ServerWide.Operations.MountPointUsage;
 using Size = Raven.Client.Util.Size;
 using System.Diagnostics.CodeAnalysis;
+using Jint;
 using Sparrow.Server.Utils;
 
 namespace Raven.Server.Documents
@@ -2203,6 +2204,13 @@ namespace Raven.Server.Documents
                 ActionToCallDuringDocumentDatabaseInternalDispose = action;
 
                 return new DisposableAction(() => ActionToCallDuringDocumentDatabaseInternalDispose = null);
+            }
+
+            internal Action<Engine> ActionToCallDuringScriptRunnerCreation;
+
+            public void CallDuringScriptRunnerCreation(Action<Engine> action)
+            {
+                ActionToCallDuringScriptRunnerCreation = action;
             }
 
             internal Func<Task, Task<bool>> Subscription_ActionToCallDuringWaitForChangedDocuments;

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2205,12 +2205,12 @@ namespace Raven.Server.Documents
                 return new DisposableAction(() => ActionToCallDuringDocumentDatabaseInternalDispose = null);
             }
 
-            internal Action Subscription_ActionToCallDuringWaitForChangedDocuments;
+            internal Func<Task, Task<bool>> Subscription_ActionToCallDuringWaitForChangedDocuments;
             internal Action<long> Subscription_ActionToCallAfterRegisterSubscriptionConnection;
             internal Action<ConcurrentSet<SubscriptionConnection>> ConcurrentSubscription_ActionToCallDuringWaitForSubscribe;
             internal Action Subscription_ActionToCallDuringWaitForAck;
 
-            internal IDisposable CallDuringWaitForChangedDocuments(Action action)
+            internal IDisposable CallDuringWaitForChangedDocuments(Func<Task, Task<bool>> action)
             {
                 Subscription_ActionToCallDuringWaitForChangedDocuments = action;
 

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -313,7 +313,8 @@ namespace Raven.Server.Documents.Patch
                 consoleObject.FastSetProperty("log", new PropertyDescriptor(new ClrFunction(ScriptEngine, "log", OutputDebug), false, false, false));
                 ScriptEngine.SetValue("console", consoleObject);
 
-                ScriptEngine.SetValue("sleep", new Action<int>(Thread.Sleep));
+                // add more functions to the script engine that are needed for testing purposes
+                _database?.ForTestingPurposes?.ActionToCallDuringScriptRunnerCreation?.Invoke(ScriptEngine);
 
                 //spatial.distance
                 ObjectInstance spatialObject = new JsObject(ScriptEngine);

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -313,6 +313,8 @@ namespace Raven.Server.Documents.Patch
                 consoleObject.FastSetProperty("log", new PropertyDescriptor(new ClrFunction(ScriptEngine, "log", OutputDebug), false, false, false));
                 ScriptEngine.SetValue("console", consoleObject);
 
+                ScriptEngine.SetValue("sleep", new Action<int>(Thread.Sleep));
+
                 //spatial.distance
                 ObjectInstance spatialObject = new JsObject(ScriptEngine);
                 var spatialFunc = new ClrFunction(ScriptEngine, "distance", Spatial_Distance);

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
@@ -328,9 +328,9 @@ public abstract class AbstractSubscriptionConnectionsState<TSubscriptionConnecti
         return _connections.IsEmpty == false;
     }
 
-    public Task<bool> WaitForSubscriptionActiveLock(int millisecondsTimeout)
+    public Task<bool> WaitForSubscriptionActiveLock(int millisecondsTimeout, CancellationToken token)
     {
-        return _subscriptionActivelyWorkingLock.WaitAsync(millisecondsTimeout);
+        return _subscriptionActivelyWorkingLock.WaitAsync(millisecondsTimeout, token);
     }
 
     public void ReleaseSubscriptionActiveLock()

--- a/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
+++ b/src/Raven.Server/Documents/Subscriptions/AbstractSubscriptionConnectionsState.cs
@@ -328,7 +328,7 @@ public abstract class AbstractSubscriptionConnectionsState<TSubscriptionConnecti
         return _connections.IsEmpty == false;
     }
 
-    public Task<bool> WaitForSubscriptionActiveLock(int millisecondsTimeout, CancellationToken token)
+    public Task<bool> WaitForSubscriptionActiveLockAsync(int millisecondsTimeout, CancellationToken token)
     {
         return _subscriptionActivelyWorkingLock.WaitAsync(millisecondsTimeout, token);
     }

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -266,7 +266,7 @@ namespace Raven.Server.Documents.Subscriptions
 
             if (sendingCurrentBatchStopwatch.Elapsed >= ISubscriptionConnection.HeartbeatTimeout)
             {
-                await SendHeartBeatAsync($"Didn't find any documents to send and more then {ISubscriptionConnection.HeartbeatTimeout.TotalMilliseconds}ms passed");
+                await SendHeartBeatAsync($"Didn't find any documents to send and more than {ISubscriptionConnection.HeartbeatTimeout.TotalMilliseconds}ms passed");
                 sendingCurrentBatchStopwatch.Restart();
             }
         }
@@ -282,7 +282,7 @@ namespace Raven.Server.Documents.Subscriptions
             where TState : AbstractSubscriptionConnectionsState<TConnection, TIncludesCommand>
             where TConnection : SubscriptionConnectionBase<TIncludesCommand>
         {
-            if (await state.WaitForSubscriptionActiveLock(ISubscriptionConnection.WaitForChangedDocumentsTimeoutInMs, CancellationTokenSource.Token) == false)
+            if (await state.WaitForSubscriptionActiveLockAsync(ISubscriptionConnection.WaitForChangedDocumentsTimeoutInMs, CancellationTokenSource.Token) == false)
                 return SubscriptionBatchStatus.EmptyBatch;
 
             try

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -148,6 +148,8 @@ namespace Raven.Server.Documents.Subscriptions
 
                 AfterProcessorCreation();
 
+                var sendingCurrentBatchStopwatch = Stopwatch.StartNew();
+
                 while (CancellationTokenSource.IsCancellationRequested == false)
                 {
                     _buffer.SetLength(0);
@@ -162,7 +164,6 @@ namespace Raven.Server.Documents.Subscriptions
                         try
                         {
                             using var markInUse = MarkInUse();
-                            var sendingCurrentBatchStopwatch = Stopwatch.StartNew();
 
                             var status = await TrySendingBatchToClientAsync<TState, TConnection>(state, sendingCurrentBatchStopwatch, batchScope, inProgressBatchStats);
 
@@ -264,7 +265,10 @@ namespace Raven.Server.Documents.Subscriptions
             Stats.UpdateBatchPerformanceStats(0, false);
 
             if (sendingCurrentBatchStopwatch.Elapsed >= ISubscriptionConnection.HeartbeatTimeout)
+            {
                 await SendHeartBeatAsync($"Didn't find any documents to send and more then {ISubscriptionConnection.HeartbeatTimeout.TotalMilliseconds}ms passed");
+                sendingCurrentBatchStopwatch.Restart();
+            }
         }
 
         protected virtual void OnError(Exception e) { }
@@ -409,7 +413,11 @@ namespace Raven.Server.Documents.Subscriptions
                 var resultingTask = await Task
                     .WhenAny(hasMoreDocsTask, _lastReplyFromClientTask, timeoutTask).ConfigureAwait(false);
 
-                TcpConnection.DocumentDatabase?.ForTestingPurposes?.Subscription_ActionToCallDuringWaitForChangedDocuments?.Invoke();
+                if (TcpConnection.DocumentDatabase is { ForTestingPurposes.Subscription_ActionToCallDuringWaitForChangedDocuments: not null })
+                {
+                    if (await TcpConnection.DocumentDatabase.ForTestingPurposes.Subscription_ActionToCallDuringWaitForChangedDocuments(hasMoreDocsTask))
+                        return true;
+                }
 
                 if (CancellationTokenSource.IsCancellationRequested)
                     return false;

--- a/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
+++ b/src/Raven.Server/Documents/Subscriptions/SubscriptionConnectionBase.cs
@@ -282,7 +282,7 @@ namespace Raven.Server.Documents.Subscriptions
             where TState : AbstractSubscriptionConnectionsState<TConnection, TIncludesCommand>
             where TConnection : SubscriptionConnectionBase<TIncludesCommand>
         {
-            if (await state.WaitForSubscriptionActiveLock(300) == false)
+            if (await state.WaitForSubscriptionActiveLock(ISubscriptionConnection.WaitForChangedDocumentsTimeoutInMs, CancellationTokenSource.Token) == false)
                 return SubscriptionBatchStatus.EmptyBatch;
 
             try

--- a/test/RachisTests/SubscriptionsFailover.cs
+++ b/test/RachisTests/SubscriptionsFailover.cs
@@ -830,10 +830,11 @@ namespace RachisTests
                             var testingStuff = db.ForTestingPurposesOnly();
                             bool shouldWaitForClusterStabilization = false;
                             var subscriptionInterrupt = new AsyncManualResetEvent();
-                            using (testingStuff.CallDuringWaitForChangedDocuments(() =>
+                            using (testingStuff.CallDuringWaitForChangedDocuments(_ =>
                                    {
                                        shouldWaitForClusterStabilization = db.SubscriptionStorage.ShouldWaitForClusterStabilization();
                                        subscriptionInterrupt.Set();
+                                       return Task.FromResult(false);
                                    }))
                             {
                                 await subscriptionInterrupt.WaitAsync(_reasonableWaitTime);
@@ -848,10 +849,11 @@ namespace RachisTests
                         var testingStuff = db.ForTestingPurposesOnly();
                         bool shouldWaitForClusterStabilization = false;
                         var subscriptionInterrupt = new AsyncManualResetEvent();
-                        using (testingStuff.CallDuringWaitForChangedDocuments(() =>
+                        using (testingStuff.CallDuringWaitForChangedDocuments(_ =>
                                {
                                    shouldWaitForClusterStabilization = db.SubscriptionStorage.ShouldWaitForClusterStabilization();
                                    subscriptionInterrupt.Set();
+                                   return Task.FromResult(false);
                                }))
                         {
                             await subscriptionInterrupt.WaitAsync(_reasonableWaitTime);

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -1535,6 +1535,14 @@ where predicate.call(doc)"
         {
             using (var store = GetDocumentStore())
             {
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var testingStuff = db.ForTestingPurposesOnly();
+
+                testingStuff.CallDuringScriptRunnerCreation(scriptEngine =>
+                {
+                    scriptEngine.SetValue("sleep", new Action<int>(Thread.Sleep));
+                });
+
                 var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
                 {
                     Query = @"declare function f(u) { 
@@ -1548,8 +1556,6 @@ select f(u)
 "
                 });
 
-                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
-                var testingStuff = db.ForTestingPurposesOnly();
                 long location = 0L;
                 var docsCount = 0;
                 using (testingStuff.CallDuringWaitForChangedDocuments(async hasMoreDocsTask =>

--- a/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
+++ b/test/SlowTests/Client/Subscriptions/ConcurrentSubscriptionsTests.cs
@@ -20,6 +20,7 @@ using Sparrow.Collections;
 using Sparrow.Extensions;
 using Sparrow.Json;
 using Sparrow.Server;
+using Sparrow.Utils;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -1526,6 +1527,134 @@ where predicate.call(doc)"
                 docs.UnionWith(await RunSubscriptionWorkerAndProcessOneDocumentAsync(store, id));
 
                 Assert.Equal(3, docs.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Subscriptions)]
+        public async Task UnluckyConcurrentSubscriptionsShouldSendHeartbeats()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var id = await store.Subscriptions.CreateAsync(new SubscriptionCreationOptions()
+                {
+                    Query = @"declare function f(u) { 
+// sleep for 3 seconds 
+
+sleep(u.Age);
+    return u;
+}
+from Users as u
+select f(u)
+"
+                });
+
+                var db = await Databases.GetDocumentDatabaseInstanceFor(store);
+                var testingStuff = db.ForTestingPurposesOnly();
+                long location = 0L;
+                var docsCount = 0;
+                using (testingStuff.CallDuringWaitForChangedDocuments(async hasMoreDocsTask =>
+                {
+                    if (Interlocked.Read(ref location) == 1)
+                    {
+                        return false;
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        session.Store(new User() { Age = 1 });
+                        session.SaveChanges();
+                    }
+
+                    var timeoutTask = TimeoutManager.WaitFor(TimeSpan.FromSeconds(1));
+
+                    var res = await Task.WhenAny(hasMoreDocsTask, timeoutTask);
+                    docsCount++;
+                    if (res == hasMoreDocsTask)
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }))
+                {
+                    var subscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+                    {
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        ConnectionStreamTimeout = TimeSpan.FromSeconds(15),
+                        MaxDocsPerBatch = 6
+                    });
+
+                    await using (var secondSubscription = store.Subscriptions.GetSubscriptionWorker(new SubscriptionWorkerOptions(id)
+                    {
+                        Strategy = SubscriptionOpeningStrategy.Concurrent,
+                        TimeToWaitBeforeConnectionRetry = TimeSpan.FromSeconds(1),
+                        ConnectionStreamTimeout = TimeSpan.FromSeconds(15)
+
+                    }))
+                    {
+                        using (var session = store.OpenSession())
+                        {
+                            session.Store(new User { Age = 3000 }, "user/0");
+                            session.Store(new User { Age = 3000 }, "user/1");
+                            session.Store(new User { Age = 3000 }, "user/2");
+                            session.Store(new User { Age = 3000 }, "user/3");
+                            session.Store(new User { Age = 3000 }, "user/4");
+                            session.Store(new User { Age = 3000 }, "user/5");
+
+                            session.SaveChanges();
+                        }
+
+                        var mre = new AsyncManualResetEvent();
+                        var mre2 = new AsyncManualResetEvent();
+
+                        subscription.OnEstablishedSubscriptionConnection += () =>
+                        {
+                            mre.Set();
+                        };
+                        subscription.AfterAcknowledgment += batch =>
+                        {
+                            mre2.Set();
+                            return Task.CompletedTask;
+                        };
+                        var con1Docs = new ConcurrentSet<string>();
+                        var con2Docs = new ConcurrentSet<string>();
+
+                        var t = subscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con1Docs.Add(item.Id);
+                            }
+                        });
+
+                        Assert.True(await mre.WaitAsync(_reasonableWaitTime));
+                        var exceptions = new ConcurrentSet<Exception>();
+
+                        secondSubscription.OnUnexpectedSubscriptionError += ex =>
+                        {
+                            exceptions.Add(ex);
+                        };
+
+                        var _ = secondSubscription.Run(x =>
+                        {
+                            foreach (var item in x.Items)
+                            {
+                                con2Docs.Add(item.Id);
+                            }
+                        });
+
+                        Assert.True(await mre2.WaitAsync(_reasonableWaitTime));
+                        Interlocked.Increment(ref location);
+
+                        await subscription.DisposeAsync();
+
+                        await AssertWaitForTrueAsync(() => Task.FromResult(con1Docs.Count + con2Docs.Count == docsCount + 6), Convert.ToInt32(_reasonableWaitTime.TotalMilliseconds));
+                        await AssertNoLeftovers(store, id);
+                        Assert.NotEmpty(con2Docs);
+                        Assert.True(exceptions.Count == 0, $"exceptions.Count == 0{Environment.NewLine}"+string.Join(", ", exceptions));
+                    }
+                }
             }
         }
 

--- a/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
+++ b/test/SlowTests/Client/Subscriptions/SubscriptionsBasic.cs
@@ -1218,7 +1218,7 @@ namespace SlowTests.Client.Subscriptions
                 var testingStuff = db.ForTestingPurposesOnly();
 
                 var subscriptionInterrupt = new AsyncManualResetEvent();
-                using (testingStuff.CallDuringWaitForChangedDocuments(() =>
+                using (testingStuff.CallDuringWaitForChangedDocuments(_ =>
                        {
                            worker1Retry ??= new AsyncManualResetEvent();
                            subscriptionInterrupt.Set();
@@ -1252,7 +1252,7 @@ namespace SlowTests.Client.Subscriptions
                        }))
                 {
                     subscriptionInterrupt.Reset(true);
-                    using (testingStuff.CallDuringWaitForChangedDocuments(() =>
+                    using (testingStuff.CallDuringWaitForChangedDocuments(_ =>
                            {
                                // drop subscription
                                worker2Retry ??= new ManualResetEvent(false);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26124

### Additional description

This pull request introduces several improvements and fixes to the subscription processing system, focusing on improving the handling of concurrent subscription wait logic under high document write rate. 

The issue was that we might not send single Heartbeat to client if documents were added (or updated) during the `WaitForChangedDocsAsync()` and the particular subscription connection was not lucky to get the active subscription lock (`WaitForSubscriptionActiveLock`) which likely to happen if the processing of subscription batch takes long or there is high contention on the lock.

Also increased the timeout for `WaitForSubscriptionActiveLock` from 300ms to 3sec, to decrease non necessary work during high document write rate, or active long subscription batch.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
