### PR TITLE
RavenDB-25986 Setup wizard Security step - Continue button is displayed as enabled even when it should be disabled if no option is selected

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSecurityStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSecurityStep.tsx
@@ -224,6 +224,9 @@ export function SetupWizardSecurityStepFooter() {
         }
     };
 
+    const isContinueDisabled =
+        (!isLetsEncryptAgreementAccepted && securityOption === "letsEncrypt") || securityOption === null;
+
     return (
         <div className="hstack justify-content-between">
             <Button variant="secondary" className="rounded-pill" onClick={handleBack}>
@@ -244,7 +247,7 @@ export function SetupWizardSecurityStepFooter() {
                     </FormCheckbox>
                 )}
                 <Button
-                    disabled={!isLetsEncryptAgreementAccepted && securityOption === "letsEncrypt"}
+                    disabled={isContinueDisabled}
                     variant="primary"
                     className="rounded-pill"
                     onClick={handleContinue}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25986

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
