### PR TITLE
RavenDB-25692 Throw meaningful exception when performing vector search using disabled embeddings generation task

### DIFF
--- a/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/DynamicQueryRunner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -225,8 +226,17 @@ namespace Raven.Server.Documents.Queries.Dynamic
                         continue;
                     
                     var embeddingsGenerationTaskIdentifier = new EmbeddingsGenerationTaskIdentifier(field.Vector.EmbeddingsGenerationTaskIdentifier);
-                    if (Database.EmbeddingsGeneratorQueries.EmbeddingTaskExists(embeddingsGenerationTaskIdentifier) == false)
+
+                    if (Database.EmbeddingsGeneratorQueries.EmbeddingTaskExists(embeddingsGenerationTaskIdentifier))
+                        continue;
+                    
+                    var taskConfiguration = Database.EtlLoader.EmbeddingsGenerationDestinations.SingleOrDefault(x => x.Identifier == field.Vector.EmbeddingsGenerationTaskIdentifier);
+
+                    if (taskConfiguration is null)
                         throw new InvalidQueryException($"Couldn't find Embeddings Generation task with '{field.Vector.EmbeddingsGenerationTaskIdentifier}' identifier");
+                        
+                    if (taskConfiguration.Disabled)
+                        throw new InvalidQueryException($"Embeddings Generation task with '{field.Vector.EmbeddingsGenerationTaskIdentifier}' identifier is disabled, and cannot be used for querying");
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-25692.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25692.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.OngoingTasks;
+using Raven.Client.Exceptions;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25692(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task QueryingDisabledEmbeddings(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            var (configuration, _) = AddEmbeddingsGenerationTask(store, embeddingsPaths: [new EmbeddingPathConfiguration() { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+            
+            var taskInfo = store.Maintenance.Send(new GetOngoingTaskInfoOperation(configuration.Identifier, OngoingTaskType.EmbeddingsGeneration));
+            
+            var disableOp = new ToggleOngoingTaskStateOperation(taskInfo.TaskId, OngoingTaskType.EmbeddingsGeneration, disable: true);
+            store.Maintenance.Send(disableOp);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var ex = await Assert.ThrowsAsync<InvalidQueryException>(async () => await session.Query<Dto>().VectorSearch(x => x.WithText(d => d.TextualValue).UsingTask(configuration.Identifier), factory => factory.ByText("some text"), minimumSimilarity: 0.75f).ToListAsync());
+
+                Assert.Contains($"Embeddings Generation task with '{configuration.Identifier}' identifier is disabled, and cannot be used for querying", ex.Message);
+            }
+        }
+    }
+    
+    private class Dto
+    {
+        public string TextualValue { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25692/Better-exception-when-query-an-embedding-task-which-disabled

### Additional description

We want to throw better exception for vector search queries using disabled task

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
