### PR TITLE
RavenDB-21854: Add debug info for flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/BasicRavenEtlTests.cs
@@ -136,7 +136,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
                 }
 
                 var timeout = 30_000;
-                WaitForValue(() =>
+                var loaded = WaitForValue(() =>
                 {
                     using (var session = dest.OpenSession())
                     {
@@ -144,6 +144,8 @@ namespace SlowTests.Server.Documents.ETL.Raven
                         return docs.Length;
                     }
                 }, expectedVal: 2, timeout);
+
+                Assert.Equal(2, loaded);
 
                 string secondaryId;
                 using (var session = dest.OpenSession())
@@ -165,16 +167,22 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     session.SaveChanges();
                 }
 
+                bool existsMain = false, existsSecondary = false;
+
                 var etlReachedDestination = WaitForValue(() =>
                 {
                     using (var session = dest.OpenSession())
                     {
-                        return session.Advanced.Exists("users/1-A,Chicago") == false &&
-                               session.Advanced.Exists(secondaryId) == false;
+                        existsMain = session.Advanced.Exists("users/1-A,Chicago");
+                        existsSecondary = session.Advanced.Exists(secondaryId);
+
+                        return existsMain == false &&
+                               existsSecondary == false;
                     }
                 }, true, timeout);
-                
-                Assert.True(etlReachedDestination, await AddDebugInfo(src, dest, srcDbMode, dstDbMode));
+
+                Assert.True(etlReachedDestination,
+                    await AddDebugInfo(src, dest, srcDbMode, dstDbMode, existsMain, existsSecondary));
 
                 using (var session = dest.OpenSession())
                 {
@@ -189,7 +197,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
             }
         }
 
-        private async Task<string> AddDebugInfo(IDocumentStore src, IDocumentStore dest, RavenDatabaseMode srcDbMode, RavenDatabaseMode destDbMode)
+        private async Task<string> AddDebugInfo(IDocumentStore src, IDocumentStore dest, RavenDatabaseMode srcDbMode, RavenDatabaseMode destDbMode, bool existsMain, bool existsSecondary)
         {
             var etlDebugInfo = await Etl.GetEtlDebugInfo(src.Database, TimeSpan.FromMilliseconds(30_000), srcDbMode);
             var sb = new StringBuilder().AppendLine(etlDebugInfo);
@@ -218,6 +226,32 @@ namespace SlowTests.Server.Documents.ETL.Raven
                         .Append(string.Join(',', ids))
                         .Append(']');
                 }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine($"exists main: {existsMain}, exists secondary: {existsSecondary}");
+
+            using (var session = dest.OpenSession())
+            {
+                var prefixDocs = session.Advanced.LoadStartingWith<object>("users/1-A");
+                var prefixIds = prefixDocs
+                    .Select(x => session.Advanced.GetDocumentId(x))
+                    .Where(x => x != null)
+                    .OrderBy(x => x)
+                    .ToList();
+
+                var users2Docs = session.Advanced
+                    .RawQuery<object>("from Users2 where startsWith(id(), 'users/1-A/')")
+                    .ToList();
+
+                var users2Ids = users2Docs
+                    .Select(x => session.Advanced.GetDocumentId(x))
+                    .Where(x => x != null)
+                    .OrderBy(x => x)
+                    .ToList();
+
+                sb.AppendLine("Remaining destination docs by LoadStartingWith: [" + string.Join(", ", prefixIds) + "]");
+                sb.Append("Remaining destination docs by Users2 query: [" + string.Join(", ", users2Ids) + "]");
             }
 
             return sb.ToString();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21854/SlowTests.Server.Documents.ETL.Raven.BasicRavenEtlTests.WithDocumentPrefixsrcDbMode-Single-dstDbMode-Sharded

### Additional description

Add extra failure diagnostics to the flaky `WithDocumentPrefix` ETL test to help investigate failures

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
