### PR TITLE
RavenDB-26142 - Removal of Queue ConnectionString is missing check fo…

### DIFF
--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -2638,6 +2638,21 @@ namespace Raven.Server.ServerWide
                             }
                         }
 
+                        var queueSinks = rawRecord.QueueSinks;
+
+                        // Don't delete the connection string if used by tasks types: Queue Sink
+                        if (queueSinks != null)
+                        {
+                            foreach (var queueSinkTask in queueSinks)
+                            {
+                                if (queueSinkTask.ConnectionStringName == connectionStringName)
+                                {
+                                    throw new InvalidOperationException(
+                                        $"Can't delete connection string: {connectionStringName}. It is used by task: {queueSinkTask.Name}");
+                                }
+                            }
+                        }
+
                         command = new RemoveQueueConnectionStringCommand(connectionStringName, databaseName, raftRequestId);
                         break;
 

--- a/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/ConnectionStringTests.cs
@@ -8,6 +8,7 @@ using Raven.Client.Documents.Operations.ETL.ElasticSearch;
 using Raven.Client.Documents.Operations.ETL.OLAP;
 using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Client.Documents.Operations.QueueSink;
 using Raven.Client.Exceptions;
 using Raven.Client.ServerWide;
 using Raven.Server.ServerWide.Context;
@@ -380,5 +381,46 @@ namespace SlowTests.Server.Documents.ETL
             Assert.False(s3SettingsAuditJson.Properties.Select(x => x.Name).Contains("AwsSecretKey"));
             Assert.False(s3SettingsAuditJson.Properties.Select(x => x.Name).Contains("AwsAccessKey"));
     }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public void CannotRemoveQueueConnectionStringUsedByQueueSinkTask()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var queueConnectionString = new QueueConnectionString
+                {
+                    Name = "QueueConnectionString-Kafka",
+                    BrokerType = QueueBrokerType.Kafka,
+                    KafkaConnectionSettings = new KafkaConnectionSettings { BootstrapServers = "localhost:9092" }
+                };
+
+                var putResult = store.Maintenance.Send(new PutConnectionStringOperation<QueueConnectionString>(queueConnectionString));
+                Assert.NotNull(putResult.RaftCommandIndex);
+
+                var queueSinkScript = new QueueSinkScript
+                {
+                    Name = "TestScript",
+                    Queues = new List<string> { "test-queue" },
+                    Script = @"put(this.Id.toString(), this)"
+                };
+
+                var queueSinkConfig = new QueueSinkConfiguration
+                {
+                    Name = "TestQueueSink",
+                    ConnectionStringName = queueConnectionString.Name,
+                    BrokerType = QueueBrokerType.Kafka,
+                    Scripts = { queueSinkScript }
+                };
+
+                var addResult = store.Maintenance.Send(new AddQueueSinkOperation<QueueConnectionString>(queueSinkConfig));
+                Assert.NotNull(addResult.RaftCommandIndex);
+
+                // Attempt to remove the connection string should fail
+                var exception = Assert.Throws<RavenException>(() =>
+                    store.Maintenance.Send(new RemoveConnectionStringOperation<QueueConnectionString>(queueConnectionString)));
+
+                Assert.Contains($"Can't delete connection string: {queueConnectionString.Name}. It is used by task: {queueSinkConfig.Name}", exception.Message);
+            }
+        }
 }
 }


### PR DESCRIPTION
…r usage by QueueSinks task

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26142

### Additional description

This pull request enhances the safety of connection string management by ensuring that queue connection strings cannot be deleted while they are still in use by Queue Sink tasks. It also adds a test to verify this behavior.

**Connection String Deletion Safeguards:**

* Updated `ServerStore.cs` to prevent deletion of a queue connection string if it is referenced by any Queue Sink task, throwing an exception with a clear message if such a case is detected.

**Testing Improvements:**

* Added a test (`CannotRemoveQueueConnectionStringUsedByQueueSinkTask`) in `ConnectionStringTests.cs` to verify that attempting to remove a queue connection string used by a Queue Sink task results in an exception with the expected error message.
* Included the necessary `using Raven.Client.Documents.Operations.QueueSink;` directive to support the new test.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
