### PR TITLE
RavenDB-26087 Update documentation links inside RavenDB package readme.txt (7.2)

### DIFF
--- a/docs/readme.linux.txt
+++ b/docs/readme.linux.txt
@@ -47,10 +47,10 @@ View its status using:
 
 * Setup
 Open browser, if not opened automatically, at url printed in "Server available on: <url>"
-Follow the web setup instructions at: https://ravendb.net/docs/article-page/7.2/csharp/start/installation/setup-wizard
+Follow the web setup instructions at: https://docs.ravendb.net/7.2/start/installation/setup-wizard/overview
 
 * Upgrading to a New Version
-Follow the upgrade instructions available at: https://ravendb.net/docs/article-page/7.2/csharp/start/installation/upgrading-to-new-version
+Follow the upgrade instructions available at: https://docs.ravendb.net/7.2/start/installation/upgrading-to-new-version
 
 
 

--- a/docs/readme.windows.txt
+++ b/docs/readme.windows.txt
@@ -25,8 +25,8 @@ To manage service you can use Stop-Service and Start-Service cmdlets (requires a
 
 * Setup
 Open browser, if not opened automatically, at url printed in "Server available on: <url>"
-Follow the web setup instructions at: https://ravendb.net/docs/article-page/7.2/csharp/start/installation/setup-wizard
+Follow the web setup instructions at: https://docs.ravendb.net/7.2/start/installation/setup-wizard/overview
 
 * Upgrading to a New Version
-Follow the upgrade instructions available at: https://ravendb.net/docs/article-page/7.2/csharp/start/installation/upgrading-to-new-version
+Follow the upgrade instructions available at: https://docs.ravendb.net/7.2/start/installation/upgrading-to-new-version
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26087/Setup-wizard-Fix-links-to-documentation

### Additional description

Updated 2 links inside `readme.txt` that can be found inside the generated package: 
<img width="795" height="247" alt="image" src="https://github.com/user-attachments/assets/6969ebcd-3843-4ea6-855f-9bd32cdeb257" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
