### PR TITLE
RavenDB_6.2-24174 : fixed flaky test WaitForIndexesAfterPatch_DynamicQuery_WithTimeoutShouldntThrow

### DIFF
--- a/test/SlowTests/Issues/RavenDB_23103.cs
+++ b/test/SlowTests/Issues/RavenDB_23103.cs
@@ -719,21 +719,19 @@ namespace SlowTests.Issues
         {
             using (var store = GetDocumentStore(new Options
             {
-                ModifyDatabaseRecord = record => record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MapBatchSize)] = 128.ToString()
+                ModifyDatabaseRecord = record =>
+                {
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ThrottlingTimeInterval)] = "1000";
+                    record.Settings[RavenConfiguration.GetKey(x => x.Indexing.MapBatchSize)] = 128.ToString();
+                }
             }))
             {
-                var indexDef = new Companies_ByName();
-                indexDef.Execute(store);
-                string indexName;
-
                 using (var session = store.OpenSession())
                 {
                     session.Query<Company>()
                         .Statistics(out var stats)
                         .Where(x => x.Name == "___")
                         .ToList();
-
-                    indexName = stats.IndexName;
                 }
 
                 using (var bulk = store.BulkInsert())
@@ -745,7 +743,6 @@ namespace SlowTests.Issues
                 }
 
                 var database = Databases.GetDocumentDatabaseInstanceFor(store).Result;
-                database.IndexStore.GetIndex(indexName).ForTestingPurposesOnly().CallDuringFinallyOfExecuteIndexing(() => Thread.Sleep(1));
                 Indexes.WaitForIndexing(store);
 
                 var iq = new IndexQuery { Query = $"from companies as c where c != null update {{ c.Name = 'Name2' }}" };
@@ -762,12 +759,16 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession())
                 {
-                    var count = session.Query<Company, Companies_ByName>().Count(x => x.Name == "Name2");
-                     Assert.NotEqual(NumberOfCompanies, count);
+                    var count = session.Query<Company>()
+                        .Statistics(out var stats)
+                        .Count(x => x.Name == "Name2");
+
+                    Assert.StartsWith("Auto/", stats.IndexName);
+                    Assert.True(stats.IsStale);
+                    Assert.NotEqual(NumberOfCompanies, count);
                 }
             }
         }
-
 
         /****************DELETE************************/
         [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Querying)]


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24174/SlowTests.Issues.RavenDB23103.WaitForIndexesAfterPatchDynamicQueryWithTimeoutShouldntThrow

### Additional description

The test was flaky because the background indexer was actively processing updates concurrently with the patch operation. On fast systems, the index would often finish within the 1ms timeout window, causing the Assert.NotEqual check to fail due to a race condition.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
