### PR TITLE
RavenDB-25768 - Avoid etag lag log when we have index lag log

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
@@ -682,8 +682,11 @@ namespace Raven.Server.ServerWide.Maintenance
                 promotableDbStats.LastIndexStats,
                 mentorCurrDbStats.LastIndexStats,
                 out var outdatedIndexesReason);
+            // Normally we avoid promotion when indexes are not up-to-date.
+            // In case indexesUpToDate is false, we only log the index staleness.
+            // The log will include the etag-lag details if the Etag difference is significant (Etag difference > 1000).
 
-            if (IsMentorAhead(lastSentEtag, mentorsEtag, timeDiff, indexesUpToDate))
+            if (indexesUpToDate && IsMentorAhead(lastSentEtag, mentorsEtag, timeDiff))
             {
                 var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because the mentor hasn't sent all of the documents yet." + Environment.NewLine +
                           $"Last sent Etag: {lastSentEtag:#,#;;0}" + Environment.NewLine +
@@ -753,18 +756,9 @@ namespace Raven.Server.ServerWide.Maintenance
             return (false, null);
         }
 
-        private static bool IsMentorAhead(long lastSentEtag, long mentorsEtag, bool timeDiff, bool indexesUpToDate)
-        {
-            if (indexesUpToDate == false)
-            {
-                // Normally we avoid promotion when indexes are not up-to-date.
-                // In this case, we only log the index staleness.
-                // The log will include the etag-lag details if the Etag difference is significant (Etag difference > 1000).
-                return false;
-            }
-
-            return lastSentEtag < mentorsEtag || timeDiff;
-        }
+        private static bool IsMentorAhead(long lastSentEtag, long mentorsEtag, bool timeDiff) 
+            => lastSentEtag < mentorsEtag || timeDiff;
+        
 
         protected virtual void RemoveOtherNodesIfNeeded(DatabaseObservationState state, ref List<DeleteDatabaseCommand> deletions)
         {

--- a/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
@@ -672,7 +672,7 @@ namespace Raven.Server.ServerWide.Maintenance
             if (state.HasActiveMigrations() == false)
             {
                 // if resharding is active skip - index staleness will not prevent it from being promoted
-                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "This only a workaround until RavenDB-21327 will be fixed properly");
+                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "This is only a workaround until RavenDB-21327 will be fixed properly");
                 databaseEtag = promotablePrevDbStats.LastEtag;
             }
 
@@ -686,7 +686,7 @@ namespace Raven.Server.ServerWide.Maintenance
             // In case indexesUpToDate is false, we only log the index staleness.
             // The log will include the etag-lag details if the Etag difference is significant (Etag difference > 1000).
 
-            if (indexesUpToDate && IsMentorAhead(lastSentEtag, mentorsEtag, timeDiff))
+            if (indexesUpToDate && IsMentorNotFullySynced(lastSentEtag, mentorsEtag, timeDiff))
             {
                 var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because the mentor hasn't sent all of the documents yet." + Environment.NewLine +
                           $"Last sent Etag: {lastSentEtag:#,#;;0}" + Environment.NewLine +
@@ -743,7 +743,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 || currentStatus != DatabasePromotionStatus.IndexNotUpToDate)
             {
                 var msg = $"Node {promotable} not ready to be a member, because the indexes are not up-to-date";
-                if (mentorsEtag - lastSentEtag > 1000)
+                if (mentorsEtag - lastSentEtag > 4000)
                 {
                     // The log will include the etag-lag details if the Etag difference is significant (Etag difference > 1000).
                     msg += $", and Mentor {mentorNode} hasn't sent all of the documents yet to {promotable} (sent etag: {lastSentEtag:#,#;;0}/{mentorsEtag:#,#;;0})";
@@ -756,7 +756,7 @@ namespace Raven.Server.ServerWide.Maintenance
             return (false, null);
         }
 
-        private static bool IsMentorAhead(long lastSentEtag, long mentorsEtag, bool timeDiff) 
+        private static bool IsMentorNotFullySynced(long lastSentEtag, long mentorsEtag, bool timeDiff) 
             => lastSentEtag < mentorsEtag || timeDiff;
         
 

--- a/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
@@ -668,8 +668,22 @@ namespace Raven.Server.ServerWide.Maintenance
             }
 
             var timeDiff = mentorCurrClusterStats.LastSuccessfulUpdateDateTime - mentorPrevClusterStats.LastSuccessfulUpdateDateTime > 3 * _supervisorSamplePeriod;
+            var databaseEtag = -1L;
+            if (state.HasActiveMigrations() == false)
+            {
+                // if resharding is active skip - index staleness will not prevent it from being promoted
+                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "This only a workaround until RavenDB-21327 will be fixed properly");
+                databaseEtag = promotablePrevDbStats.LastEtag;
+            }
 
-            if (lastSentEtag < mentorsEtag || timeDiff)
+            var indexesUpToDate = CheckIndexProgress(
+                databaseEtag,
+                promotablePrevDbStats.LastIndexStats,
+                promotableDbStats.LastIndexStats,
+                mentorCurrDbStats.LastIndexStats,
+                out var outdatedIndexesReason);
+
+            if (IsMentorAhead(lastSentEtag, mentorsEtag, timeDiff, indexesUpToDate))
             {
                 var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because the mentor hasn't sent all of the documents yet." + Environment.NewLine +
                           $"Last sent Etag: {lastSentEtag:#,#;;0}" + Environment.NewLine +
@@ -710,22 +724,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
-            var databaseEtag = -1L;
-            if (state.HasActiveMigrations() == false)
-            {
-                // if resharding is active skip - index staleness will not prevent it from being promoted
-                DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Karmel, DevelopmentHelper.Severity.Normal, "This only a workaround until RavenDB-21327 will be fixed properly");
-                databaseEtag = promotablePrevDbStats.LastEtag;
-            }
-
-            var indexesCaughtUp = CheckIndexProgress(
-                databaseEtag,
-                promotablePrevDbStats.LastIndexStats,
-                promotableDbStats.LastIndexStats,
-                mentorCurrDbStats.LastIndexStats,
-                out var reason);
-
-            if (indexesCaughtUp)
+            if (indexesUpToDate)
             {
                 _logger.Log($"We try to promote the database '{dbName}' on {promotable} to be a full member", state.ObserverIteration, database: dbName);
 
@@ -735,17 +734,36 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (true, $"Node {promotable} is up-to-date so promoting it to be member");
             }
 
-            _logger.Log($"The database '{dbName}' on {promotable} is not ready to be promoted, because {reason}{Environment.NewLine}", state.ObserverIteration, database: dbName);
+            _logger.Log($"The database '{dbName}' on {promotable} is not ready to be promoted, because {outdatedIndexesReason}{Environment.NewLine}", state.ObserverIteration, database: dbName);
 
             if (topology.PromotablesStatus.TryGetValue(promotable, out var currentStatus) == false
                 || currentStatus != DatabasePromotionStatus.IndexNotUpToDate)
             {
                 var msg = $"Node {promotable} not ready to be a member, because the indexes are not up-to-date";
+                if (mentorsEtag - lastSentEtag > 1000)
+                {
+                    // The log will include the etag-lag details if the Etag difference is significant (Etag difference > 1000).
+                    msg += $", and Mentor {mentorNode} hasn't sent all of the documents yet to {promotable} (sent etag: {lastSentEtag:#,#;;0}/{mentorsEtag:#,#;;0})";
+                }
+
                 topology.PromotablesStatus[promotable] = DatabasePromotionStatus.IndexNotUpToDate;
                 topology.DemotionReasons[promotable] = msg;
                 return (false, msg);
             }
             return (false, null);
+        }
+
+        private static bool IsMentorAhead(long lastSentEtag, long mentorsEtag, bool timeDiff, bool indexesUpToDate)
+        {
+            if (indexesUpToDate == false)
+            {
+                // Normally we avoid promotion when indexes are not up-to-date.
+                // In this case, we only log the index staleness.
+                // The log will include the etag-lag details if the Etag difference is significant (Etag difference > 1000).
+                return false;
+            }
+
+            return lastSentEtag < mentorsEtag || timeDiff;
         }
 
         protected virtual void RemoveOtherNodesIfNeeded(DatabaseObservationState state, ref List<DeleteDatabaseCommand> deletions)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25768/Cluster-Observer-Misleading-Replication-not-up-to-date-message-when-Index-Lag-is-the-actual-blocker-for-Rehab-exit

### Additional description

When we have outdated indexes and etag lag, the etag lag is probably outcoming of the stale index..
Therefore, when both conditions occur (outdated indexes **and** Etag lag), we do not log the Etag lag separately.
Instead, we log the index staleness, and if the Etag difference is significant (>1000), the staleness message will also include the Etag gap.
<img width="730" height="301" alt="image" src="https://github.com/user-attachments/assets/fc441222-1b3f-4366-bceb-97502b62371a" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
