### PR TITLE
RavenDB-26145 AutoIndexes fixes - index creation from order by distance.

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Spatial.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.Spatial.cs
@@ -86,7 +86,7 @@ namespace Raven.Client.Documents.Session
 
             AssertIsDynamicQuery(field, nameof(OrderByDistance));
 
-            OrderByDistance($"'{field.ToField(EnsureValidFieldName)}'", latitude, longitude, field.RoundFactor);
+            OrderByDistance($"{field.ToField(EnsureValidFieldName)}", latitude, longitude, field.RoundFactor);
         }
 
         /// <inheritdoc />
@@ -110,7 +110,7 @@ namespace Raven.Client.Documents.Session
 
             AssertIsDynamicQuery(field, nameof(OrderByDistance));
 
-            OrderByDistance($"'{field.ToField(EnsureValidFieldName)}'", shapeWkt, field.RoundFactor);
+            OrderByDistance($"{field.ToField(EnsureValidFieldName)}", shapeWkt, field.RoundFactor);
         }
 
         /// <inheritdoc />
@@ -134,7 +134,7 @@ namespace Raven.Client.Documents.Session
 
             AssertIsDynamicQuery(field, nameof(OrderByDistanceDescending));
 
-            OrderByDistanceDescending($"'{field.ToField(EnsureValidFieldName)}'", latitude, longitude, field.RoundFactor);
+            OrderByDistanceDescending($"{field.ToField(EnsureValidFieldName)}", latitude, longitude, field.RoundFactor);
         }
 
         public void OrderByDistanceDescending(string fieldName, double latitude, double longitude)
@@ -156,7 +156,7 @@ namespace Raven.Client.Documents.Session
 
             AssertIsDynamicQuery(field, nameof(OrderByDistanceDescending));
 
-            OrderByDistanceDescending($"'{field.ToField(EnsureValidFieldName)}'", shapeWkt, field.RoundFactor);
+            OrderByDistanceDescending($"{field.ToField(EnsureValidFieldName)}", shapeWkt, field.RoundFactor);
         }
 
         public void OrderByDistanceDescending(string fieldName, string shapeWkt)

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -1182,7 +1182,22 @@ function execute(doc, args){
                 {
                     var visitor = new FillWhereFieldsAndParametersVisitor(this, fromAlias, QueryText);
                     visitor.HandleSpatial("spatial.distance", me.Arguments, withoutAlias: true, parameters);
-                    fieldName = new QueryFieldName(firstArgME.GetText(null), true);
+                    
+                    var stringFieldName = $"{firstArgME.Name}({string.Join(", ", firstArgME.Arguments.Select(GetParameterForDistance))})";
+                    
+                    fieldName = new QueryFieldName(stringFieldName, true);
+
+                    string GetParameterForDistance(QueryExpression argument)
+                    {
+                        if (argument is FieldExpression fe)
+                        {
+                            return ShouldStripAlias(fe) 
+                                ? fe.GetText(null) 
+                                : fe.GetTextWithAlias(null);
+                        }
+                        
+                        return argument.GetText(null);
+                    }
                 }
                 else
                 {

--- a/test/SlowTests/Issues/RavenDB_26145.cs
+++ b/test/SlowTests/Issues/RavenDB_26145.cs
@@ -1,0 +1,249 @@
+﻿using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26145(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void SpatialAutoIndexCanWorkNestedPoint(Options options)
+    {
+        using var store = GetStoreWithDocuments(options);
+        using var session = store.OpenSession();
+        
+        var result = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0, 0))")
+            .Statistics(out var stats)
+            .WaitForNonStaleResults()
+            .ToList();
+        Assert.Equal("Auto/Documents/BySpatial.point(Location.Latitude|Location.Longitude)", stats.IndexName);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("close", result[0].Name);
+        Assert.Equal("far", result[1].Name);
+
+        store.Maintenance.Send(new DeleteIndexOperation(stats.IndexName));
+        var aliased = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' myAlias order by spatial.distance(spatial.point(myAlias.Location.Latitude, myAlias.Location.Longitude), spatial.point(0, 0))")
+            .Statistics(out var statsAliased)
+            .WaitForNonStaleResults()
+            .ToList();
+        
+        Assert.NotNull(aliased);
+        Assert.Equal(2, aliased.Count);
+        Assert.Equal("close", aliased[0].Name);
+        Assert.Equal("far", aliased[1].Name);
+        Assert.Equal(stats.IndexName, statsAliased.IndexName);
+    }
+    
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void SpatialAutoIndexCanWorkNestedWkt(Options options)
+    {
+        using var store = GetStoreWithDocuments(options);
+        using var session = store.OpenSession();
+        
+        var result = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' order by spatial.distance(spatial.wkt(Location.Wkt), spatial.point(0, 0))")
+            .Statistics(out var stats)
+            .WaitForNonStaleResults()
+            .ToList();
+        Assert.Equal("Auto/Documents/BySpatial.wkt(Location.Wkt)", stats.IndexName);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("close", result[0].Name);
+        Assert.Equal("far", result[1].Name);
+
+        store.Maintenance.Send(new DeleteIndexOperation(stats.IndexName));
+        var aliased = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' myAlias order by spatial.distance(spatial.wkt(myAlias.Location.Wkt), spatial.point(0, 0))")
+            .Statistics(out var statsAliased)
+            .WaitForNonStaleResults()
+            .ToList();
+        
+        Assert.NotNull(aliased);
+        Assert.Equal(2, aliased.Count);
+        Assert.Equal("close", aliased[0].Name);
+        Assert.Equal("far", aliased[1].Name);
+        Assert.Equal(stats.IndexName, statsAliased.IndexName);
+        
+        store.Maintenance.Send(new DeleteIndexOperation(stats.IndexName));
+        aliased = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' myAlias order by spatial.distance(spatial.wkt(Location.Wkt), spatial.point(0, 0))")
+            .Statistics(out statsAliased)
+            .WaitForNonStaleResults()
+            .ToList();
+        
+        Assert.NotNull(aliased);
+        Assert.Equal(2, aliased.Count);
+        Assert.Equal("close", aliased[0].Name);
+        Assert.Equal("far", aliased[1].Name);
+        Assert.Equal(stats.IndexName, statsAliased.IndexName);
+    }
+    
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void SpatialAutoIndexCanWorkDoubleNested(Options options)
+    {
+        using var store = GetStoreWithDocuments(options);
+        using var session = store.OpenSession();
+        var result = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' order by spatial.distance(spatial.point(Address.Location.Latitude, Address.Location.Longitude), spatial.point(0, 0))")
+            .Statistics(out var stats)
+            .WaitForNonStaleResults()
+            .ToList();
+        Assert.Equal("Auto/Documents/BySpatial.point(Address.Location.Latitude|Address.Location.Longitude)", stats.IndexName);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("close", result[0].Name);
+        Assert.Equal("far", result[1].Name);
+        store.Maintenance.Send(new DeleteIndexOperation(stats.IndexName));
+
+        var aliased = session.Advanced
+            .RawQuery<Document>(@"from 'Documents' myAlias order by spatial.distance(spatial.point(myAlias.Address.Location.Latitude, myAlias.Address.Location.Longitude), spatial.point(0, 0))")
+            .Statistics(out var statsAliased)
+            .WaitForNonStaleResults()
+            .ToList();
+        
+        Assert.NotNull(aliased);
+        Assert.Equal(2, aliased.Count);
+        Assert.Equal("close", aliased[0].Name);
+        Assert.Equal("far", aliased[1].Name);
+        Assert.Equal(stats.IndexName, statsAliased.IndexName);
+    }
+
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void SpatialPointAutoIndexCanWorkLinq(Options options)
+    {
+        using var store = GetStoreWithDocuments(options);
+        using var session = store.OpenSession();
+
+        var result = session.Query<Document>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Statistics(out var stats)
+            .OrderByDistance(pnt => pnt.Point(doc => doc.Location.Latitude, doc => doc.Location.Longitude), 0, 0)
+            .ToList();
+        Assert.Equal("Auto/Documents/BySpatial.point(Location.Latitude|Location.Longitude)", stats.IndexName);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("close", result[0].Name);
+        Assert.Equal("far", result[1].Name);
+        store.Maintenance.Send(new DeleteIndexOperation(stats.IndexName));
+
+        result = session.Query<Document>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Statistics(out stats)
+            .OrderByDistanceDescending(pnt => pnt.Point(doc => doc.Location.Latitude, doc => doc.Location.Longitude), 0, 0)
+            .ToList();
+        Assert.Equal("Auto/Documents/BySpatial.point(Location.Latitude|Location.Longitude)", stats.IndexName);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("far", result[0].Name);
+        Assert.Equal("close", result[1].Name);
+    }
+    
+    [RavenTheory(RavenTestCategory.Spatial | RavenTestCategory.Querying)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single, SearchEngineMode = RavenSearchEngineMode.Lucene)]
+    public void SpatialWktPointAutoIndexCanWorkLinq(Options options)
+    {
+        using var store = GetStoreWithDocuments(options);
+        using var session = store.OpenSession();
+
+        var result = session.Query<Document>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Statistics(out var stats)
+            .OrderByDistance(pnt => pnt.Wkt(doc => doc.Location.Wkt), 0, 0)
+            .ToList();
+        
+        Assert.Equal("Auto/Documents/BySpatial.wkt(Location.Wkt)", stats.IndexName);
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("close", result[0].Name);
+        Assert.Equal("far", result[1].Name);
+        store.Maintenance.Send(new DeleteIndexOperation(stats.IndexName));
+        
+        result = session.Query<Document>()
+            .Customize(x => x.WaitForNonStaleResults())
+            .Statistics(out stats)
+            .OrderByDistanceDescending(pnt => pnt.Wkt(doc => doc.Location.Wkt), 0, 0)
+            .ToList();
+        Assert.Equal("Auto/Documents/BySpatial.wkt(Location.Wkt)", stats.IndexName);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("far", result[0].Name);
+        Assert.Equal("close", result[1].Name);
+    }
+    
+    private IDocumentStore GetStoreWithDocuments(Options options)
+    {
+        IDocumentStore store = null;
+        try
+        {
+            store = GetDocumentStore(options);
+            using var session = store.OpenSession();
+            session.Store(new Document
+            {
+                Name = "far",
+                Address = new Address("test", new Location(50, 50)),
+                Location = new Location(50, 50)
+            });
+
+            session.Store(new Document
+            {
+                Name = "close",
+                Address = new Address("test", new Location(10, 10)),
+                Location = new Location(10, 10)
+            });
+
+            session.SaveChanges();
+        }
+        catch
+        {
+            store?.Dispose();
+            throw;
+        }
+
+        return store;
+    }
+    
+    private class Document
+    {
+        public string Name { get; set; }
+        public Address Address { get; set; }
+        public Location Location { get; set; }
+    }
+    
+    private class Location
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        
+        public string Wkt { get; set; }
+
+        public Location()
+        {
+        }
+        
+        public Location(double latitude, double longitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+            Wkt = $"POINT({longitude} {latitude})";
+        }
+    }
+
+    private record Address(string Street, Location Location);
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26145

### Additional description
- Fix aliasing removal for spatial.distance
- Fix dynamic OrderByDistance in the client API. Do not wrap the result of the location factory in single quotes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
