### PR TITLE
RavenDB-26003 - Setup Wizard: Unsecure flow shows “HTTPS” instead of “HTTP”

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -439,11 +439,17 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
     );
 }
 
-function NodeDetailsPanelView({ index, control }: { index: number; control: Control<SetupWizardFormData> }) {
-    const nodeData = useWatch({
+interface NodeDetailsPanelViewProps {
+    index: number;
+    control: Control<SetupWizardFormData>;
+}
+
+function NodeDetailsPanelView({ index, control }: NodeDetailsPanelViewProps) {
+    const setupWizardData = useWatch({
         control,
-        name: `nodeAddressStep.nodes.${index}`,
     });
+
+    const nodeData = setupWizardData.nodeAddressStep.nodes[index];
 
     const localIpPortAddress = `${nodeData.ipAddress[0].ipAddress}:${nodeData.httpPort}`;
     return (
@@ -495,7 +501,9 @@ function NodeDetailsPanelView({ index, control }: { index: number; control: Cont
             <RichPanelDetailItem>
                 <div className="d-flex flex-column">
                     <span className="hstack">
-                        <span className="md-label mb-0">HTTPS port</span>
+                        <span className="md-label mb-0">
+                            {setupWizardData.securityStep.securityOption === "none" ? "HTTP" : "HTTPS"} port
+                        </span>
                         <PopoverWithHoverWrapper
                             message={
                                 <SetupWizardInfoPopover
@@ -691,12 +699,11 @@ function NodeDetailsPanelEdit({
                     <Col md={colWidth}>
                         <FormGroup>
                             <FormLabel className="d-flex">
-                                HTTPS port
+                                {securityOption === "none" ? "HTTP" : "HTTPS"} port
                                 <PopoverWithHoverWrapper
                                     message={
                                         <SetupWizardInfoPopover
-                                            description="Defines the private HTTPS port used by clients and browsers.
-                                                By default, this value is set to 443."
+                                            description={`Defines the private ${securityOption === "none" ? "HTTP" : "HTTPS"} port used by clients and browsers. By default, this value is set to ${securityOption === "none" ? "8080" : "443"}.`}
                                             docsLink="https://docs.ravendb.net/server/configuration/core-configuration#serverurl"
                                         />
                                     }

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSummaryStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSummaryStep.tsx
@@ -70,7 +70,7 @@ export function SetupWizardSummaryStep() {
                         <LocationDistribution>
                             <DistributionLegend>
                                 <div className="top"></div>
-                                <div className="node">HTTPS port</div>
+                                <div className="node">{securityOption === "none" ? "HTTP" : "HTTPS"} port</div>
                                 <div>TCP port</div>
                                 <div>IP address/Hostname</div>
                             </DistributionLegend>


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26003

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
