### PR TITLE
RavenDB-26118 - skip ONNX tests on 32 bits

### DIFF
--- a/test/SlowTests/Corax/RavenDB_23453.cs
+++ b/test/SlowTests/Corax/RavenDB_23453.cs
@@ -18,7 +18,7 @@ namespace SlowTests.Corax;
 
 public class RavenDB_23453_Integration(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [InlineData(true, true)]
     [InlineData(true, false)]
     [InlineData(false, true)]
@@ -103,7 +103,7 @@ public class RavenDB_23453_Integration(ITestOutputHelper output) : RavenTestBase
     }
 
 
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax)]
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Querying | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [InlineDataWithRandomSeed(true, true)]
     [InlineDataWithRandomSeed(true, false)]
     [InlineDataWithRandomSeed(false, true)]

--- a/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/GenerateEmbeddingsTests.cs
@@ -930,7 +930,7 @@ Console.WriteLine(""Hello, World!"");";
         }
     }
 
-    [RavenFact(RavenTestCategory.Ai | RavenTestCategory.Vector | RavenTestCategory.Etl)]
+    [RavenMultiplatformFact(RavenTestCategory.Ai | RavenTestCategory.Vector | RavenTestCategory.Etl, RavenArchitecture.AllX64)]
     public async Task QuantizationOfEmbeddingsInTwoTasks()
     {
         using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));

--- a/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/LoadVectorFromExternalDocumentTests.cs
@@ -18,13 +18,13 @@ namespace SlowTests.Server.Documents.AI.Embeddings;
 
 public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : EmbeddingsGenerationTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexSingleVectorGeneratedByEtlForDifferentDocument() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByName>();
     
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexSingleVectorGeneratedByEtlForDifferentDocumentExplicitCollectionName() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByNameExplicitCollection>();
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexSingleVectorGeneratedByEtlForDifferentDocumentJs() => await CanIndexSingleVectorGeneratedByEtlBase<IndexByNameJs>();
 
     private async Task CanIndexSingleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
@@ -110,13 +110,13 @@ public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : Emb
         AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Name", ["sdklfjklsadjkl;assdjaskll"], dtoId);
     }
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexMultipleVectorGeneratedByEtlForDifferentDocumentExplicitCollectionName() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesExplicitCollection>();
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexMultipleVectorGeneratedByEtlForDifferentDocument() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNames>();
     
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexMultipleVectorGeneratedByEtlForDifferentDocumentJs() => await CanIndexMultipleVectorGeneratedByEtlBase<IndexByNamesJs>();
 
     private async Task CanIndexMultipleVectorGeneratedByEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
@@ -198,13 +198,13 @@ public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : Emb
         AssertEmbeddingsForPath(store, aiIntegrationIdentifier, aiConnectionStringIdentifier, "Names", ["sdklfjklsadjkl;assdjaskll"], dtoId);
     }
     
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexVectorFromTwoDifferentEtlExplicitCollectionName() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsExplicitCollection>();
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexVectorFromTwoDifferentEtl() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFields>();
     
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public async Task CanIndexVectorFromTwoDifferentEtlJs() => await CanIndexVectorFromTwoDifferentEtlBase<IndexByFieldTwoFieldsJs>();
 
     private async Task CanIndexVectorFromTwoDifferentEtlBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()
@@ -297,10 +297,10 @@ public class LoadVectorFromExternalDocumentTests(ITestOutputHelper output) : Emb
         AssertEmbeddingsForPath(store, new EmbeddingsGenerationTaskIdentifier(config2.Identifier), new AiConnectionStringIdentifier(connectionString2.Identifier), "Names", ["Jimmy"], id);
     }
 
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public Task CanLoadVectorsFromTwoDifferentCollections() => CanLoadVectorsFromTwoDifferentCollectionsBase<IndexByNamesFromCurrentAndDifferentCollection>();
     
-    [RavenFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformFact(RavenTestCategory.Etl | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     public Task CanLoadVectorsFromTwoDifferentCollectionJs() => CanLoadVectorsFromTwoDifferentCollectionsBase<IndexByNamesFromCurrentAndDifferentCollectionJs>();
     
     private async Task CanLoadVectorsFromTwoDifferentCollectionsBase<TIndex>() where TIndex : AbstractIndexCreationTask, new()

--- a/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
+++ b/test/SlowTests/Server/Documents/AI/Embeddings/QueryingTests.cs
@@ -397,7 +397,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
         }
     }
 
-    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task WillFindUpdatedEmbeddingValues(Options options)
     {
@@ -439,7 +439,7 @@ public class QueryingTests(ITestOutputHelper output) : EmbeddingsGenerationTestB
     }
 
 
-    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
     public async Task MultiVectorSearchMinOnDuplicates(Options options)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26118

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
