### PR TITLE
RavenDB-22293 Use JsonPatch instead of JavaScript in session Patch methods

### DIFF
--- a/src/Raven.Client/Documents/Commands/Batches/JsonPatchCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/JsonPatchCommandData.cs
@@ -27,16 +27,16 @@ namespace Raven.Client.Documents.Commands.Batches
 
         public DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
         {
-            var serializer = DocumentConventions.Default.Serialization.CreateSerializer(new CreateSerializerOptions { TypeNameHandling = TypeNameHandling.None });
+            var serializer = conventions.Serialization.CreateSerializer(new CreateSerializerOptions { TypeNameHandling = TypeNameHandling.None });
             var json = new DynamicJsonValue
             {
                 [nameof(Id)] = Id,
                 [nameof(ChangeVector)] = null,
                 [nameof(JsonPatch)] = new DynamicJsonValue
                 {
-                    ["Operations"] = 
+                    ["Operations"] =
                         new DynamicJsonArray(
-                            JsonPatch.Operations.Select(o=> DocumentConventions.Default.Serialization.DefaultConverter.ToBlittable(o, context, serializer)))
+                            JsonPatch.Operations.Select(o=> conventions.Serialization.DefaultConverter.ToBlittable(o, context, serializer)))
                 },
                 [nameof(ReturnDocument)] = ReturnDocument,
                 [nameof(Type)] = Type.ToString()

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -330,6 +330,8 @@ namespace Raven.Client.Documents.Conventions
 
             MaxNumberOfRequestsPerSession = 30;
 
+            SessionPatchBehavior = SessionPatchBehavior.JsonPatch;
+
             BulkInsert = new BulkInsertConventions(this);
             Sharding = new ShardingConventions(this);
 
@@ -379,6 +381,7 @@ namespace Raven.Client.Documents.Conventions
 
         private bool _saveEnumsAsIntegers;
         private bool _saveEnumsAsIntegersForPatching;
+        private SessionPatchBehavior _sessionPatchBehavior;
         private char _identityPartsSeparator;
         private bool _disableTopologyUpdates;
 
@@ -1117,6 +1120,23 @@ namespace Raven.Client.Documents.Conventions
             {
                 AssertNotFrozen();
                 _saveEnumsAsIntegersForPatching = value;
+            }
+        }
+
+        /// <summary>
+        ///     Determines whether the session <c>Patch</c> methods emit RFC 6902 JsonPatch commands
+        ///     (<see cref="Conventions.SessionPatchBehavior.JsonPatch" />, the default) or legacy
+        ///     JavaScript patch commands (<see cref="Conventions.SessionPatchBehavior.JavaScript" />).
+        ///     Set to <see cref="Conventions.SessionPatchBehavior.JavaScript" /> to opt out of the
+        ///     JsonPatch code path entirely and restore the previous behavior.
+        /// </summary>
+        public SessionPatchBehavior SessionPatchBehavior
+        {
+            get => _sessionPatchBehavior;
+            set
+            {
+                AssertNotFrozen();
+                _sessionPatchBehavior = value;
             }
         }
 

--- a/src/Raven.Client/Documents/Conventions/SessionPatchBehavior.cs
+++ b/src/Raven.Client/Documents/Conventions/SessionPatchBehavior.cs
@@ -1,0 +1,21 @@
+namespace Raven.Client.Documents.Conventions
+{
+    /// <summary>
+    /// Controls the patch command format used by the session <c>Patch</c> methods
+    /// (property set, array Add/RemoveAt, dictionary Add/Remove).
+    /// </summary>
+    public enum SessionPatchBehavior
+    {
+        /// <summary>
+        /// Generate RFC 6902 JsonPatch commands where possible (default). Operations without a
+        /// JsonPatch equivalent still fall back to JavaScript-based patch commands.
+        /// </summary>
+        JsonPatch,
+
+        /// <summary>
+        /// Always generate JavaScript-based patch commands (the behavior prior to JsonPatch support).
+        /// Use this to opt out of the JsonPatch code path entirely.
+        /// </summary>
+        JavaScript
+    }
+}

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -189,7 +189,7 @@ namespace Raven.Client.Documents.Session
             var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
 
             if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false
-                && HasDictionaryIndexer(pathScript) == false)
+                && HasDictionaryIndexer(pathScript) == false && IsSimplePropertyPath(pathScript))
             {
                 var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
                 var jpd = new JsonPatchDocument();
@@ -546,6 +546,13 @@ namespace Raven.Client.Documents.Session
         private static bool HasDictionaryIndexer(string jsPath)
         {
             return jsPath.Contains("[\"") || jsPath.Contains("['");
+        }
+
+        private static bool IsSimplePropertyPath(string jsPath)
+        {
+            // Paths containing function calls (e.g. LINQ .Where().FirstOrDefault() compiled to .filter()())
+            // cannot be converted to JSON Pointer and must use the JavaScript patch path.
+            return jsPath.Contains("(") == false;
         }
 
         private bool HasExistingJavaScriptPatch(string id)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
-using System.Text;
 using Lambda2Js;
 using Microsoft.AspNetCore.JsonPatch;
 using Raven.Client.Documents.Commands.Batches;
@@ -186,14 +185,10 @@ namespace Raven.Client.Documents.Session
 
         public void Patch<T, U>(string id, Expression<Func<T, U>> path, U value)
         {
-            var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
-
             if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false
-                && HasDictionaryIndexer(pathScript) == false && IsSimplePropertyPath(pathScript))
+                && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
-                var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
                 var jpd = new JsonPatchDocument();
-
                 jpd.Replace(jsonPointer, ConvertValueForJsonPatch(value));
 
                 if (TryMergeJsonPatches(id, jpd) == false)
@@ -202,6 +197,7 @@ namespace Raven.Client.Documents.Session
                 return;
             }
 
+            var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
             var valueForJs = AddTypeNameToValueIfNeeded(path.Body.Type, value);
             if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
             {
@@ -257,15 +253,13 @@ namespace Raven.Client.Documents.Session
         public void Patch<T, TKey, TValue>(string id, Expression<Func<T, IDictionary<TKey, TValue>>> path,
             Expression<Func<JavaScriptDictionary<TKey, TValue>, object>> dictionaryAdder)
         {
-            var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
-
             if (!(dictionaryAdder.Body is MethodCallExpression call))
             {
                 ThrowUnsupportedExpression(dictionaryAdder);
                 return; // never hit
             }
 
-            if (HasExistingJavaScriptPatch(id) == false)
+            if (HasExistingJavaScriptPatch(id) == false && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 switch (call.Method.Name)
                 {
@@ -274,7 +268,6 @@ namespace Raven.Client.Documents.Session
                         var (dictKey, dictValue) = GetKeyAndValue<TKey, TValue>(call);
                         if (ShouldUseJsonPatch(typeof(TValue), dictValue))
                         {
-                            var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
                             var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
                             var jpd = new JsonPatchDocument();
 
@@ -291,7 +284,6 @@ namespace Raven.Client.Documents.Session
                     case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
                     {
                         var dictKey = GetKey(call);
-                        var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
                         var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
                         var jpd = new JsonPatchDocument();
                         jpd.Remove($"{jsonPointer}/{escapedKey}");
@@ -304,6 +296,7 @@ namespace Raven.Client.Documents.Session
                 }
             }
 
+            var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
             var patchRequest = new PatchRequest();
             object key;
             switch (call.Method.Name)
@@ -470,42 +463,68 @@ namespace Raven.Client.Documents.Session
             return JavascriptConversionExtensions.ToJsStringLiteral(key.ToString());
         }
 
-        private static string ConvertJavaScriptPathToJsonPointer(string jsPath)
-        {
-            var sb = new StringBuilder("/");
-            for (int i = 0; i < jsPath.Length; i++)
-            {
-                char c = jsPath[i];
-                switch (c)
-                {
-                    case '.':
-                        sb.Append('/');
-                        break;
-                    case '[':
-                        sb.Append('/');
-                        break;
-                    case ']':
-                    case '"':
-                    case '\'':
-                        break;
-                    case '~':
-                        sb.Append("~0");
-                        break;
-                    case '/':
-                        sb.Append("~1");
-                        break;
-                    default:
-                        sb.Append(c);
-                        break;
-                }
-            }
-
-            return sb.ToString();
-        }
-
         private static string EscapeJsonPointerSegment(string segment)
         {
             return segment.Replace("~", "~0").Replace("/", "~1");
+        }
+
+        private bool TryBuildJsonPointer(Expression body, out string jsonPointer)
+        {
+            jsonPointer = null;
+            var segments = new List<string>();
+            var current = body;
+
+            while (current != null)
+            {
+                switch (current)
+                {
+                    case ParameterExpression:
+                        // reached the root parameter (x =>), done
+                        current = null;
+                        break;
+
+                    case MemberExpression member:
+                        var name = Conventions.GetConvertedPropertyNameFor(member.Member);
+                        segments.Add(EscapeJsonPointerSegment(name));
+                        current = member.Expression;
+                        break;
+
+                    case BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex:
+                        if (arrayIndex.Right is ConstantExpression indexConst && indexConst.Value is int idx)
+                        {
+                            segments.Add(idx.ToString());
+                            current = arrayIndex.Left;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                        break;
+
+                    case MethodCallExpression call when call.Method.Name == "get_Item" && call.Arguments.Count == 1:
+                        if (call.Arguments[0] is ConstantExpression itemConst && itemConst.Value is int itemIdx)
+                        {
+                            segments.Add(itemIdx.ToString());
+                            current = call.Object;
+                        }
+                        else
+                        {
+                            return false;
+                        }
+                        break;
+
+                    case UnaryExpression unary:
+                        current = unary.Operand;
+                        break;
+
+                    default:
+                        return false;
+                }
+            }
+
+            segments.Reverse();
+            jsonPointer = "/" + string.Join("/", segments);
+            return true;
         }
 
         private static bool ShouldUseJsonPatch(Type propertyType, object value)
@@ -543,18 +562,6 @@ namespace Raven.Client.Documents.Session
             return true;
         }
 
-        private static bool HasDictionaryIndexer(string jsPath)
-        {
-            return jsPath.Contains("[\"") || jsPath.Contains("['");
-        }
-
-        private static bool IsSimplePropertyPath(string jsPath)
-        {
-            // Paths containing function calls (e.g. LINQ .Where().FirstOrDefault() compiled to .filter()())
-            // cannot be converted to JSON Pointer and must use the JavaScript patch path.
-            return jsPath.Contains("(") == false;
-        }
-
         private bool HasExistingJavaScriptPatch(string id)
         {
             return DeferredCommandsDictionary.ContainsKey((id, CommandType.PATCH, null));
@@ -577,8 +584,9 @@ namespace Raven.Client.Documents.Session
             if (CollectArrayOperations(arrayAdder.Body, operations) == false)
                 return false;
 
-            var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
-            var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
+            if (TryBuildJsonPointer(path.Body, out var jsonPointer) == false)
+                return false;
+
             var jpd = new JsonPatchDocument();
 
             foreach (var (methodName, values) in operations)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -259,19 +259,26 @@ namespace Raven.Client.Documents.Session
                 return; // never hit
             }
 
+            object key;
+            object value = null;
+
+            if (call.Method.Name == nameof(JavaScriptDictionary<TKey, TValue>.Add))
+                (key, value) = GetKeyAndValue<TKey, TValue>(call);
+            else
+                key = GetKey(call);
+
             if (HasExistingJavaScriptPatch(id) == false && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 switch (call.Method.Name)
                 {
                     case nameof(JavaScriptDictionary<TKey, TValue>.Add):
                     {
-                        var (dictKey, dictValue) = GetKeyAndValue<TKey, TValue>(call);
-                        if (ShouldUseJsonPatch(typeof(TValue), dictValue))
+                        if (ShouldUseJsonPatch(typeof(TValue), value))
                         {
-                            var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
+                            var escapedKey = EscapeJsonPointerSegment(key.ToString());
                             var jpd = new JsonPatchDocument();
 
-                            jpd.Add($"{jsonPointer}/{escapedKey}", ConvertValueForJsonPatch(dictValue));
+                            jpd.Add($"{jsonPointer}/{escapedKey}", ConvertValueForJsonPatch(value));
 
                             if (TryMergeJsonPatches(id, jpd) == false)
                                 Defer(new JsonPatchCommandData(id, jpd));
@@ -283,8 +290,7 @@ namespace Raven.Client.Documents.Session
                     }
                     case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
                     {
-                        var dictKey = GetKey(call);
-                        var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
+                        var escapedKey = EscapeJsonPointerSegment(key.ToString());
                         var jpd = new JsonPatchDocument();
                         jpd.Remove($"{jsonPointer}/{escapedKey}");
 
@@ -298,12 +304,9 @@ namespace Raven.Client.Documents.Session
 
             var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
             var patchRequest = new PatchRequest();
-            object key;
             switch (call.Method.Name)
             {
                 case nameof(JavaScriptDictionary<TKey, TValue>.Add):
-                    object value;
-                    (key, value) = GetKeyAndValue<TKey, TValue>(call);
                     var formattedKey = FormatKeyForJavaScript(key);
                     patchRequest.Script = $"this.{pathScript}[{formattedKey}] = args.val_{_valsCount};";
                     if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
@@ -314,7 +317,6 @@ namespace Raven.Client.Documents.Session
                     _valsCount++;
                     break;
                 case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
-                    key = GetKey(call);
                     formattedKey = FormatKeyForJavaScript(key);
                     patchRequest.Script = $"delete this.{pathScript}[{formattedKey}];";
                     break;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using Lambda2Js;
 using Microsoft.AspNetCore.JsonPatch;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Json;
@@ -185,8 +186,9 @@ namespace Raven.Client.Documents.Session
 
         public void Patch<T, U>(string id, Expression<Func<T, U>> path, U value)
         {
-            if (ShouldUseJsonPatch(value) && HasExistingJavaScriptPatch(id) == false
-                                          && TryBuildJsonPointer(path.Body, out var jsonPointer))
+            if (Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch
+                && ShouldUseJsonPatch(value) && HasExistingJavaScriptPatch(id) == false
+                && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 var jpd = new JsonPatchDocument();
                 var convertedValue = ConvertValueForJsonPatch(value);
@@ -234,7 +236,8 @@ namespace Raven.Client.Documents.Session
         public void Patch<T, U>(string id, Expression<Func<T, IEnumerable<U>>> path,
             Expression<Func<JavaScriptArray<U>, object>> arrayAdder)
         {
-            if (HasExistingJavaScriptPatch(id) == false && TryCreateArrayJsonPatch(id, path, arrayAdder))
+            if (Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch
+                && HasExistingJavaScriptPatch(id) == false && TryCreateArrayJsonPatch(id, path, arrayAdder))
                 return;
 
             var extension = new JavascriptConversionExtensions.CustomMethods
@@ -276,7 +279,8 @@ namespace Raven.Client.Documents.Session
             else
                 key = GetKey(call);
 
-            if (HasExistingJavaScriptPatch(id) == false && TryBuildJsonPointer(path.Body, out var jsonPointer))
+            if (Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch
+                && HasExistingJavaScriptPatch(id) == false && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 var keyString = key?.ToString();
                 if (IsValidJsonPointerSegment(keyString))

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -188,14 +188,19 @@ namespace Raven.Client.Documents.Session
         {
             var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
 
-            if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false)
+            if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false
+                && HasDictionaryIndexer(pathScript) == false)
             {
                 var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
                 var jpd = new JsonPatchDocument();
 
                 object valueToUse = value;
-                if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
-                    valueToUse = Convert.ToInt32(value);
+                if (value is Enum)
+                {
+                    valueToUse = DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
+                        ? Convert.ToInt32(value)
+                        : value.ToString();
+                }
 
                 jpd.Replace(jsonPointer, valueToUse);
 
@@ -281,8 +286,12 @@ namespace Raven.Client.Documents.Session
                             var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
                             var jpd = new JsonPatchDocument();
 
-                            if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && dictValue is Enum)
-                                dictValue = Convert.ToInt32(dictValue);
+                            if (dictValue is Enum)
+                            {
+                                dictValue = DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
+                                    ? Convert.ToInt32(dictValue)
+                                    : dictValue.ToString();
+                            }
 
                             jpd.Add($"{jsonPointer}/{escapedKey}", dictValue);
 
@@ -491,6 +500,8 @@ namespace Raven.Client.Documents.Session
                         sb.Append('/');
                         break;
                     case ']':
+                    case '"':
+                    case '\'':
                         break;
                     case '~':
                         sb.Append("~0");
@@ -547,6 +558,11 @@ namespace Raven.Client.Documents.Session
             return true;
         }
 
+        private static bool HasDictionaryIndexer(string jsPath)
+        {
+            return jsPath.Contains("[\"") || jsPath.Contains("['");
+        }
+
         private bool HasExistingJavaScriptPatch(string id)
         {
             return DeferredCommandsDictionary.ContainsKey((id, CommandType.PATCH, null));
@@ -571,8 +587,12 @@ namespace Raven.Client.Documents.Session
                         foreach (var val in values)
                         {
                             object valueToUse = val;
-                            if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && val is Enum)
-                                valueToUse = Convert.ToInt32(val);
+                            if (val is Enum)
+                            {
+                                valueToUse = DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
+                                    ? Convert.ToInt32(val)
+                                    : val.ToString();
+                            }
                             jpd.Add($"{jsonPointer}/-", valueToUse);
                         }
                         break;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -539,7 +539,7 @@ namespace Raven.Client.Documents.Session
                 return false;
 #endif
 
-            if (propertyType != typeOfValue && typeOfValue.IsClass)
+            if (typeOfValue.IsClass && typeOfValue != typeof(string))
                 return false;
 
             return true;
@@ -596,6 +596,9 @@ namespace Raven.Client.Documents.Session
                     case nameof(JavaScriptArray<U>.Add):
                         foreach (var val in values)
                         {
+                            if (ShouldUseJsonPatch(typeof(U), val) == false)
+                                return false;
+
                             jpd.Add($"{jsonPointer}/-", ConvertValueForJsonPatch(val));
                         }
                         break;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
+using System.Text;
 using Lambda2Js;
+using Microsoft.AspNetCore.JsonPatch;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations;
@@ -186,13 +188,30 @@ namespace Raven.Client.Documents.Session
         {
             var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
 
-            var valueToUse = AddTypeNameToValueIfNeeded(path.Body.Type, value);
-            if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
+            if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false)
             {
-                valueToUse = Convert.ToInt32(value);
+                var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
+                var jpd = new JsonPatchDocument();
+
+                object valueToUse = value;
+                if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
+                    valueToUse = Convert.ToInt32(value);
+
+                jpd.Replace(jsonPointer, valueToUse);
+
+                if (TryMergeJsonPatches(id, jpd) == false)
+                    Defer(new JsonPatchCommandData(id, jpd));
+
+                return;
             }
 
-            var patchRequest = new PatchRequest { Script = $"this.{pathScript} = args.val_{_valsCount};", Values = { [$"val_{_valsCount}"] = valueToUse } };
+            var valueForJs = AddTypeNameToValueIfNeeded(path.Body.Type, value);
+            if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
+            {
+                valueForJs = Convert.ToInt32(value);
+            }
+
+            var patchRequest = new PatchRequest { Script = $"this.{pathScript} = args.val_{_valsCount};", Values = { [$"val_{_valsCount}"] = valueForJs } };
 
             _valsCount++;
 
@@ -213,6 +232,9 @@ namespace Raven.Client.Documents.Session
         public void Patch<T, U>(string id, Expression<Func<T, IEnumerable<U>>> path,
             Expression<Func<JavaScriptArray<U>, object>> arrayAdder)
         {
+            if (HasExistingJavaScriptPatch(id) == false && TryCreateArrayJsonPatch(id, path, arrayAdder))
+                return;
+
             var extension = new JavascriptConversionExtensions.CustomMethods
             {
                 Suffix = _customCount++,
@@ -244,6 +266,48 @@ namespace Raven.Client.Documents.Session
             {
                 ThrowUnsupportedExpression(dictionaryAdder);
                 return; // never hit
+            }
+
+            if (HasExistingJavaScriptPatch(id) == false)
+            {
+                switch (call.Method.Name)
+                {
+                    case nameof(JavaScriptDictionary<TKey, TValue>.Add):
+                    {
+                        var (dictKey, dictValue) = GetKeyAndValue<TKey, TValue>(call);
+                        if (ShouldUseJsonPatch(typeof(TValue), dictValue))
+                        {
+                            var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
+                            var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
+                            var jpd = new JsonPatchDocument();
+
+                            if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && dictValue is Enum)
+                                dictValue = Convert.ToInt32(dictValue);
+
+                            jpd.Add($"{jsonPointer}/{escapedKey}", dictValue);
+
+                            if (TryMergeJsonPatches(id, jpd) == false)
+                                Defer(new JsonPatchCommandData(id, jpd));
+
+                            return;
+                        }
+
+                        break;
+                    }
+                    case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
+                    {
+                        var dictKey = GetKey(call);
+                        var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
+                        var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
+                        var jpd = new JsonPatchDocument();
+                        jpd.Remove($"{jsonPointer}/{escapedKey}");
+
+                        if (TryMergeJsonPatches(id, jpd) == false)
+                            Defer(new JsonPatchCommandData(id, jpd));
+
+                        return;
+                    }
+                }
             }
 
             var patchRequest = new PatchRequest();
@@ -410,6 +474,176 @@ namespace Raven.Client.Documents.Session
                 throw new ArgumentNullException(nameof(key), "Dictionary key cannot be null");
 
             return JavascriptConversionExtensions.ToJsStringLiteral(key.ToString());
+        }
+
+        private static string ConvertJavaScriptPathToJsonPointer(string jsPath)
+        {
+            var sb = new StringBuilder("/");
+            for (int i = 0; i < jsPath.Length; i++)
+            {
+                char c = jsPath[i];
+                switch (c)
+                {
+                    case '.':
+                        sb.Append('/');
+                        break;
+                    case '[':
+                        sb.Append('/');
+                        break;
+                    case ']':
+                        break;
+                    case '~':
+                        sb.Append("~0");
+                        break;
+                    case '/':
+                        sb.Append("~1");
+                        break;
+                    default:
+                        sb.Append(c);
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static string EscapeJsonPointerSegment(string segment)
+        {
+            return segment.Replace("~", "~0").Replace("/", "~1");
+        }
+
+        private static bool ShouldUseJsonPatch(Type propertyType, object value)
+        {
+            if (value == null)
+                return true;
+
+            var typeOfValue = value.GetType();
+
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            if (value is DateOnly or TimeOnly)
+                return false;
+#endif
+
+            if (propertyType != typeOfValue && typeOfValue.IsClass)
+                return false;
+
+            return true;
+        }
+
+        private bool TryMergeJsonPatches(string id, JsonPatchDocument patch)
+        {
+            if (DeferredCommandsDictionary.TryGetValue((id, CommandType.JsonPatch, null), out ICommandData command) == false)
+                return false;
+
+            DeferredCommands.Remove(command);
+
+            var oldPatch = (JsonPatchCommandData)command;
+            foreach (var op in patch.Operations)
+            {
+                oldPatch.JsonPatch.Operations.Add(op);
+            }
+
+            Defer(oldPatch);
+            return true;
+        }
+
+        private bool HasExistingJavaScriptPatch(string id)
+        {
+            return DeferredCommandsDictionary.ContainsKey((id, CommandType.PATCH, null));
+        }
+
+        private bool TryCreateArrayJsonPatch<T, U>(string id, Expression<Func<T, IEnumerable<U>>> path,
+            Expression<Func<JavaScriptArray<U>, object>> arrayAdder)
+        {
+            var operations = new List<(string MethodName, List<object> Values)>();
+            if (CollectArrayOperations(arrayAdder.Body, operations) == false)
+                return false;
+
+            var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
+            var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
+            var jpd = new JsonPatchDocument();
+
+            foreach (var (methodName, values) in operations)
+            {
+                switch (methodName)
+                {
+                    case nameof(JavaScriptArray<U>.Add):
+                        foreach (var val in values)
+                        {
+                            object valueToUse = val;
+                            if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && val is Enum)
+                                valueToUse = Convert.ToInt32(val);
+                            jpd.Add($"{jsonPointer}/-", valueToUse);
+                        }
+                        break;
+                    case nameof(JavaScriptArray<U>.RemoveAt):
+                        jpd.Remove($"{jsonPointer}/{values[0]}");
+                        break;
+                    default:
+                        return false;
+                }
+            }
+
+            if (TryMergeJsonPatches(id, jpd) == false)
+                Defer(new JsonPatchCommandData(id, jpd));
+
+            return true;
+        }
+
+        private static bool CollectArrayOperations(Expression expression, List<(string MethodName, List<object> Values)> operations)
+        {
+            if (expression is UnaryExpression unary)
+                expression = unary.Operand;
+
+            if (expression is not MethodCallExpression mce)
+                return false;
+
+            // Handle chaining: the Object of the method call may itself be a method call
+            if (mce.Object is MethodCallExpression innerCall)
+            {
+                if (CollectArrayOperations(innerCall, operations) == false)
+                    return false;
+            }
+
+            var methodName = mce.Method.Name;
+
+            if (methodName == nameof(JavaScriptArray<object>.RemoveAll))
+                return false;
+
+            var values = new List<object>();
+            foreach (var arg in mce.Arguments)
+            {
+                if (arg.Type.IsArray)
+                {
+                    if (arg is NewArrayExpression newArray)
+                    {
+                        foreach (var element in newArray.Expressions)
+                        {
+                            if (LinqPathProvider.GetValueFromExpressionWithoutConversion(element, out var val) == false)
+                                return false;
+                            values.Add(val);
+                        }
+                    }
+                    else if (LinqPathProvider.GetValueFromExpressionWithoutConversion(arg, out var arrayValue) && arrayValue is Array array)
+                    {
+                        foreach (var item in array)
+                            values.Add(item);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (LinqPathProvider.GetValueFromExpressionWithoutConversion(arg, out var val) == false)
+                        return false;
+                    values.Add(val);
+                }
+            }
+
+            operations.Add((methodName, values));
+            return true;
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -185,11 +185,20 @@ namespace Raven.Client.Documents.Session
 
         public void Patch<T, U>(string id, Expression<Func<T, U>> path, U value)
         {
-            if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false
-                                                          && TryBuildJsonPointer(path.Body, out var jsonPointer))
+            if (ShouldUseJsonPatch(value) && HasExistingJavaScriptPatch(id) == false
+                                          && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 var jpd = new JsonPatchDocument();
-                jpd.Replace(jsonPointer, ConvertValueForJsonPatch(value));
+                var convertedValue = ConvertValueForJsonPatch(value);
+
+                // Match the old JavaScript "this.x = value" semantics: assigning to a named
+                // member creates it when absent (JsonPatch "add" creates-or-replaces an object
+                // member), while assigning to an existing positional element overwrites it in
+                // place (JsonPatch "replace"; "add" would insert before the index instead).
+                if (IsNamedMemberAccess(path.Body))
+                    jpd.Add(jsonPointer, convertedValue);
+                else
+                    jpd.Replace(jsonPointer, convertedValue);
 
                 if (TryMergeJsonPatches(id, jpd) == false)
                     Defer(new JsonPatchCommandData(id, jpd));
@@ -276,7 +285,7 @@ namespace Raven.Client.Documents.Session
                     {
                         case nameof(JavaScriptDictionary<TKey, TValue>.Add):
                         {
-                            if (ShouldUseJsonPatch(typeof(TValue), value))
+                            if (ShouldUseJsonPatch(value))
                             {
                                 var escapedKey = EscapeJsonPointerSegment(keyString);
                                 var jpd = new JsonPatchDocument();
@@ -543,7 +552,7 @@ namespace Raven.Client.Documents.Session
             return true;
         }
 
-        private static bool ShouldUseJsonPatch(Type propertyType, object value)
+        private static bool ShouldUseJsonPatch(object value)
         {
             if (value == null)
                 return true;
@@ -559,6 +568,17 @@ namespace Raven.Client.Documents.Session
                 return false;
 
             return true;
+        }
+
+        private static bool IsNamedMemberAccess(Expression body)
+        {
+            while (body is UnaryExpression unary)
+                body = unary.Operand;
+
+            // A named member (x => x.Foo or x => x.Foo.Bar) maps to a JSON object member,
+            // which "add" creates-or-replaces. Array/list indexing (x => x.Items[0]) and
+            // dictionary indexers are handled by "replace" so existing elements are not shifted.
+            return body is MemberExpression;
         }
 
         private bool TryMergeJsonPatches(string id, JsonPatchDocument patch)
@@ -612,7 +632,7 @@ namespace Raven.Client.Documents.Session
                     case nameof(JavaScriptArray<U>.Add):
                         foreach (var val in values)
                         {
-                            if (ShouldUseJsonPatch(typeof(U), val) == false)
+                            if (ShouldUseJsonPatch(val) == false)
                                 return false;
 
                             jpd.Add($"{jsonPointer}/-", ConvertValueForJsonPatch(val));

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -58,7 +58,6 @@ namespace Raven.Client.Documents.Session
 
         public void AddOrIncrement<T, TU>(string id, T entity, Expression<Func<T, TU>> path, TU valueToAdd)
         {
-
             var pathScript = path.CompileToJavascript(_pathScriptCompilationOptions.Value);
 
             var variable = $"this.{pathScript}";
@@ -143,6 +142,7 @@ namespace Raven.Client.Documents.Session
             {
                 valueToUse = Convert.ToInt32(value);
             }
+
             var patchRequest = new PatchRequest
             {
                 Script = $"this.{patchScript} = args.val_{_valsCount};",
@@ -186,7 +186,7 @@ namespace Raven.Client.Documents.Session
         public void Patch<T, U>(string id, Expression<Func<T, U>> path, U value)
         {
             if (ShouldUseJsonPatch(path.Body.Type, value) && HasExistingJavaScriptPatch(id) == false
-                && TryBuildJsonPointer(path.Body, out var jsonPointer))
+                                                          && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 var jpd = new JsonPatchDocument();
                 jpd.Replace(jsonPointer, ConvertValueForJsonPatch(value));
@@ -313,6 +313,7 @@ namespace Raven.Client.Documents.Session
                     {
                         value = Convert.ToInt32(value);
                     }
+
                     patchRequest.Values[$"val_{_valsCount}"] = value;
                     _valsCount++;
                     break;
@@ -501,6 +502,7 @@ namespace Raven.Client.Documents.Session
                         {
                             return false;
                         }
+
                         break;
 
                     case MethodCallExpression call when call.Method.Name == "get_Item" && call.Arguments.Count == 1:
@@ -513,6 +515,7 @@ namespace Raven.Client.Documents.Session
                         {
                             return false;
                         }
+
                         break;
 
                     case UnaryExpression unary:
@@ -603,6 +606,7 @@ namespace Raven.Client.Documents.Session
 
                             jpd.Add($"{jsonPointer}/-", ConvertValueForJsonPatch(val));
                         }
+
                         break;
                     case nameof(JavaScriptArray<U>.RemoveAt):
                         jpd.Remove($"{jsonPointer}/{values[0]}");

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -186,7 +186,7 @@ namespace Raven.Client.Documents.Session
 
         public void Patch<T, U>(string id, Expression<Func<T, U>> path, U value)
         {
-            if (Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch
+            if (UseJsonPatchInSessionPatchMethods
                 && ShouldUseJsonPatch(value) && HasExistingJavaScriptPatch(id) == false
                 && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
@@ -202,8 +202,7 @@ namespace Raven.Client.Documents.Session
                 else
                     jpd.Replace(jsonPointer, convertedValue);
 
-                if (TryMergeJsonPatches(id, jpd) == false)
-                    Defer(new JsonPatchCommandData(id, jpd));
+                DeferJsonPatchIfNotMerged(id, jpd);
 
                 return;
             }
@@ -236,7 +235,7 @@ namespace Raven.Client.Documents.Session
         public void Patch<T, U>(string id, Expression<Func<T, IEnumerable<U>>> path,
             Expression<Func<JavaScriptArray<U>, object>> arrayAdder)
         {
-            if (Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch
+            if (UseJsonPatchInSessionPatchMethods
                 && HasExistingJavaScriptPatch(id) == false && TryCreateArrayJsonPatch(id, path, arrayAdder))
                 return;
 
@@ -279,7 +278,7 @@ namespace Raven.Client.Documents.Session
             else
                 key = GetKey(call);
 
-            if (Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch
+            if (UseJsonPatchInSessionPatchMethods
                 && HasExistingJavaScriptPatch(id) == false && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
                 var keyString = key?.ToString();
@@ -296,8 +295,7 @@ namespace Raven.Client.Documents.Session
 
                                 jpd.Add($"{jsonPointer}/{escapedKey}", ConvertValueForJsonPatch(value));
 
-                                if (TryMergeJsonPatches(id, jpd) == false)
-                                    Defer(new JsonPatchCommandData(id, jpd));
+                                DeferJsonPatchIfNotMerged(id, jpd);
 
                                 return;
                             }
@@ -310,8 +308,7 @@ namespace Raven.Client.Documents.Session
                             var jpd = new JsonPatchDocument();
                             jpd.Remove($"{jsonPointer}/{escapedKey}");
 
-                            if (TryMergeJsonPatches(id, jpd) == false)
-                                Defer(new JsonPatchCommandData(id, jpd));
+                            DeferJsonPatchIfNotMerged(id, jpd);
 
                             return;
                         }
@@ -602,6 +599,14 @@ namespace Raven.Client.Documents.Session
             return true;
         }
 
+        private void DeferJsonPatchIfNotMerged(string id, JsonPatchDocument patch)
+        {
+            if (TryMergeJsonPatches(id, patch) == false)
+                Defer(new JsonPatchCommandData(id, patch));
+        }
+
+        private bool UseJsonPatchInSessionPatchMethods => Conventions.SessionPatchBehavior == SessionPatchBehavior.JsonPatch;
+
         private bool HasExistingJavaScriptPatch(string id)
         {
             return DeferredCommandsDictionary.ContainsKey((id, CommandType.PATCH, null));
@@ -651,8 +656,7 @@ namespace Raven.Client.Documents.Session
                 }
             }
 
-            if (TryMergeJsonPatches(id, jpd) == false)
-                Defer(new JsonPatchCommandData(id, jpd));
+            DeferJsonPatchIfNotMerged(id, jpd);
 
             return true;
         }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -269,35 +269,39 @@ namespace Raven.Client.Documents.Session
 
             if (HasExistingJavaScriptPatch(id) == false && TryBuildJsonPointer(path.Body, out var jsonPointer))
             {
-                switch (call.Method.Name)
+                var keyString = key?.ToString();
+                if (IsValidJsonPointerSegment(keyString))
                 {
-                    case nameof(JavaScriptDictionary<TKey, TValue>.Add):
+                    switch (call.Method.Name)
                     {
-                        if (ShouldUseJsonPatch(typeof(TValue), value))
+                        case nameof(JavaScriptDictionary<TKey, TValue>.Add):
                         {
-                            var escapedKey = EscapeJsonPointerSegment(key.ToString());
-                            var jpd = new JsonPatchDocument();
+                            if (ShouldUseJsonPatch(typeof(TValue), value))
+                            {
+                                var escapedKey = EscapeJsonPointerSegment(keyString);
+                                var jpd = new JsonPatchDocument();
 
-                            jpd.Add($"{jsonPointer}/{escapedKey}", ConvertValueForJsonPatch(value));
+                                jpd.Add($"{jsonPointer}/{escapedKey}", ConvertValueForJsonPatch(value));
+
+                                if (TryMergeJsonPatches(id, jpd) == false)
+                                    Defer(new JsonPatchCommandData(id, jpd));
+
+                                return;
+                            }
+
+                            break;
+                        }
+                        case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
+                        {
+                            var escapedKey = EscapeJsonPointerSegment(keyString);
+                            var jpd = new JsonPatchDocument();
+                            jpd.Remove($"{jsonPointer}/{escapedKey}");
 
                             if (TryMergeJsonPatches(id, jpd) == false)
                                 Defer(new JsonPatchCommandData(id, jpd));
 
                             return;
                         }
-
-                        break;
-                    }
-                    case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
-                    {
-                        var escapedKey = EscapeJsonPointerSegment(key.ToString());
-                        var jpd = new JsonPatchDocument();
-                        jpd.Remove($"{jsonPointer}/{escapedKey}");
-
-                        if (TryMergeJsonPatches(id, jpd) == false)
-                            Defer(new JsonPatchCommandData(id, jpd));
-
-                        return;
                     }
                 }
             }
@@ -469,6 +473,13 @@ namespace Raven.Client.Documents.Session
         private static string EscapeJsonPointerSegment(string segment)
         {
             return segment.Replace("~", "~0").Replace("/", "~1");
+        }
+
+        private static bool IsValidJsonPointerSegment(string segment)
+        {
+            // Server-side JsonPatchCommand.Parse rejects whitespace-only path segments.
+            // Fall back to JavaScript for keys that would produce such segments.
+            return string.IsNullOrWhiteSpace(segment) == false;
         }
 
         private bool TryBuildJsonPointer(Expression body, out string jsonPointer)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -194,15 +194,7 @@ namespace Raven.Client.Documents.Session
                 var jsonPointer = ConvertJavaScriptPathToJsonPointer(pathScript);
                 var jpd = new JsonPatchDocument();
 
-                object valueToUse = value;
-                if (value is Enum)
-                {
-                    valueToUse = DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
-                        ? Convert.ToInt32(value)
-                        : value.ToString();
-                }
-
-                jpd.Replace(jsonPointer, valueToUse);
+                jpd.Replace(jsonPointer, ConvertValueForJsonPatch(value));
 
                 if (TryMergeJsonPatches(id, jpd) == false)
                     Defer(new JsonPatchCommandData(id, jpd));
@@ -286,14 +278,7 @@ namespace Raven.Client.Documents.Session
                             var escapedKey = EscapeJsonPointerSegment(dictKey.ToString());
                             var jpd = new JsonPatchDocument();
 
-                            if (dictValue is Enum)
-                            {
-                                dictValue = DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
-                                    ? Convert.ToInt32(dictValue)
-                                    : dictValue.ToString();
-                            }
-
-                            jpd.Add($"{jsonPointer}/{escapedKey}", dictValue);
+                            jpd.Add($"{jsonPointer}/{escapedKey}", ConvertValueForJsonPatch(dictValue));
 
                             if (TryMergeJsonPatches(id, jpd) == false)
                                 Defer(new JsonPatchCommandData(id, jpd));
@@ -568,6 +553,16 @@ namespace Raven.Client.Documents.Session
             return DeferredCommandsDictionary.ContainsKey((id, CommandType.PATCH, null));
         }
 
+        private object ConvertValueForJsonPatch(object value)
+        {
+            if (value is not Enum)
+                return value;
+
+            return DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
+                ? Convert.ToInt32(value)
+                : value.ToString();
+        }
+
         private bool TryCreateArrayJsonPatch<T, U>(string id, Expression<Func<T, IEnumerable<U>>> path,
             Expression<Func<JavaScriptArray<U>, object>> arrayAdder)
         {
@@ -586,14 +581,7 @@ namespace Raven.Client.Documents.Session
                     case nameof(JavaScriptArray<U>.Add):
                         foreach (var val in values)
                         {
-                            object valueToUse = val;
-                            if (val is Enum)
-                            {
-                                valueToUse = DocumentStore.Conventions.SaveEnumsAsIntegersForPatching
-                                    ? Convert.ToInt32(val)
-                                    : val.ToString();
-                            }
-                            jpd.Add($"{jsonPointer}/-", valueToUse);
+                            jpd.Add($"{jsonPointer}/-", ConvertValueForJsonPatch(val));
                         }
                         break;
                     case nameof(JavaScriptArray<U>.RemoveAt):

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -693,7 +693,7 @@ namespace Raven.Server.Documents.Handlers.Batches
         [DoesNotReturn]
         private static void ThrowMissingJsonPatchProperty()
         {
-            throw new InvalidOperationException($"JsonPatch command must have a '{nameof(CommandData.JsonPatchCommands)}' property");
+            throw new InvalidOperationException($"JsonPatch command must have a '{nameof(CommandPropertyName.JsonPatch)}' property");
         }
 
         [DoesNotReturn]

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -626,6 +626,11 @@ namespace Raven.Server.Documents.Handlers.Batches
                         ThrowMissingPatchProperty();
                     break;
 
+                case CommandType.JsonPatch:
+                    if (commandData.JsonPatchCommands == null)
+                        ThrowMissingJsonPatchProperty();
+                    break;
+
                 case CommandType.AttachmentPUT:
                     if (commandData.Name == null)
                         ThrowMissingNameProperty();
@@ -683,6 +688,12 @@ namespace Raven.Server.Documents.Handlers.Batches
         private static void ThrowMissingPatchProperty()
         {
             throw new InvalidOperationException($"PUT command must have a '{nameof(CommandData.Patch)}' property");
+        }
+
+        [DoesNotReturn]
+        private static void ThrowMissingJsonPatchProperty()
+        {
+            throw new InvalidOperationException($"JsonPatch command must have a '{nameof(CommandData.JsonPatchCommands)}' property");
         }
 
         [DoesNotReturn]

--- a/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommandDto.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/Commands/MergedBatchCommandDto.cs
@@ -16,23 +16,31 @@ public sealed class MergedBatchCommandDto : IReplayableCommandDto<DocumentsOpera
     {
         foreach (var parsedCommand in ParsedCommands)
         {
-            if (parsedCommand.Type != CommandType.PATCH)
-                continue;
-
-            parsedCommand.PatchCommand = new PatchDocumentCommand(
-                context: context,
-                id: parsedCommand.Id,
-                expectedChangeVector: parsedCommand.ChangeVector,
-                skipPatchIfChangeVectorMismatch: false,
-                patch: (parsedCommand.Patch, parsedCommand.PatchArgs),
-                patchIfMissing: (parsedCommand.PatchIfMissing, parsedCommand.PatchIfMissingArgs),
-                identityPartsSeparator: database.IdentityPartsSeparator,
-                createIfMissing: parsedCommand.CreateIfMissing,
-                isTest: false,
-                debugMode: false,
-                collectResultsNeeded: true,
-                returnDocument: parsedCommand.ReturnDocument
-            );
+            if (parsedCommand.Type == CommandType.PATCH)
+            {
+                parsedCommand.PatchCommand = new PatchDocumentCommand(
+                    context: context,
+                    id: parsedCommand.Id,
+                    expectedChangeVector: parsedCommand.ChangeVector,
+                    skipPatchIfChangeVectorMismatch: false,
+                    patch: (parsedCommand.Patch, parsedCommand.PatchArgs),
+                    patchIfMissing: (parsedCommand.PatchIfMissing, parsedCommand.PatchIfMissingArgs),
+                    identityPartsSeparator: database.IdentityPartsSeparator,
+                    createIfMissing: parsedCommand.CreateIfMissing,
+                    isTest: false,
+                    debugMode: false,
+                    collectResultsNeeded: true,
+                    returnDocument: parsedCommand.ReturnDocument
+                );
+            }
+            else if (parsedCommand.Type == CommandType.JsonPatch)
+            {
+                parsedCommand.JsonPatchCommand = new JsonPatchCommand(
+                    parsedCommand.Id,
+                    parsedCommand.JsonPatchCommands,
+                    parsedCommand.ReturnDocument,
+                    context);
+            }
         }
 
         var newCmd = new MergedBatchCommand(database)

--- a/src/Raven.Server/Documents/Handlers/JsonPatchHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/JsonPatchHandler.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Documents;
 using Raven.Server.Documents.TransactionMerger.Commands;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide.Context;
@@ -34,6 +35,9 @@ namespace Raven.Server.Documents.Handlers
                     case PatchStatus.NotModified:
                         HttpContext.Response.StatusCode = (int)HttpStatusCode.OK;
                         break;
+
+                    case PatchStatus.DocumentDoesNotExist:
+                        throw new DocumentDoesNotExistException($"Cannot apply json patch because the document {id} does not exist");
 
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
@@ -105,7 +105,7 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
                     };
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not Raven.Client.Exceptions.SchemaValidation.SchemaValidationException)
             {
                 throw new InvalidOperationException($"An error occurred while trying to apply json patch operation to document {_id}.", ex);
             }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/JsonPatchCommand.cs
@@ -36,7 +36,8 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
 
             if (document == null)
             {
-                throw new InvalidOperationException($"Cannot apply json patch because the document {_id} does not exist");
+                _patchResult = new JsonPatchResult { Status = PatchStatus.DocumentDoesNotExist };
+                return 1;
             }
 
             try

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -6,7 +6,6 @@ using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -4,7 +4,6 @@ using FastTests;
 using Orders;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Session;
-using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -5,6 +5,7 @@ using FastTests;
 using Newtonsoft.Json;
 using Orders;
 using Raven.Client;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
@@ -31,10 +32,12 @@ namespace SlowTests.Issues
             public Address Address { get; set; }
         }
 
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void Patch_SimpleProperty_UsesJsonPatch()
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        [InlineData(SessionPatchBehavior.JsonPatch, CommandType.JsonPatch)]
+        [InlineData(SessionPatchBehavior.JavaScript, CommandType.PATCH)]
+        public void Patch_SimpleProperty_UsesConfiguredBehavior(SessionPatchBehavior behavior, CommandType expected)
         {
-            using (var store = GetDocumentStore())
+            using (var store = GetPatchStore(behavior))
             {
                 using (var session = store.OpenSession())
                 {
@@ -45,10 +48,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertUsesPatchBehavior(session, "users/1", expected);
                     session.SaveChanges();
                 }
 
@@ -57,6 +57,132 @@ namespace SlowTests.Issues
                     var user = session.Load<UserWithTags>("users/1");
                     Assert.Equal("Updated", user.Name);
                     Assert.Equal(25, user.Age);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        [InlineData(SessionPatchBehavior.JsonPatch, CommandType.JsonPatch)]
+        [InlineData(SessionPatchBehavior.JavaScript, CommandType.PATCH)]
+        public void Patch_ArrayAdd_UsesConfiguredBehavior(SessionPatchBehavior behavior, CommandType expected)
+        {
+            using (var store = GetPatchStore(behavior))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("c"));
+                    AssertUsesPatchBehavior(session, "users/1", expected);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(3, user.Tags.Count);
+                    Assert.Equal("c", user.Tags[2]);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        [InlineData(SessionPatchBehavior.JsonPatch, CommandType.JsonPatch)]
+        [InlineData(SessionPatchBehavior.JavaScript, CommandType.PATCH)]
+        public void Patch_ArrayRemoveAt_UsesConfiguredBehavior(SessionPatchBehavior behavior, CommandType expected)
+        {
+            using (var store = GetPatchStore(behavior))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(1));
+                    AssertUsesPatchBehavior(session, "users/1", expected);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Tags.Count);
+                    Assert.Equal("a", user.Tags[0]);
+                    Assert.Equal("c", user.Tags[1]);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        [InlineData(SessionPatchBehavior.JsonPatch, CommandType.JsonPatch)]
+        [InlineData(SessionPatchBehavior.JavaScript, CommandType.PATCH)]
+        public void Patch_DictionaryAdd_UsesConfiguredBehavior(SessionPatchBehavior behavior, CommandType expected)
+        {
+            using (var store = GetPatchStore(behavior))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Add("lang", "en"));
+                    AssertUsesPatchBehavior(session, "users/1", expected);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Settings.Count);
+                    Assert.Equal("light", user.Settings["theme"]);
+                    Assert.Equal("en", user.Settings["lang"]);
+                }
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        [InlineData(SessionPatchBehavior.JsonPatch, CommandType.JsonPatch)]
+        [InlineData(SessionPatchBehavior.JavaScript, CommandType.PATCH)]
+        public void Patch_DictionaryRemove_UsesConfiguredBehavior(SessionPatchBehavior behavior, CommandType expected)
+        {
+            using (var store = GetPatchStore(behavior))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" }, { "lang", "en" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Remove("lang"));
+                    AssertUsesPatchBehavior(session, "users/1", expected);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Single(user.Settings);
+                    Assert.Equal("light", user.Settings["theme"]);
                 }
             }
         }
@@ -79,10 +205,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Address.City, "NewCity");
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
                     session.SaveChanges();
                 }
 
@@ -109,10 +232,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, null);
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
                     session.SaveChanges();
                 }
 
@@ -138,10 +258,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
                     session.SaveChanges();
                 }
 
@@ -169,9 +286,8 @@ namespace SlowTests.Issues
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
                     session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-                    Assert.Equal(1, sessionOps.DeferredCommandsCount);
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
+                    AssertDeferredCommandCount(session, 1);
 
                     session.SaveChanges();
                 }
@@ -201,8 +317,7 @@ namespace SlowTests.Issues
                     var user = session.Load<UserWithTags>("users/1");
                     session.Advanced.Patch(user, u => u.Name, "Updated");
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
 
                     var cv = session.Advanced.GetChangeVectorFor(user);
 
@@ -225,36 +340,6 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void Patch_ArrayAdd_UsesJsonPatch()
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b" } }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("c"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal(3, user.Tags.Count);
-                    Assert.Equal("c", user.Tags[2]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
         public void Patch_ArrayAddMultiple_UsesJsonPatch()
         {
             using (var store = GetDocumentStore())
@@ -268,10 +353,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("b", "c"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
                     session.SaveChanges();
                 }
 
@@ -281,37 +363,6 @@ namespace SlowTests.Issues
                     Assert.Equal(3, user.Tags.Count);
                     Assert.Equal("b", user.Tags[1]);
                     Assert.Equal("c", user.Tags[2]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void Patch_ArrayRemoveAt_UsesJsonPatch()
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(1));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal(2, user.Tags.Count);
-                    Assert.Equal("a", user.Tags[0]);
-                    Assert.Equal("c", user.Tags[1]);
                 }
             }
         }
@@ -331,9 +382,8 @@ namespace SlowTests.Issues
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAll(t => t == "b"));
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    AssertDeferredCommand(session, "users/1", CommandType.PATCH);
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch, exists: false);
 
                     session.SaveChanges();
                 }
@@ -344,83 +394,6 @@ namespace SlowTests.Issues
                     Assert.Equal(2, user.Tags.Count);
                     Assert.Contains("a", user.Tags);
                     Assert.Contains("c", user.Tags);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void Patch_DictionaryAdd_UsesJsonPatch()
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags
-                    {
-                        Name = "Test",
-                        Settings = new Dictionary<string, string> { { "theme", "light" } }
-                    }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string, string>("users/1",
-                        u => u.Settings,
-                        d => d.Add("lang", "en"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal(2, user.Settings.Count);
-                    Assert.Equal("light", user.Settings["theme"]);
-                    Assert.Equal("en", user.Settings["lang"]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void Patch_DictionaryRemove_UsesJsonPatch()
-        {
-            using (var store = GetDocumentStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags
-                    {
-                        Name = "Test",
-                        Settings = new Dictionary<string, string>
-                        {
-                            { "theme", "light" },
-                            { "lang", "en" }
-                        }
-                    }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string, string>("users/1",
-                        u => u.Settings,
-                        d => d.Remove("lang"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Single(user.Settings);
-                    Assert.Equal("light", user.Settings["theme"]);
                 }
             }
         }
@@ -443,9 +416,8 @@ namespace SlowTests.Issues
                     // Patch should fall back to JavaScript and merge
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    AssertDeferredCommand(session, "users/1", CommandType.PATCH);
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch, exists: false);
 
                     session.SaveChanges();
                 }
@@ -477,10 +449,9 @@ namespace SlowTests.Issues
                     // Increment creates a separate JavaScript patch command
                     session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.Equal(2, sessionOps.DeferredCommandsCount);
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
+                    AssertDeferredCommand(session, "users/1", CommandType.PATCH);
+                    AssertDeferredCommandCount(session, 2);
 
                     session.SaveChanges();
                 }
@@ -510,8 +481,7 @@ namespace SlowTests.Issues
                     var user = session.Load<UserWithTags>("users/1");
                     session.Advanced.Patch(user, u => u.Name, "Updated");
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
 
                     session.SaveChanges();
 
@@ -623,9 +593,8 @@ namespace SlowTests.Issues
                 {
                     session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
 
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    AssertDeferredCommand(session, "users/1", CommandType.PATCH);
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch, exists: false);
 
                     session.SaveChanges();
                 }
@@ -656,10 +625,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
                     session.SaveChanges(); // must not throw even though 'Age' is absent on the stored document
                 }
 
@@ -688,10 +654,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags[1], "B");
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "users/1", CommandType.JsonPatch);
                     session.SaveChanges();
                 }
 
@@ -732,10 +695,7 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<WeatherDoc, Temperature>("weather/1", x => x.Temp, new Temperature { Celsius = 30 });
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("weather/1", CommandType.JsonPatch, null)));
-
+                    AssertDeferredCommand(session, "weather/1", CommandType.JsonPatch);
                     session.SaveChanges();
                 }
 
@@ -765,170 +725,6 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void SessionPatchBehavior_JavaScript_SimpleProperty_UsesJavaScript()
-        {
-            using (var store = GetJavaScriptPatchStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal("Updated", user.Name);
-                    Assert.Equal(25, user.Age);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void SessionPatchBehavior_JavaScript_ArrayAdd_UsesJavaScript()
-        {
-            using (var store = GetJavaScriptPatchStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b" } }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("c"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal(3, user.Tags.Count);
-                    Assert.Equal("c", user.Tags[2]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void SessionPatchBehavior_JavaScript_ArrayRemoveAt_UsesJavaScript()
-        {
-            using (var store = GetJavaScriptPatchStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(1));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal(2, user.Tags.Count);
-                    Assert.Equal("a", user.Tags[0]);
-                    Assert.Equal("c", user.Tags[1]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void SessionPatchBehavior_JavaScript_DictionaryAdd_UsesJavaScript()
-        {
-            using (var store = GetJavaScriptPatchStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags
-                    {
-                        Name = "Test",
-                        Settings = new Dictionary<string, string> { { "theme", "light" } }
-                    }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Add("lang", "en"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Equal(2, user.Settings.Count);
-                    Assert.Equal("en", user.Settings["lang"]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
-        public void SessionPatchBehavior_JavaScript_DictionaryRemove_UsesJavaScript()
-        {
-            using (var store = GetJavaScriptPatchStore())
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new UserWithTags
-                    {
-                        Name = "Test",
-                        Settings = new Dictionary<string, string> { { "theme", "light" }, { "lang", "en" } }
-                    }, "users/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Remove("lang"));
-
-                    var sessionOps = (InMemoryDocumentSessionOperations)session;
-                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
-                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
-
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    var user = session.Load<UserWithTags>("users/1");
-                    Assert.Single(user.Settings);
-                    Assert.Equal("light", user.Settings["theme"]);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
         public void SessionPatchBehavior_ArrayRemoveAtOutOfRange_ThrowsUnderJsonPatch_NoOpUnderJavaScript()
         {
             // Default (JsonPatch): out-of-range RemoveAt reaches the server as `remove /Tags/10`,
@@ -949,7 +745,7 @@ namespace SlowTests.Issues
             }
 
             // JavaScript convention mitigates it: legacy splice(10, 1) is a silent no-op.
-            using (var store = GetJavaScriptPatchStore())
+            using (var store = GetPatchStore(SessionPatchBehavior.JavaScript))
             {
                 using (var session = store.OpenSession())
                 {
@@ -996,7 +792,7 @@ namespace SlowTests.Issues
             }
 
             // JavaScript convention mitigates it: `delete obj['missing']` is a silent no-op.
-            using (var store = GetJavaScriptPatchStore())
+            using (var store = GetPatchStore(SessionPatchBehavior.JavaScript))
             {
                 using (var session = store.OpenSession())
                 {
@@ -1023,12 +819,31 @@ namespace SlowTests.Issues
             }
         }
 
-        private Raven.Client.Documents.IDocumentStore GetJavaScriptPatchStore()
+        private IDocumentStore GetPatchStore(SessionPatchBehavior behavior)
         {
             return GetDocumentStore(new Options
             {
-                ModifyDocumentStore = s => s.Conventions.SessionPatchBehavior = SessionPatchBehavior.JavaScript
+                ModifyDocumentStore = s => s.Conventions.SessionPatchBehavior = behavior
             });
+        }
+
+        private static void AssertUsesPatchBehavior(IDocumentSession session, string id, CommandType expected)
+        {
+            var other = expected == CommandType.JsonPatch ? CommandType.PATCH : CommandType.JsonPatch;
+            AssertDeferredCommand(session, id, expected);
+            AssertDeferredCommand(session, id, other, exists: false);
+        }
+
+        private static void AssertDeferredCommand(IDocumentSession session, string id, CommandType type, bool exists = true)
+        {
+            var sessionOps = (InMemoryDocumentSessionOperations)session;
+            Assert.Equal(exists, sessionOps.DeferredCommandsDictionary.ContainsKey((id, type, null)));
+        }
+
+        private static void AssertDeferredCommandCount(IDocumentSession session, int count)
+        {
+            var sessionOps = (InMemoryDocumentSessionOperations)session;
+            Assert.Equal(count, sessionOps.DeferredCommandsCount);
         }
 
         private struct Temperature

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -529,7 +529,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    session.Advanced.UseOptimisticConcurrency = true;
+                    session.Advanced.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes;
 
                     var user = await session.LoadAsync<UserWithTags>("users/1");
 
@@ -573,7 +573,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenAsyncSession())
                 {
-                    session.Advanced.UseOptimisticConcurrency = true;
+                    session.Advanced.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes;
 
                     var user = await session.LoadAsync<UserWithTags>("users/1");
 

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -6,7 +6,9 @@ using Newtonsoft.Json;
 using Orders;
 using Raven.Client;
 using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
 using Tests.Infrastructure;
 using Xunit;
@@ -751,6 +753,282 @@ namespace SlowTests.Issues
                     Assert.Equal(30, doc.Temp.Celsius);
                 }
             }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_DefaultsToJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                Assert.Equal(SessionPatchBehavior.JsonPatch, store.Conventions.SessionPatchBehavior);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_JavaScript_SimpleProperty_UsesJavaScript()
+        {
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                    Assert.Equal(25, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_JavaScript_ArrayAdd_UsesJavaScript()
+        {
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("c"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(3, user.Tags.Count);
+                    Assert.Equal("c", user.Tags[2]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_JavaScript_ArrayRemoveAt_UsesJavaScript()
+        {
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(1));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Tags.Count);
+                    Assert.Equal("a", user.Tags[0]);
+                    Assert.Equal("c", user.Tags[1]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_JavaScript_DictionaryAdd_UsesJavaScript()
+        {
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Add("lang", "en"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Settings.Count);
+                    Assert.Equal("en", user.Settings["lang"]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_JavaScript_DictionaryRemove_UsesJavaScript()
+        {
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" }, { "lang", "en" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Remove("lang"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Single(user.Settings);
+                    Assert.Equal("light", user.Settings["theme"]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_ArrayRemoveAtOutOfRange_ThrowsUnderJsonPatch_NoOpUnderJavaScript()
+        {
+            // Default (JsonPatch): out-of-range RemoveAt reaches the server as `remove /Tags/10`,
+            // which strict RFC 6902 remove rejects -> SaveChanges throws.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(10));
+                    Assert.ThrowsAny<RavenException>(() => session.SaveChanges());
+                }
+            }
+
+            // JavaScript convention mitigates it: legacy splice(10, 1) is a silent no-op.
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(10));
+                    session.SaveChanges(); // no-op, must not throw
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(3, user.Tags.Count); // unchanged
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void SessionPatchBehavior_DictionaryRemoveAbsentKey_ThrowsUnderJsonPatch_NoOpUnderJavaScript()
+        {
+            // Default (JsonPatch): removing a missing key reaches the server as `remove /Settings/missing`,
+            // which strict RFC 6902 remove rejects -> SaveChanges throws.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Remove("missing"));
+                    Assert.ThrowsAny<RavenException>(() => session.SaveChanges());
+                }
+            }
+
+            // JavaScript convention mitigates it: `delete obj['missing']` is a silent no-op.
+            using (var store = GetJavaScriptPatchStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1", u => u.Settings, d => d.Remove("missing"));
+                    session.SaveChanges(); // no-op, must not throw
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Single(user.Settings);
+                    Assert.Equal("light", user.Settings["theme"]);
+                }
+            }
+        }
+
+        private Raven.Client.Documents.IDocumentStore GetJavaScriptPatchStore()
+        {
+            return GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s => s.Conventions.SessionPatchBehavior = SessionPatchBehavior.JavaScript
+            });
         }
 
         private struct Temperature

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -510,6 +512,94 @@ namespace SlowTests.Issues
                     session.SaveChanges();
 
                     Assert.Equal("Updated", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public async Task Patch_WithOptimisticConcurrency_DoesNotSendChangeVector_JsonPatch()
+        {
+            // Session.Advanced.Patch does not enforce optimistic concurrency (change vector is always null).
+            // A concurrent modification between Load and Patch+SaveChanges should succeed, not throw ConcurrencyException.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    var user = await session.LoadAsync<UserWithTags>("users/1");
+
+                    // Simulate a concurrent modification by another session
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<UserWithTags>("users/1");
+                        otherUser.Age = 99;
+                        otherSession.SaveChanges();
+                    }
+
+                    // JsonPatch path
+                    session.Advanced.Patch(user, u => u.Name, "Updated");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    await session.SaveChangesAsync(); // should not throw ConcurrencyException
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public async Task Patch_WithOptimisticConcurrency_DoesNotSendChangeVector_JavaScript()
+        {
+            // Same test as above but forcing the JavaScript patch path via Increment,
+            // to confirm both paths behave identically with optimistic concurrency.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    session.Advanced.UseOptimisticConcurrency = true;
+
+                    var user = await session.LoadAsync<UserWithTags>("users/1");
+
+                    // Simulate a concurrent modification by another session
+                    using (var otherSession = store.OpenSession())
+                    {
+                        var otherUser = otherSession.Load<UserWithTags>("users/1");
+                        otherUser.Age = 99;
+                        otherSession.SaveChanges();
+                    }
+
+                    // JavaScript patch path (Increment always uses JavaScript)
+                    session.Advanced.Increment<UserWithTags, int>(user, u => u.Age, 1);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+
+                    await session.SaveChangesAsync(); // should not throw ConcurrencyException
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(100, user.Age); // 99 + 1
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using FastTests;
 using Orders;
+using Raven.Client.Documents.Commands.Batches;
+using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
@@ -37,6 +39,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -67,6 +73,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Address.City, "NewCity");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -93,6 +103,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, null);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -118,6 +132,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -144,6 +162,11 @@ namespace SlowTests.Issues
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
                     session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    Assert.Equal(1, sessionOps.DeferredCommandsCount);
+
                     session.SaveChanges();
                 }
 
@@ -171,6 +194,9 @@ namespace SlowTests.Issues
                 {
                     var user = session.Load<UserWithTags>("users/1");
                     session.Advanced.Patch(user, u => u.Name, "Updated");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
 
                     var cv = session.Advanced.GetChangeVectorFor(user);
 
@@ -206,6 +232,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("c"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -232,6 +262,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("b", "c"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -259,6 +293,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(1));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -286,6 +324,11 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAll(t => t == "b"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -319,6 +362,10 @@ namespace SlowTests.Issues
                     session.Advanced.Patch<UserWithTags, string, string>("users/1",
                         u => u.Settings,
                         d => d.Add("lang", "en"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -356,6 +403,10 @@ namespace SlowTests.Issues
                     session.Advanced.Patch<UserWithTags, string, string>("users/1",
                         u => u.Settings,
                         d => d.Remove("lang"));
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -385,6 +436,11 @@ namespace SlowTests.Issues
                     session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
                     // Patch should fall back to JavaScript and merge
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 
@@ -414,6 +470,12 @@ namespace SlowTests.Issues
                     session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
                     // Increment creates a separate JavaScript patch command
                     session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.Equal(2, sessionOps.DeferredCommandsCount);
+
                     session.SaveChanges();
                 }
 
@@ -441,6 +503,10 @@ namespace SlowTests.Issues
                 {
                     var user = session.Load<UserWithTags>("users/1");
                     session.Advanced.Patch(user, u => u.Name, "Updated");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
 
                     Assert.Equal("Updated", user.Name);
@@ -462,6 +528,11 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 {
                     session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.PATCH, null)));
+                    Assert.False(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
                     session.SaveChanges();
                 }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -1,0 +1,476 @@
+using System.Collections.Generic;
+using FastTests;
+using Orders;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22293 : RavenTestBase
+    {
+        public RavenDB_22293(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class UserWithTags
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public List<string> Tags { get; set; }
+            public Dictionary<string, string> Settings { get; set; }
+            public Address Address { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_SimpleProperty_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                    Assert.Equal(25, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_NestedProperty_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Address = new Address { City = "OldCity", Country = "US" }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Address.City, "NewCity");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("NewCity", user.Address.City);
+                    Assert.Equal("US", user.Address.Country);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_NullValue_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, null);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Null(user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_IntegerValue_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(30, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_MultipleProperties_MergesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+                    session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                    Assert.Equal(30, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_TrackedEntity_UpdatesAfterSaveChanges()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    session.Advanced.Patch(user, u => u.Name, "Updated");
+
+                    var cv = session.Advanced.GetChangeVectorFor(user);
+
+                    session.SaveChanges();
+
+                    Assert.Equal("Updated", user.Name);
+                    Assert.NotEqual(cv, session.Advanced.GetChangeVectorFor(user));
+
+                    user.Age = 30;
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                    Assert.Equal(30, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_ArrayAdd_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("c"));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(3, user.Tags.Count);
+                    Assert.Equal("c", user.Tags[2]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_ArrayAddMultiple_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.Add("b", "c"));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(3, user.Tags.Count);
+                    Assert.Equal("b", user.Tags[1]);
+                    Assert.Equal("c", user.Tags[2]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_ArrayRemoveAt_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAt(1));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Tags.Count);
+                    Assert.Equal("a", user.Tags[0]);
+                    Assert.Equal("c", user.Tags[1]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_ArrayRemoveAll_FallsBackToJavaScript()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags, tags => tags.RemoveAll(t => t == "b"));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Tags.Count);
+                    Assert.Contains("a", user.Tags);
+                    Assert.Contains("c", user.Tags);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_DictionaryAdd_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string> { { "theme", "light" } }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1",
+                        u => u.Settings,
+                        d => d.Add("lang", "en"));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(2, user.Settings.Count);
+                    Assert.Equal("light", user.Settings["theme"]);
+                    Assert.Equal("en", user.Settings["lang"]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_DictionaryRemove_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags
+                    {
+                        Name = "Test",
+                        Settings = new Dictionary<string, string>
+                        {
+                            { "theme", "light" },
+                            { "lang", "en" }
+                        }
+                    }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string, string>("users/1",
+                        u => u.Settings,
+                        d => d.Remove("lang"));
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Single(user.Settings);
+                    Assert.Equal("light", user.Settings["theme"]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_AfterIncrement_FallsBackToJavaScript()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    // Increment creates a JavaScript patch
+                    session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
+                    // Patch should fall back to JavaScript and merge
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                    Assert.Equal(30, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_ThenIncrement_KeepsBothCommands()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original", Age = 25 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    // Patch creates a JsonPatch command
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Name, "Updated");
+                    // Increment creates a separate JavaScript patch command
+                    session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Updated", user.Name);
+                    Assert.Equal(30, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_EntityOverload_UsesJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Original" }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    session.Advanced.Patch(user, u => u.Name, "Updated");
+                    session.SaveChanges();
+
+                    Assert.Equal("Updated", user.Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Increment_StaysAsJavaScript()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Age = 10 }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Increment<UserWithTags, int>("users/1", u => u.Age, 5);
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(15, user.Age);
+                }
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_22293.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_22293.cs
@@ -1,9 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
+using Newtonsoft.Json;
 using Orders;
+using Raven.Client;
 using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Documents.Session;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -630,6 +634,150 @@ namespace SlowTests.Issues
                     Assert.Equal(15, user.Age);
                 }
             }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_AbsentProperty_CreatesPropertyViaJsonPatch()
+        {
+            using (var store = GetDocumentStore())
+            {
+                // Store a document that does NOT contain the 'Age' property at all
+                // (simulating schema evolution / a document written under an older shape,
+                // or a store configured to omit nulls). A JsonPatch "replace" would throw
+                // server-side; the old JavaScript "this.Age = value" silently created it.
+                using (var commands = store.Commands())
+                {
+                    commands.Put("users/1", null, new { Name = "Test" },
+                        new Dictionary<string, object> { { Constants.Documents.Metadata.Collection, "UserWithTags" } });
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, int>("users/1", u => u.Age, 30);
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges(); // must not throw even though 'Age' is absent on the stored document
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal("Test", user.Name);
+                    Assert.Equal(30, user.Age);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_ArrayElementByIndex_ReplacesInPlace()
+        {
+            // Guards the JsonPatch op selection: assigning to an existing positional element
+            // must overwrite it ("replace"), not insert before it ("add").
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new UserWithTags { Name = "Test", Tags = new List<string> { "a", "b", "c" } }, "users/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<UserWithTags, string>("users/1", u => u.Tags[1], "B");
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("users/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var user = session.Load<UserWithTags>("users/1");
+                    Assert.Equal(3, user.Tags.Count); // replaced in place, not inserted
+                    Assert.Equal("a", user.Tags[0]);
+                    Assert.Equal("B", user.Tags[1]);
+                    Assert.Equal("c", user.Tags[2]);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.ClientApi)]
+        public void Patch_Value_UsesStoreSerializationConventions()
+        {
+            // A value routed through JsonPatch must be serialized with the store's configured
+            // conventions (custom converter -> "30C"), not DocumentConventions.Default
+            // (which would emit an object like {"Celsius":30}).
+            using (var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new NewtonsoftJsonSerializationConventions
+                    {
+                        CustomizeJsonSerializer = serializer => serializer.Converters.Add(new TemperatureConverter())
+                    };
+                }
+            }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new WeatherDoc { Temp = new Temperature { Celsius = 20 } }, "weather/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<WeatherDoc, Temperature>("weather/1", x => x.Temp, new Temperature { Celsius = 30 });
+
+                    var sessionOps = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(sessionOps.DeferredCommandsDictionary.ContainsKey(("weather/1", CommandType.JsonPatch, null)));
+
+                    session.SaveChanges();
+                }
+
+                using (var commands = store.Commands())
+                {
+                    var doc = commands.Get("weather/1").BlittableJson;
+                    Assert.True(doc.TryGet(nameof(WeatherDoc.Temp), out string temp),
+                        "Temp should be serialized as a string via the store's custom converter");
+                    Assert.Equal("30C", temp);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<WeatherDoc>("weather/1");
+                    Assert.Equal(30, doc.Temp.Celsius);
+                }
+            }
+        }
+
+        private struct Temperature
+        {
+            public int Celsius { get; set; }
+        }
+
+        private class TemperatureConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType) => objectType == typeof(Temperature);
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue($"{((Temperature)value).Celsius}C");
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                var s = (string)reader.Value;
+                return new Temperature { Celsius = int.Parse(s.Substring(0, s.Length - 1)) };
+            }
+        }
+
+        private class WeatherDoc
+        {
+            public string Id { get; set; }
+            public Temperature Temp { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22293

### Additional description

Session Patch, array, and dictionary methods now generate JsonPatchCommandData (RFC 6902) instead of PatchCommandData (JavaScript) for all supported operations:
- Property set → JsonPatch replace
- Array Add/AddMultiple → JsonPatch add at /-
- Array RemoveAt → JsonPatch remove at /index
- Dictionary Add → JsonPatch add at /key
- Dictionary Remove → JsonPatch remove at /key

Falls back to JavaScript for operations without JsonPatch equivalents: Increment, RemoveAll(predicate), AddOrPatch, AddOrIncrement, polymorphic values, and DateOnly/TimeOnly.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
