### PR TITLE
RavenDB-25975 - Add `sendToModel` on the conversation level

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
@@ -1,32 +1,38 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.AI;
 
 public class AiConversationCreationOptions : IDynamicJson
 {
-    public Dictionary<string, object> Parameters { get; set; }
+    public Dictionary<string, AiConversationParameterValue> Parameters { get; set; }
     public int? ExpirationInSec { get; set; }
     public int? MaxModelIterationsPerCall { get; set; }
 
     public AiConversationCreationOptions()
     {
-         
     }
-    public AiConversationCreationOptions AddParameter(string name, object value)
+
+    public AiConversationCreationOptions AddParameter(string name, object value, bool sendToModel = true)
     {
         if (value is not string && value is IEnumerable ie)
             value = new DynamicJsonArray(ie);
-        Parameters ??= new Dictionary<string, object>();
-        Parameters.Add(name, value);
+        Parameters ??= new Dictionary<string, AiConversationParameterValue>();
+        Parameters.Add(name, new AiConversationParameterValue { Value = value, SendToModel = sendToModel});
         return this;
+    }
+
+    public AiConversationCreationOptions(Dictionary<string, AiConversationParameterValue> parameters)
+    {
+        Parameters = parameters;
     }
 
     public AiConversationCreationOptions(Dictionary<string, object> parameters)
     {
-        Parameters = parameters;
+        Parameters = parameters.ToDictionary(kv => kv.Key, kv => new AiConversationParameterValue { Value = kv.Value, SendToModel = true});
     }
 
     public DynamicJsonValue ToJson()
@@ -35,6 +41,23 @@ public class AiConversationCreationOptions : IDynamicJson
         {
             [nameof(ExpirationInSec)] = ExpirationInSec,
             [nameof(Parameters)] = Parameters != null ? DynamicJsonValue.Convert(Parameters) : null,
+        };
+    }
+}
+
+public class AiConversationParameterValue : IDynamicJson
+{
+    public object Value { get; set; }
+    public bool SendToModel { get; set; } = true;
+    public DynamicJsonValue ToJson()
+    {
+        var json = Value as IDynamicJson;
+        var val = json == null ? (object)Value : json.ToJson();
+
+        return new DynamicJsonValue
+        {
+            [nameof(Value)] = val,
+            [nameof(SendToModel)] = SendToModel
         };
     }
 }

--- a/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
@@ -8,7 +8,7 @@ namespace Raven.Client.Documents.AI;
 
 public class AiConversationCreationOptions : IDynamicJson
 {
-    public Dictionary<string, AiConversationParameterValue> Parameters { get; set; }
+    public Dictionary<string, AiConversationParameter> Parameters { get; set; }
     public int? ExpirationInSec { get; set; }
     public int? MaxModelIterationsPerCall { get; set; }
 
@@ -16,23 +16,23 @@ public class AiConversationCreationOptions : IDynamicJson
     {
     }
 
-    public AiConversationCreationOptions AddParameter(string name, object value, bool sendToModel = true)
+    public AiConversationCreationOptions AddParameter(string name, object value, AiConversationParameterOptions options = null)
     {
         if (value is not string && value is IEnumerable ie)
             value = new DynamicJsonArray(ie);
-        Parameters ??= new Dictionary<string, AiConversationParameterValue>();
-        Parameters.Add(name, new AiConversationParameterValue { Value = value, SendToModel = sendToModel});
+        Parameters ??= new Dictionary<string, AiConversationParameter>();
+        Parameters.Add(name, new AiConversationParameter { Value = value, SendToModel = options?.SendToModel ?? true});
         return this;
     }
 
-    public AiConversationCreationOptions(Dictionary<string, AiConversationParameterValue> parameters)
+    public AiConversationCreationOptions(Dictionary<string, AiConversationParameter> parameters)
     {
         Parameters = parameters;
     }
 
     public AiConversationCreationOptions(Dictionary<string, object> parameters)
     {
-        Parameters = parameters.ToDictionary(kv => kv.Key, kv => new AiConversationParameterValue { Value = kv.Value, SendToModel = true});
+        Parameters = parameters.ToDictionary(kv => kv.Key, kv => new AiConversationParameter { Value = kv.Value, SendToModel = true});
     }
 
     public DynamicJsonValue ToJson()
@@ -45,7 +45,12 @@ public class AiConversationCreationOptions : IDynamicJson
     }
 }
 
-public class AiConversationParameterValue : IDynamicJson
+public class AiConversationParameterOptions
+{
+    public bool SendToModel { get; set; } = true;
+}
+
+public class AiConversationParameter : IDynamicJson
 {
     public object Value { get; set; }
     public bool SendToModel { get; set; } = true;

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -128,7 +128,7 @@ public class ChatCompletionClient : IDisposable
         foreach (var subAgent in configuration.SubAgents ?? [])
         {
             var subAgentConfiguration = handler.GetAiAgentConfiguration(subAgent.Identifier);
-            var parameters = ConversationHandler.BuildSubAgentParameters(context, configuration, subAgentConfiguration);
+            var parameters = handler.BuildSubAgentParameters(context, configuration, subAgentConfiguration);
             var paramsSchema = ConversationHandler.GetSchemaForSubAgentTool(context, parameters);
             var description = new StringBuilder(subAgent.Description).AppendLine();
             subAgentConfiguration.AppendCapabilities(description);

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -45,27 +45,40 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         if (Messages.Count > 0)
             throw new InvalidOperationException("conversation document is already initialized. Cannot re-initialize.");
 
-        List<AiAgentParameter> relevantParameters = [];
-        var parameters = configuration.Parameters;
+        List<AiAgentParameter> modelParameters = [];
+        var configParams = configuration.Parameters ?? [];
 
-        if (parameters != null)
+        foreach (var p in configParams)
         {
-            for (int i = 0; i < parameters.Count; i++)
+            // Skip parameters that should not be sent to the model
+            if (p.SendToModel == false)
+                continue;
+
+            if (Parameters == null || Parameters.TryGet(p.Name, out object value) == false)
+                throw new MissingAiAgentParameterException($"Parameter '{p.Name}' is missing.");
+
+            var param = ConversationHandler.GetAiConversationParameter(p.Name, value);
+            if (param.SendToModel)
+                modelParameters.Add(p);
+        }
+
+        // Additional Parameters (that are not defined in the configuration, but still should be sent to the model)
+        if (Parameters != null)
+        {
+            foreach (var paramName in Parameters.GetPropertyNames())
             {
-                var p = parameters[i];
-                if (p.SendToModel != false)
-                    relevantParameters.Add(p);
+                if (configParams.Any(p => p.Name == paramName))
+                    continue;
+
+                var param = ConversationHandler.GetAiConversationParameter(paramName, Parameters[paramName]);
+                if (param.SendToModel)
+                    modelParameters.Add(new AiAgentParameter(paramName));
             }
         }
 
-        foreach (var parameter in relevantParameters)
-        {
-            if (Parameters == null || Parameters.TryGet(parameter.Name, out object _) == false)
-                throw new MissingAiAgentParameterException($"Parameter '{parameter.Name}' is missing.");
-        }
 
         var promptMessage = configuration.SystemPrompt;
-        if (TryCreateParameterDescriptionMessage(relevantParameters, out string message))
+        if (TryCreateParameterDescriptionMessage(modelParameters, out string message))
         {
             promptMessage += "\n" + message;
         }
@@ -76,12 +89,12 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
             [ChatCompletionClient.Constants.RequestFields.Content] = promptMessage
         }, "system/msg"), usage: null);
 
-        if (relevantParameters.Count > 0)
+        if (modelParameters.Count > 0)
         {
             AddMessage(context, context.ReadObject(new DynamicJsonValue
             {
                 [ChatCompletionClient.Constants.RequestFields.Role] = ChatCompletionClient.Constants.RequestFields.RoleUserValue,
-                [ChatCompletionClient.Constants.RequestFields.Content] = ParametersToString(relevantParameters)
+                [ChatCompletionClient.Constants.RequestFields.Content] = ParametersToString(modelParameters)
             }, "system/msg"), usage: null);
         }
 
@@ -155,9 +168,8 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         var sb = new StringBuilder("AI Agent Parameters:\n");
         foreach (var parameter in parameters)
         {
-            var value = ConversationHandler.GetAiConversationParameter(parameter.Name, Parameters[parameter.Name]);
-            if (value.SendToModel)
-                sb.AppendLine($"{parameter.Name} = {value.Value?.ToString() ?? "null"}");
+            var value = ConversationHandler.GetAiConversationParameter(parameter.Name, Parameters[parameter.Name]).Value;
+            sb.AppendLine($"{parameter.Name} = {value?.ToString() ?? "null"}");
         }
 
         return sb.ToString();

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -155,8 +155,9 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         var sb = new StringBuilder("AI Agent Parameters:\n");
         foreach (var parameter in parameters)
         {
-            var value = Parameters[parameter.Name];
-            sb.AppendLine($"{parameter.Name} = {value?.ToString() ?? "null"}");
+            var value = ConversationHandler.GetAiConversationParameterValue(parameter.Name, Parameters[parameter.Name]);
+            if (value.SendToModel)
+                sb.AppendLine($"{parameter.Name} = {value.Value.ToString()}");
         }
 
         return sb.ToString();

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -155,9 +155,9 @@ public class ConversationDocument([NotNull] string agent, BlittableJsonReaderObj
         var sb = new StringBuilder("AI Agent Parameters:\n");
         foreach (var parameter in parameters)
         {
-            var value = ConversationHandler.GetAiConversationParameterValue(parameter.Name, Parameters[parameter.Name]);
+            var value = ConversationHandler.GetAiConversationParameter(parameter.Name, Parameters[parameter.Name]);
             if (value.SendToModel)
-                sb.AppendLine($"{parameter.Name} = {value.Value.ToString()}");
+                sb.AppendLine($"{parameter.Name} = {value.Value?.ToString() ?? "null"}");
         }
 
         return sb.ToString();

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.SubAgent.cs
@@ -60,6 +60,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
 
             args.Modifications = new DynamicJsonValue(args);
+            // this is going to be the prompt so we remove this from the parameters we pass to the sub-agent,
+            // we want to keep the parameters clean and only with what the sub-agent needs to do its work
             args.Modifications.Remove(ConversationDocument.SubAgentUserPromptKey);
 
             var parameters = MergeParams(context, document.Parameters, args);
@@ -213,7 +215,7 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             }
         }
 
-        public static Dictionary<string, ParameterDefinition> BuildSubAgentParameters(JsonOperationContext context, AiAgentConfiguration parent, AiAgentConfiguration child)
+        public Dictionary<string, ParameterDefinition> BuildSubAgentParameters(JsonOperationContext context, AiAgentConfiguration parent, AiAgentConfiguration child)
         {
             var parameters = new Dictionary<string, ParameterDefinition>();
             // We only add what the sub-agent has that the root agent doesn't have
@@ -235,6 +237,12 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
                     }
 
                     // parent has this parameter with matching type
+                    continue;
+                }
+
+                if (_document.Parameters.TryGetMember(parameter.Name, out _))
+                {
+                    // conversation has this parameter
                     continue;
                 }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -172,6 +172,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             if (requestParameters.TryGetMember(configParam.Name, out object value) == false)
                 continue;
 
+            value = GetAiConversationParameterValue(configParam.Name, value).Value;
             var expectedType = configParam.Type;
 
             if (expectedType == AiAgentParameterValueType.Default)
@@ -297,6 +298,45 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 return false;
         }
     }
+
+    public static AiConversationParameterValue GetAiConversationParameterValue(string paramName, object paramValue)
+    {
+        var sendToModel = true; // At the conversation level
+        var realValue = paramValue;
+        if (paramValue is BlittableJsonReaderObject obj)
+        {
+            // Backward compatibility:
+            // * Old payload format:
+            // {
+            //     "maxBudgetNis": 3500
+            // }
+            // * New payload format:
+            // {
+            //     "maxBudgetNis": {
+            //         "value": 3500,
+            //         "sendToModel": true
+            //     }
+            // }
+            // If the parameter is not an object with a "value" field, we assume it's the old format and use the value directly.
+
+            if (obj.TryGetMember("Value", out realValue) == false)
+            {
+                // Should never reach here - Object parameters are not supported
+                throw new InvalidCastException(
+                    $"Parameter '{paramName}' has unsupported type. " +
+                    $"Actual: Object");
+            }
+            if (obj.TryGet("SendToModel", out sendToModel) == false)
+                sendToModel = true; //default
+        }
+
+        return new AiConversationParameterValue
+        {
+            Value = realValue,
+            SendToModel = sendToModel
+        };
+    }
+
 
 
     private ChatCompletionClient _client;
@@ -610,7 +650,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             // Important: we *override* any parameter from the model with the user provided values
             // to ensure the safety & security of this feature. Model cannot override those values, period.
             parameters.GetPropertyByIndex(i, ref prop);
-            args.Modifications[prop.Name] = prop.Value;
+            args.Modifications[prop.Name] = GetAiConversationParameterValue(prop.Name, prop.Value).Value;
         }
 
         return context.ReadObject(args, "args");

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -172,7 +172,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             if (requestParameters.TryGetMember(configParam.Name, out object value) == false)
                 continue;
 
-            value = GetAiConversationParameterValue(configParam.Name, value).Value;
+            value = GetAiConversationParameter(configParam.Name, value).Value;
             var expectedType = configParam.Type;
 
             if (expectedType == AiAgentParameterValueType.Default)
@@ -299,7 +299,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
     }
 
-    public static AiConversationParameterValue GetAiConversationParameterValue(string paramName, object paramValue)
+    public static AiConversationParameter GetAiConversationParameter(string paramName, object paramValue)
     {
         var sendToModel = true; // At the conversation level
         var realValue = paramValue;
@@ -319,18 +319,18 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             // }
             // If the parameter is not an object with a "value" field, we assume it's the old format and use the value directly.
 
-            if (obj.TryGetMember("Value", out realValue) == false)
+            if (obj.TryGetMember(nameof(AiConversationParameter.Value), out realValue) == false)
             {
                 // Should never reach here - Object parameters are not supported
                 throw new InvalidCastException(
                     $"Parameter '{paramName}' has unsupported type. " +
                     $"Actual: Object");
             }
-            if (obj.TryGet("SendToModel", out sendToModel) == false)
+            if (obj.TryGet(nameof(AiConversationParameter.SendToModel), out sendToModel) == false)
                 sendToModel = true; //default
         }
 
-        return new AiConversationParameterValue
+        return new AiConversationParameter
         {
             Value = realValue,
             SendToModel = sendToModel
@@ -650,7 +650,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             // Important: we *override* any parameter from the model with the user provided values
             // to ensure the safety & security of this feature. Model cannot override those values, period.
             parameters.GetPropertyByIndex(i, ref prop);
-            args.Modifications[prop.Name] = GetAiConversationParameterValue(prop.Name, prop.Value).Value;
+            args.Modifications[prop.Name] = GetAiConversationParameter(prop.Name, prop.Value).Value;
         }
 
         return context.ReadObject(args, "args");

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -167,7 +167,7 @@ const runChat = createAsyncThunk(
         const result = await services.aiAgentService.runAiAgent(
             databaseName,
             {
-                UserPrompt: getUserPrompt(toolCallParameters?.length ?? 0, formValues.prompts),
+                UserPrompt: createUserPromptDto(toolCallParameters?.length ?? 0, formValues.prompts),
                 ArtificialActions: [],
                 ActionResponses: toolCallParameters?.map((x) => ({
                     ToolId: x.id,
@@ -175,10 +175,7 @@ const runChat = createAsyncThunk(
                 })),
                 AttachmentCommands: null,
                 CreationOptions: {
-                    Parameters:
-                        conversationId == null
-                            ? Object.fromEntries(formValues.parameters.map((x) => [x.name, x.value]))
-                            : null,
+                    Parameters: createParametersDto(conversationId, formValues.parameters),
                     ExpirationInSec:
                         (isDocumentExpirationEnabled || formValues.isEnableDocumentExpiration) &&
                         formValues.isDocumentExpireInCustomizeEnabled
@@ -190,13 +187,14 @@ const runChat = createAsyncThunk(
             conversationId != null ? conversationId : formValues.persistenceConversationIdPrefix,
             changeVector
         );
+
         dispatch(chatAiAgentActions.activePromptIndexSet(0));
         dispatch(chatAiAgentActions.conversationIdSet(result.ConversationId));
         await dispatch(chatAiAgentActions.getDocument({ databaseName, id: result.ConversationId })).unwrap();
     }
 );
 
-function getUserPrompt(
+function createUserPromptDto(
     toolCallParametersCount: number,
     prompts: ChatAiAgentFormData["prompts"]
 ): RunAiAgentRequestDto["UserPrompt"] {
@@ -213,6 +211,25 @@ function getUserPrompt(
     }
 
     return prompts[0].text;
+}
+
+function createParametersDto(
+    conversationId: string,
+    formParameters: ChatAiAgentFormData["parameters"]
+): Record<string, Raven.Client.Documents.AI.AiConversationParameter> {
+    if (conversationId) {
+        return null;
+    }
+
+    return Object.fromEntries(
+        formParameters.map((x) => [
+            x.name,
+            {
+                Value: x.value,
+                SendToModel: true,
+            },
+        ])
+    );
 }
 
 const getIsDocumentExpirationEnabled = createAsyncThunk(

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/hooks/useToolQueryDetails.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/hooks/useToolQueryDetails.ts
@@ -36,11 +36,15 @@ export default function useToolQueryDetails({
         return matches.map((x) => ({ key: x, value: parametersFromUser?.[x] })).filter((x) => x.value);
     };
 
-    const getArgumentFormattedValue = (value: string): string => {
-        if (typeof value === "number") {
-            return value;
+    const getArgumentFormattedValue = (
+        value: string | Raven.Client.Documents.AI.AiConversationParameter
+    ): string | number => {
+        const extractedValue = typeof value === "object" && "Value" in value ? value.Value : value;
+
+        if (typeof extractedValue === "number") {
+            return extractedValue;
         }
-        return JSON.stringify(value);
+        return JSON.stringify(extractedValue);
     };
 
     const getQueryWithParameters = (): string => {

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
@@ -5,7 +5,7 @@ import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 
 interface AiAgentParametersDropdownProps {
-    parameters: Record<string, string>;
+    parameters: Record<string, string | Raven.Client.Documents.AI.AiConversationParameter>;
     isCompact?: boolean;
 }
 
@@ -33,31 +33,44 @@ export default function AiAgentParametersDropdown({ parameters, isCompact = fals
                 className="panel-bg-1 p-3 rounded-2 overflow-auto"
             >
                 {parametersArray.map((x, idx) => (
-                    <div key={x.name} className="w-100">
-                        <div className="hstack justify-content-between">
-                            <Badge
-                                bg="primary"
-                                className="text-truncate me-2 fs-5"
-                                title={x.name}
-                                style={{ width: "150px" }}
-                                pill
-                            >
-                                {x.name}
-                            </Badge>
-                            <div className="flex-grow-1">
-                                <Form.Control
-                                    type="text"
-                                    value={x.value}
-                                    disabled
-                                    className="text-truncate"
-                                    title={x.value}
-                                />
-                            </div>
-                        </div>
-                        {idx !== parametersArray.length - 1 && <hr className="my-1" />}
-                    </div>
+                    <ParameterItem
+                        key={x.name}
+                        name={x.name}
+                        value={x.value}
+                        isLast={idx === parametersArray.length - 1}
+                    />
                 ))}
             </Dropdown.Menu>
         </Dropdown>
+    );
+}
+
+interface ParameterItemProps {
+    name: string;
+    value: string | Raven.Client.Documents.AI.AiConversationParameter;
+    isLast: boolean;
+}
+
+function ParameterItem({ name, value, isLast }: ParameterItemProps) {
+    const extractedValue = typeof value === "object" && "Value" in value ? value.Value : value;
+
+    return (
+        <div className="w-100">
+            <div className="hstack justify-content-between">
+                <Badge bg="primary" className="text-truncate me-2 fs-5" title={name} style={{ width: "150px" }} pill>
+                    {name}
+                </Badge>
+                <div className="flex-grow-1">
+                    <Form.Control
+                        type="text"
+                        value={extractedValue}
+                        disabled
+                        className="text-truncate"
+                        title={extractedValue}
+                    />
+                </div>
+            </div>
+            {!isLast && <hr className="my-1" />}
+        </div>
     );
 }

--- a/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
@@ -72,7 +72,7 @@ export class AiAgentStubs {
         return new document({
             Agent: "first-agent",
             Parameters: {
-                company: "companies/90-A",
+                company: { Value: "companies/90-A", SendToModel: true },
             },
             Messages: [
                 {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25186.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
@@ -25,12 +26,12 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true, true])]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [false, false, false])]
         [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single, Data = [null, true, true])]
-        public async Task SendToModelVariants(Options options, GenAiConfiguration configuration, bool? exposed, bool expectEcho, bool expectRaw)
+        public async Task SendToModelVariants(Options options, GenAiConfiguration configuration, bool? sendToModel, bool expectEcho, bool expectRaw)
         {
             using var store = GetDocumentStore(options);
             await PutConn(store, configuration);
 
-            var agent = CreateShoppingAssistant(configuration.ConnectionStringName, exposed);
+            var agent = CreateShoppingAssistant(configuration.ConnectionStringName, sendToModel);
             var agentId = (await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance)).Identifier;
 
             var chat = store.AI.Conversation(agentId, "chats/",
@@ -41,9 +42,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.Equal(AiConversationResult.Done, result.Status);
 
             await AssertConversationAsync(store, chat.Id,
-                expectEcho: expectEcho,
-                expectRawValueLeak: expectRaw,
-                expectParamStored: true);
+                shouldProjectParams: expectEcho,
+                shouldProjectCompanyParam: expectRaw);
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
@@ -69,65 +69,66 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             using var s = store.OpenAsyncSession();
             var conv = await s.LoadAsync<BlittableJsonReaderObject>(chat.Id);
 
-            Assert.True(conv.TryGet(nameof(ConversationDocument.Parameters), out BlittableJsonReaderObject p));
-            Assert.True(p.TryGet("company", out string company));
-            Assert.True(p.TryGet("userId", out string userId));
-            Assert.Equal("companies/90-A", company);
-            Assert.Equal("users/1-A", userId);
+            Assert.True(conv.TryGet(nameof(ConversationDocument.Parameters), out BlittableJsonReaderObject parameters));
+            Assert.True(parameters.TryGet("company", out BlittableJsonReaderObject companyAiConversationValue));
+            Assert.True(companyAiConversationValue.TryGet("Value", out string companyValue));
+            Assert.Equal("companies/90-A", companyValue);
 
-            Assert.True(conv.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray msgs));
-            var content = string.Join("\n", msgs.Items.Select(i =>
-            {
+
+            Assert.True(parameters.TryGet("userId", out BlittableJsonReaderObject userIdAiConversationValue));
+            Assert.True(userIdAiConversationValue.TryGet("Value", out string userIdValue));
+            Assert.Equal("users/1-A", userIdValue);
+
+            Assert.True(conv.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages));
+            var messagesContents = messages.Items.Select(i => {
                 var o = (BlittableJsonReaderObject)i;
                 return o.TryGet("content", out string c) ? c : null;
-            }).Where(x => x != null));
+            }).Where(x => x != null).ToList();
 
-            Assert.Contains("AI Agent Parameters:", content);
-            Assert.Contains("company = companies/90-A", content);
-            Assert.DoesNotContain("userId =", content);
-            Assert.DoesNotContain("users/1-A", content);
+            Assert.True(messagesContents.Any(msg => msg.Contains("AI Agent Parameters:")));
+            Assert.True(messagesContents.Any(msg => msg.Contains("company = companies/90-A")));
+            Assert.False(messagesContents.Any(msg => msg.Contains("userId =")));
+            Assert.False(messagesContents.Any(msg => msg.Contains("users/1-A")));
         }
 
         private static async Task PutConn(IDocumentStore store, GenAiConfiguration cfg) =>
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(cfg.Connection));
 
         private static async Task AssertConversationAsync(IDocumentStore store, string id,
-            bool expectEcho, bool expectRawValueLeak, bool expectParamStored)
+            bool shouldProjectParams, bool shouldProjectCompanyParam)
         {
-            using var s = store.OpenAsyncSession();
-            var conv = await s.LoadAsync<BlittableJsonReaderObject>(id);
-            Assert.NotNull(conv);
-
-            Assert.True(conv.TryGet(nameof(ConversationDocument.Parameters), out BlittableJsonReaderObject convParams));
-            var hasParam = convParams.TryGet("company", out string companyValue);
-            Assert.Equal(expectParamStored, hasParam);
-            if (expectParamStored)
+            using (var session = store.OpenAsyncSession())
+            {
+                var chat = await session.LoadAsync<BlittableJsonReaderObject>(id);
+                Assert.True(chat.TryGet(nameof(ConversationDocument.Parameters), out BlittableJsonReaderObject parameters));
+                Assert.True(parameters.TryGet("company", out BlittableJsonReaderObject companyAiConversationValue));
+                Assert.True(companyAiConversationValue.TryGet("Value", out string companyValue));
                 Assert.Equal("companies/90-A", companyValue);
 
-            Assert.True(conv.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray msgs));
-            var content = string.Join("\n", msgs.Items.Select(i =>
-            {
-                var o = (BlittableJsonReaderObject)i;
-                return o.TryGet("content", out string c) ? c : null;
-            }).Where(x => x != null));
+                Assert.True(chat.TryGet(nameof(ConversationDocument.Messages), out BlittableJsonReaderArray messages));
+                var messagesContents = messages.Items.Select(i =>
+                {
+                    var o = (BlittableJsonReaderObject)i;
+                    return o.TryGet("content", out string c) ? c : null;
+                }).Where(x => x != null).ToList();
 
-            var echoed = content.Contains("AI Agent Parameters:");
-            var leaked = content.Contains("companies/90-A");
+                var parametersProjectedInMessages = messagesContents.Any(msg => msg.Contains("AI Agent Parameters:"));
+                var companyParameterProjectedInMessages = messagesContents.Any(msg => msg.Contains("companies/90-A"));
 
-            Assert.Equal(expectEcho, echoed);
-            Assert.Equal(expectRawValueLeak, leaked);
+                Assert.Equal(shouldProjectParams, parametersProjectedInMessages);
+                Assert.Equal(shouldProjectCompanyParam, companyParameterProjectedInMessages);
+            }
         }
 
-        private static AiAgentConfiguration CreateShoppingAssistant(string csName, bool? exposed)
+        private static AiAgentConfiguration CreateShoppingAssistant(string csName, bool? sendToModel)
         {
             var agent = new AiAgentConfiguration("shopping assistant", csName,
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
 
-            if (exposed.HasValue == false)
+            if (sendToModel.HasValue == false)
                 agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id"));
             else
-                agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id", exposed.Value));
-
+                agent.Parameters.Add(new AiAgentParameter("company", "Tenant company id", sendToModel.Value));
 
             agent.Queries =
             [

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
@@ -79,12 +79,13 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
             // only maxBudgetNis and minRamGb should be sent to the model,
             // customerId shouldn't be sent (sendToModel is false on chat), customerName shouldn't be sent (additional param - only for sub-agent use)
-            var expectedParamsMsg = "AI Agent Parameters:\nmaxBudgetNis = 3500" + Environment.NewLine + "minRamGb = 16" + Environment.NewLine;
+            var expectedParamsMsg = "AI Agent Parameters:\nmaxBudgetNis = 3500" + Environment.NewLine + 
+                                    "minRamGb = 16" + Environment.NewLine + 
+                                    "customerName = Shahar" + Environment.NewLine;
             using (var session = store.OpenAsyncSession())
             {
                 var doc = await session.LoadAsync<Chat>("Chats/1");
-                Assert.True(
-                    doc.Messages.Any(m => m.Content as string == expectedParamsMsg));
+                Assert.True(doc.Messages.Any(m => m.Content as string == expectedParamsMsg));
             }
         }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
@@ -84,7 +84,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             {
                 var doc = await session.LoadAsync<Chat>("Chats/1");
                 Assert.True(
-                    doc.Messages.Any(m => (string)m.Content == expectedParamsMsg));
+                    doc.Messages.Any(m => m.Content as string == expectedParamsMsg));
             }
         }
 
@@ -120,10 +120,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                     }
                 }
             };
-            productsSearchAgent.Parameters.Add(new AiAgentParameter("productType", "product type")
-            {
-                Type = AiAgentParameterValueType.String
-            });
             productsSearchAgent.Parameters.Add(new AiAgentParameter("maxBudgetNis", "Max budget (NIS)")
             {
                 Type = AiAgentParameterValueType.Number
@@ -139,8 +135,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "store-clerk-agent",
                 config.ConnectionStringName,
                 "You are the store clerk (root). " +
-                "Use the `products-search-agent` to retrieve product IDs.\n\nIf the user did not specify any criteria for products or laptops, "+
-                "call `products-search-agent` without parameters (or with empty parameters). "+
+                "Use the `products-search-agent` to retrieve product IDs.\n\nIf the user did not specify any criteria for products or laptops, " +
+                "call `products-search-agent` without parameters (or with empty parameters). " +
                 "only 'subAgentUserPrompt'  param is mandatory."
             )
             {
@@ -159,43 +155,58 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 rootId,
                 "Chats/1",
                 new AiConversationCreationOptions()
-                    .AddParameter("customerId", "Customers/1")// send to root-agent and to the sub-agent. sub-agent won't send it cause its config doesn't have this param definition
+                  
                     // for sub-agent only (additional params)
-                    .AddParameter("productType", "Laptop", new AiConversationParameterOptions(){ SendToModel = true}) // send to sub-agent
-                    .AddParameter("minRamGb", 16, new AiConversationParameterOptions(){ SendToModel = false}) // don't-send (only for sub-agent query)
-                    .AddParameter("maxBudgetNis", 3500, new AiConversationParameterOptions(){ SendToModel = false}) //don't-send to sub-agent (only for sub-agent query)
+                    .AddParameter("minRamGb", 16, new AiConversationParameterOptions() { SendToModel = false }) // don't-send (only for sub-agent query)
+                    .AddParameter("maxBudgetNis", 3500, new AiConversationParameterOptions() { SendToModel = false }) //don't-send to sub-agent (only for sub-agent query)
+
+                    // additional params
+                    .AddParameter("customerId", "Customers/1") // additional at the sub-agent - send to root-agent and to the sub-agent
+                    .AddParameter("productType", "Laptop", new AiConversationParameterOptions() { SendToModel = true }) // additional param (true) - send to root and sub-agent
+                    .AddParameter("someAdditionalParam", "abc", new AiConversationParameterOptions() { SendToModel = false }) // additional param (false) - don't send to root/sub-agent
             );
             chat.SetUserPrompt("Find laptops for me.");
             var r = await chat.RunAsync<OutputSchema>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
 
-            // only customerId is sent to the model (root agent), all the rest are additional
-            var expectedParamsMsg1 = "AI Agent Parameters:\ncustomerId = Customers/1" + Environment.NewLine;
+            var expectedParamsMsg1 = "AI Agent Parameters:\ncustomerId = Customers/1" + Environment.NewLine + "productType = Laptop" + Environment.NewLine;
             using (var session = store.OpenAsyncSession())
             {
                 var doc = await session.LoadAsync<Chat>("Chats/1");
-                Assert.True(
-                    doc.Messages.Any(m => (string)m.Content == expectedParamsMsg1));
+                Assert.Equal(5, doc.Parameters.Count);
+                Assert.True(doc.Messages.Any(m => m.Content as string == expectedParamsMsg1));
+
+                var subDoc = (await session.Advanced.LoadStartingWithAsync<Chat>("Chats/1/products-search-agent/")).Single();
+                Assert.Equal(5, subDoc.Parameters.Count);
+                Assert.True(subDoc.Messages.Any(m => m.Content as string == expectedParamsMsg1));
             }
 
-            try
-            {
-                // only productType is sent to the model (sub-agent agent),
-                // customerId isn't on the agent config, and minRamGb&maxBudgetNis defined as 'sendToModel' false on the chat
-                var expectedParamsMsg2 = "AI Agent Parameters:\nproductType = Laptop" + Environment.NewLine;
-                using (var session = store.OpenAsyncSession())
-                {
-                    var doc = (await session.Advanced.LoadStartingWithAsync<Chat>("Chats/1/products-search-agent/")).Single();
-                    Assert.True(
-                        doc.Messages.Any(m => (string)m.Content == expectedParamsMsg2));
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine(ex);
-                Console.ForegroundColor = ConsoleColor.White;
-                WaitForUserToContinueTheTest(store, false);
-            }
+            // Expected Flow:
+
+            // credit-card true
+            // root credit-card false -> false
+            // child credit-card true -> true
+
+            // credit-card false
+            // root credit-card false -> false
+            // child credit-card true -> false
+
+            //Additional Param:
+            // credit-card false
+            // root          -> false
+            // child credit-card true -> false
+
+            // credit-card true
+            // root          -> true
+            // child credit-card true
+
+            // credit-card true
+            // root          -> true
+            // child credit-card false -> false
+
+            // credit-card false
+            // root          -> false
+            // child credit-card false -> false
         }
 
 
@@ -250,6 +261,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         // Chat
         private class Chat
         {
+            public Dictionary<string, AiConversationParameter> Parameters { get; set; }
             public List<Message> Messages { get; set; }
         }
 

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
@@ -68,9 +68,9 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 "Chats/1",
                 new AiConversationCreationOptions().AddParameter("maxBudgetNis", 3500) // send
                     .AddParameter("minRamGb", 16) // send
-                    .AddParameter("customerId", "Customers/1", sendToModel: false) //don't-send
+                    .AddParameter("customerId", "Customers/1", new AiConversationParameterOptions(){ SendToModel = false}) //don't-send
                     // Additional fields for sub-agent
-                    .AddParameter("customerName", "Shahar", sendToModel: true) // dont-send (pass it as is to the sub-agent if exists)
+                    .AddParameter("customerName", "Shahar", new AiConversationParameterOptions(){ SendToModel = true}) // dont-send (pass it as is to the sub-agent if exists)
             );
             chat.SetUserPrompt(
                 "Find laptops for me."
@@ -161,9 +161,9 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 new AiConversationCreationOptions()
                     .AddParameter("customerId", "Customers/1")// send to root-agent and to the sub-agent. sub-agent won't send it cause its config doesn't have this param definition
                     // for sub-agent only (additional params)
-                    .AddParameter("productType", "Laptop", sendToModel: true) // send to sub-agent
-                    .AddParameter("minRamGb", 16, sendToModel: false) // don't-send (only for sub-agent query)
-                    .AddParameter("maxBudgetNis", 3500, sendToModel: false) //don't-send to sub-agent (only for sub-agent query)
+                    .AddParameter("productType", "Laptop", new AiConversationParameterOptions(){ SendToModel = true}) // send to sub-agent
+                    .AddParameter("minRamGb", 16, new AiConversationParameterOptions(){ SendToModel = false}) // don't-send (only for sub-agent query)
+                    .AddParameter("maxBudgetNis", 3500, new AiConversationParameterOptions(){ SendToModel = false}) //don't-send to sub-agent (only for sub-agent query)
             );
             chat.SetUserPrompt("Find laptops for me.");
             var r = await chat.RunAsync<OutputSchema>();

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25975.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25975(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task SendToModelOnChat(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            await SeedProducts(store);
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "Find top 3 laptops within a budget and minimum RAM. and return all matching results. if you have 3 return 3, not less!"
+            )
+            {
+                Queries = new List<AiAgentToolQuery>
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "FindTopLaptops",
+                        Description = "Return top 3 laptops that match budget and min RAM. Return all of the laptops you found that will fit to the request.",
+                        Query =
+                            "from Products as p " +
+                            "where p.Category = 'Laptop' " +
+                            "and p.PriceNis <= $maxBudgetNis " +
+                            "and p.RamGb >= $minRamGb " +
+                            "order by p.PriceNis asc " +
+                            "limit 0, 3",
+                        ParametersSampleObject = "{}"
+                    }
+                }
+            };
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("maxBudgetNis", "Max budget (NIS)")
+            {
+                Type = AiAgentParameterValueType.Number
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("minRamGb", "Min RAM (GB)")
+            {
+                Type = AiAgentParameterValueType.Number
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("customerId", "Customer Id")
+            {
+                Type = AiAgentParameterValueType.String
+            });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            var chat = store.AI.Conversation(
+                productsSearchId,
+                "Chats/1",
+                new AiConversationCreationOptions().AddParameter("maxBudgetNis", 3500) // send
+                    .AddParameter("minRamGb", 16) // send
+                    .AddParameter("customerId", "Customers/1", sendToModel: false) //don't-send
+                    // Additional fields for sub-agent
+                    .AddParameter("customerName", "Shahar", sendToModel: true) // dont-send (pass it as is to the sub-agent if exists)
+            );
+            chat.SetUserPrompt(
+                "Find laptops for me."
+            );
+            var r = await chat.RunAsync<OutputSchema>();
+
+            // only maxBudgetNis and minRamGb should be sent to the model,
+            // customerId shouldn't be sent (sendToModel is false on chat), customerName shouldn't be sent (additional param - only for sub-agent use)
+            var expectedParamsMsg = "AI Agent Parameters:\nmaxBudgetNis = 3500" + Environment.NewLine + "minRamGb = 16" + Environment.NewLine;
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Chat>("Chats/1");
+                Assert.True(
+                    doc.Messages.Any(m => (string)m.Content == expectedParamsMsg));
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task SendToModelOnChat_MultiAgent(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+            await SeedProducts(store);
+
+            // products-search-agent
+            var productsSearchAgent = new AiAgentConfiguration(
+                "products-search-agent",
+                config.ConnectionStringName,
+                "Find top 3 laptops. if you have 3 return 3, not less!"
+            )
+            {
+                Queries = new List<AiAgentToolQuery>
+                {
+                    new AiAgentToolQuery
+                    {
+                        Name = "FindTopLaptops",
+                        Description = "Return top 3 laptops that match customer requirements",
+                        Query =
+                            "from Products as p " +
+                            "where p.Category = 'Laptop' " +
+                            "and p.PriceNis <= $maxBudgetNis " +
+                            "and p.RamGb >= $minRamGb " +
+                            "order by p.PriceNis asc " +
+                            "limit 0, 3",
+                        ParametersSampleObject = "{}"
+                    }
+                }
+            };
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("productType", "product type")
+            {
+                Type = AiAgentParameterValueType.String
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("maxBudgetNis", "Max budget (NIS)")
+            {
+                Type = AiAgentParameterValueType.Number
+            });
+            productsSearchAgent.Parameters.Add(new AiAgentParameter("minRamGb", "Min RAM (GB)")
+            {
+                Type = AiAgentParameterValueType.Number
+            });
+            var productsSearchId = (await store.AI.CreateAgentAsync(productsSearchAgent, OutputSchema.Instance)).Identifier;
+
+            // root agent
+            var root = new AiAgentConfiguration(
+                "store-clerk-agent",
+                config.ConnectionStringName,
+                "You are the store clerk (root). " +
+                "Use the `products-search-agent` to retrieve product IDs.\n\nIf the user did not specify any criteria for products or laptops, "+
+                "call `products-search-agent` without parameters (or with empty parameters). "+
+                "only 'subAgentUserPrompt'  param is mandatory."
+            )
+            {
+                SubAgents =
+                [
+                    new AiAgentToolSubAgent { Identifier = productsSearchId, Description = "Find products" },
+                ]
+            };
+            root.Parameters.Add(new AiAgentParameter("customerId", "Customer Id")
+            {
+                Type = AiAgentParameterValueType.String
+            });
+
+            var rootId = (await store.AI.CreateAgentAsync(root, OutputSchema.Instance)).Identifier;
+            var chat = store.AI.Conversation(
+                rootId,
+                "Chats/1",
+                new AiConversationCreationOptions()
+                    .AddParameter("customerId", "Customers/1")// send to root-agent and to the sub-agent. sub-agent won't send it cause its config doesn't have this param definition
+                    // for sub-agent only (additional params)
+                    .AddParameter("productType", "Laptop", sendToModel: true) // send to sub-agent
+                    .AddParameter("minRamGb", 16, sendToModel: false) // don't-send (only for sub-agent query)
+                    .AddParameter("maxBudgetNis", 3500, sendToModel: false) //don't-send to sub-agent (only for sub-agent query)
+            );
+            chat.SetUserPrompt("Find laptops for me.");
+            var r = await chat.RunAsync<OutputSchema>();
+
+            // only customerId is sent to the model (root agent), all the rest are additional
+            var expectedParamsMsg1 = "AI Agent Parameters:\ncustomerId = Customers/1" + Environment.NewLine;
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<Chat>("Chats/1");
+                Assert.True(
+                    doc.Messages.Any(m => (string)m.Content == expectedParamsMsg1));
+            }
+
+            try
+            {
+                // only productType is sent to the model (sub-agent agent),
+                // customerId isn't on the agent config, and minRamGb&maxBudgetNis defined as 'sendToModel' false on the chat
+                var expectedParamsMsg2 = "AI Agent Parameters:\nproductType = Laptop" + Environment.NewLine;
+                using (var session = store.OpenAsyncSession())
+                {
+                    var doc = (await session.Advanced.LoadStartingWithAsync<Chat>("Chats/1/products-search-agent/")).Single();
+                    Assert.True(
+                        doc.Messages.Any(m => (string)m.Content == expectedParamsMsg2));
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine(ex);
+                Console.ForegroundColor = ConsoleColor.White;
+                WaitForUserToContinueTheTest(store, false);
+            }
+        }
+
+
+        private static async Task SeedProducts(IDocumentStore store)
+        {
+            using var session = store.OpenAsyncSession();
+
+            // Matches (<=3500 & >=16GB): Products/5 (2790), Products/4 (2990), Products/1 (3290)
+            await session.StoreAsync(new Product { Id = "Products/1", Category = "Laptop", RamGb = 16, PriceNis = 3290 });
+            await session.StoreAsync(new Product { Id = "Products/4", Category = "Laptop", RamGb = 16, PriceNis = 2990 });
+            await session.StoreAsync(new Product { Id = "Products/5", Category = "Laptop", RamGb = 16, PriceNis = 2790 });
+
+            // Additional valid (<=3500 & >=16GB) for add flow
+            await session.StoreAsync(new Product { Id = "Products/6", Category = "Laptop", RamGb = 24, PriceNis = 3490 });
+
+            // Non-matching examples
+            await session.StoreAsync(new Product { Id = "Products/2", Category = "Laptop", RamGb = 32, PriceNis = 4890 }); // above budget
+            await session.StoreAsync(new Product { Id = "Products/3", Category = "Laptop", RamGb = 8, PriceNis = 1990 }); // below RAM
+
+            await session.SaveChangesAsync();
+        }
+
+
+        // Entities
+        private class Product
+        {
+            public string Id { get; set; }
+            public string Category { get; set; } // "Laptop"
+            public int RamGb { get; set; }
+            public decimal PriceNis { get; set; }
+        }
+
+        // Minimal tool payloads
+        private class OutputSchema
+        {
+            public static OutputSchema Instance = new()
+            {
+                Answer = "Those are the laptops I found fitting your criteria: Products/5, Products/4, Products/1",
+                ProductIds = new List<string> { "Products/5", "Products/4", "Products/1" }
+            };
+
+            public string Answer { get; set; }
+            public List<string> ProductIds { get; set; }
+
+            public override string ToString()
+            {
+                var ids = ProductIds != null ? string.Join(", ", ProductIds) : "null";
+                return $"Answer: {Answer} | ProductIds: [{ids}]";
+            }
+        }
+
+        // Chat
+        private class Chat
+        {
+            public List<Message> Messages { get; set; }
+        }
+
+        private class Message
+        {
+            [JsonProperty("role")]
+            public string Role { get; set; }
+
+            [JsonProperty("content")]
+            public object Content { get; set; }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB_24887_3.cs
@@ -638,7 +638,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
 
         using (var session = store.OpenAsyncSession())
         {
-            var doc1 = await session.LoadAsync<Chat>("chats/1/movies-agent-1/Vsy3aOyNusK5fwwmHq4j4kuYQgrH1whMJWuce86epm8=");
+            var doc1 = (await session.Advanced.LoadStartingWithAsync<Chat>("chats/1/movies-agent-1/")).Single(d => d.Id.Contains("/recommendation-agent") == false);
             var toolCallsAnswers1 = doc1.Messages.Where(m => m.Role == "tool").ToList();
             Assert.True(toolCallsAnswers1.Any(a => a.Content is string content && content.Contains($"Failed to communicate with the agent '{userAgentId}'")));
 
@@ -656,6 +656,7 @@ public class RavenDB_24887_3(ITestOutputHelper output) : RavenTestBase(output)
 
     private class Chat
     {
+        public string Id { get; set; }
         public List<Message> Messages { get; set; }
     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25975/Passing-Root-Parameter-Without-exposing-them-to-the-sub-agent-model-when-the-sub-agent-doesnt-have-those-params

### Additional description

Add `sendToModel` on the conversation level, Add additional parameters (wont send to model on root - just pass them to sub), support old conversation payload of params, Fix tests.
* **Couldn't get Studio to compile — this needs a better fix there**.
#### Behaviour:
Parameters are passed to the **root agent**, but only those **defined in its configuration** and with ;sendToModel = true; **both at the agent configuration level _and_ the chat level** are projected to the model (appear in the messages).
All other parameters are **not exposed to the model** and are only available for internal use:
* **Additional parameters** (not defined in the root-agent configuration) - are forwarded to the **sub-agents**.
* **Relevant parameters** (defined in the root-agent configuration) that aren't sent to the model - are used only by **query tools** _and_ forwarded to the **sub-agents**.

Any parameter (with its `sendToModel` value at the chat level) is also forwarded to sub-agents.
Each sub-agent then applies the same filtering logic.
The test `SendToModelOnChat_MultiAgent` demonstrates this behavior clearly.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change 
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

* **Not breaking change** on Server:  Maintained backward compatibility by continuing to support the old parameter format alongside the new version.
* **Breaking change** on client: `Dictionary<string, object> Parameters` => `Dictionary<string, AiConversationParameterValue> Parameters`

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed

