### PR TITLE
[Cusotm-6.2] RavenDB-25912 - Improve the performance of AssertNotAboutToRunOutOfMemory

### DIFF
--- a/scripts/sign.ps1
+++ b/scripts/sign.ps1
@@ -5,76 +5,97 @@ function SignFile( $projectDir, $filePath, $dryRun ) {
         return;
     }
 
-    $signTool = "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\signtool.exe"
-    if (!(Test-Path $signTool))
-    {
-        $signTool = "C:\Program Files (x86)\Windows Kits\8.0\bin\x86\signtool.exe"
+    $requiredEnvVars = @("AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID")
+    foreach ($var in $requiredEnvVars) {
+        if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($var))) {
+            throw "Missing required environment variable for Azure Auth: $var. Ensure this is set in TeamCity parameters."
+        }
+    }
 
-        if (!(Test-Path $signTool))
-        {
-            $signTool = "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\signtool.exe"
+    $signTool = $null
 
-            if (!(Test-Path $signTool))
-            {
-                $signTool = "C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe"
+    if (![string]::IsNullOrWhiteSpace($env:BUILD_TOOLS_PATH)) {
+        $customPattern = Join-Path $env:BUILD_TOOLS_PATH "Microsoft.Windows.SDK.BuildTools\bin\*\x64\signtool.exe"
+        Write-Host "Searching BUILD_TOOLS_PATH: $customPattern"
 
-                if (!(Test-Path $signTool)) 
-                {
-                    throw "Could not find SignTool.exe under the specified path $signTool"
-                }
+        $signTool = Get-ChildItem -Path $customPattern -ErrorAction SilentlyContinue | 
+                    Where-Object { $_.Exists } |
+                    Sort-Object @{Expression={[System.Diagnostics.FileVersionInfo]::GetVersionInfo($_.FullName).FileVersion}; Descending=$true} | 
+                    Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if ([string]::IsNullOrWhiteSpace($signTool)) {
+        $standardPattern = "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe"
+        Write-Host "Searching Standard Path: $standardPattern"
+
+        $signTool = Get-ChildItem -Path $standardPattern -ErrorAction SilentlyContinue | 
+                    Where-Object { $_.Exists } |
+                    Sort-Object @{Expression={[System.Diagnostics.FileVersionInfo]::GetVersionInfo($_.FullName).FileVersion}; Descending=$true} | 
+                    Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if ([string]::IsNullOrWhiteSpace($signTool)) {
+        $signTool = "C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool\signtool.exe"
+
+        if (!(Test-Path $signTool)) {
+            throw "Could not find SignTool.exe under the specified path $signTool"
+        }
+    }
+
+    $azureLibPath = $env:CODESIGN_AZURELIB_PATH
+    if (!(Test-Path $azureLibPath)) {
+        throw "Could not find Azure Signing lib path at: $azureLibPath"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:CODESIGN_METADATA_CONTENT)) {
+        throw "Missing environment variable: CODESIGN_METADATA_CONTENT (JSON content required)."
+    }
+
+    $tempMetadataPath = [System.IO.Path]::GetTempFileName()
+    Set-Content -Path $tempMetadataPath -Value $env:CODESIGN_METADATA_CONTENT -Encoding UTF8
+    Write-Host "Created temporary metadata file at: $tempMetadataPath"
+
+    try {
+        Write-Host "Signing the following file: $filePath"
+        $timeservers = @(
+            "http://timestamp.digicert.com",
+            "http://timestamp.globalsign.com/tsa/r6advanced1",
+            "http://rfc3161timestamp.globalsign.com/advanced",
+            "http://timestamp.sectigo.com",
+            "http://timestamp.apple.com/ts01",
+            "http://tsa.mesign.com",
+            "http://time.certum.pl",
+            "https://freetsa.org",
+            "http://tsa.startssl.com/rfc3161",
+            "http://dse200.ncipher.com/TSS/HttpTspServer",
+            "http://zeitstempel.dfn.de",
+            "https://ca.signfiles.com/tsa/get.aspx",
+            "http://services.globaltrustfinder.com/adss/tsa",
+            "https://tsp.iaik.tugraz.at/tsp/TspRequest",
+            "http://timestamp.entrust.net/TSS/RFC3161sha2TS"
+        )
+
+        foreach ($time in $timeservers) {
+            try {
+                Write-Host "Command: $signTool /fd SHA256 /tr `"$time`" /td SHA256 /d `"RavenDB`" /du `"https://ravendb.net`" /dlib `"$azureLibPath`" /dmdf `"$metadataPath`" /v /debug `"$filePath`""
+                exec { & $signTool sign /fd SHA256 /tr "$time" /td SHA256 /d "RavenDB" /du "https://ravendb.net" /dlib "$azureLibPath" /dmdf "$tempMetadataPath" /v /debug "$filePath" }
+                
+                CheckLastExitCode
+                Write-Host "Successfully signed: $filePath"
+                return
+            }
+            catch {
+                Write-Warning "Failed to sign with $time. Error: $($_.Exception.Message)"
+                continue
             }
         }
+
+        throw "Error signing $filePath - All timestamp servers failed or SignTool encountered a critical error."
     }
-
-    $installerCert = $env:CODESIGN_CERTPATH
-
-    if (!(Test-Path $installerCert))
-    {
-        throw "Could not find pfx file under the path $installerCert to sign the installer"
-    }
-
-    $certPasswordPath = $env:CODESIGN_PASSPATH
-
-    if (!(Test-Path $certPasswordPath))
-    {
-        throw "Could not find the path for the certificate password of the installer"
-    }
-
-    $certPassword = Get-Content $certPasswordPath
-    if ($certPassword -eq $null)
-    {
-        throw "Certificate password must be provided"
-    }
-
-    Write-Host "Signing the following file: $filePath"
-    $timeservers = @(
-        "http://timestamp.digicert.com",
-        "http://timestamp.globalsign.com/tsa/r6advanced1",
-        "http://rfc3161timestamp.globalsign.com/advanced",
-        "http://timestamp.sectigo.com",
-        "http://timestamp.apple.com/ts01",
-        "http://tsa.mesign.com",
-        "http://time.certum.pl",
-        "https://freetsa.org",
-        "http://tsa.startssl.com/rfc3161",
-        "http://dse200.ncipher.com/TSS/HttpTspServer",
-        "http://zeitstempel.dfn.de",
-        "https://ca.signfiles.com/tsa/get.aspx",
-        "http://services.globaltrustfinder.com/adss/tsa",
-        "https://tsp.iaik.tugraz.at/tsp/TspRequest",
-        "http://timestamp.entrust.net/TSS/RFC3161sha2TS"
-    )
-    foreach ($time in $timeservers) {
-        try {
-            Write-Host "Command: $signTool sign /f `"$installerCert`" /p `"PASSWORD`" /d `"RavenDB`" /du `"https://ravendb.net`" /t `"$time`" /v /debug `"$filePath`""
-            exec { & $signTool sign /f "$installerCert" /p "$certPassword" /fd SHA256 /d "RavenDB" /du "https://ravendb.net" /tr "$time" /td SHA256 /v /debug "$filePath" }
-            CheckLastExitCode
-            return
-        }
-        catch {
-            continue
+    finally {
+        if (Test-Path $tempMetadataPath) {
+            Remove-Item -Path $tempMetadataPath -Force -ErrorAction SilentlyContinue
+            Write-Host "Cleaned up temporary metadata file."
         }
     }
-
-    throw "Error signing $filePath - see SignTool.exe error above."
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25912/High-CPU-usage-when-starting-the-server

### Additional description

Custom build based on 6.2.12 with the following fix: https://github.com/ravendb/ravendb/pull/22237

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
