### PR TITLE
RavenDB-26113 - don't check CheckForMissingAttachmentsAndThrowIfNeede…

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
@@ -75,7 +75,7 @@ namespace Raven.Server.Documents.TcpHandlers
 
             var databaseContext = DatabaseContext;
             if (databaseContext != null)
-                sb.Append($" for database '{databaseContext.DatabaseName}'");
+                sb.Append($" for sharded database '{databaseContext.DatabaseName}'");
 
             return sb.ToString();
         }

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -326,7 +326,7 @@ namespace FastTests
 
                     store.BeforeDispose += (sender, args) =>
                     {
-                        CheckForMissingAttachmentsAndThrowIfNeeded(store, Context, name, serverToUse, caller);
+                        CheckForMissingAttachmentsAndThrowIfNeeded(store, Context, name, serverToUse, caller, sharded);
 
                         var realException = Context.GetException();
                         try
@@ -409,8 +409,11 @@ namespace FastTests
             "Can_push_via_filtered_replication" //TODO: remove when RavenDB-24415 is fixed
         ];
 
-        private static void CheckForMissingAttachmentsAndThrowIfNeeded(DocumentStore store, Context context, string name, RavenServer serverToUse, string caller)
+        private static void CheckForMissingAttachmentsAndThrowIfNeeded(DocumentStore store, Context context, string name, RavenServer serverToUse, string caller, bool sharded)
         {
+            if (sharded)
+                return;
+
             if (IsRavenTestCategoryTest(context, RavenTestCategory.Attachments | RavenTestCategory.Replication) == false)
                 return;
 


### PR DESCRIPTION
…d for sharded tests

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26113/SlowTests.Server.Replication.ReplicationSpecialCases.IdenticalContentConflictResolutionoptions-DatabaseMode-Sharded

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
