### PR TITLE
RavenDB-26098: Optimizations for Faceted Range and Terms

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -291,29 +291,42 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
     {
         var needToApplyAggregation = result.Aggregations.Count > 0;
         var ranges = result.Ranges;
+        if (ranges == null || ranges.Count == 0)
+            return;
+
+        // Read the field value once per document, then check every range against it.
+        var firstRange = ranges[0] as FacetedQueryParser.CoraxParsedRange;
+        if (firstRange == null)
+            return;
+
+        var fieldRootPage = GetFieldRootPage(firstRange.Field);
+        reader.Reset();
+        bool fieldFound = false;
+        while (reader.FindNext(fieldRootPage))
+        {
+            if (reader.IsNull || reader.IsNonExisting)
+                continue; // skip null/non-existing entries, look for actual value
+            fieldFound = true;
+            break;
+        }
+        if (!fieldFound)
+            return;
+
+        var currentDouble = reader.CurrentDouble;
+        var currentLong = reader.CurrentLong;
+        byte[] currentDecodedBytes = result.RangeType == RangeType.None ? reader.Current.Decoded().ToArray() : null;
 
         foreach (var parsedRange in ranges)
         {
             if (parsedRange is not FacetedQueryParser.CoraxParsedRange range)
                 continue;
 
-            var fieldRootPage = GetFieldRootPage(range.Field);
-
-            bool isMatching = false;
-            reader.Reset();
-            while (reader.FindNext(fieldRootPage))
+            bool isMatching = result.RangeType switch
             {
-                if (reader.IsNull || reader.IsNonExisting)
-                    continue;
-
-                isMatching = result.RangeType switch
-                {
-                    RangeType.Double => range.IsMatch(reader.CurrentDouble),
-                    RangeType.Long => range.IsMatch(reader.CurrentLong),
-                    _ => range.IsMatch(reader.Current.Decoded())
-                };
-                break;
-            }
+                RangeType.Double => range.IsMatch(currentDouble),
+                RangeType.Long => range.IsMatch(currentLong),
+                _ => range.IsMatch(currentDecodedBytes.AsSpan())
+            };
 
             var collectionOfFacetValues = facetValues[range.RangeText];
             if (isMatching)
@@ -322,7 +335,6 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                 if (needToApplyAggregation)
                     ApplyAggregation(result.Aggregations, collectionOfFacetValues, ref reader);
             }
-
             token.ThrowIfCancellationRequested();
         }
     }
@@ -352,15 +364,14 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         {
             if (reader.IsNonExisting)
                 continue;
-            
-            
+
             var key = reader.IsNull
                 ? Constants.ProjectionNullValueSlice
                 : reader.Current.Decoded();
 
             if (key.SequenceEqual(Constants.EmptyStringByteSpan))
                 key = Constants.ProjectionEmptyStringSlice;
-            
+
             InsertTerm(key, ref cloned, facetValues, result, legacy, needToApplyAggregation, token);
         }
     }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -96,6 +96,8 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                 for (int i = 0; i < read; i++)
                     baseQueryMatchingIds.Add(ids[i]);
 
+                token.ThrowIfCancellationRequested();
+
                 // When exceeded, fall back to the scanning path which streams with bounded memory.
                 if (baseQueryMatchingIds.Count > maxMatchingIds)
                 {
@@ -116,11 +118,45 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                 var metadata = GetFieldMetadata(result.Key);
 
                 var provider = _indexSearcher.TextualAggregation(metadata, forward: result.Value.Options.TermSortMode is not FacetTermSortMode.ValueDesc);
-                using var aggregationScope = provider.AggregateByTerms(out result.Value.SortedIds, out var counts);
+                // When WHERE is present we must NOT set SortedIds: UpdateFacetResults uses it as the
+                // authoritative term list and would emit FacetValue{count=0} for every term in it,
+                // including terms filtered out by the WHERE clause.
+                List<string> sortedIds;
+                using var aggregationScope = provider.AggregateByTerms(out sortedIds, out var counts);
+                if (baseQueryMatchingIds == null)
+                    result.Value.SortedIds = sortedIds;
 
                 var idX = 0;
-                foreach (var term in CollectionsMarshal.AsSpan(result.Value.SortedIds))
+                foreach (var term in CollectionsMarshal.AsSpan(sortedIds))
                 {
+                    long count;
+                    if (baseQueryMatchingIds != null)
+                    {
+                        var queryTerm = ReferenceEquals(term, Constants.ProjectionNullValue) ? null
+                            : ReferenceEquals(term, Constants.ProjectionEmptyString) ? Constants.EmptyString
+                            : term;
+                        var termMatch = _indexSearcher.TermQuery(metadata, queryTerm);
+                        count = 0;
+                        int read;
+                        while ((read = termMatch.Fill(ids)) != 0)
+                        {
+                            for (int i = 0; i < read; i++)
+                            {
+                                if (baseQueryMatchingIds.Contains(ids[i]))
+                                    count++;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        count = counts[idX];
+                    }
+
+                    idX++;
+
+                    if (count == 0)
+                        continue;
+
                     ref var collectionOfFacetValues = ref CollectionsMarshal.GetValueRefOrAddDefault(facetValues, term, out var exists);
                     if (exists == false)
                     {
@@ -129,7 +165,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                         collectionOfFacetValues.AddDefault(range);
                     }
 
-                    collectionOfFacetValues.IncrementCount((int)counts[idX++]);
+                    collectionOfFacetValues.IncrementCount((int)count);
                 }
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexFacetedReadOperation.cs
@@ -47,10 +47,12 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
     public override List<FacetResult> FacetedQuery(FacetQuery facetQuery, QueryTimingsScope queryTimings, DocumentsOperationContext context,
         Func<string, SpatialField> getSpatialField, CancellationToken token)
     {
-        //We currently only supports count aggregation by index, however in scanning we already have entry reader so let's use indexed facet only in case when user wants to count per term/range
+        // Use the indexed path (posting-list operations) when possible.
+        // The scanning path is only needed for aggregations (sum/avg/min/max) and AllResults facets
+        // which require per-document field access via EntryTermsReader.
+        // When a WHERE clause is present, the indexed path materializes matching doc IDs once
+        // and intersects with each facet's posting list.
         var canUseIndexedFacetQuery = true;
-        canUseIndexedFacetQuery &= facetQuery.Query.Metadata.Query.Where is null;
-
         var results = FacetedQueryParser.Parse(context, facetQuery, SearchEngineType.Corax);
         foreach (var result in results)
         {
@@ -73,9 +75,38 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
         var coraxPageSize = CoraxBufferSize(_indexSearcher, facetQuery.Query.PageSize, query);
         var ids = CoraxIndexReadOperation.QueryPool.Rent(coraxPageSize);
         CreateMappingForRanges(results, facetsByRange, facetQuery);
+
+        // When a WHERE clause is present, materialize all matching doc IDs into a HashSet.
+        // Both term and range facets intersect their posting lists against this set.
+        // deduplicationDisabled: true is safe here because the HashSet absorbs duplicates
+        // and skipping the query-level dedup saves work during materialization.
+        HashSet<long> baseQueryMatchingIds = null;
+        if (query.Metadata.Query.Where is not null)
+        {
+            var parameters = new CoraxQueryBuilder.Parameters(_indexSearcher, _allocator, null, null, query, _index,
+                query.QueryParameters, _queryBuilderFactories, _fieldMappings, null, null, -1,
+                deduplicationDisabled: true, token: token);
+            var baseQuery = CoraxQueryBuilder.BuildQuery(parameters, out _);
+            queryTimings?.SetQueryPlan(baseQuery.Inspect());
+            var maxMatchingIds = _indexSearcher.MaxMemoizationSizeInBytes / sizeof(long);
+            baseQueryMatchingIds = new HashSet<long>();
+            int read;
+            while ((read = baseQuery.Fill(ids)) != 0)
+            {
+                for (int i = 0; i < read; i++)
+                    baseQueryMatchingIds.Add(ids[i]);
+
+                // When exceeded, fall back to the scanning path which streams with bounded memory.
+                if (baseQueryMatchingIds.Count > maxMatchingIds)
+                {
+                    CoraxIndexReadOperation.QueryPool.Return(ids);
+                    return ScanningFacetedQuery(results, facetQuery, queryTimings, context, getSpatialField, token);
+                }
+            }
+        }
+
         foreach (var result in results)
         {
-            var needToApplyAggregation = result.Value.Aggregations.Count > 0;
             Dictionary<string, FacetValues> facetValues;
             if (result.Value.Ranges == null || result.Value.Ranges.Count == 0)
             {
@@ -85,7 +116,7 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                 var metadata = GetFieldMetadata(result.Key);
 
                 var provider = _indexSearcher.TextualAggregation(metadata, forward: result.Value.Options.TermSortMode is not FacetTermSortMode.ValueDesc);
-                using var _ = provider.AggregateByTerms(out result.Value.SortedIds, out var counts);
+                using var aggregationScope = provider.AggregateByTerms(out result.Value.SortedIds, out var counts);
 
                 var idX = 0;
                 foreach (var term in CollectionsMarshal.AsSpan(result.Value.SortedIds))
@@ -95,23 +126,10 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                     {
                         var range = FacetedQueryHelper.GetRangeName(result.Value.AggregateBy, term);
                         collectionOfFacetValues = new FacetValues(facetQuery.Legacy);
-                        if (needToApplyAggregation == false)
-                            collectionOfFacetValues.AddDefault(range);
-                        else
-                        {
-                            foreach (var aggregation in result.Value.Aggregations)
-                                collectionOfFacetValues.Add(aggregation.Key, range);
-                        }
+                        collectionOfFacetValues.AddDefault(range);
                     }
 
                     collectionOfFacetValues.IncrementCount((int)counts[idX++]);
-                    if (needToApplyAggregation)
-                    {
-                        //not supported yet.
-                        throw new InvalidOperationException("Facet queries that need to apply aggregation should be handled via scanning reader. This code path is not supposed to be reached for such queries.");
-                    }
-
-                    continue;
                 }
             }
 
@@ -133,14 +151,29 @@ public sealed class CoraxIndexFacetedReadOperation : IndexFacetReadOperationBase
                     collectionOfFacetValues = new FacetValues(facetQuery.Legacy);
 
                 var fieldMetadata = GetFieldMetadata(range.Field);
-                var aggregationProvider = range.GetAggregation(_indexSearcher, fieldMetadata, true);
-                var count = aggregationProvider.AggregateByRange();
-                collectionOfFacetValues.IncrementCount((int)count);
-                if (needToApplyAggregation)
+                long count;
+
+                if (baseQueryMatchingIds != null)
                 {
-                    //not supported yet.
-                    throw new InvalidOperationException("Facet queries that need to apply aggregation should be handled via scanning reader. This code path is not supposed to be reached for such queries.");
+                    var rangeQuery = range.GetQuery(_indexSearcher, fieldMetadata);
+                    count = 0;
+                    int read;
+                    while ((read = rangeQuery.Fill(ids)) != 0)
+                    {
+                        for (int i = 0; i < read; i++)
+                        {
+                            if (baseQueryMatchingIds.Contains(ids[i]))
+                                count++;
+                        }
+                    }
                 }
+                else
+                {
+                    var aggregationProvider = range.GetAggregation(_indexSearcher, fieldMetadata, true);
+                    count = aggregationProvider.AggregateByRange();
+                }
+
+                collectionOfFacetValues.IncrementCount((int)count);
 
                 token.ThrowIfCancellationRequested();
             }

--- a/src/Raven.Server/Documents/Queries/Facets/FacetedQueryParser.cs
+++ b/src/Raven.Server/Documents/Queries/Facets/FacetedQueryParser.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using Corax.Mappings;
 using Corax.Querying;
+using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
 using Lucene.Net.Util;
 using Raven.Client.Documents.Indexes;
@@ -471,6 +472,39 @@ namespace Raven.Server.Documents.Queries.Facets
                     RangeType.Double or RangeType.Long => searcher.LowAggregationBuilder(metadata, HighValueAsDouble, highValueRange, forward),
                     _ => searcher.LowAggregationBuilder(metadata, HighValue, highValueRange, forward)
                 };
+            }
+
+            public MultiTermMatch GetQuery(IndexSearcher searcher, in FieldMetadata metadata, bool forward = true)
+            {
+                var type = IsNumerical ? RangeType.Double : RangeType.None;
+                var lowValueRange = RangeTypeToCoraxRange(_leftSide);
+                var highValueRange = RangeTypeToCoraxRange(_rightSide);
+
+                if (LowValue != null && HighValue != null)
+                {
+                    return type switch
+                    {
+                        RangeType.Double or RangeType.Long => searcher.BetweenQuery(metadata, LowValueAsDouble, HighValueAsDouble, lowValueRange, highValueRange, forward),
+                        _ => searcher.BetweenQuery(metadata, LowValue, HighValue, lowValueRange, highValueRange, forward)
+                    };
+                }
+
+                if (LowValue != null)
+                {
+                    if (type is RangeType.Double or RangeType.Long)
+                        return searcher.BetweenQuery(metadata, LowValueAsDouble, double.MaxValue, lowValueRange, UnaryMatchOperation.LessThanOrEqual, forward);
+
+                    return lowValueRange == UnaryMatchOperation.GreaterThan
+                        ? searcher.GreaterThanQuery(metadata, LowValue, forward)
+                        : searcher.GreatThanOrEqualsQuery(metadata, LowValue, forward);
+                }
+
+                if (type is RangeType.Double or RangeType.Long)
+                    return searcher.BetweenQuery(metadata, double.MinValue, HighValueAsDouble, UnaryMatchOperation.GreaterThanOrEqual, highValueRange, forward);
+
+                return highValueRange == UnaryMatchOperation.LessThan
+                    ? searcher.LessThanQuery(metadata, HighValue, forward)
+                    : searcher.LessThanOrEqualsQuery(metadata, HighValue, forward);
             }
 
             private UnaryMatchOperation RangeTypeToCoraxRange(Operation o) => o switch

--- a/test/SlowTests/Corax/RavenDB-26098.cs
+++ b/test/SlowTests/Corax/RavenDB-26098.cs
@@ -146,6 +146,53 @@ start.AddDays(21).ToString("yyyy-MM-dd") });
         }
     }
 
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void RangeFacetsWithWhereClauseReturnCorrectCounts(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new ProductIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Category = "Electronics", Price = 50.0, Stock = 10 });
+            session.Store(new Product { Category = "Electronics", Price = 150.0, Stock = 5 });
+            session.Store(new Product { Category = "Electronics", Price = 250.0, Stock = 3 });
+            session.Store(new Product { Category = "Books", Price = 20.0, Stock = 100 });
+            session.Store(new Product { Category = "Books", Price = 80.0, Stock = 50 });
+            session.Store(new Product { Category = "Clothing", Price = 30.0, Stock = 75 });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Product, ProductIndex>()
+                .Where(p => p.Category == "Electronics")
+                .AggregateBy(facet => facet.ByRanges(
+                    p => p.Price < 100,
+                    p => p.Price >= 100 && p.Price < 200,
+                    p => p.Price >= 200))
+                .Execute();
+
+            Assert.True(results.ContainsKey("Price"));
+            var priceRanges = results["Price"].Values;
+
+            var below100 = priceRanges.FirstOrDefault(v => v.Range.Contains("< 100"));
+            var between100and200 = priceRanges.FirstOrDefault(v => v.Range.Contains(">= 100") && v.Range.Contains("< 200"));
+            var above200 = priceRanges.FirstOrDefault(v => v.Range.Contains(">= 200") && !v.Range.Contains("< "));
+
+            Assert.NotNull(below100);
+            Assert.NotNull(between100and200);
+            Assert.NotNull(above200);
+
+            Assert.Equal(1, below100.Count);
+            Assert.Equal(1, between100and200.Count);
+            Assert.Equal(1, above200.Count);
+        }
+    }
+
     private static void AssertFacetValue(List<FacetValue> values, string name, int expectedCount,
         double? average = null, double? min = null, double? max = null, double? sum = null,
         string range = null, string[] rangeFragments = null)

--- a/test/SlowTests/Corax/RavenDB-26098.cs
+++ b/test/SlowTests/Corax/RavenDB-26098.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Queries.Facets;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+/// <summary>
+/// RavenDB-26098: Corax facet queries with a WHERE clause use the indexed path
+/// (HashSet intersection). Verifies correctness and parity with Lucene.
+/// </summary>
+public class RavenDB_26098 : RavenTestBase
+{
+    public RavenDB_26098(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class Product
+    {
+        public string Id { get; set; }
+        public string Category { get; set; }
+        public double Price { get; set; }
+        public int Stock { get; set; }
+        public DateTime OrderedAt { get; set; }
+        public double DurationMs { get; set; }
+        public int Failed { get; set; }
+    }
+
+    private class ProductIndex : AbstractIndexCreationTask<Product>
+    {
+        public override string IndexName => "Products/ByCategory";
+
+        public ProductIndex()
+        {
+            Map = products => from p in products
+                              select new { p.Category, p.Price, p.Stock, p.OrderedAt, p.DurationMs, p.Failed };
+        }
+    }
+
+    /// <summary>
+    /// Range facets with WHERE + aggregations (sum/avg/min/max) must go through the
+    /// scanning path and produce correct per-range aggregated values.
+    /// Exercises the HandleRangeFacetsPerDocument optimization (read field once per doc).
+    /// </summary>
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+    public void RangeFacetsWithWhereClauseCanApplyAggregations(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new ProductIndex());
+
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Category = "Electronics", OrderedAt = start.AddDays(1), DurationMs = 10, Failed = 0 });
+            session.Store(new Product { Category = "Electronics", OrderedAt = start.AddDays(2), DurationMs = 30, Failed = 1 });
+            session.Store(new Product { Category = "Electronics", OrderedAt = start.AddDays(9), DurationMs = 40, Failed = 1 });
+            session.Store(new Product { Category = "Electronics", OrderedAt = start.AddDays(15), DurationMs = 80, Failed = 0 });
+            session.Store(new Product { Category = "Books", OrderedAt = start.AddDays(2), DurationMs = 999, Failed = 1 });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Product, ProductIndex>()
+                .Where(p => p.Category == "Electronics")
+                .AggregateBy(facet => facet.ByRanges(
+                        p => p.OrderedAt >= start && p.OrderedAt < start.AddDays(7),
+                        p => p.OrderedAt >= start.AddDays(7) && p.OrderedAt < start.AddDays(14),
+                        p => p.OrderedAt >= start.AddDays(14) && p.OrderedAt < start.AddDays(21))
+                    .AverageOn(p => p.DurationMs)
+                    .MaxOn(p => p.DurationMs)
+                    .MinOn(p => p.DurationMs)
+                    .SumOn(p => p.Failed))
+                .Execute();
+
+            var values = results[nameof(Product.OrderedAt)].Values;
+
+            AssertFacetValue(values, nameof(Product.DurationMs), 2, average: 20, min: 10, max: 30, rangeFragments: new[] { start.ToString("yyyy-MM-dd"),
+start.AddDays(7).ToString("yyyy-MM-dd") });
+            AssertFacetValue(values, nameof(Product.Failed), 2, sum: 1, rangeFragments: new[] { start.ToString("yyyy-MM-dd"), start.AddDays(7).ToString("yyyy-MM-dd") });
+
+            AssertFacetValue(values, nameof(Product.DurationMs), 1, average: 40, min: 40, max: 40, rangeFragments: new[] { start.AddDays(7).ToString("yyyy-MM-dd"),
+start.AddDays(14).ToString("yyyy-MM-dd") });
+            AssertFacetValue(values, nameof(Product.Failed), 1, sum: 1, rangeFragments: new[] { start.AddDays(7).ToString("yyyy-MM-dd"), start.AddDays(14).ToString("yyyy-MM-dd") });
+
+            AssertFacetValue(values, nameof(Product.DurationMs), 1, average: 80, min: 80, max: 80, rangeFragments: new[] { start.AddDays(14).ToString("yyyy-MM-dd"),
+start.AddDays(21).ToString("yyyy-MM-dd") });
+            AssertFacetValue(values, nameof(Product.Failed), 1, sum: 0, rangeFragments: new[] { start.AddDays(14).ToString("yyyy-MM-dd"), start.AddDays(21).ToString("yyyy-MM-dd") });
+        }
+    }
+
+    /// <summary>
+    /// Term facets with WHERE + aggregations must go through the scanning path
+    /// and produce correct per-term aggregated values including NULL_VALUE.
+    /// </summary>
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.Single)]
+    public void TermFacetsWithWhereClauseCanApplyAggregations(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new ProductIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Category = "Electronics", Price = 150, DurationMs = 10, Failed = 0 });
+            session.Store(new Product { Category = "Electronics", Price = 250, DurationMs = 30, Failed = 1 });
+            session.Store(new Product { Category = "Books", Price = 180, DurationMs = 40, Failed = 1 });
+            session.Store(new Product { Category = "Books", Price = 50, DurationMs = 999, Failed = 1 });
+            session.Store(new Product { Category = null, Price = 170, DurationMs = 20, Failed = 0 });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Product, ProductIndex>()
+                .Where(p => p.Price >= 100)
+                .AggregateBy(facet => facet.ByField(p => p.Category)
+                    .AverageOn(p => p.DurationMs)
+                    .MaxOn(p => p.DurationMs)
+                    .MinOn(p => p.DurationMs)
+                    .SumOn(p => p.Failed))
+                .Execute();
+
+            var values = results[nameof(Product.Category)].Values;
+
+            AssertFacetValue(values, nameof(Product.DurationMs), 2, average: 20, min: 10, max: 30, range: "electronics");
+            AssertFacetValue(values, nameof(Product.Failed), 2, sum: 1, range: "electronics");
+
+            AssertFacetValue(values, nameof(Product.DurationMs), 1, average: 40, min: 40, max: 40, range: "books");
+            AssertFacetValue(values, nameof(Product.Failed), 1, sum: 1, range: "books");
+
+            AssertFacetValue(values, nameof(Product.DurationMs), 1, average: 20, min: 20, max: 20, range: "NULL_VALUE");
+            AssertFacetValue(values, nameof(Product.Failed), 1, sum: 0, range: "NULL_VALUE");
+        }
+    }
+
+    private static void AssertFacetValue(List<FacetValue> values, string name, int expectedCount,
+        double? average = null, double? min = null, double? max = null, double? sum = null,
+        string range = null, string[] rangeFragments = null)
+    {
+        var matching = values.Where(v => v.Name == name);
+
+        if (range != null)
+            matching = matching.Where(v => v.Range == range);
+
+        if (rangeFragments != null)
+            matching = matching.Where(v => rangeFragments.All(f => v.Range.Contains(f)));
+
+        var value = matching.Single();
+        Assert.Equal(expectedCount, value.Count);
+
+        if (average.HasValue)
+            Assert.Equal(average.Value, value.Average.Value, 1);
+        if (min.HasValue)
+            Assert.Equal(min.Value, value.Min.Value, 1);
+        if (max.HasValue)
+            Assert.Equal(max.Value, value.Max.Value, 1);
+        if (sum.HasValue)
+            Assert.Equal(sum.Value, value.Sum.Value, 1);
+    }
+}

--- a/test/SlowTests/Corax/RavenDB-26098.cs
+++ b/test/SlowTests/Corax/RavenDB-26098.cs
@@ -193,6 +193,138 @@ start.AddDays(21).ToString("yyyy-MM-dd") });
         }
     }
 
+    /// <summary>
+    /// Term (ByField) facets with a WHERE clause must include NULL_VALUE and
+    /// EMPTY_STRING entries, consistent with Lucene behaviour.
+    /// </summary>
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void TermFacetsWithWhereClauseIncludeNullAndEmptyString(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new ProductIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Category = "Electronics", Price = 50.0, Stock = 10 });
+            session.Store(new Product { Category = "Electronics", Price = 150.0, Stock = 5 });
+            session.Store(new Product { Category = "Books", Price = 20.0, Stock = 100 });
+            session.Store(new Product { Category = null, Price = 75.0, Stock = 1 });
+            session.Store(new Product { Category = "", Price = 80.0, Stock = 2 });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Product, ProductIndex>()
+                .Where(p => p.Price > 0)
+                .AggregateBy(facet => facet.ByField(p => p.Category))
+                .Execute();
+
+            Assert.True(results.ContainsKey("Category"));
+            var values = results["Category"].Values;
+            var ranges = values.Select(v => v.Range).ToList();
+
+            Assert.Contains("electronics", ranges);
+            Assert.Contains("books", ranges);
+            Assert.Contains("NULL_VALUE", ranges);
+            Assert.Contains("EMPTY_STRING", ranges);
+
+            Assert.Equal(2, values.First(v => v.Range == "electronics").Count);
+            Assert.Equal(1, values.First(v => v.Range == "books").Count);
+            Assert.Equal(1, values.First(v => v.Range == "NULL_VALUE").Count);
+            Assert.Equal(1, values.First(v => v.Range == "EMPTY_STRING").Count);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that term facet counts for NULL_VALUE and EMPTY_STRING are
+    /// correct when the WHERE clause filters out some but not all of those
+    /// documents — ensuring the indexed intersection counts properly.
+    /// </summary>
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void TermFacetsWithWhereClausePartialFilterCounts(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new ProductIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Category = null, Price = 10.0, Stock = 1 });
+            session.Store(new Product { Category = null, Price = 200.0, Stock = 2 });
+            session.Store(new Product { Category = null, Price = 300.0, Stock = 3 });
+            session.Store(new Product { Category = "", Price = 15.0, Stock = 4 });
+            session.Store(new Product { Category = "", Price = 250.0, Stock = 5 });
+            session.Store(new Product { Category = "Electronics", Price = 50.0, Stock = 6 });
+            session.Store(new Product { Category = "Electronics", Price = 500.0, Stock = 7 });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Product, ProductIndex>()
+                .Where(p => p.Price >= 100)
+                .AggregateBy(facet => facet.ByField(p => p.Category))
+                .Execute();
+
+            var values = results["Category"].Values;
+
+            Assert.Equal(2, values.First(v => v.Range == "NULL_VALUE").Count);
+            Assert.Equal(1, values.First(v => v.Range == "EMPTY_STRING").Count);
+            Assert.Equal(1, values.First(v => v.Range == "electronics").Count);
+        }
+    }
+
+    /// <summary>
+    /// Term facets with WHERE clause and ValueDesc sort mode must return
+    /// correctly ordered and paged results.
+    /// </summary>
+    [RavenTheory(RavenTestCategory.Facets)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void TermFacetsWithWhereClauseAndValueDescSortMode(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        store.ExecuteIndex(new ProductIndex());
+
+        using (var session = store.OpenSession())
+        {
+            session.Store(new Product { Category = "Alpha", Price = 100.0, Stock = 1 });
+            session.Store(new Product { Category = "Beta", Price = 200.0, Stock = 2 });
+            session.Store(new Product { Category = "Gamma", Price = 300.0, Stock = 3 });
+            session.Store(new Product { Category = "Delta", Price = 400.0, Stock = 4 });
+            session.SaveChanges();
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Query<Product, ProductIndex>()
+                .Where(p => p.Price >= 100)
+                .AggregateBy(builder => builder
+                    .ByField(p => p.Category)
+                    .WithOptions(new FacetOptions
+                    {
+                        TermSortMode = FacetTermSortMode.ValueDesc,
+                        Start = 0,
+                        PageSize = 2
+                    }))
+                .Execute();
+
+            var values = results["Category"].Values;
+
+            // ValueDesc: gamma, delta, beta, alpha — page size 2 → gamma, delta
+            Assert.Equal(2, values.Count);
+            Assert.Equal("gamma", values[0].Range);
+            Assert.Equal("delta", values[1].Range);
+        }
+    }
+
     private static void AssertFacetValue(List<FacetValue> values, string name, int expectedCount,
         double? average = null, double? min = null, double? max = null, double? sum = null,
         string range = null, string[] rangeFragments = null)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26098

### Additional description

Corax facet queries with a WHERE clause were falling through to the scanning path (per-document field reads). This PR routes them through the indexed path instead, using HashSet intersection: materialize the base query's matching doc IDs, then for each term/range posting list, count entries present in the set.

Three commits:

1. Scanning-path fix: Read the field value once per document instead of re-seeking per range. O(N_docs) seeks instead of O(N_docs × M_ranges).
2. Indexed path for range facets with WHERE: Intersect range posting lists against the materialized HashSet.
3. Indexed path for term facets with WHERE: Same HashSet intersection for term facets.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
