### PR TITLE
RavenDB-24486 Fixed ETL with empty DocumentIdPostfix so that it generated a document ID with duplicate slashes

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtlScriptRun.cs
@@ -363,7 +363,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
         private string GetRemoteDocumentId(string localDocId)
         {
-            if (_transformation.DocumentIdPostfix != null)
+            if (string.IsNullOrEmpty(_transformation.DocumentIdPostfix) == false)
             {
                 if (localDocId.EndsWith("/"))
                 {

--- a/test/SlowTests/Issues/RavenDB_24486.cs
+++ b/test/SlowTests/Issues/RavenDB_24486.cs
@@ -1,0 +1,67 @@
+using System;
+using FastTests;
+using Raven.Client.Documents.Operations.ETL;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using Employee = Orders.Employee;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_24486 : RavenTestBase
+    {
+        public RavenDB_24486(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public void EtlWithEmptyPostfixShouldNotGenerateDuplicateSlashesInId()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                var connectionStringName = "my-conn";
+
+                Etl.AddEtl(src, new RavenEtlConfiguration
+                {
+                    Name = connectionStringName,
+                    ConnectionStringName = connectionStringName,
+                    Transforms =
+                    {
+                        new Transformation
+                        {
+                            Name = $"ETL : {connectionStringName}",
+                            Collections = { "Employees" },
+                            Script = "loadToNewEmployees({ Name: this.LastName });",
+                            DocumentIdPostfix = ""
+                        }
+                    }
+                }, new RavenConnectionString
+                {
+                    Name = connectionStringName,
+                    Database = dest.Database,
+                    TopologyDiscoveryUrls = dest.Urls
+                });
+
+                var etlDone = Etl.WaitForEtlToComplete(src);
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new Employee { LastName = "Doe" });
+                    session.SaveChanges();
+                }
+
+                Assert.True(etlDone.Wait(TimeSpan.FromSeconds(30)));
+
+                using (var session = dest.OpenSession())
+                {
+                    var docs = session.Advanced.LoadStartingWith<Employee>("employees/1-A/newEmployees/");
+                    Assert.Equal(1, docs.Length);
+
+                    var docId = session.Advanced.GetDocumentId(docs[0]);
+                    Assert.DoesNotContain("//", docId);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24486

### Additional description

Fixing an edge case

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
