### PR TITLE
[v7.1] RavenDB-26148 fix (setup wizard): Removed redundant setup method heading

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSetupMethodStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSetupMethodStep.tsx
@@ -33,7 +33,6 @@ export function SetupWizardSetupMethodStep() {
                 You can set up a new cluster, create a configuration package for external setup, or continue with an
                 existing setup package.
             </p>
-            <h2 className="mb-1">Choose your setup method</h2>
             <div className="mt-4">
                 <h5 className="mb-1">I&apos;m starting a new cluster setup:</h5>
                 <SetupWizardClickableCard


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26148

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
