### PR TITLE
RavenDB-26166 - Optimize memory allocation and prevent transaction retention in `MapReduce` indexing

### DIFF
--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceIndexingContext.cs
@@ -41,6 +41,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             DocumentMapEntries = null;
             MapPhaseTree = null;
             ReducePhaseTree = null;
+            ResultsStoreTypes = null;
             ProcessedDocEtags.Clear();
             ProcessedTombstoneEtags.Clear();
             ProcessedTimeSeriesDeletedRangeEtags.Clear();

--- a/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
+++ b/src/Raven.Server/Documents/Indexes/MapReduce/MapReduceResultsStore.cs
@@ -24,6 +24,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
         private readonly Transaction _tx;
 
         private NestedMapResultsSection _nestedSection;
+        private bool _initializedTree = false;
 
         public MapResultsStorageType Type { get; private set; }
 
@@ -54,15 +55,13 @@ namespace Raven.Server.Documents.Indexes.MapReduce
             }
         }
 
-        private readonly HashSet<string> _alreadyInitializedTrees = new HashSet<string>();
-
         private void InitializeTree(bool create)
         {
             var treeName = ReduceTreePrefix + _reduceKeyHash;
             var options = _tx.LowLevelTransaction.Environment.Options.RunningOn32Bits ? TreeFlags.None : TreeFlags.LeafsCompressed;
             Tree = create ? _tx.CreateTree(treeName, flags: options) : _tx.ReadTree(treeName);
 
-            if (_alreadyInitializedTrees.Contains(treeName) == false)
+            if (_initializedTree == false)
             {
                 Tree.PageModified += (page, flags) =>
                 {
@@ -82,7 +81,7 @@ namespace Raven.Server.Documents.Indexes.MapReduce
                     ModifiedPages.Remove(page);
                 };
 
-                _alreadyInitializedTrees.Add(treeName);
+                _initializedTree = true;
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26166/MapReduceResultsStore-allocates-a-redundant-HashSetstring-per-reduce-key

### Additional description

This PR introduces targeted memory management optimizations within the MapReduce indexing pipeline. These changes reduce garbage collection (GC) overhead during lengthy indexing batches and prevent the indefinite retention of transactions when indexing is idle.

1. Optimize memory allocation in `MapReduceResultsStore` by replacing the `HashSet<string> _alreadyInitializedTrees1` collection with a simple `bool _initializedTree` flag. Because there is only one reduce key hash per store instance, `InitializeTree` is always called with the exact same tree name, making the `HashSet` semantically unnecessary. Furthermore, both the `HashSet` and the allocated string for the tree name act as long-lived objects that survive the duration of lengthy indexing batches, often leading to their promotion to Gen 1 or Gen 2 garbage collection generations. By transitioning to a primitive boolean, we entirely eliminate these allocations and the associated GC pressure.
<img width="540" height="97" alt="image" src="https://github.com/user-attachments/assets/828c8ba6-9d67-4d8a-82a8-c7eac236c510" />

2. Resolve a memory retention issue by explicitly nulling out `ResultsStoreTypes` within `MapReduceIndexingContext.Dispose()`. `ResultsStoreTypes` is a `FixedSizeTree` that maintains a reference to the `LowLevelTransaction` it was originally created with. Since `MapReduceIndexingContext` persists for the entire lifetime of the `MapReduceIndex`, failing to clear this field during disposal inadvertently pins the old transaction and everything it references in memory until a new indexing batch eventually overwrites it via `InitializeIndexingWork`. Nulling this field ensures that the transaction memory is safely released immediately after a batch finishes, preventing indefinite memory bloat when indexing is idle or stopped.
<img width="693" height="568" alt="image" src="https://github.com/user-attachments/assets/cb11bb74-ca0a-45a8-ba6c-a20f8f42b5b7" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
