### PR TITLE
RavenDB-26146 - Use the correct highlightings terms when using range filters

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -875,7 +875,7 @@ public static class CoraxQueryBuilder
 
             if (builderParameters.HighlightingTerms != null)
             {
-                var highlightingTerm = new CoraxHighlightingTermIndex {FieldName = fieldName, Values = (valueFirst, valueSecond)};
+                var highlightingTerm = new CoraxHighlightingTermIndex { FieldName = fieldName, Values = new Tuple<string, string>(valueFirstAsString, valueSecondAsString) };
                 builderParameters.HighlightingTerms[fieldName] = highlightingTerm;
             }
 

--- a/test/SlowTests/Issues/RavenDB-26146.cs
+++ b/test/SlowTests/Issues/RavenDB-26146.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Highlighting;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26146 : RavenTestBase
+    {
+        public RavenDB_26146(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Highlighting | RavenTestCategory.Corax)]
+        [RavenData(SearchEngineMode = RavenSearchEngineMode.All)]
+        public void Highlighting_with_two_range_filters(Options options)
+        {
+            using var store = GetDocumentStore(options);
+            new SearchCallLogsIndex().Execute(store);
+
+            var start = new DateTimeOffset(2025, 01, 01, 0, 0, 0, TimeSpan.Zero);
+            var end = start.AddDays(10);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new CallLog
+                {
+                    CreatedOn = start.AddDays(2),
+                    TranscribeText = "hello world, something to highlight"
+                });
+
+                session.Store(new CallLog
+                {
+                    CreatedOn = start.AddDays(20), // outside range
+                    TranscribeText = "hello world"
+                });
+
+                session.SaveChanges();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenSession())
+            {
+                var tagsToUse = new HighlightingOptions
+                {
+                    PreTags = new[] { "`" },
+                    PostTags = new[] { "`" }
+                };
+
+                var results = session
+                    .Query<CallLog, SearchCallLogsIndex>()
+                    .Where(x => x.CreatedOn >= start)
+                    .Where(x => x.CreatedOn <= end)
+                    .Search(x => x.TranscribeText, "hello", 100)
+                    .Highlight(x => x.TranscribeText, 18, 8, tagsToUse, out var highlights)
+                    .ToList();
+
+                Assert.Equal(1, results.Count);
+
+                var id = session.Advanced.GetDocumentId(results[0]);
+                var frags = highlights.GetFragments(id);
+
+                Assert.NotNull(frags);
+                Assert.Equal(1, frags.Length);
+                Assert.Equal("`hello` world,", frags[0]);
+            }
+        }
+
+        private class CallLog
+        {
+            public string Id { get; set; }
+            public DateTimeOffset CreatedOn { get; set; }
+            public string TranscribeText { get; set; }
+        }
+
+        private class SearchCallLogsIndex : AbstractIndexCreationTask<CallLog>
+        {
+            public SearchCallLogsIndex()
+            {
+                Map = docs => from d in docs
+                    select new
+                    {
+                        d.CreatedOn,
+                        d.TranscribeText
+                    };
+
+                Index(x => x.TranscribeText, FieldIndexing.Search);
+                TermVector(x => x.TranscribeText, FieldTermVector.WithPositionsAndOffsets);
+                Store(x => x.TranscribeText, FieldStorage.Yes);
+
+                Index(x => x.CreatedOn, FieldIndexing.Default);
+                Store(x => x.CreatedOn, FieldStorage.Yes);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26146/Highlighting-with-range-filters-throws-NotSupportedException

### Additional description

Use the correct highlightings terms when using range filters

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
