### PR TITLE
RavenDB-25821 - Setup Wizard: Persist Node configuration state when going back

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -66,7 +66,7 @@ export function SetupWizardNodeAddressStep() {
 
     const getDomainForWildcard = (tag: string | null): string => {
         if (cns.length === 0) {
-            return "";
+            return null;
         }
 
         const cn = cns[0];
@@ -323,9 +323,10 @@ function NodeDetailsPanelHeader({ control, index, onRemove, editNodeForm }: Node
     const handleSaveEdit = handleSubmit(async (formData: NodeEditFormData) => {
         setValue(`nodeAddressStep.nodes.${index}`, {
             ...formData,
+            dnsName: securityOption === "ownCertificate" ? formData.dnsName : null,
             nodeUrl: handleNodeUrl(formData),
             httpPort: formData.httpPort == null ? (securityOption === "none" ? 8080 : 443) : formData.httpPort,
-            nodeTag: formData.isPassive ? undefined : formData.nodeTag,
+            nodeTag: formData.isPassive ? null : formData.nodeTag,
             isEditing: false,
             isNewlyAdded: false,
         });
@@ -1321,7 +1322,7 @@ export function SetupWizardNodeAddressStepFooter() {
         }
     };
 
-    const isContinueDisabled = isEditing || exceedsLicenseLimit;
+    const isContinueDisabled = isEditing || exceedsLicenseLimit || nodeData.length === 0;
 
     return (
         <div className="hstack justify-content-between">
@@ -1358,8 +1359,33 @@ function useRevalidatePersistedNodesOnEntry() {
 
     useEffect(() => {
         const nodes = getValues("nodeAddressStep.nodes");
+        const securityOption = getValues("securityStep.securityOption");
+        const cns = getValues("selfSignedCertificateStep.cns");
 
-        nodes.forEach((_, index) => {
+        nodes.forEach((node, index) => {
+            if (securityOption !== "ownCertificate" && node.dnsName) {
+                setValue(`nodeAddressStep.nodes.${index}.dnsName`, null);
+            }
+
+            if (securityOption === "ownCertificate" && node.dnsName) {
+                const isDnsNameInCns = cns?.some((cn) => cn === node.dnsName);
+                if (!isDnsNameInCns) {
+                    if (cns.length === 1) {
+                        // set first CN if only one is available
+                        setValue(`nodeAddressStep.nodes.${index}.dnsName`, cns[0]);
+                    } else {
+                        setValue(`nodeAddressStep.nodes.${index}.dnsName`, null);
+                    }
+                }
+            }
+
+            /*
+             * “Discard” restores the node to its pre-edit state. If the user returned here after changing earlier steps, restoring is not allowed because it would cause a validation error, the node must be either saved or removed.
+             * When `isNewlyAdded` is true, the “Remove” button is shown instead of “Discard”.
+             */
+            setValue(`nodeAddressStep.nodes.${index}.isNewlyAdded`, true, {
+                shouldValidate: true,
+            });
             setValue(`nodeAddressStep.nodes.${index}.isEditing`, true, {
                 shouldValidate: true,
             });

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -916,7 +916,7 @@ function AddAnotherNode({ onAddNode }: AddAnotherNodeProps) {
     const nodeData = getValues("nodeAddressStep.nodes");
 
     const maxClusterSize = licenseKeyStep?.licenseInfo?.maxClusterSize ?? setupWizardConstants.AGPL_MAX_CLUSTER_SIZE;
-    const isMaxClusterNodes = maxClusterSize <= nodeData?.length;
+    const isMaxClusterNodes = nodeData?.length >= maxClusterSize;
 
     return (
         <div
@@ -1190,7 +1190,7 @@ export function SetupWizardNodeAddressStepFooter() {
     const licenseKeyStep = getValues("licenseKeyStep");
 
     const maxClusterSize = licenseKeyStep?.licenseInfo?.maxClusterSize ?? setupWizardConstants.AGPL_MAX_CLUSTER_SIZE;
-    const exceedsLicenseLimit = nodeData?.length > maxClusterSize;
+    const hasExceededLicenseLimit = nodeData?.length > maxClusterSize;
 
     const isEditing = nodeData?.some((node) => node.isEditing);
 
@@ -1322,7 +1322,7 @@ export function SetupWizardNodeAddressStepFooter() {
         }
     };
 
-    const isContinueDisabled = isEditing || exceedsLicenseLimit || nodeData.length === 0;
+    const isContinueDisabled = isEditing || hasExceededLicenseLimit || nodeData.length === 0;
 
     return (
         <div className="hstack justify-content-between">
@@ -1332,11 +1332,11 @@ export function SetupWizardNodeAddressStepFooter() {
             <ConditionalPopover
                 conditions={[
                     {
-                        isActive: exceedsLicenseLimit,
+                        isActive: hasExceededLicenseLimit,
                         message: <LicenseLimitExceededMessage />,
                     },
                     {
-                        isActive: isEditing && !exceedsLicenseLimit,
+                        isActive: isEditing && !hasExceededLicenseLimit,
                         message: "You can't proceed if you have unsaved nodes. Save your changes first.",
                     },
                 ]}

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -42,7 +42,6 @@ import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { setupWizardConstants, setupWizardGA4Prefixes } from "components/setupWizard/utils/setupWizardConstants";
 import useBoolean from "hooks/useBoolean";
 import { SetupWizardInfoPopover } from "components/setupWizard/partials/SetupWizardInfoPopover";
-import { setupWizardFormDefaultValues } from "components/setupWizard/utils/setupWizardFormDefaultValues";
 import { components, OptionProps, SingleValueProps } from "react-select";
 import Badge from "react-bootstrap/Badge";
 
@@ -135,6 +134,8 @@ export function SetupWizardNodeAddressStep() {
             });
         }
     }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useRevalidatePersistedNodesOnEntry();
 
     return (
         <div>
@@ -914,7 +915,7 @@ function AddAnotherNode({ onAddNode }: AddAnotherNodeProps) {
     const nodeData = getValues("nodeAddressStep.nodes");
 
     const maxClusterSize = licenseKeyStep?.licenseInfo?.maxClusterSize ?? setupWizardConstants.AGPL_MAX_CLUSTER_SIZE;
-    const isMaxClusterNodes = maxClusterSize === nodeData?.length;
+    const isMaxClusterNodes = maxClusterSize <= nodeData?.length;
 
     return (
         <div
@@ -1185,6 +1186,10 @@ export function SetupWizardNodeAddressStepFooter() {
     const { reportEvent } = useEventsCollector();
 
     const nodeData = getValues("nodeAddressStep.nodes");
+    const licenseKeyStep = getValues("licenseKeyStep");
+
+    const maxClusterSize = licenseKeyStep?.licenseInfo?.maxClusterSize ?? setupWizardConstants.AGPL_MAX_CLUSTER_SIZE;
+    const exceedsLicenseLimit = nodeData?.length > maxClusterSize;
 
     const isEditing = nodeData?.some((node) => node.isEditing);
 
@@ -1314,8 +1319,9 @@ export function SetupWizardNodeAddressStepFooter() {
                 setValue("currentStep", "Security");
                 break;
         }
-        setValue("nodeAddressStep", setupWizardFormDefaultValues["nodeAddressStep"]);
     };
+
+    const isContinueDisabled = isEditing || exceedsLicenseLimit;
 
     return (
         <div className="hstack justify-content-between">
@@ -1323,16 +1329,70 @@ export function SetupWizardNodeAddressStepFooter() {
                 <Icon icon="arrow-left" /> Back
             </Button>
             <ConditionalPopover
-                conditions={{
-                    isActive: isEditing,
-                    message: "You can't proceed if you have unsaved nodes. Save your changes first.",
-                }}
+                conditions={[
+                    {
+                        isActive: exceedsLicenseLimit,
+                        message: <LicenseLimitExceededMessage />,
+                    },
+                    {
+                        isActive: isEditing && !exceedsLicenseLimit,
+                        message: "You can't proceed if you have unsaved nodes. Save your changes first.",
+                    },
+                ]}
             >
-                <Button disabled={isEditing} variant="primary" className="rounded-pill" onClick={handleContinue}>
+                <Button
+                    disabled={isContinueDisabled}
+                    variant="primary"
+                    className="rounded-pill"
+                    onClick={handleContinue}
+                >
                     Continue <Icon icon="arrow-right" margin="m-0" />
                 </Button>
             </ConditionalPopover>
         </div>
+    );
+}
+
+function useRevalidatePersistedNodesOnEntry() {
+    const { setValue, getValues } = useFormContext<SetupWizardFormData>();
+
+    useEffect(() => {
+        const nodes = getValues("nodeAddressStep.nodes");
+
+        nodes.forEach((_, index) => {
+            setValue(`nodeAddressStep.nodes.${index}.isEditing`, true, {
+                shouldValidate: true,
+            });
+        });
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+}
+
+function LicenseLimitExceededMessage() {
+    const { getValues } = useFormContext<SetupWizardFormData>();
+
+    const nodeData = getValues("nodeAddressStep.nodes");
+    const licenseKeyStep = getValues("licenseKeyStep");
+
+    const maxClusterSize = licenseKeyStep?.licenseInfo?.maxClusterSize ?? setupWizardConstants.AGPL_MAX_CLUSTER_SIZE;
+    const currentNodeCount = nodeData?.length;
+
+    return (
+        <>
+            <p className="mb-0">
+                Your license allows maximum <strong>{maxClusterSize}</strong> node(s), but you have configured{" "}
+                <strong>{currentNodeCount}</strong> nodes.
+            </p>
+            <p className="mb-0">
+                Remove <strong>{currentNodeCount - maxClusterSize}</strong> node(s) or upgrade your license to continue.
+            </p>
+            <hr className="my-2" />
+            <span className="md-label">
+                <Icon icon="link" /> See{" "}
+                <a href="https://ravendb.net/buy" target="_blank">
+                    licenses comparison <Icon icon="newtab" />
+                </a>
+            </span>
+        </>
     );
 }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25821

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
