### PR TITLE
RavenDB-26167 fix gen ai task from a context concurrent usage 

### DIFF
--- a/src/Raven.Server/Documents/ETL/EtlTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/EtlTransformer.cs
@@ -426,7 +426,7 @@ namespace Raven.Server.Documents.ETL
             throw new InvalidOperationException(message);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             using (ReturnMainRun)
             using (_behaviorFunctionsRun)

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiBatchPatchCommand.cs
@@ -23,9 +23,8 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
     private readonly RavenLogger _logger;
     private readonly EtlProcessStatistics _statistics;
     private readonly GenAiStatsScope _scope;
-    private readonly DocumentDatabase _database;
 
-    public GenAiBatchPatchCommand(DocumentsOperationContext context,
+    public GenAiBatchPatchCommand(
         List<GenAiResultItem> items,
         PatchRequest patchRequest,
         string taskIdentifier,
@@ -42,10 +41,6 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
         if (string.IsNullOrEmpty(taskIdentifier))
             throw new ArgumentException(nameof(taskIdentifier));
         _taskIdentifier = taskIdentifier;
-
-        if (context == null)
-            throw new ArgumentNullException(nameof(context));
-        _database = context.DocumentDatabase;
     }
 
     protected override long ExecuteCmd(DocumentsOperationContext context)
@@ -54,7 +49,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
         using (var statsScope = _scope.For(GenAiOperations.ApplyUpdateScript))
         {
-            using (_database.Scripts.GetScriptRunner(_patchRequest, readOnly: false, out var runner))
+            using (context.DocumentDatabase.Scripts.GetScriptRunner(_patchRequest, readOnly: false, out var runner))
             {
                 foreach (var item in _items)
                 {
@@ -222,7 +217,7 @@ internal sealed class GenAiBatchPatchCommand : DocumentMergedTransactionCommand
 
     private Document GetCurrentDocument(DocumentsOperationContext context, string id)
     {
-        var originalDocument = _database.DocumentsStorage.Get(context, id);
+        var originalDocument = context.DocumentDatabase.DocumentsStorage.Get(context, id);
 
         if (originalDocument != null)
         {

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiScriptTransformer.cs
@@ -106,6 +106,12 @@ var ai = new AI();
         _stats = stats.For(EtlOperations.Transform, start: false);
     }
 
+    public override void Dispose()
+    {
+        Context.CloseTransaction();
+        base.Dispose();
+    }
+
     public override void Initialize(bool debugMode)
     {
         _configurationPartialHash = GetInitialHash(_configuration);

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -160,7 +160,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
             exceptions = SendToModel(results, context, scope, cts.Token);
         }
 
-        ApplyUpdateScript(context, results, scope);
+        ApplyUpdateScript(results, scope);
 
         if (exceptions?.Count > 0)
         {
@@ -179,12 +179,10 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         return results.Count;
     }
 
-    private List<Exception> SendToModel(List<GenAiResultItem> items, DocumentsOperationContext context, GenAiStatsScope scope, CancellationToken batchToken)
+    private List<Exception> SendToModel(List<GenAiResultItem> items, JsonOperationContext context, GenAiStatsScope scope, CancellationToken batchToken)
     {
         using (var statsScope = scope.For(GenAiOperations.LoadToModel))
         {
-            context.CloseTransaction();
-
             List<Task<GenAiHandlerResult>> tasks = [];
             Task[] executingTasks = new Task[Math.Max(1, _maxConcurrency)];
             Array.Fill(executingTasks, Task.CompletedTask);
@@ -256,7 +254,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         }
     }
 
-    private AiAgentConfiguration CreateAgentConfiguration(DocumentsOperationContext context, GenAiResultItem item)
+    private AiAgentConfiguration CreateAgentConfiguration(JsonOperationContext context, GenAiResultItem item)
     {
         var agentParameters = new List<AiAgentParameter>();
         var contextObjPropNames = item.ContextOutput.Context.GetPropertyNames();
@@ -278,7 +276,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         return agentConfiguration;
     }
 
-    private List<Exception> ProcessModelResults(List<GenAiResultItem> items, DocumentsOperationContext context, List<Task<GenAiHandlerResult>> tasks, GenAiStatsScope statsScope)
+    private List<Exception> ProcessModelResults(List<GenAiResultItem> items, JsonOperationContext context, List<Task<GenAiHandlerResult>> tasks, GenAiStatsScope statsScope)
     {
         List<Exception> exceptions = null;
 
@@ -365,10 +363,10 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
         }
     }
 
-    private void ApplyUpdateScript(DocumentsOperationContext context, List<GenAiResultItem> results, GenAiStatsScope scope)
+    private void ApplyUpdateScript(List<GenAiResultItem> results, GenAiStatsScope scope)
     {
         PatchRequest req = new(Configuration.UpdateScript, PatchRequestType.GenAi);
-        var cmd = new GenAiBatchPatchCommand(context, results, req, Configuration.Identifier, Logger, Statistics, scope);
+        var cmd = new GenAiBatchPatchCommand(results, req, Configuration.Identifier, Logger, Statistics, scope);
 
         Database.TxMerger.EnqueueSync(cmd);
     }

--- a/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/AI/GenAi/GenAiTask.cs
@@ -214,7 +214,7 @@ public sealed class GenAiTask : EtlProcess<GenAiItem, GenAiScriptResult, GenAiCo
 
                 handler.Initialize(agentConfiguration, $"{Configuration.Identifier}/{item.DocumentId}/", new RequestBody
                 {
-                    Parameters = item.ContextOutput.Context,
+                    Parameters = item.ContextOutput.Context.CloneOnTheSameContext(), // we need that to be a root blittable, so we can use the concurrent read method
                     CreationOptions = new AiConversationCreationOptions
                     {
                         ExpirationInSec = Configuration.ExpirationInSec

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -38,7 +38,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
     protected ConversationDocument _document;
     private string _conversationId;
-    private RequestBody _request;
+    protected RequestBody _request;
     private AiAgentConfiguration _configuration;
     private string _changeVector;
     private string _raftId;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/GenAiConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/GenAiConversationHandler.cs
@@ -15,6 +15,10 @@ internal class GenAiConversationHandler(ServerStore server, DocumentDatabase dat
     public async Task<GenAiHandlerResult> HandleRequest(CancellationToken token)
     {
         using var _ = _database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context);
+
+        // the parameters is a BlittableJsonReaderObject which use a shared underlying context that is not thread safe, so we need to clone it for concurrent read
+        _request.Parameters = _request.Parameters?.CloneForConcurrentRead(context);
+
         var response = await HandleRequest(context, token);
         var result = new GenAiHandlerResult
         {

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -1084,12 +1084,19 @@ namespace Sparrow.Json
             // we have to provide external context that will be used for that purpose during the read action
             // note that we don't copy the blittable data but still read from the original pointer
 
+            AssertRootObject();
             AssertContextNotDisposed(externalContext);
             
             return new BlittableJsonReaderObject(_mem, _size, externalContext)
             {
                 NoCache = NoCache
             };
+        }
+
+        private void AssertRootObject()
+        {
+            if (_isRoot == false)
+                throw new InvalidOperationException("This method can be called only on a root blittable");
         }
 
         public void BlittableValidation()

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
@@ -18,7 +18,7 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
     {
     }
 
-    private const string ProductSearch = nameof(ProductSearch);
+    internal const string ProductSearch = nameof(ProductSearch);
     internal const string RecentOrder = nameof(RecentOrder);
     private class Sample
     {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24883.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24883.cs
@@ -25,6 +25,8 @@ public class RavenDB_24883 : RavenTestBase
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
         var agent = AiAgentClientApiHandleActionCalls.BuildAgent(config.ConnectionStringName);
+        agent.Actions.RemoveAll(a => a.Name == AiAgentClientApiHandleActionCalls.ProductSearch);
+
         var r  = await store.AI.CreateAgentAsync(agent, new 
         {
             Answer = "the answer"

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25269.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25269.cs
@@ -101,7 +101,7 @@ this.Comments[idx].IsBlocked = $output.Blocked;
 
                     // run update phase *manually* (in test mode the update phase goes through a different code path than regular GenAI flow)
                     var req = new PatchRequest(config.UpdateScript, PatchRequestType.GenAi);
-                    var cmd = new GenAiBatchPatchCommand(context, result.Results, req, config.Identifier, RavenLogManager.Instance.GetLoggerForDatabase<RavenDB_25269>(database), new EtlProcessStatistics(), new GenAiStatsScope(new EtlRunStats()));
+                    var cmd = new GenAiBatchPatchCommand(result.Results, req, config.Identifier, RavenLogManager.Instance.GetLoggerForDatabase<RavenDB_25269>(database), new EtlProcessStatistics(), new GenAiStatsScope(new EtlRunStats()));
 
                     // should not throw NRE even if the document was deleted
                     await database.TxMerger.Enqueue(cmd);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26167

### Additional description

- Small refactoring to avoid passing context to a ctor of `MergedTransactionCommand`.
- In GenAI the parameters for the tasks are generated on the same context, so we need to be able to read them in thread safe manner

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
