### PR TITLE
RavenDB-25891 Add node tag to export db file name

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/exportDatabase.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/exportDatabase.ts
@@ -117,7 +117,10 @@ class exportDatabase extends shardViewModelBase {
 
     private setupDefaultExportFilename(): void {
         const date = moment().format("YYYY-MM-DD HH-mm");
-        const detailedDatabaseName = DatabaseUtils.default.formatNameForFile(this.db.name, this.location);
+
+        const detailedDatabaseName = DatabaseUtils.default.formatNameForFile(this.db.name, {
+            nodeTag: this.db.clusterNodeTag(),
+        });
         
         this.model.exportFileName(`Dump of ${detailedDatabaseName} ${date}`);
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25891/Exported-database-file-name-should-include-the-node-tag

### Additional description

`this.location` works only for views with `shardingMode: "singleShard"`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
