### PR TITLE
RavenDB-25803 : fixed the double deletion issue that caused the test to fail.

### DIFF
--- a/src/Raven.Server/Documents/DatabasesLandlord.cs
+++ b/src/Raven.Server/Documents/DatabasesLandlord.cs
@@ -489,19 +489,7 @@ namespace Raven.Server.Documents
             {
                 removeLockAndReturn?.Dispose();
             }
-            var requestId = ComputeRemovalRequestId(dbName, databaseId, _serverStore.NodeTag);
-            NotifyLeaderAboutRemoval(dbName, databaseId, requestId);
-        }
-
-        private static string ComputeRemovalRequestId(string dbName, string databaseId, string nodeTag)
-        {
-            dbName ??= string.Empty;
-            databaseId ??= string.Empty;
-            nodeTag ??= string.Empty;
-
-            var input = string.Concat(dbName, "|", databaseId, "|", nodeTag);
-            var hash = Hashing.XXHash64.Calculate(System.Text.Encoding.UTF8.GetBytes(input));
-            return hash.ToString();
+            NotifyLeaderAboutRemoval(dbName, databaseId);
         }
 
         [DoesNotReturn]
@@ -510,8 +498,9 @@ namespace Raven.Server.Documents
             throw new InvalidOperationException($"Unknown cluster database change type: {type}");
         }
 
-        private void NotifyLeaderAboutRemoval(string dbName, string databaseId, string requestId)
+        private void NotifyLeaderAboutRemoval(string dbName, string databaseId, string requestId = null)
         {
+            requestId ??= RaftIdGenerator.NewId();
             var cmd = new RemoveNodeFromDatabaseCommand(dbName, databaseId, requestId)
             {
                 NodeTag = _serverStore.NodeTag

--- a/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RemoveNodeFromDatabaseCommand.cs
@@ -55,20 +55,26 @@ namespace Raven.Server.ServerWide.Commands
             }
         }
 
-        public string UpdateShardedDatabaseRecord(DatabaseRecord record, int shardNumber, long etag)
+        public void UpdateShardedDatabaseRecord(DatabaseRecord record, int shardNumber, long etag)
         {
+            var deletionStatus = DeletionInProgressStatus.No;
+            record.DeletionInProgress?.TryGetValue(DatabaseRecord.GetKeyForDeletionInProgress(NodeTag, shardNumber), out deletionStatus);
+            if (deletionStatus == DeletionInProgressStatus.No)
+                return;
+
             record.Sharding.Shards[shardNumber].RemoveFromTopology(NodeTag);
             record.DeletionInProgress?.Remove(DatabaseRecord.GetKeyForDeletionInProgress(NodeTag, shardNumber));
 
             if (DatabaseId == null)
-                return null;
+                return;
 
-            if (record.UnusedDatabaseIds == null)
-                record.UnusedDatabaseIds = new HashSet<string>();
+            if (deletionStatus == DeletionInProgressStatus.HardDelete)
+            {
+                if (record.UnusedDatabaseIds == null)
+                    record.UnusedDatabaseIds = new HashSet<string>();
 
-            record.UnusedDatabaseIds.Add(DatabaseId);
-
-            return null;
+                record.UnusedDatabaseIds.Add(DatabaseId);
+            }
         }
 
         public override void FillJson(DynamicJsonValue json)

--- a/test/SlowTests/Sharding/Cluster/RavenDB-25353.cs
+++ b/test/SlowTests/Sharding/Cluster/RavenDB-25353.cs
@@ -87,7 +87,7 @@ namespace SlowTests.Sharding.Cluster
                         var topology = res.Sharding.Shards[SrcShard];
 
                         return topology.Members.Contains(bringBackNode);
-                    }, true, timeout: 30_000);
+                    }, true, timeout: 70_000);
                     Assert.True(added, $"didn't revive node {bringBackNode} on time");
 
                     SrcShard = destShard;
@@ -127,7 +127,7 @@ namespace SlowTests.Sharding.Cluster
                 {
                     var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                     return record.Sharding.BucketMigrations.Count == 0;
-                }, expectedVal: true, timeout: 15000);
+                }, expectedVal: true, timeout: 15_000);
 
                 Assert.True(finished, "The migration didn't finish in time.");
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25803/SlowTests.Sharding.Cluster.RavenDB25353.ReshardingSimpleMove1To0

### Additional description

We added a guard to UpdateShardedDatabaseRecord to align its behavior with UpdateDatabaseRecord.
By verifying that the node is actually still in DeletionInProgress status before executing the removal, we prevent multiple deletion commands. This protects nodes that were quickly revived from being accidentally removed from the topology.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
