### PR TITLE
RavenDB-26147: expose gc metrics on /monitoring/v1/prometheus

### DIFF
--- a/src/Raven.Server/Dashboard/Cluster/Notifications/GcInfoPayload.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/GcInfoPayload.cs
@@ -83,8 +83,6 @@ public class GcInfoPayload : AbstractClusterDashboardNotification
         public long HeapSizeInMb { get; set; }
         public long HighMemoryLoadThresholdInMb { get; set; }
         public long MemoryLoadInMb { get; set; }
-        public double? PauseDurations1InSec { get; set; }
-        public double? PauseDurations2InSec { get; set; }
         public long PinnedObjectsCount { get; set; }
         public long PromotedInMb { get; set; }
         public long TotalAvailableMemoryInMb { get; set; }
@@ -99,14 +97,20 @@ public class GcInfoPayload : AbstractClusterDashboardNotification
             djv[nameof(HeapSizeInMb)] = HeapSizeInMb;
             djv[nameof(HighMemoryLoadThresholdInMb)] = HighMemoryLoadThresholdInMb;
             djv[nameof(MemoryLoadInMb)] = MemoryLoadInMb;
-            djv[nameof(PauseDurations1InSec)] = PauseDurations1InSec;
-            djv[nameof(PauseDurations2InSec)] = PauseDurations2InSec;
             djv[nameof(PinnedObjectsCount)] = PinnedObjectsCount;
             djv[nameof(PromotedInMb)] = PromotedInMb;
             djv[nameof(TotalAvailableMemoryInMb)] = TotalAvailableMemoryInMb;
             djv[nameof(TotalCommittedInMb)] = TotalCommittedInMb;
 
             return djv;
+        }
+
+        public double? GetPauseDurationSeconds(int index)
+        {
+            if (PauseDurationsInMs == null || PauseDurationsInMs.Count <= index)
+                return null;
+
+            return PauseDurationsInMs[index] / 1000d;
         }
     }
 

--- a/src/Raven.Server/Dashboard/Cluster/Notifications/GcInfoPayload.cs
+++ b/src/Raven.Server/Dashboard/Cluster/Notifications/GcInfoPayload.cs
@@ -56,7 +56,7 @@ public class GcInfoPayload : AbstractClusterDashboardNotification
 
         public GenerationInfoSize PinnedObjectHeapSize { get; set; }
 
-        public DynamicJsonValue ToJson()
+        public virtual DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
@@ -67,12 +67,46 @@ public class GcInfoPayload : AbstractClusterDashboardNotification
                 [nameof(PauseTimePercentage)] = PauseTimePercentage,
                 [nameof(PauseDurationsInMs)] = PauseDurationsInMs,
                 [nameof(TotalHeapSizeAfterBytes)] = TotalHeapSizeAfterBytes,
-                [nameof(Gen0HeapSize)] = Gen0HeapSize.ToJson(),
-                [nameof(Gen1HeapSize)] = Gen1HeapSize.ToJson(),
-                [nameof(Gen2HeapSize)] = Gen2HeapSize.ToJson(),
-                [nameof(LargeObjectHeapSize)] = LargeObjectHeapSize.ToJson(),
-                [nameof(PinnedObjectHeapSize)] = PinnedObjectHeapSize.ToJson(),
+                [nameof(Gen0HeapSize)] = Gen0HeapSize?.ToJson(),
+                [nameof(Gen1HeapSize)] = Gen1HeapSize?.ToJson(),
+                [nameof(Gen2HeapSize)] = Gen2HeapSize?.ToJson(),
+                [nameof(LargeObjectHeapSize)] = LargeObjectHeapSize?.ToJson(),
+                [nameof(PinnedObjectHeapSize)] = PinnedObjectHeapSize?.ToJson(),
             };
+        }
+    }
+
+    public sealed class GcMemoryInfoMetrics : GcMemoryInfo
+    {
+        public long FinalizationPendingCount { get; set; }
+        public long FragmentedInMb { get; set; }
+        public long HeapSizeInMb { get; set; }
+        public long HighMemoryLoadThresholdInMb { get; set; }
+        public long MemoryLoadInMb { get; set; }
+        public double? PauseDurations1InSec { get; set; }
+        public double? PauseDurations2InSec { get; set; }
+        public long PinnedObjectsCount { get; set; }
+        public long PromotedInMb { get; set; }
+        public long TotalAvailableMemoryInMb { get; set; }
+        public long TotalCommittedInMb { get; set; }
+
+        public override DynamicJsonValue ToJson()
+        {
+            var djv = base.ToJson();
+
+            djv[nameof(FinalizationPendingCount)] = FinalizationPendingCount;
+            djv[nameof(FragmentedInMb)] = FragmentedInMb;
+            djv[nameof(HeapSizeInMb)] = HeapSizeInMb;
+            djv[nameof(HighMemoryLoadThresholdInMb)] = HighMemoryLoadThresholdInMb;
+            djv[nameof(MemoryLoadInMb)] = MemoryLoadInMb;
+            djv[nameof(PauseDurations1InSec)] = PauseDurations1InSec;
+            djv[nameof(PauseDurations2InSec)] = PauseDurations2InSec;
+            djv[nameof(PinnedObjectsCount)] = PinnedObjectsCount;
+            djv[nameof(PromotedInMb)] = PromotedInMb;
+            djv[nameof(TotalAvailableMemoryInMb)] = TotalAvailableMemoryInMb;
+            djv[nameof(TotalCommittedInMb)] = TotalCommittedInMb;
+
+            return djv;
         }
     }
 

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -183,14 +183,11 @@ public sealed class MetricsProvider
             HeapSizeInMb = new Size(info.HeapSizeBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
             HighMemoryLoadThresholdInMb = new Size(info.HighMemoryLoadThresholdBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
             MemoryLoadInMb = new Size(info.MemoryLoadBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
-            PauseDurations1InSec = GetPauseSeconds(info, 0),
-            PauseDurations2InSec = GetPauseSeconds(info, 1),
             PauseTimePercentage = info.PauseTimePercentage,
             PinnedObjectsCount = info.PinnedObjectsCount,
             PromotedInMb = new Size(info.PromotedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
             TotalAvailableMemoryInMb = new Size(info.TotalAvailableMemoryBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
             TotalCommittedInMb = new Size(info.TotalCommittedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
-
             TotalHeapSizeAfterBytes = info.HeapSizeBytes,
             PauseDurationsInMs =
             [
@@ -205,15 +202,6 @@ public sealed class MetricsProvider
         };
 
         return result;
-    }
-
-    private static double? GetPauseSeconds(GCMemoryInfo info, int index)
-    {
-        var pauses = info.PauseDurations;
-        if (pauses.IsEmpty || pauses.Length <= index)
-            return null;
-
-        return pauses[index].TotalSeconds;
     }
 
     private static GcInfoPayload.GenerationInfoSize GetGenerationInfoSize(GCMemoryInfo info, int index)

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -49,6 +49,7 @@ public sealed class MetricsProvider
         result.Backup = GetBackupMetrics();
         result.Cpu = GetCpuMetrics();
         result.Memory = GetMemoryMetrics();
+        result.Gc = GetGcMetrics();
         result.Network = GetNetworkMetrics();
         result.License = GetLicenseMetrics();
         result.Disk = GetDiskMetrics();
@@ -161,6 +162,41 @@ public sealed class MetricsProvider
         result.UnmanagedMemoryInBytes = AbstractLowMemoryMonitor.GetUnmanagedAllocationsInBytes();
 
         return result;
+    }
+
+    private GcMetrics GetGcMetrics()
+    {
+        var result = new GcMetrics();
+
+        var info = _server.MetricCacher.GetValue<GCMemoryInfo>(MetricCacher.Keys.Server.GcAny);
+
+        result.Index = info.Index;
+        result.Generation = info.Generation;
+        result.Compacted = info.Compacted;
+        result.Concurrent = info.Concurrent;
+        result.FinalizationPendingCount = info.FinalizationPendingCount;
+        result.FragmentedInMb = new Size(info.FragmentedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.HeapSizeInMb = new Size(info.HeapSizeBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.HighMemoryLoadThresholdInMb = new Size(info.HighMemoryLoadThresholdBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.MemoryLoadInMb = new Size(info.MemoryLoadBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.PauseDurations1InSec = GetPauseSeconds(info, 0);
+        result.PauseDurations2InSec = GetPauseSeconds(info, 1);
+        result.PauseTimePercentage = info.PauseTimePercentage;
+        result.PinnedObjectsCount = info.PinnedObjectsCount;
+        result.PromotedInMb = new Size(info.PromotedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.TotalAvailableMemoryInMb = new Size(info.TotalAvailableMemoryBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.TotalCommittedInMb = new Size(info.TotalCommittedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+
+        return result;
+    }
+
+    private static double? GetPauseSeconds(GCMemoryInfo info, int index)
+    {
+        var pauses = info.PauseDurations;
+        if (pauses.IsEmpty || pauses.Length <= index)
+            return null;
+
+        return pauses[index].TotalSeconds;
     }
 
     private LicenseMetrics GetLicenseMetrics()

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Raven.Client;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
+using Raven.Server.Dashboard.Cluster.Notifications;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.ServerWide;
@@ -163,7 +164,6 @@ public sealed class MetricsProvider
 
         return result;
     }
-
     private GcMetrics GetGcMetrics()
     {
         var result = new GcMetrics();
@@ -172,7 +172,7 @@ public sealed class MetricsProvider
         if (info.Index == 0)
             return result;
 
-        result.Any = new GcMemoryInfoMetrics
+        result.Any = new GcInfoPayload.GcMemoryInfoMetrics
         {
             Index = info.Index,
             Generation = info.Generation,
@@ -189,7 +189,19 @@ public sealed class MetricsProvider
             PinnedObjectsCount = info.PinnedObjectsCount,
             PromotedInMb = new Size(info.PromotedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
             TotalAvailableMemoryInMb = new Size(info.TotalAvailableMemoryBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
-            TotalCommittedInMb = new Size(info.TotalCommittedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes)
+            TotalCommittedInMb = new Size(info.TotalCommittedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+
+            TotalHeapSizeAfterBytes = info.HeapSizeBytes,
+            PauseDurationsInMs =
+            [
+                info.PauseDurations.Length > 0 ? info.PauseDurations[0].TotalMilliseconds : 0,
+                info.PauseDurations.Length > 1 ? info.PauseDurations[1].TotalMilliseconds : 0
+            ],
+            Gen0HeapSize = GetGenerationInfoSize(info, 0),
+            Gen1HeapSize = GetGenerationInfoSize(info, 1),
+            Gen2HeapSize = GetGenerationInfoSize(info, 2),
+            LargeObjectHeapSize = GetGenerationInfoSize(info, 3),
+            PinnedObjectHeapSize = GetGenerationInfoSize(info, 4)
         };
 
         return result;
@@ -202,6 +214,21 @@ public sealed class MetricsProvider
             return null;
 
         return pauses[index].TotalSeconds;
+    }
+
+    private static GcInfoPayload.GenerationInfoSize GetGenerationInfoSize(GCMemoryInfo info, int index)
+    {
+        var generationInfo = info.GenerationInfo;
+        if (generationInfo.IsEmpty || generationInfo.Length <= index)
+            return null;
+
+        return new GcInfoPayload.GenerationInfoSize
+        {
+            SizeBeforeBytes = generationInfo[index].SizeBeforeBytes,
+            SizeAfterBytes = generationInfo[index].SizeAfterBytes,
+            FragmentationBeforeBytes = generationInfo[index].FragmentationBeforeBytes,
+            FragmentationAfterBytes = generationInfo[index].FragmentationAfterBytes
+        };
     }
 
     private LicenseMetrics GetLicenseMetrics()

--- a/src/Raven.Server/Monitoring/MetricsProvider.cs
+++ b/src/Raven.Server/Monitoring/MetricsProvider.cs
@@ -168,24 +168,29 @@ public sealed class MetricsProvider
     {
         var result = new GcMetrics();
 
-        var info = _server.MetricCacher.GetValue<GCMemoryInfo>(MetricCacher.Keys.Server.GcAny);
+        var info = GC.GetGCMemoryInfo(GCKind.Any);
+        if (info.Index == 0)
+            return result;
 
-        result.Index = info.Index;
-        result.Generation = info.Generation;
-        result.Compacted = info.Compacted;
-        result.Concurrent = info.Concurrent;
-        result.FinalizationPendingCount = info.FinalizationPendingCount;
-        result.FragmentedInMb = new Size(info.FragmentedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        result.HeapSizeInMb = new Size(info.HeapSizeBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        result.HighMemoryLoadThresholdInMb = new Size(info.HighMemoryLoadThresholdBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        result.MemoryLoadInMb = new Size(info.MemoryLoadBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        result.PauseDurations1InSec = GetPauseSeconds(info, 0);
-        result.PauseDurations2InSec = GetPauseSeconds(info, 1);
-        result.PauseTimePercentage = info.PauseTimePercentage;
-        result.PinnedObjectsCount = info.PinnedObjectsCount;
-        result.PromotedInMb = new Size(info.PromotedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        result.TotalAvailableMemoryInMb = new Size(info.TotalAvailableMemoryBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        result.TotalCommittedInMb = new Size(info.TotalCommittedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        result.Any = new GcMemoryInfoMetrics
+        {
+            Index = info.Index,
+            Generation = info.Generation,
+            Compacted = info.Compacted,
+            Concurrent = info.Concurrent,
+            FinalizationPendingCount = info.FinalizationPendingCount,
+            FragmentedInMb = new Size(info.FragmentedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+            HeapSizeInMb = new Size(info.HeapSizeBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+            HighMemoryLoadThresholdInMb = new Size(info.HighMemoryLoadThresholdBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+            MemoryLoadInMb = new Size(info.MemoryLoadBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+            PauseDurations1InSec = GetPauseSeconds(info, 0),
+            PauseDurations2InSec = GetPauseSeconds(info, 1),
+            PauseTimePercentage = info.PauseTimePercentage,
+            PinnedObjectsCount = info.PinnedObjectsCount,
+            PromotedInMb = new Size(info.PromotedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+            TotalAvailableMemoryInMb = new Size(info.TotalAvailableMemoryBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes),
+            TotalCommittedInMb = new Size(info.TotalCommittedBytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes)
+        };
 
         return result;
     }

--- a/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
+++ b/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
@@ -141,6 +141,19 @@ namespace Raven.Server.Utils.Monitoring
     }
     public sealed class GcMetrics
     {
+        public GcMemoryInfoMetrics Any { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Any)] = Any?.ToJson()
+            };
+        }
+    }
+
+    public sealed class GcMemoryInfoMetrics
+    {
         public long Index { get; set; }
         public int Generation { get; set; }
         public bool Compacted { get; set; }

--- a/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
+++ b/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
@@ -1,5 +1,6 @@
 ﻿using Raven.Client.ServerWide;
 using Raven.Server.Commercial;
+using Raven.Server.Dashboard.Cluster.Notifications;
 using Sparrow.Json.Parsing;
 using Sparrow.LowMemory;
 
@@ -141,56 +142,13 @@ namespace Raven.Server.Utils.Monitoring
     }
     public sealed class GcMetrics
     {
-        public GcMemoryInfoMetrics Any { get; set; }
+        public GcInfoPayload.GcMemoryInfo Any { get; set; }
 
         public DynamicJsonValue ToJson()
         {
             return new DynamicJsonValue
             {
                 [nameof(Any)] = Any?.ToJson()
-            };
-        }
-    }
-
-    public sealed class GcMemoryInfoMetrics
-    {
-        public long Index { get; set; }
-        public int Generation { get; set; }
-        public bool Compacted { get; set; }
-        public bool Concurrent { get; set; }
-        public long FinalizationPendingCount { get; set; }
-        public long FragmentedInMb { get; set; }
-        public long HeapSizeInMb { get; set; }
-        public long HighMemoryLoadThresholdInMb { get; set; }
-        public long MemoryLoadInMb { get; set; }
-        public double? PauseDurations1InSec { get; set; }
-        public double? PauseDurations2InSec { get; set; }
-        public double PauseTimePercentage { get; set; }
-        public long PinnedObjectsCount { get; set; }
-        public long PromotedInMb { get; set; }
-        public long TotalAvailableMemoryInMb { get; set; }
-        public long TotalCommittedInMb { get; set; }
-
-        public DynamicJsonValue ToJson()
-        {
-            return new DynamicJsonValue
-            {
-                [nameof(Index)] = Index,
-                [nameof(Generation)] = Generation,
-                [nameof(Compacted)] = Compacted,
-                [nameof(Concurrent)] = Concurrent,
-                [nameof(FinalizationPendingCount)] = FinalizationPendingCount,
-                [nameof(FragmentedInMb)] = FragmentedInMb,
-                [nameof(HeapSizeInMb)] = HeapSizeInMb,
-                [nameof(HighMemoryLoadThresholdInMb)] = HighMemoryLoadThresholdInMb,
-                [nameof(MemoryLoadInMb)] = MemoryLoadInMb,
-                [nameof(PauseDurations1InSec)] = PauseDurations1InSec,
-                [nameof(PauseDurations2InSec)] = PauseDurations2InSec,
-                [nameof(PauseTimePercentage)] = PauseTimePercentage,
-                [nameof(PinnedObjectsCount)] = PinnedObjectsCount,
-                [nameof(PromotedInMb)] = PromotedInMb,
-                [nameof(TotalAvailableMemoryInMb)] = TotalAvailableMemoryInMb,
-                [nameof(TotalCommittedInMb)] = TotalCommittedInMb
             };
         }
     }

--- a/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
+++ b/src/Raven.Server/Utils/Monitoring/ServerMetrics.cs
@@ -15,6 +15,7 @@ namespace Raven.Server.Utils.Monitoring
         public BackupMetrics Backup { get; set; }
         public CpuMetrics Cpu { get; set; }
         public MemoryMetrics Memory { get; set; }
+        public GcMetrics Gc { get; set; }
         public DiskMetrics Disk { get; set; }
         public LicenseMetrics License { get; set; }
         public NetworkMetrics Network { get; set; }
@@ -34,6 +35,7 @@ namespace Raven.Server.Utils.Monitoring
                 [nameof(Backup)] = Backup.ToJson(),
                 [nameof(Cpu)] = Cpu.ToJson(),
                 [nameof(Memory)] = Memory.ToJson(),
+                [nameof(Gc)] = Gc.ToJson(),
                 [nameof(Disk)] = Disk.ToJson(),
                 [nameof(License)] = License.ToJson(),
                 [nameof(Network)] = Network.ToJson(),
@@ -134,6 +136,48 @@ namespace Raven.Server.Utils.Monitoring
                 [nameof(AvailableMemoryForProcessingInMb)] = AvailableMemoryForProcessingInMb,
                 [nameof(ManagedMemoryInBytes)] = ManagedMemoryInBytes,
                 [nameof(UnmanagedMemoryInBytes)] = UnmanagedMemoryInBytes
+            };
+        }
+    }
+    public sealed class GcMetrics
+    {
+        public long Index { get; set; }
+        public int Generation { get; set; }
+        public bool Compacted { get; set; }
+        public bool Concurrent { get; set; }
+        public long FinalizationPendingCount { get; set; }
+        public long FragmentedInMb { get; set; }
+        public long HeapSizeInMb { get; set; }
+        public long HighMemoryLoadThresholdInMb { get; set; }
+        public long MemoryLoadInMb { get; set; }
+        public double? PauseDurations1InSec { get; set; }
+        public double? PauseDurations2InSec { get; set; }
+        public double PauseTimePercentage { get; set; }
+        public long PinnedObjectsCount { get; set; }
+        public long PromotedInMb { get; set; }
+        public long TotalAvailableMemoryInMb { get; set; }
+        public long TotalCommittedInMb { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(Index)] = Index,
+                [nameof(Generation)] = Generation,
+                [nameof(Compacted)] = Compacted,
+                [nameof(Concurrent)] = Concurrent,
+                [nameof(FinalizationPendingCount)] = FinalizationPendingCount,
+                [nameof(FragmentedInMb)] = FragmentedInMb,
+                [nameof(HeapSizeInMb)] = HeapSizeInMb,
+                [nameof(HighMemoryLoadThresholdInMb)] = HighMemoryLoadThresholdInMb,
+                [nameof(MemoryLoadInMb)] = MemoryLoadInMb,
+                [nameof(PauseDurations1InSec)] = PauseDurations1InSec,
+                [nameof(PauseDurations2InSec)] = PauseDurations2InSec,
+                [nameof(PauseTimePercentage)] = PauseTimePercentage,
+                [nameof(PinnedObjectsCount)] = PinnedObjectsCount,
+                [nameof(PromotedInMb)] = PromotedInMb,
+                [nameof(TotalAvailableMemoryInMb)] = TotalAvailableMemoryInMb,
+                [nameof(TotalCommittedInMb)] = TotalCommittedInMb
             };
         }
     }

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -149,9 +149,9 @@ namespace Raven.Server.Web.System
                         new Size(serverMetrics.Memory.UnmanagedMemoryInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Bytes));
 
                     // gc
-                    if (includeGc)
+                    if (includeGc && serverMetrics.Gc?.Any != null)
                     {
-                        WriteGcMetrics(writer, serverMetrics.Gc);
+                        WriteGcMetrics(writer, serverMetrics.Gc.Any, "any");
                     }
 
                     // network
@@ -203,9 +203,9 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private void WriteGcMetrics(StreamWriter writer, GcMetrics gcMetrics)
+        private void WriteGcMetrics(StreamWriter writer, GcMemoryInfoMetrics gcMetrics, string gcKind)
         {
-            var tags = SerializeTags(new Dictionary<string, string> { { "gckind", "any" } });
+            var tags = SerializeTags(new Dictionary<string, string> { { "gckind", gcKind } });
 
             // HELP strings for the GC metrics below are based on the official .NET API documentation for System.GCMemoryInfo
             // property descriptions, lightly adapted to match our Prometheus help style.

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -11,7 +11,6 @@ using Raven.Server.Documents;
 using Raven.Server.Monitoring;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Utils;
 using Raven.Server.Utils.Monitoring;
 using Sparrow;
 using Sparrow.LowMemory;
@@ -152,7 +151,7 @@ namespace Raven.Server.Web.System
                     // gc
                     if (includeGc)
                     {
-                        WriteGcMetrics(writer, Server.MetricCacher);
+                        WriteGcMetrics(writer, serverMetrics.Gc);
                     }
 
                     // network
@@ -204,50 +203,30 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private void WriteGcMetrics(StreamWriter writer, MetricCacher metricCacher)
+        private void WriteGcMetrics(StreamWriter writer, GcMetrics gcMetrics)
         {
-            WriteGcMetricsForKind(writer, metricCacher, GCKind.Any, MetricCacher.Keys.Server.GcAny);
-        }
+            var tags = SerializeTags(new Dictionary<string, string> { { "gckind", "any" } });
 
-        private void WriteGcMetricsForKind(StreamWriter writer, MetricCacher metricCacher, GCKind gcKind, string cacheKey)
-        {
-
-            var info = metricCacher.GetValue<GCMemoryInfo>(cacheKey);
-            var tags = SerializeTags(new Dictionary<string, string> { { nameof(GCKind).ToLower(), gcKind.ToString().ToLower() } });
-
-            // HELP strings for the GC metrics below are based on the official .NET API documentation for System.GCMemoryInfo (property descriptions),
-            // lightly adapted to match our Prometheus help style
+            // HELP strings for the GC metrics below are based on the official .NET API documentation for System.GCMemoryInfo
+            // property descriptions, lightly adapted to match our Prometheus help style.
             // https://learn.microsoft.com/en-us/dotnet/api/system.gcmemoryinfo
-            WriteGaugeWithHelp(writer, "Index of the last garbage collection", "gc_index", info.Index, tags);
-            WriteGaugeWithHelp(writer, "Generation collected by the last garbage collection", "gc_generation", info.Generation, tags);
-            WriteGaugeWithHelp(writer, "Whether the last garbage collection was compacting (1 = true, 0 = false)", "gc_compacted", info.Compacted ? 1 : 0, tags);
-            WriteGaugeWithHelp(writer, "Whether the last garbage collection was concurrent (1 = true, 0 = false)", "gc_concurrent", info.Concurrent ? 1 : 0, tags);
-            WriteGaugeWithHelp(writer, "Number of objects pending finalization observed during the last garbage collection", "gc_finalization_pending_count", info.FinalizationPendingCount, tags);
-            WriteGaugeWithHelp(writer, "Heap fragmentation in MB after the last garbage collection", "gc_fragmented_mb", BytesToMb(info.FragmentedBytes), tags);
-            WriteGaugeWithHelp(writer, "Total GC heap size in MB after the last garbage collection", "gc_heap_size_mb", BytesToMb(info.HeapSizeBytes), tags);
-            WriteGaugeWithHelp(writer, "High memory load threshold in MB at the time of the last garbage collection", "gc_high_memory_load_threshold_mb", BytesToMb(info.HighMemoryLoadThresholdBytes), tags);
-            WriteGaugeWithHelp(writer, "Memory load in MB at the time of the last garbage collection", "gc_memory_load_mb", BytesToMb(info.MemoryLoadBytes), tags);
-            WriteGaugeWithHelp(writer, "First GC pause duration in seconds recorded during the last garbage collection", "gc_pause_durations1_seconds", GetPauseSeconds(info, 0), tags);
-            WriteGaugeWithHelp(writer, "Second GC pause duration in seconds recorded during the last garbage collection", "gc_pause_durations2_seconds", GetPauseSeconds(info, 1), tags);
-            WriteGaugeWithHelp(writer, "Percentage of time spent paused for GC since the previous collection", "gc_pause_time_percentage", info.PauseTimePercentage, tags);
-            WriteGaugeWithHelp(writer, "Number of pinned objects observed during the last garbage collection", "gc_pinned_objects_count", info.PinnedObjectsCount, tags);
-            WriteGaugeWithHelp(writer, "Memory promoted during the last garbage collection in MB", "gc_promoted_mb", BytesToMb(info.PromotedBytes), tags);
-            WriteGaugeWithHelp(writer, "Total available memory for the GC in MB at the time of the last garbage collection", "gc_total_available_memory_mb", BytesToMb(info.TotalAvailableMemoryBytes), tags);
-            WriteGaugeWithHelp(writer, "Total committed managed heap size in MB after the last garbage collection", "gc_total_committed_mb", BytesToMb(info.TotalCommittedBytes), tags);
-        }
 
-        private static long BytesToMb(long bytes)
-        {
-            return new Size(bytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
-        }
-
-        private static double? GetPauseSeconds(GCMemoryInfo info, int index)
-        {
-            var pauses = info.PauseDurations;
-            if (pauses.IsEmpty || pauses.Length <= index)
-                return null;
-
-            return pauses[index].TotalSeconds;
+            WriteGaugeWithHelp(writer, "Index of the last garbage collection.", "gc_index", gcMetrics.Index, tags);
+            WriteGaugeWithHelp(writer, "Generation collected by the last garbage collection.", "gc_generation", gcMetrics.Generation, tags);
+            WriteGaugeWithHelp(writer, "Whether the last garbage collection was compacting (1 = true, 0 = false).", "gc_compacted", gcMetrics.Compacted ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Whether the last garbage collection was concurrent (1 = true, 0 = false).", "gc_concurrent", gcMetrics.Concurrent ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Number of objects pending finalization observed during the last garbage collection.", "gc_finalization_pending_count", gcMetrics.FinalizationPendingCount, tags);
+            WriteGaugeWithHelp(writer, "Heap fragmentation in MB after the last garbage collection.", "gc_fragmented_mb", gcMetrics.FragmentedInMb, tags);
+            WriteGaugeWithHelp(writer, "Total GC heap size in MB after the last garbage collection.", "gc_heap_size_mb", gcMetrics.HeapSizeInMb, tags);
+            WriteGaugeWithHelp(writer, "High memory load threshold in MB at the time of the last garbage collection.", "gc_high_memory_load_threshold_mb", gcMetrics.HighMemoryLoadThresholdInMb, tags);
+            WriteGaugeWithHelp(writer, "Memory load in MB at the time of the last garbage collection.", "gc_memory_load_mb", gcMetrics.MemoryLoadInMb, tags);
+            WriteGaugeWithHelp(writer, "First GC pause duration in seconds recorded during the last garbage collection.", "gc_pause_durations_1_seconds", gcMetrics.PauseDurations1InSec, tags);
+            WriteGaugeWithHelp(writer, "Second GC pause duration in seconds recorded during the last garbage collection.", "gc_pause_durations_2_seconds", gcMetrics.PauseDurations2InSec, tags);
+            WriteGaugeWithHelp(writer, "Percentage of time spent paused for GC since the previous collection.", "gc_pause_time_percentage", gcMetrics.PauseTimePercentage, tags);
+            WriteGaugeWithHelp(writer, "Number of pinned objects observed during the last garbage collection.", "gc_pinned_objects_count", gcMetrics.PinnedObjectsCount, tags);
+            WriteGaugeWithHelp(writer, "Memory promoted during the last garbage collection in MB.", "gc_promoted_mb", gcMetrics.PromotedInMb, tags);
+            WriteGaugeWithHelp(writer, "Total available memory for the GC in MB at the time of the last garbage collection.", "gc_total_available_memory_mb", gcMetrics.TotalAvailableMemoryInMb, tags);
+            WriteGaugeWithHelp(writer, "Total committed managed heap size in MB after the last garbage collection.", "gc_total_committed_mb", gcMetrics.TotalCommittedInMb, tags);
         }
 
         private static double KiloBytesToBytes(long? input)

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -212,30 +212,28 @@ namespace Raven.Server.Web.System
         private void WriteGcMetricsForKind(StreamWriter writer, MetricCacher metricCacher, GCKind gcKind, string cacheKey)
         {
 
-            var info = metricCacher.GetValue<GCMemoryInfo>(MetricCacher.Keys.Server.GcAny);
-
+            var info = metricCacher.GetValue<GCMemoryInfo>(cacheKey);
             var tags = SerializeTags(new Dictionary<string, string> { { nameof(GCKind).ToLower(), gcKind.ToString().ToLower() } });
 
             // HELP strings for the GC metrics below are based on the official .NET API documentation for System.GCMemoryInfo (property descriptions),
             // lightly adapted to match our Prometheus help style
             // https://learn.microsoft.com/en-us/dotnet/api/system.gcmemoryinfo
-
-            WriteGaugeWithHelp(writer, "The index of this GC", "gc_index", info.Index, tags);
-            WriteGaugeWithHelp(writer, "Gets the generation this GC collected", "gc_generation", info.Generation, tags);
-            WriteGaugeWithHelp(writer, "Specifies if this is a compacting GC or not", "gc_compacted", info.Compacted ? 1 : 0, tags);
-            WriteGaugeWithHelp(writer, "Specifies if this is a concurrent GC or not", "gc_concurrent", info.Concurrent ? 1 : 0, tags);
-            WriteGaugeWithHelp(writer, "Gets the number of objects ready for finalization this GC observed", "gc_finalization_pending_count", info.FinalizationPendingCount, tags);
-            WriteGaugeWithHelp(writer, "Gets the total fragmentation (in MB) when the last garbage collection occurred", "gc_fragmented_mb", BytesToMb(info.FragmentedBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the total heap size (in MB) when the last garbage collection occurred", "gc_heap_size_mb", BytesToMb(info.HeapSizeBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the high memory load threshold (in MB) when the last garbage collection occurred", "gc_high_memory_load_threshold_mb", BytesToMb(info.HighMemoryLoadThresholdBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the memory load (in MB) when the last garbage collection occurred", "gc_memory_load_mb", BytesToMb(info.MemoryLoadBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the pause durations. First item in the array", "gc_pause_durations_1_seconds", GetPauseSeconds(info, 0), tags);
-            WriteGaugeWithHelp(writer, "Gets the pause durations. Second item in the array", "gc_pause_durations_2_seconds", GetPauseSeconds(info, 1), tags);
-            WriteGaugeWithHelp(writer, "Gets the pause time percentage in the GC so far", "gc_pause_time_percentage", info.PauseTimePercentage, tags);
-            WriteGaugeWithHelp(writer, "Gets the number of pinned objects this GC observed", "gc_pinned_objects_count", info.PinnedObjectsCount, tags);
-            WriteGaugeWithHelp(writer, "Gets the promoted MB for this GC", "gc_promoted_mb", BytesToMb(info.PromotedBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the total available memory (in MB) for the garbage collector to use when the last garbage collection occurred", "gc_total_available_memory_mb", BytesToMb(info.TotalAvailableMemoryBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the total committed MB of the managed heap", "gc_total_committed_mb", BytesToMb(info.TotalCommittedBytes), tags);
+            WriteGaugeWithHelp(writer, "Index of the last garbage collection", "gc_index", info.Index, tags);
+            WriteGaugeWithHelp(writer, "Generation collected by the last garbage collection", "gc_generation", info.Generation, tags);
+            WriteGaugeWithHelp(writer, "Whether the last garbage collection was compacting (1 = true, 0 = false)", "gc_compacted", info.Compacted ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Whether the last garbage collection was concurrent (1 = true, 0 = false)", "gc_concurrent", info.Concurrent ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Number of objects pending finalization observed during the last garbage collection", "gc_finalization_pending_count", info.FinalizationPendingCount, tags);
+            WriteGaugeWithHelp(writer, "Heap fragmentation in MB after the last garbage collection", "gc_fragmented_mb", BytesToMb(info.FragmentedBytes), tags);
+            WriteGaugeWithHelp(writer, "Total GC heap size in MB after the last garbage collection", "gc_heap_size_mb", BytesToMb(info.HeapSizeBytes), tags);
+            WriteGaugeWithHelp(writer, "High memory load threshold in MB at the time of the last garbage collection", "gc_high_memory_load_threshold_mb", BytesToMb(info.HighMemoryLoadThresholdBytes), tags);
+            WriteGaugeWithHelp(writer, "Memory load in MB at the time of the last garbage collection", "gc_memory_load_mb", BytesToMb(info.MemoryLoadBytes), tags);
+            WriteGaugeWithHelp(writer, "First GC pause duration in seconds recorded during the last garbage collection", "gc_pause_durations1_seconds", GetPauseSeconds(info, 0), tags);
+            WriteGaugeWithHelp(writer, "Second GC pause duration in seconds recorded during the last garbage collection", "gc_pause_durations2_seconds", GetPauseSeconds(info, 1), tags);
+            WriteGaugeWithHelp(writer, "Percentage of time spent paused for GC since the previous collection", "gc_pause_time_percentage", info.PauseTimePercentage, tags);
+            WriteGaugeWithHelp(writer, "Number of pinned objects observed during the last garbage collection", "gc_pinned_objects_count", info.PinnedObjectsCount, tags);
+            WriteGaugeWithHelp(writer, "Memory promoted during the last garbage collection in MB", "gc_promoted_mb", BytesToMb(info.PromotedBytes), tags);
+            WriteGaugeWithHelp(writer, "Total available memory for the GC in MB at the time of the last garbage collection", "gc_total_available_memory_mb", BytesToMb(info.TotalAvailableMemoryBytes), tags);
+            WriteGaugeWithHelp(writer, "Total committed managed heap size in MB after the last garbage collection", "gc_total_committed_mb", BytesToMb(info.TotalCommittedBytes), tags);
         }
 
         private static long BytesToMb(long bytes)

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -220,22 +220,22 @@ namespace Raven.Server.Web.System
             // lightly adapted to match our Prometheus help style
             // https://learn.microsoft.com/en-us/dotnet/api/system.gcmemoryinfo
 
-            WriteGaugeWithHelp(writer, "The index of this GC.", "gc_index", info.Index, tags);
-            WriteGaugeWithHelp(writer, "Gets the generation this GC collected.", "gc_generation", info.Generation, tags);
-            WriteGaugeWithHelp(writer, "Specifies if this is a compacting GC or not.", "gc_compacted", info.Compacted ? 1 : 0, tags);
-            WriteGaugeWithHelp(writer, "Specifies if this is a concurrent GC or not.", "gc_concurrent", info.Concurrent ? 1 : 0, tags);
-            WriteGaugeWithHelp(writer, "Gets the number of objects ready for finalization this GC observed.", "gc_finalization_pending_count", info.FinalizationPendingCount, tags);
-            WriteGaugeWithHelp(writer, "Gets the total fragmentation (in MB) when the last garbage collection occurred.", "gc_fragmented_mb", BytesToMb(info.FragmentedBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the total heap size (in MB) when the last garbage collection occurred.", "gc_heap_size_mb", BytesToMb(info.HeapSizeBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the high memory load threshold (in MB) when the last garbage collection occurred.", "gc_high_memory_load_threshold_mb", BytesToMb(info.HighMemoryLoadThresholdBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the memory load (in MB) when the last garbage collection occurred.", "gc_memory_load_mb", BytesToMb(info.MemoryLoadBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the pause durations. First item in the array.", "gc_pause_durations_1_seconds", GetPauseSeconds(info, 0), tags);
-            WriteGaugeWithHelp(writer, "Gets the pause durations. Second item in the array.", "gc_pause_durations_2_seconds", GetPauseSeconds(info, 1), tags);
-            WriteGaugeWithHelp(writer, "Gets the pause time percentage in the GC so far.", "gc_pause_time_percentage", info.PauseTimePercentage, tags);
-            WriteGaugeWithHelp(writer, "Gets the number of pinned objects this GC observed.", "gc_pinned_objects_count", info.PinnedObjectsCount, tags);
-            WriteGaugeWithHelp(writer, "Gets the promoted MB for this GC.", "gc_promoted_mb", BytesToMb(info.PromotedBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the total available memory (in MB) for the garbage collector to use when the last garbage collection occurred.", "gc_total_available_memory_mb", BytesToMb(info.TotalAvailableMemoryBytes), tags);
-            WriteGaugeWithHelp(writer, "Gets the total committed MB of the managed heap.", "gc_total_committed_mb", BytesToMb(info.TotalCommittedBytes), tags);
+            WriteGaugeWithHelp(writer, "The index of this GC", "gc_index", info.Index, tags);
+            WriteGaugeWithHelp(writer, "Gets the generation this GC collected", "gc_generation", info.Generation, tags);
+            WriteGaugeWithHelp(writer, "Specifies if this is a compacting GC or not", "gc_compacted", info.Compacted ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Specifies if this is a concurrent GC or not", "gc_concurrent", info.Concurrent ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Gets the number of objects ready for finalization this GC observed", "gc_finalization_pending_count", info.FinalizationPendingCount, tags);
+            WriteGaugeWithHelp(writer, "Gets the total fragmentation (in MB) when the last garbage collection occurred", "gc_fragmented_mb", BytesToMb(info.FragmentedBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the total heap size (in MB) when the last garbage collection occurred", "gc_heap_size_mb", BytesToMb(info.HeapSizeBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the high memory load threshold (in MB) when the last garbage collection occurred", "gc_high_memory_load_threshold_mb", BytesToMb(info.HighMemoryLoadThresholdBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the memory load (in MB) when the last garbage collection occurred", "gc_memory_load_mb", BytesToMb(info.MemoryLoadBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the pause durations. First item in the array", "gc_pause_durations_1_seconds", GetPauseSeconds(info, 0), tags);
+            WriteGaugeWithHelp(writer, "Gets the pause durations. Second item in the array", "gc_pause_durations_2_seconds", GetPauseSeconds(info, 1), tags);
+            WriteGaugeWithHelp(writer, "Gets the pause time percentage in the GC so far", "gc_pause_time_percentage", info.PauseTimePercentage, tags);
+            WriteGaugeWithHelp(writer, "Gets the number of pinned objects this GC observed", "gc_pinned_objects_count", info.PinnedObjectsCount, tags);
+            WriteGaugeWithHelp(writer, "Gets the promoted MB for this GC", "gc_promoted_mb", BytesToMb(info.PromotedBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the total available memory (in MB) for the garbage collector to use when the last garbage collection occurred", "gc_total_available_memory_mb", BytesToMb(info.TotalAvailableMemoryBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the total committed MB of the managed heap", "gc_total_committed_mb", BytesToMb(info.TotalCommittedBytes), tags);
         }
 
         private static long BytesToMb(long bytes)

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -12,6 +12,7 @@ using Raven.Server.Monitoring;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils.Monitoring;
+using Raven.Server.Dashboard.Cluster.Notifications;
 using Sparrow;
 using Sparrow.LowMemory;
 
@@ -149,9 +150,9 @@ namespace Raven.Server.Web.System
                         new Size(serverMetrics.Memory.UnmanagedMemoryInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Bytes));
 
                     // gc
-                    if (includeGc && serverMetrics.Gc?.Any != null)
+                    if (includeGc && serverMetrics.Gc.Any is GcInfoPayload.GcMemoryInfoMetrics gcMetrics)
                     {
-                        WriteGcMetrics(writer, serverMetrics.Gc.Any, "any");
+                        WriteGcMetrics(writer, gcMetrics, "any");
                     }
 
                     // network
@@ -203,7 +204,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private void WriteGcMetrics(StreamWriter writer, GcMemoryInfoMetrics gcMetrics, string gcKind)
+        private void WriteGcMetrics(StreamWriter writer, GcInfoPayload.GcMemoryInfoMetrics gcMetrics, string gcKind)
         {
             var tags = SerializeTags(new Dictionary<string, string> { { "gckind", gcKind } });
 

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -221,8 +221,8 @@ namespace Raven.Server.Web.System
             WriteGaugeWithHelp(writer, "Total GC heap size in MB after the last garbage collection.", "gc_heap_size_mb", gcMetrics.HeapSizeInMb, tags);
             WriteGaugeWithHelp(writer, "High memory load threshold in MB at the time of the last garbage collection.", "gc_high_memory_load_threshold_mb", gcMetrics.HighMemoryLoadThresholdInMb, tags);
             WriteGaugeWithHelp(writer, "Memory load in MB at the time of the last garbage collection.", "gc_memory_load_mb", gcMetrics.MemoryLoadInMb, tags);
-            WriteGaugeWithHelp(writer, "First GC pause duration in seconds recorded during the last garbage collection.", "gc_pause_durations_1_seconds", gcMetrics.PauseDurations1InSec, tags);
-            WriteGaugeWithHelp(writer, "Second GC pause duration in seconds recorded during the last garbage collection.", "gc_pause_durations_2_seconds", gcMetrics.PauseDurations2InSec, tags);
+            WriteGaugeWithHelp(writer, "First GC pause duration in seconds recorded during the last garbage collection.", "gc_pause_durations_1_seconds", gcMetrics.GetPauseDurationSeconds(0), tags);
+            WriteGaugeWithHelp(writer, "Second GC pause duration in seconds recorded during the last garbage collection.", "gc_pause_durations_2_seconds", gcMetrics.GetPauseDurationSeconds(1), tags);
             WriteGaugeWithHelp(writer, "Percentage of time spent paused for GC since the previous collection.", "gc_pause_time_percentage", gcMetrics.PauseTimePercentage, tags);
             WriteGaugeWithHelp(writer, "Number of pinned objects observed during the last garbage collection.", "gc_pinned_objects_count", gcMetrics.PinnedObjectsCount, tags);
             WriteGaugeWithHelp(writer, "Memory promoted during the last garbage collection in MB.", "gc_promoted_mb", gcMetrics.PromotedInMb, tags);

--- a/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
+++ b/src/Raven.Server/Web/System/AdminPrometheusMonitoringHandler.cs
@@ -11,6 +11,7 @@ using Raven.Server.Documents;
 using Raven.Server.Monitoring;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
+using Raven.Server.Utils;
 using Raven.Server.Utils.Monitoring;
 using Sparrow;
 using Sparrow.LowMemory;
@@ -57,6 +58,7 @@ namespace Raven.Server.Web.System
             var skipDatabases = GetBoolValueQueryString("skipDatabasesMetrics", false) ?? false;
             var skipIndexes = GetBoolValueQueryString("skipIndexesMetrics", false) ?? false;
             var skipCollections = GetBoolValueQueryString("skipCollectionsMetrics", false) ?? false;
+            var includeGc = GetBoolValueQueryString("includeGcMetrics", false) ?? false;
 
             var provider = new MetricsProvider(Server);
 
@@ -66,7 +68,7 @@ namespace Raven.Server.Web.System
             
             if (skipServer == false)
             {
-                await WriteServerMetricsAsync(provider, responseStream);
+                await WriteServerMetricsAsync(provider, responseStream, includeGc);
             }
 
             if (skipDatabases == false)
@@ -85,7 +87,7 @@ namespace Raven.Server.Web.System
             }
         }
 
-        private async Task WriteServerMetricsAsync(MetricsProvider provider, Stream responseStream)
+        private async Task WriteServerMetricsAsync(MetricsProvider provider, Stream responseStream, bool includeGc)
         {
             var serverMetrics = provider.CollectServerMetrics();
 
@@ -147,6 +149,12 @@ namespace Raven.Server.Web.System
                     WriteGaugeWithHelp(writer, "Unmanaged memory", "unmanaged_memory_bytes",
                         new Size(serverMetrics.Memory.UnmanagedMemoryInBytes, SizeUnit.Bytes).GetValue(SizeUnit.Bytes));
 
+                    // gc
+                    if (includeGc)
+                    {
+                        WriteGcMetrics(writer, Server.MetricCacher);
+                    }
+
                     // network
                     WriteGaugeWithHelp(writer, "Number of active TCP connections", "network_tcp_active_connections", serverMetrics.Network.TcpActiveConnections);
                     WriteGaugeWithHelp(writer, "Number of concurrent requests", "network_concurrent_requests_count", serverMetrics.Network.ConcurrentRequestsCount);
@@ -194,6 +202,54 @@ namespace Raven.Server.Web.System
                 ms.Position = 0;
                 await ms.CopyToAsync(responseStream);
             }
+        }
+
+        private void WriteGcMetrics(StreamWriter writer, MetricCacher metricCacher)
+        {
+            WriteGcMetricsForKind(writer, metricCacher, GCKind.Any, MetricCacher.Keys.Server.GcAny);
+        }
+
+        private void WriteGcMetricsForKind(StreamWriter writer, MetricCacher metricCacher, GCKind gcKind, string cacheKey)
+        {
+
+            var info = metricCacher.GetValue<GCMemoryInfo>(MetricCacher.Keys.Server.GcAny);
+
+            var tags = SerializeTags(new Dictionary<string, string> { { nameof(GCKind).ToLower(), gcKind.ToString().ToLower() } });
+
+            // HELP strings for the GC metrics below are based on the official .NET API documentation for System.GCMemoryInfo (property descriptions),
+            // lightly adapted to match our Prometheus help style
+            // https://learn.microsoft.com/en-us/dotnet/api/system.gcmemoryinfo
+
+            WriteGaugeWithHelp(writer, "The index of this GC.", "gc_index", info.Index, tags);
+            WriteGaugeWithHelp(writer, "Gets the generation this GC collected.", "gc_generation", info.Generation, tags);
+            WriteGaugeWithHelp(writer, "Specifies if this is a compacting GC or not.", "gc_compacted", info.Compacted ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Specifies if this is a concurrent GC or not.", "gc_concurrent", info.Concurrent ? 1 : 0, tags);
+            WriteGaugeWithHelp(writer, "Gets the number of objects ready for finalization this GC observed.", "gc_finalization_pending_count", info.FinalizationPendingCount, tags);
+            WriteGaugeWithHelp(writer, "Gets the total fragmentation (in MB) when the last garbage collection occurred.", "gc_fragmented_mb", BytesToMb(info.FragmentedBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the total heap size (in MB) when the last garbage collection occurred.", "gc_heap_size_mb", BytesToMb(info.HeapSizeBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the high memory load threshold (in MB) when the last garbage collection occurred.", "gc_high_memory_load_threshold_mb", BytesToMb(info.HighMemoryLoadThresholdBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the memory load (in MB) when the last garbage collection occurred.", "gc_memory_load_mb", BytesToMb(info.MemoryLoadBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the pause durations. First item in the array.", "gc_pause_durations_1_seconds", GetPauseSeconds(info, 0), tags);
+            WriteGaugeWithHelp(writer, "Gets the pause durations. Second item in the array.", "gc_pause_durations_2_seconds", GetPauseSeconds(info, 1), tags);
+            WriteGaugeWithHelp(writer, "Gets the pause time percentage in the GC so far.", "gc_pause_time_percentage", info.PauseTimePercentage, tags);
+            WriteGaugeWithHelp(writer, "Gets the number of pinned objects this GC observed.", "gc_pinned_objects_count", info.PinnedObjectsCount, tags);
+            WriteGaugeWithHelp(writer, "Gets the promoted MB for this GC.", "gc_promoted_mb", BytesToMb(info.PromotedBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the total available memory (in MB) for the garbage collector to use when the last garbage collection occurred.", "gc_total_available_memory_mb", BytesToMb(info.TotalAvailableMemoryBytes), tags);
+            WriteGaugeWithHelp(writer, "Gets the total committed MB of the managed heap.", "gc_total_committed_mb", BytesToMb(info.TotalCommittedBytes), tags);
+        }
+
+        private static long BytesToMb(long bytes)
+        {
+            return new Size(bytes, SizeUnit.Bytes).GetValue(SizeUnit.Megabytes);
+        }
+
+        private static double? GetPauseSeconds(GCMemoryInfo info, int index)
+        {
+            var pauses = info.PauseDurations;
+            if (pauses.IsEmpty || pauses.Length <= index)
+                return null;
+
+            return pauses[index].TotalSeconds;
         }
 
         private static double KiloBytesToBytes(long? input)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26147/Expose-GC-metrics-on-monitoring-v1-prometheus

### Additional description

Adds optional GC metrics to the Prometheus monitoring endpoint (`/admin/monitoring/v1/prometheus`).

GC metrics are exposed only when the query parameter `IncludeGcMetrics=true` is provided, so the default behavior and payload size of the endpoint remain unchanged.

The metrics are based on .NET System.GCMemoryInfo values and follow the same caching mechanism used by other monitoring integrations by retrieving values through MetricCacher (`MetricCacher.Keys.Server.GcAny`) this allows us to avoid repeated runtime calls during Prometheus scrapes.

Descriptions were adapted from the official .NET GCMemoryInfo documentation.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [X] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [] Not relevant

### Backward compatibility

- [ X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [X] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [X] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [X] No UI work is needed
