### PR TITLE
RavenDB-25527 - Fix (genai, etl): resolve tests and ETL stop race condition

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlProcess.cs
+++ b/src/Raven.Server/Documents/ETL/EtlProcess.cs
@@ -725,10 +725,11 @@ namespace Raven.Server.Documents.ETL
             _cts.Cancel();
 
             var longRunningWork = _longRunningWork;
-            _longRunningWork = null;
 
             if (longRunningWork != PoolOfThreads.LongRunningWork.Current) // prevent a deadlock
                 longRunningWork.Join(int.MaxValue);
+
+            _longRunningWork = null;
 
             OnProcessStopped();
         }

--- a/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/GenAiBasics.cs
@@ -714,7 +714,7 @@ for(const comment of this.Comments)
         }
 
         var db = await GetDatabase(store.Database);
-        var etlProcess = db.EtlLoader.Processes.FirstOrDefault() as GenAiTask;
+        var etlProcess = db.EtlLoader.Processes.SingleOrDefault() as GenAiTask;
         Assert.NotNull(etlProcess);
 
         EtlPerformanceStats[] stats = null;
@@ -743,7 +743,22 @@ for(const comment of this.Comments)
         Assert.Equal(OngoingTaskState.Disabled, taskInfo.TaskState);
 
         await AssertWaitForTrueAsync(() => Task.FromResult(etlProcess.IsRunning == false));
-        
+
+        long etag = 0;
+        var baselineUtc = DateTime.UtcNow;
+        using (var session = store.OpenSession())
+        {
+            // modify the doc to trigger etl 
+            // the post's Body remains the same - this change won't affect the generated context object 
+            // context should be resent because of the hash-mismatch, not because of the comments addition
+
+            var doc = session.Load<Post>(docId);
+            doc.Comments.Add(new Comment("spam comment", "evil bot"));
+            etag = ChangeVectorUtils.GetEtagById(session.Advanced.GetChangeVectorFor(doc), db.DbBase64Id);
+
+            session.SaveChanges();
+        }
+
         // update the configuration
         changeConfig(config);
         store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
@@ -760,20 +775,6 @@ for(const comment of this.Comments)
         Assert.Equal(genAiTaskInfo.Configuration.UpdateScript, config.UpdateScript);
 
         etlDone = Etl.WaitForEtlToComplete(store);
-        long etag = 0;
-        var baselineUtc = DateTime.UtcNow;
-        using (var session = store.OpenSession())
-        {
-            // modify the doc to trigger etl 
-            // the post's Body remains the same - this change won't affect the generated context object 
-            // context should be resent because of the hash-mismatch, not because of the comments addition
-
-            var doc = session.Load<Post>(docId);
-            doc.Comments.Add(new Comment("spam comment", "evil bot"));
-            etag = ChangeVectorUtils.GetEtagById(session.Advanced.GetChangeVectorFor(doc), db.DbBase64Id);
-
-            session.SaveChanges();
-        }
 
         Assert.True(await etlDone.WaitAsync(TimeSpan.FromMinutes(1)));
 
@@ -820,7 +821,8 @@ for(const comment of this.Comments)
             return op is { TotalSentToModel: 1, NumberOfContextObjects: 1, TotalCachedContexts: 0 };
         });
 
-        Assert.True(resend != null, $"baselineUtc: {baselineUtc}, etag: {etag} " + Environment.NewLine + await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
+        Assert.True(resend != null, $"baselineUtc: {baselineUtc}, etag: {etag} " + 
+                                    Environment.NewLine + await Etl.GetEtlDebugInfo(store.Database, TimeSpan.FromSeconds(60)));
 
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25527/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenSchemaChangesoptions-DatabaseMode-Single-configuration

https://issues.hibernatingrhinos.com/issue/RavenDB-25350/SlowTests.Server.Documents.AI.GenAi.GenAiBasics.ShouldResendContextWhenUpdateScriptChangesoptions-DatabaseMode-Single

### Additional description

Fix (genai, etl): resolve tests and ETL stop race condition:
- Fix `ShouldResendContextWhenSchemaChanges` and `ShouldResendContextWhenUpdateScriptChanges` tests by ensuring context refreshes on metadata updates.
- Add concurrency checks (passing cv) to `UpdateHashesInMetadata` to prevent document changing during GenAI batch processing.
- Fix race condition in `EtlProcess.Stop` where `_longRunningWork` could be null before being joined, leading to incorrect 'IsRunning'.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
