### PR TITLE
RavenDB-26189 - Fix bulk insert compression stream not being finalized on .NET Framework

### DIFF
--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -61,6 +61,13 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 
                         await WriteToStreamAsync(_currentWriteStream, _requestBodyStream, _memoryBuffer).ConfigureAwait(false);
                         await _requestBodyStream.FlushAsync(_token).ConfigureAwait(false);
+
+                        // Must dispose the compression stream (e.g. GZipStream) to write
+                        // final compression footer bytes. Without this, the compressed
+                        // data is incomplete and the server cannot decompress it.
+                        // On .NET Framework, GZipStream.Flush() is a no-op, so Dispose
+                        // is the only way to finalize the compressed stream.
+                        DisposeRequestStream();
                     }
                 }
                 finally

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -75,7 +75,7 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
                         // Without compression, _requestBodyStream IS the HTTP stream,
                         // and disposing it would cause an ObjectDisposedException.
                         if (_isCompressionEnabled)
-                            DisposeRequestStream();
+                            _requestBodyStream.Dispose();
                     }
                 }
                 finally
@@ -204,10 +204,5 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
     public virtual async ValueTask DisposeAsync()
     {
         await _disposeOnce.DisposeAsync().ConfigureAwait(false);
-    }
-
-    public void DisposeRequestStream()
-    {
-        _requestBodyStream?.Dispose();
     }
 }

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertWriterBase.cs
@@ -25,6 +25,8 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
     private JsonOperationContext.MemoryBuffer _memoryBuffer;
     private JsonOperationContext.MemoryBuffer _backgroundMemoryBuffer;
     private bool _isInitialWrite = true;
+    private bool _isCompressionEnabled;
+
     internal DateTime LastFlushToStream { get; private set; }
 
     private Stream _requestBodyStream;
@@ -67,7 +69,13 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
                         // data is incomplete and the server cannot decompress it.
                         // On .NET Framework, GZipStream.Flush() is a no-op, so Dispose
                         // is the only way to finalize the compressed stream.
-                        DisposeRequestStream();
+                        // Only dispose when compression is enabled — the compression
+                        // streams are created with leaveOpen: true, so this finalizes
+                        // the compressor without closing the underlying HTTP stream.
+                        // Without compression, _requestBodyStream IS the HTTP stream,
+                        // and disposing it would cause an ObjectDisposedException.
+                        if (_isCompressionEnabled)
+                            DisposeRequestStream();
                     }
                 }
                 finally
@@ -166,6 +174,8 @@ internal abstract class BulkInsertWriterBase : IAsyncDisposable
 
         if (compressionLevel != CompressionLevel.NoCompression)
         {
+            _isCompressionEnabled = true;
+
             switch (compressionAlgorithm)
             {
                 case HttpCompressionAlgorithm.Gzip:

--- a/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/BulkInsert/ShardedBulkInsertOperation.cs
@@ -168,13 +168,6 @@ internal sealed class ShardedBulkInsertOperation : BulkInsertOperationBase<Shard
             }
         }
 
-        var disposeRequests = new ExceptionAggregator("Failed to dispose bulk insert requests opened per shard");
-
-        foreach (var shardNumber in _databaseContext.ShardsTopology.Keys)
-        {
-            disposeRequests.Execute(() => _writers?[shardNumber].DisposeRequestStream());
-        }
-
         var returnContexts = new ExceptionAggregator("Failed to return bulk insert contexts allocated per shard");
 
         foreach (IDisposable returnContext in _returnContexts)
@@ -183,7 +176,6 @@ internal sealed class ShardedBulkInsertOperation : BulkInsertOperationBase<Shard
         }
 
         disposeOperations.ThrowIfNeeded();
-        disposeRequests.ThrowIfNeeded();
         returnContexts.ThrowIfNeeded();
     }
 }

--- a/test/EmbeddedTests/BulkInsertTests.cs
+++ b/test/EmbeddedTests/BulkInsertTests.cs
@@ -1,0 +1,59 @@
+﻿using System.IO.Compression;
+using System.Threading.Tasks;
+using Raven.Client.Documents.BulkInsert;
+using Raven.Client.Http;
+using Raven.Embedded;
+using Xunit;
+
+namespace EmbeddedTests
+{
+    public class BulkInsertTests : EmbeddedTestBase
+    {
+        [Theory]
+        [InlineData(CompressionLevel.NoCompression, HttpCompressionAlgorithm.Gzip)]
+        [InlineData(CompressionLevel.Optimal, HttpCompressionAlgorithm.Gzip)]
+        public async Task Simple_Bulk_Insert(CompressionLevel compressionLevel, HttpCompressionAlgorithm compressionAlgorithm)
+        {
+            var options = CopyServerAndCreateOptions();
+
+            using (var embedded = new EmbeddedServer())
+            {
+                embedded.StartServer(options);
+
+                using (var store = embedded.GetDocumentStore(new DatabaseOptions("TestBulkInsert")
+                {
+                    Conventions = new Raven.Client.Documents.Conventions.DocumentConventions
+                    {
+                        HttpCompressionAlgorithm = compressionAlgorithm
+                    }
+                }))
+                {
+                    using (var bulkInsert = store.BulkInsert(new BulkInsertOptions
+                    {
+                        CompressionLevel = compressionLevel
+                    }))
+                    {
+                        for (int i = 0; i < 1000; i++)
+                        {
+                            await bulkInsert.StoreAsync(new FooBar
+                            {
+                                Name = "foobar/" + i
+                            }, "FooBars/" + i);
+                        }
+                    }
+
+                    using (var session = store.OpenSession())
+                    {
+                        var len = session.Advanced.LoadStartingWith<FooBar>("FooBars/", null, 0, 1000, null);
+                        Assert.Equal(1000, len.Length);
+                    }
+                }
+            }
+        }
+
+        private class FooBar
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -51,10 +51,13 @@ namespace FastTests.Client
             options.AdminCertificate = adminCertificate;
             options.ClientCertificate = clientCertificate;
             options.ModifyDatabaseName = s => dbName;
-            options.ModifyDocumentStore = s => s.Conventions.HttpCompressionAlgorithm = compressionAlgorithm;
+            options.ModifyDocumentStore = s =>
+            {
+                s.Conventions.HttpCompressionAlgorithm = compressionAlgorithm;
 
-            if (useSsl)
-                options.ModifyDocumentStore = s => s.OnFailedRequest += (_, args) => Console.WriteLine($"Failed Request ('{args.Database}'): {args.Url}. Exception: {args.Exception}");
+                if (useSsl)
+                    s.OnFailedRequest += (_, args) => Console.WriteLine($"Failed Request ('{args.Database}'): {args.Url}. Exception: {args.Exception}");
+            };
 
             using (var store = GetDocumentStore(options))
             {

--- a/test/FastTests/Client/BulkInserts.cs
+++ b/test/FastTests/Client/BulkInserts.cs
@@ -17,7 +17,6 @@ using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Server.Json.Sync;
 using Tests.Infrastructure;
-using xRetry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,9 +29,11 @@ namespace FastTests.Client
         }
 
         [RavenTheory(RavenTestCategory.BulkInsert)]
-        [RavenData(false, CompressionLevel.NoCompression, DatabaseMode = RavenDatabaseMode.All)]
-        [RavenData(false, CompressionLevel.Optimal, DatabaseMode = RavenDatabaseMode.All)]
-        public async Task Simple_Bulk_Insert(Options options, bool useSsl, CompressionLevel compressionLevel)
+        [RavenData(false, CompressionLevel.NoCompression, HttpCompressionAlgorithm.Gzip, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, CompressionLevel.NoCompression, HttpCompressionAlgorithm.Zstd, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, CompressionLevel.Optimal, HttpCompressionAlgorithm.Gzip, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(false, CompressionLevel.Optimal, HttpCompressionAlgorithm.Zstd, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Simple_Bulk_Insert(Options options, bool useSsl, CompressionLevel compressionLevel, HttpCompressionAlgorithm compressionAlgorithm)
         {
             string dbName = GetDatabaseName();
             X509Certificate2 clientCertificate = null;
@@ -50,6 +51,7 @@ namespace FastTests.Client
             options.AdminCertificate = adminCertificate;
             options.ClientCertificate = clientCertificate;
             options.ModifyDatabaseName = s => dbName;
+            options.ModifyDocumentStore = s => s.Conventions.HttpCompressionAlgorithm = compressionAlgorithm;
 
             if (useSsl)
                 options.ModifyDocumentStore = s => s.OnFailedRequest += (_, args) => Console.WriteLine($"Failed Request ('{args.Database}'): {args.Url}. Exception: {args.Exception}");

--- a/test/SlowTests/Client/BulkInserts.cs
+++ b/test/SlowTests/Client/BulkInserts.cs
@@ -2,8 +2,8 @@
 using System.IO.Compression;
 using System.Threading.Tasks;
 using FastTests;
+using Raven.Client.Http;
 using Tests.Infrastructure;
-using xRetry;
 using Xunit.Abstractions;
 
 namespace SlowTests.Client
@@ -15,12 +15,15 @@ namespace SlowTests.Client
         }
 
         [RavenRetryTheory(RavenTestCategory.BulkInsert)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public async Task Simple_Bulk_Insert_With_Ssl(RavenTestBase.Options options)
+        [RavenData(CompressionLevel.NoCompression, HttpCompressionAlgorithm.Gzip, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(CompressionLevel.NoCompression, HttpCompressionAlgorithm.Zstd, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(CompressionLevel.Optimal, HttpCompressionAlgorithm.Gzip, DatabaseMode = RavenDatabaseMode.All)]
+        [RavenData(CompressionLevel.Optimal, HttpCompressionAlgorithm.Zstd, DatabaseMode = RavenDatabaseMode.All)]
+        public async Task Simple_Bulk_Insert_With_Ssl(RavenTestBase.Options options, CompressionLevel compressionLevel, HttpCompressionAlgorithm compressionAlgorithm)
         {
             using (var x = new FastTests.Client.BulkInserts(Output))
             {
-                await x.Simple_Bulk_Insert(options, useSsl: true, compressionLevel: CompressionLevel.NoCompression);
+                await x.Simple_Bulk_Insert(options, useSsl: true, compressionLevel, compressionAlgorithm);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26189/BulkInsert-with-compression-fails-on-on-dotnet-framework

### Additional description

Bulk insert with compression enabled (`CompressionLevel != NoCompression`) fails on .NET Framework but works on .NET Core.

When compression is enabled, `_requestBodyStream` in `BulkInsertWriterBase` is wrapped in a `GZipStream`. During dispose, the code writes the closing `]`, flushes remaining data to the compression stream, and calls `FlushAsync()` before signaling `StreamExposer.Done()`. However, on .NET Framework, `GZipStream.Flush()` is a **no-op** - it does not flush buffered compressed data or write the gzip footer (CRC32 + size). The final compressed bytes are only emitted on `Dispose()`. This causes the server to receive a truncated gzip stream that cannot be decompressed.

On .NET Core, `GZipStream.FlushAsync()` performs a `Z_SYNC_FLUSH` which pushes all pending compressed blocks to the underlying stream, masking the bug.

## Fix

Added a call to `DisposeRequestStream()` in the `BulkInsertWriterBase` dispose lambda, after flushing data to the compression stream but before calling `StreamExposer.Done()`. This ensures the compression stream writes its final block and footer bytes.

The `DisposeRequestStream()` method already existed but was never called.

## Impact on other compression types

The fix applies only to `GZipStream` on .NET Framework in practice, since `BrotliStream` (`FEATURE_BROTLI_SUPPORT`) and `ZstdStream` (`FEATURE_ZSTD_SUPPORT`) are not available on .NET Framework - only on .NET Core and later targets.

However, the fix is equally correct for all compression types. Every compression stream in `EnsureStreamAsync` is created with `leaveOpen: true`, so `Dispose()` will:

- ✅ Flush remaining buffered compressed data
- ✅ Write the final compression block/footer
- ✅ **Not** close the underlying HTTP stream

Before this fix, `BrotliStream` and `ZstdStream` on .NET Core were also technically incomplete (missing end-of-stream markers), but .NET Core's `FlushAsync()` pushed enough data for the server to tolerate it. The `Dispose()` call now makes all compression types fully correct across all runtimes.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
