### PR TITLE
RavenDB-26180 VectorSearch exact search: nodesIdsToScan disposal fix.

### DIFF
--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -37,6 +37,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
 
     // Voron VectorSearch Retriever
     private Hnsw.VectorSearchRetriever[] _vectorsRetrievers;
+    private ContextBoundNativeList<long> _nodesIdsToScan;
     private bool _vectorRetrieverInitialized;
 
     private bool _resultsPersisted;
@@ -91,14 +92,13 @@ public struct MultiVectorSearchMatch : IQueryMatch
         }
 
         _scanningQuery = IndexSearcher.VectorSearchUtils.ShouldScan(_indexSearcher, _filterMatchesCount, _isExact, _filterQuery, _scanningThreshold, _numberOfCandidates);
-        ContextBoundNativeList<long> nodesIdsToScan = default;
         if (_scanningQuery)
         {
-            var hasNodes = IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults!.Value, out nodesIdsToScan);
+            var hasNodes = IndexSearcher.VectorSearchUtils.TryConvertDocumentsIdsToNodesIds(_indexSearcher, _metadata, _filterResults!.Value, out _nodesIdsToScan);
             if (hasNodes == false)
             {
                 _isEmpty = true;
-                nodesIdsToScan.Dispose();
+                _nodesIdsToScan.Dispose();
                 _filterResults?.Dispose();
                 foreach (var vector in _vectorsToSearch)
                     vector.Dispose();
@@ -114,7 +114,8 @@ public struct MultiVectorSearchMatch : IQueryMatch
             var vector = _vectorsToSearch[i].GetEmbeddingMemory();
             _vectorsRetrievers[i] = (_isExact) switch
             {
-                _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, nodesIdsToScan),
+
+                _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, _nodesIdsToScan),
                 true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
                 false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)), 
                 false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
@@ -178,6 +179,9 @@ public struct MultiVectorSearchMatch : IQueryMatch
             vectorSearcher.Dispose();
             _vectorsToSearch[i].Dispose();
         }
+
+        if (_scanningQuery)
+            _nodesIdsToScan.Dispose();
 
         // Min on distances is Max on score.
         var uniqueCount = Sorting.SortAndMinOnDuplicates(_matches.Results, _distances.Results);

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -39,6 +39,7 @@ public struct VectorSearchMatch : IQueryMatch
     
     // Voron VectorSearch Retriever
     private Hnsw.VectorSearchRetriever _vectorSearchRetriever;
+    private ContextBoundNativeList<long> _nodesIdsToScan;
     private bool _vectorRetrieverInitialized;
     
     private bool _resultsPersisted;
@@ -126,6 +127,8 @@ public struct VectorSearchMatch : IQueryMatch
                 _filterResults?.Dispose();
                 return;
             }
+            
+            _nodesIdsToScan = nodesIdsToScan;
         }
         
         
@@ -347,6 +350,8 @@ public struct VectorSearchMatch : IQueryMatch
 
     private void Dispose()
     {
+        if (_scanningQuery)
+            _nodesIdsToScan.Dispose();
         _filterResults?.Dispose();
         _vectorSearchRetriever.Dispose();
         _vectorToSearch.Dispose();

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -40,7 +40,6 @@ public partial class Hnsw
                 _searchState._candidatesQ.Clear();
                 _searchState._nearestEdgesQ.Clear();
                 _candidates.Dispose();
-                _nodesToScan?.Dispose();
             }
 
             public IEnumerable<bool> Search()

--- a/test/SlowTests/Corax/RavenDB-23453.cs
+++ b/test/SlowTests/Corax/RavenDB-23453.cs
@@ -272,6 +272,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
     [InlineDataWithRandomSeed(true, false)]
     [InlineDataWithRandomSeed(false, true)]
     [InlineDataWithRandomSeed(true, true)]
+    [InlineData(true, true, 1045861081)]
     [InlineDataWithRandomSeed(false, false, Skip = "Too small set")]
     public void FilterQueryAndWithMethodMultiVectorSearch(bool shouldScan, bool isExact, int seed)
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26180 

### Additional description

In the case of MultiVectorSearch, the list of nodes to scan is reused for each vector in the query; thus, we must ensure it will not be disposed of between retrieving documents for different vectors.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
