### PR TITLE
RavenDB-22300 Wait for previous write to request-stream before writing attahcment to it

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -126,11 +126,12 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
         return WriteToStreamAsync(src, dst, _memoryBuffer);
     }
 
-    protected Task WriteToRequestStreamAsync(Stream src)
+    protected async Task WriteToRequestStreamAsync(Stream src)
     {
-        return WriteToStreamAsync(src, _requestBodyStream, _memoryBuffer);
+        await _asyncWrite.ConfigureAwait(false);
+        await WriteToStreamAsync(src, _requestBodyStream, _memoryBuffer).ConfigureAwait(false);
     }
-
+    
     private async Task WriteToStreamAsync(Stream src, Stream dst, JsonOperationContext.MemoryBuffer buffer, bool forceDstFlush = false)
     {
         src.Seek(0, SeekOrigin.Begin);

--- a/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
@@ -77,17 +77,18 @@ internal sealed class ShardedBulkInsertOperation : BulkInsertOperationBase<Shard
         await ExecuteBeforeStore();
 
         int shardNumber = _databaseContext.GetShardNumberFor(_context, id);
+        var shardWriter = _writers[shardNumber];
 
-        await _writers[shardNumber].WriteStreamAsync(command.Stream);
+        await shardWriter.WriteStreamAsync(command.Stream);
 
         if (command.AttachmentStream.Stream != null)
         {
-            await _writers[shardNumber].FlushIfNeeded(force: true);
-            await _writers[shardNumber].WriteStreamDirectlyToRequestAsync(command.AttachmentStream.Stream);
+            await shardWriter.FlushIfNeeded(force: true);
+            await shardWriter.WriteStreamDirectlyToRequestAsync(command.AttachmentStream.Stream);
         }
         else
         {
-            await _writers[shardNumber].FlushIfNeeded();
+            await shardWriter.FlushIfNeeded();
         }
     }
 

--- a/test/SlowTests/Client/Attachments/BulkInsertAttachments.cs
+++ b/test/SlowTests/Client/Attachments/BulkInsertAttachments.cs
@@ -2,14 +2,17 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using FastTests;
+using Microsoft.Extensions.Primitives;
 using Raven.Client.Documents.BulkInsert;
 using Raven.Client.Documents.Operations.Attachments;
 using Raven.Client.Documents.Operations.Counters;
 using Raven.Client.Exceptions.Documents.BulkInsert;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Extensions;
 using Xunit;
@@ -176,6 +179,63 @@ namespace SlowTests.Client.Attachments
             }
         }
 
+        
+        [RavenRetryTheory(RavenTestCategory.BulkInsert)]
+        [RavenDataWithRandomSeed(DatabaseMode = RavenDatabaseMode.All)]
+        public async Task BulkStoreAttachmentsWhileBulkStoringBigDocs(Options options, int seed)
+        {
+            const int propSize = 16 * JsonOperationContext.MemoryBuffer.DefaultSize;
+            const int count = 16;
+            const int attachmentSize = propSize;
+            const string attachmentName = "attachmentname";
+            var suffix = (options.DatabaseMode & RavenDatabaseMode.Sharded) != 0 ? "$somesuffix" : "";
+            
+            var rnd = new Random(seed);
+
+            using var store = GetDocumentStore(options);
+            var streams = new Dictionary<string, MemoryStream>();
+            await using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var id = $"user/{i}{suffix}";
+                    bulkInsert.Store(new TestObj { Prop = GenerateRandomString() }, id);
+                    var attachmentsBulkInsert = bulkInsert.AttachmentsFor(id);
+                        
+                    var bArr = new byte[attachmentSize];
+                    rnd.NextBytes(bArr);
+                        
+                    var stream = new MemoryStream(bArr);
+                    await attachmentsBulkInsert.StoreAsync(attachmentName, stream);
+
+                    stream.Position = 0;
+                    streams[id] = stream;
+                }
+            }
+
+            var tester = store.ForSessionTesting();
+
+            await tester.AssertAllAsync((_, session) =>
+            {
+                var attachmentRequests = streams.Select(x => new AttachmentRequest(x.Key, attachmentName));
+                var attachmentsEnumerator = session.Advanced.Attachments.Get(attachmentRequests);
+
+                while (attachmentsEnumerator.MoveNext())
+                {
+                    Assert.NotNull(attachmentsEnumerator.Current != null);
+                    Assert.True(AttachmentsStreamTests.CompareStreams(attachmentsEnumerator.Current.Stream, streams[attachmentsEnumerator.Current.Details.DocumentId]));
+                }
+            });
+
+            return;
+
+            static StringSegment GenerateRandomString()
+            {
+                var bytes = RandomNumberGenerator.GetBytes((propSize + 1) / 2);
+                var hex = Convert.ToHexString(bytes);
+                return new StringSegment(hex, 0, propSize);
+            }
+        }
 
         [RavenTheory(RavenTestCategory.BulkInsert)]
         [RavenData(DatabaseMode = RavenDatabaseMode.All)]
@@ -356,6 +416,12 @@ namespace SlowTests.Client.Attachments
                     Assert.Equal(ConflictStatus.Update, cvStatus);
                 }
             }
+        }
+
+        class TestObj
+        {
+            public string Id { get; set; }
+            public StringSegment Prop { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22300

### Additional description
When writing the attachment stream to the request stream, we must wait first for the flush from the buffer to the request stream to finish.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
