### PR TITLE
RavenDB-26065 - Setup Wizard: Add validation to "Setup certificate path"

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
+++ b/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
@@ -156,12 +156,7 @@ const additionalSettingsStepSchema = yup.object({
                 }
 
                 // Check if the path ends with .pfx (case-insensitive)
-                if (!/\.pfx$/i.test(value)) {
-                    return false;
-                }
-
-                // Check if the path doesn't end with a directory separator
-                return !(value.endsWith("/") || value.endsWith("\\"));
+                return /\.pfx$/i.test(value);
             }
         ),
     postgresqlIntegration: yup.boolean(),

--- a/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
+++ b/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
@@ -144,7 +144,26 @@ const additionalSettingsStepSchema = yup.object({
 
     // advanced settings
     dataDirectory: yup.string().nullable(),
-    setupCertificatePath: yup.string().nullable(),
+    setupCertificatePath: yup
+        .string()
+        .nullable()
+        .test(
+            "is-pfx-file",
+            "The certificate path must be a full file path ending with .pfx extension, not a directory path.",
+            (value) => {
+                if (!value) {
+                    return true; // Allow empty/null values
+                }
+
+                // Check if the path ends with .pfx (case-insensitive)
+                if (!/\.pfx$/i.test(value)) {
+                    return false;
+                }
+
+                // Check if the path doesn't end with a directory separator
+                return !(value.endsWith("/") || value.endsWith("\\"));
+            }
+        ),
     postgresqlIntegration: yup.boolean(),
     logsPath: yup.string().nullable(),
     staticIndexingEngineType: yup.string().oneOf(setupWizardConstants.indexingEngineTypes).nullable(),

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardAdditionalSettingsStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardAdditionalSettingsStep.tsx
@@ -8,7 +8,7 @@ import { setupWizardConstants, setupWizardGA4Prefixes } from "components/setupWi
 import { HrHeader } from "components/common/HrHeader";
 import classNames from "classnames";
 import { useEffect, useMemo } from "react";
-import { getFullDomain, getLicenseType } from "components/setupWizard/utils/setupWizardUtils";
+import { getFullDomain, getLicenseType, sanitizeCommonName } from "components/setupWizard/utils/setupWizardUtils";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
 import { useServices } from "hooks/useServices";
@@ -331,7 +331,7 @@ function AdvancedSettingsContent({ control, isVisible }: AdvancedSettingsContent
     const defaultCertificatePathFileName = useMemo(() => {
         switch (securityOption) {
             case "ownCertificate":
-                return `cluster.server.certificate.${selfSignedCertificateStep.cns[0]}.pfx`; // For own certificates, we use the first Common Name (CN) as the main identifier
+                return sanitizeCommonName(`cluster.server.certificate.${selfSignedCertificateStep.cns[0]}.pfx`); // For own certificates, we use the first Common Name (CN) as the main identifier
             case "letsEncrypt":
                 return `cluster.server.certificate.${getFullDomain(domainStep)}.pfx`;
             default:

--- a/src/Raven.Studio/typescript/components/setupWizard/utils/setupWizardUtils.ts
+++ b/src/Raven.Studio/typescript/components/setupWizard/utils/setupWizardUtils.ts
@@ -53,3 +53,7 @@ export function base64ToFile(base64: string, filename: string, mimeType = "appli
 export function getFullDomain(domainStep: SetupWizardFormData["domainStep"]) {
     return domainStep.domain + "." + domainStep.rootDomain;
 }
+
+export function sanitizeCommonName(cn: string) {
+    return cn.replace(/\*/g, "").replace(/\.{2,}/g, ".");
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26065

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
