### PR TITLE
RavenDB-26186 - Release stale `LowLevelTransaction` references retained by Lucene's per-thread cache and bloom filters

### DIFF
--- a/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
+++ b/src/Raven.Server/Documents/Indexes/CollectionOfBloomFilters.cs
@@ -12,7 +12,7 @@ using Voron.Data.BTrees;
 
 namespace Raven.Server.Documents.Indexes
 {
-    public sealed class CollectionOfBloomFilters : IDisposable
+    public sealed class CollectionOfBloomFilters
     {
         private const string BloomFiltersTreeName = "BloomFilters";
 
@@ -308,10 +308,6 @@ namespace Raven.Server.Documents.Indexes
                 filter.Flush();
         }
 
-        public void Dispose()
-        {
-        }
-
         public sealed class BloomFilter32 : BloomFilter
         {
             public const int PtrSize = 32 * 1024;
@@ -338,7 +334,7 @@ namespace Raven.Server.Documents.Indexes
             }
         }
 
-        public abstract unsafe class BloomFilter : IDisposable
+        public abstract unsafe class BloomFilter
         {
             private const long K = 10;
 
@@ -574,10 +570,6 @@ namespace Raven.Server.Documents.Indexes
                     return; // avoid re-throwing it
 
                 _tree.Delete(_keySlice);
-            }
-
-            public void Dispose()
-            {
             }
 
             private sealed class Partition

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -35,6 +35,9 @@ namespace Raven.Server.Documents.Indexes
 
         public override IDisposable InitializeIndexingWork(TransactionOperationContext indexContext)
         {
+            if (SearchEngineType != SearchEngineType.Lucene)
+                return null;
+
             var mode = DocumentDatabase.Is32Bits
                 ? CollectionOfBloomFilters.Mode.X86
                 : CollectionOfBloomFilters.Mode.X64;

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Indexes;
+using Raven.Client.Util;
 using Raven.Server.Documents.Includes;
 using Raven.Server.Documents.Indexes.Persistence;
 using Raven.Server.Documents.Indexes.Static;
@@ -45,7 +46,16 @@ namespace Raven.Server.Documents.Indexes
             if (_filters == null || _filters.Consumed == false)
                 _filters = CollectionOfBloomFilters.Load(mode, indexContext);
 
-            return _filters;
+            return new DisposableAction(() =>
+            {
+                // If the filters are not consumed, they hold a reference to a Tree which holds 
+                // a reference to a LowLevelTransaction. We must release that reference when the 
+                // transaction ends to avoid keeping the LowLevelTransaction alive (e.g. when the 
+                // index is idle or disabled). We always reload _filters at the start of each transaction anyway.
+                // When consumed, the filters were created with tree: null, so no transaction reference is held.
+                if (_filters.Consumed == false)
+                    _filters = null;
+            });
         }
 
         public override void HandleDelete(Tombstone tombstone, string collection, Lazy<IndexWriteOperationBase> writer, TransactionOperationContext indexContext, IndexingStatsScope stats)

--- a/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/MapIndexBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Util;
@@ -17,7 +18,8 @@ namespace Raven.Server.Documents.Indexes
 {
     public abstract class MapIndexBase<T, TField> : Index<T, TField> where T : IndexDefinitionBaseServerSide<TField> where TField : IndexFieldBase
     {
-        private CollectionOfBloomFilters _filters;
+        private CollectionOfBloomFilters _filters = null;
+        private bool _consumed;
         private IndexingStatsScope _statsInstance;
         private readonly MapStats _stats = new MapStats();
 
@@ -39,12 +41,22 @@ namespace Raven.Server.Documents.Indexes
             if (SearchEngineType != SearchEngineType.Lucene)
                 return null;
 
+            if (_consumed)
+            {
+                Debug.Assert(_filters != null);
+                return null;
+            }
+
             var mode = DocumentDatabase.Is32Bits
                 ? CollectionOfBloomFilters.Mode.X86
                 : CollectionOfBloomFilters.Mode.X64;
 
-            if (_filters == null || _filters.Consumed == false)
-                _filters = CollectionOfBloomFilters.Load(mode, indexContext);
+            _filters = CollectionOfBloomFilters.Load(mode, indexContext);
+            if (_filters.Consumed)
+            {
+                _consumed = true;
+                return null;
+            }
 
             return new DisposableAction(() =>
             {
@@ -53,8 +65,7 @@ namespace Raven.Server.Documents.Indexes
                 // transaction ends to avoid keeping the LowLevelTransaction alive (e.g. when the 
                 // index is idle or disabled). We always reload _filters at the start of each transaction anyway.
                 // When consumed, the filters were created with tree: null, so no transaction reference is held.
-                if (_filters.Consumed == false)
-                    _filters = null;
+                _filters = null;
             });
         }
 

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Voron;
+using Voron.Data;
+using Voron.Data.BTrees;
+using Voron.Impl;
+
+namespace Raven.Server.Indexing;
+
+public sealed class LuceneVoronStream : VoronStream
+{
+    public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
+    {
+        RegisterTransactionCleanup();
+    }
+
+    private void RegisterTransactionCleanup()
+    {
+        Llt.Transaction.LowLevelTransaction.OnDispose += _ =>
+        {
+            // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
+            // the transaction that created them. Nulling _llt here allows the GC to collect the
+            // disposed LowLevelTransaction and its associated structures (page positions, journal
+            // references, etc.), which can be substantial depending on the indexing batch size.
+            // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
+            Llt = null;
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UpdateCurrentTransaction(Transaction tx)
+    {
+        if (tx != null)
+        {
+            if (Llt == tx.LowLevelTransaction)
+                return;
+
+            Llt = tx.LowLevelTransaction;
+            RegisterTransactionCleanup();
+            LastPage = default(Page);
+            return;
+        }
+
+        ThrowTransactionIsNull();
+    }
+
+    [DoesNotReturn]
+    private static void ThrowTransactionIsNull()
+    {
+        throw new ArgumentNullException("tx");
+    }
+}

--- a/src/Raven.Server/Indexing/VoronBufferedInput.cs
+++ b/src/Raven.Server/Indexing/VoronBufferedInput.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Lucene.Net.Store;
 using Raven.Client.Extensions.Streams;
-using Voron.Data;
 using Voron.Impl;
 
 namespace Raven.Server.Indexing;
@@ -18,7 +17,7 @@ public sealed class VoronBufferedInput : BufferedIndexInput
     private readonly LuceneVoronDirectory _directory;
     private readonly string _name;
     private readonly string _tree;
-    private VoronStream _stream;
+    private LuceneVoronStream _stream;
     private bool _isDisposed = false;
 
     private bool _isOriginal = true;

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using Lucene.Net.Store;
 using Raven.Client.Extensions.Streams;
 using Voron;
-using Voron.Data;
 using Voron.Impl;
 
 namespace Raven.Server.Indexing
@@ -18,7 +17,7 @@ namespace Raven.Server.Indexing
         private readonly LuceneVoronDirectory _directory;
         private readonly string _name;
         private readonly string _tree;
-        private VoronStream _stream;
+        private LuceneVoronStream _stream;
 
         private bool _isOriginal = true;
 
@@ -36,7 +35,7 @@ namespace Raven.Server.Indexing
             return _name;
         }
 
-        internal static VoronStream OpenVoronStream(Transaction transaction, LuceneVoronDirectory directory, string name, string tree)
+        internal static LuceneVoronStream OpenVoronStream(Transaction transaction, LuceneVoronDirectory directory, string name, string treeName)
         {
             if (transaction.IsWriteTransaction == false)
             {
@@ -49,23 +48,23 @@ namespace Raven.Server.Indexing
                             // we don't dispose here explicitly, the fileName needs to be
                             // alive as long as the transaction is
                             Slice.From(transaction.Allocator, name, out Slice fileName);
-                            return new VoronStream(fileName, details, transaction.LowLevelTransaction, releaseTransactionOnDispose: true);
+                            return new LuceneVoronStream(fileName, details, transaction.LowLevelTransaction);
                         }
                     }
                 }
             }
 
-            var fileTree = transaction.ReadTree(tree);
+            var fileTree = transaction.ReadTree(treeName);
             if (fileTree == null)
-                throw new FileNotFoundException($"Could not find '{tree}' tree for index input", name);
+                throw new FileNotFoundException($"Could not find '{treeName}' tree for index input", name);
 
             using (Slice.From(transaction.Allocator, name, out Slice fileName))
             {
-                var stream = fileTree.ReadStream(fileName, releaseTransactionOnDispose: true);
-                if (stream == null)
+                var details = fileTree.ReadTreeChunks(fileName, out var tree);
+                if (details == null)
                     throw new FileNotFoundException("Could not find index input", name);
 
-                return stream;
+                return new LuceneVoronStream(tree.Name, details, fileTree.Llt);
             }
         }
         

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Indexing
                             // we don't dispose here explicitly, the fileName needs to be
                             // alive as long as the transaction is
                             Slice.From(transaction.Allocator, name, out Slice fileName);
-                            return new VoronStream(fileName, details, transaction.LowLevelTransaction);
+                            return new VoronStream(fileName, details, transaction.LowLevelTransaction, releaseTransactionOnDispose: true);
                         }
                     }
                 }
@@ -61,7 +61,7 @@ namespace Raven.Server.Indexing
 
             using (Slice.From(transaction.Allocator, name, out Slice fileName))
             {
-                var stream = fileTree.ReadStream(fileName);
+                var stream = fileTree.ReadStream(fileName, releaseTransactionOnDispose: true);
                 if (stream == null)
                     throw new FileNotFoundException("Could not find index input", name);
 

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -232,12 +232,12 @@ namespace Voron.Data.BTrees
                 return ReadStream(str);
         }
 
-        public VoronStream ReadStream(Slice key)
+        public VoronStream ReadStream(Slice key, bool releaseTransactionOnDispose = false)
         {
             var pieces = ReadTreeChunks(key, out var tree);
             if (pieces == null)
                 return null;
-            return new VoronStream(tree.Name, pieces, _llt);
+            return new VoronStream(tree.Name, pieces, _llt, releaseTransactionOnDispose);
         }
 
         public ChunkDetails[] ReadTreeChunks(Slice key, out FixedSizeTree tree)

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -232,12 +232,12 @@ namespace Voron.Data.BTrees
                 return ReadStream(str);
         }
 
-        public VoronStream ReadStream(Slice key, bool releaseTransactionOnDispose = false)
+        public VoronStream ReadStream(Slice key)
         {
             var pieces = ReadTreeChunks(key, out var tree);
             if (pieces == null)
                 return null;
-            return new VoronStream(tree.Name, pieces, _llt, releaseTransactionOnDispose);
+            return new VoronStream(tree.Name, pieces, _llt);
         }
 
         public ChunkDetails[] ReadTreeChunks(Slice key, out FixedSizeTree tree)

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -29,15 +29,16 @@ namespace Voron.Data
             return Name.ToString();
         }
 
-        public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
+        public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt, bool releaseTransactionOnDispose)
         {
             Name = name;
-
             _chunksDetails = chunksDetails;
             _chunksOffsets = new long[_chunksDetails.Length];
 
             _index = 0;
-            _llt = llt;
+
+            SetLowLevelTransaction(llt, releaseTransactionOnDispose);
+            
             _encrypted = _llt.Environment.Options.Encryption.IsEnabled && _llt.Transaction.IsWriteTransaction == false;
             _lastPage = default(Page);
             _position = 0;
@@ -50,6 +51,24 @@ namespace Voron.Data
             }
         }
 
+        private void SetLowLevelTransaction(LowLevelTransaction llt, bool releaseTransactionOnDispose)
+        {
+            _llt = llt;
+
+            if (releaseTransactionOnDispose)
+            {
+                _llt.Transaction.LowLevelTransaction.OnDispose += _ =>
+                {
+                    // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
+                    // the transaction that created them. Nulling _llt here allows the GC to collect the
+                    // disposed LowLevelTransaction and its associated structures (page positions, journal
+                    // references, etc.), which can be substantial depending on the indexing batch size.
+                    // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
+                    _llt = null;
+                };
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void UpdateCurrentTransaction(Transaction tx)
         {
@@ -58,7 +77,7 @@ namespace Voron.Data
                 if (_llt == tx.LowLevelTransaction)
                     return;
 
-                _llt = tx.LowLevelTransaction;
+                SetLowLevelTransaction(tx.LowLevelTransaction, releaseTransactionOnDispose: true);
                 _lastPage = default(Page);
                 return;
             }

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.CompilerServices;
 using Sparrow;
 using Voron.Data.BTrees;
 using Voron.Impl;
 
 namespace Voron.Data
 {
-    public sealed unsafe class VoronStream : Stream
+    public unsafe class VoronStream : Stream
     {
         public Slice Name { get; }
 
@@ -17,19 +16,20 @@ namespace Voron.Data
         private readonly bool _encrypted;
         private long _position;
         private int _index;
-        private LowLevelTransaction _llt;
-        
+        protected LowLevelTransaction Llt;
+        protected Page LastPage;
+
         public override bool CanRead => true;
         public override bool CanSeek => true;
         public override bool CanWrite => false;
-        public override long Length { get; }
+        public sealed override long Length { get; }
 
         public override string ToString()
         {
             return Name.ToString();
         }
 
-        public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt, bool releaseTransactionOnDispose)
+        public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
         {
             Name = name;
             _chunksDetails = chunksDetails;
@@ -37,10 +37,10 @@ namespace Voron.Data
 
             _index = 0;
 
-            SetLowLevelTransaction(llt, releaseTransactionOnDispose);
-            
-            _encrypted = _llt.Environment.Options.Encryption.IsEnabled && _llt.Transaction.IsWriteTransaction == false;
-            _lastPage = default(Page);
+            Llt = llt;
+
+            _encrypted = Llt.Environment.Options.Encryption.IsEnabled && Llt.Transaction.IsWriteTransaction == false;
+            LastPage = default(Page);
             _position = 0;
 
             for (int index = 0; index < _chunksDetails.Length; index++)
@@ -49,46 +49,6 @@ namespace Voron.Data
                 _chunksOffsets[index] = Length;
                 Length += cd.ChunkSize;
             }
-        }
-
-        private void SetLowLevelTransaction(LowLevelTransaction llt, bool releaseTransactionOnDispose)
-        {
-            _llt = llt;
-
-            if (releaseTransactionOnDispose)
-            {
-                _llt.Transaction.LowLevelTransaction.OnDispose += _ =>
-                {
-                    // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
-                    // the transaction that created them. Nulling _llt here allows the GC to collect the
-                    // disposed LowLevelTransaction and its associated structures (page positions, journal
-                    // references, etc.), which can be substantial depending on the indexing batch size.
-                    // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-                    _llt = null;
-                };
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void UpdateCurrentTransaction(Transaction tx)
-        {
-            if (tx != null)
-            {
-                if (_llt == tx.LowLevelTransaction)
-                    return;
-
-                SetLowLevelTransaction(tx.LowLevelTransaction, releaseTransactionOnDispose: true);
-                _lastPage = default(Page);
-                return;
-            }
-
-            ThrowTransactionIsNull();            
-        }
-
-        [DoesNotReturn]
-        private void ThrowTransactionIsNull()
-        {
-            throw new ArgumentNullException("tx");
         }
 
         public override long Position
@@ -134,8 +94,6 @@ namespace Voron.Data
             }
         }
 
-        private Page _lastPage;
-
         public override int ReadByte()
         {
             var chunk = _chunksDetails[_index];
@@ -156,7 +114,7 @@ namespace Voron.Data
 
             var pos = _position - _chunksOffsets[_index];
             _position++; //move ptr
-            return _lastPage.DataPointer[pos];
+            return LastPage.DataPointer[pos];
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -188,7 +146,7 @@ namespace Voron.Data
             var pos = _position - _chunksOffsets[_index];
             fixed (byte* dst = buffer)
             {
-                Memory.Copy(dst + offset, _lastPage.DataPointer + pos, count);
+                Memory.Copy(dst + offset, LastPage.DataPointer + pos, count);
             }
 
             //move ptr
@@ -198,22 +156,22 @@ namespace Voron.Data
 
         private void UpdateLastPageIfNeeded(long pageNumber)
         {
-            if (_lastPage.IsValid && _lastPage.PageNumber == pageNumber)
+            if (LastPage.IsValid && LastPage.PageNumber == pageNumber)
                 return;
 
             if (_encrypted == false)
             {
-                _lastPage = _llt.GetPage(pageNumber);
+                LastPage = Llt.GetPage(pageNumber);
                 return;
             }
 
-            if (_lastPage.IsValid)
+            if (LastPage.IsValid)
             {
                 // the last page won't be needed anymore, we'll try to release it
-                _llt.TryReleasePage(_lastPage.PageNumber);
+                Llt.TryReleasePage(LastPage.PageNumber);
             }
 
-            _lastPage = _llt.GetPageWithoutCache(pageNumber);
+            LastPage = Llt.GetPageWithoutCache(pageNumber);
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
+++ b/test/FastTests/Server/Documents/Indexing/BloomFilterTests.cs
@@ -27,32 +27,30 @@ namespace FastTests.Server.Documents.Indexing
                     var key1 = context.GetLazyString("orders/1");
                     var key2 = context.GetLazyString("orders/2");
 
-                    using (var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator))
-                    {
-                        Assert.False(filter.Contains(key1));
-                        Assert.False(filter.Contains(key2));
-                        Assert.Equal(0, filter.Count);
+                    var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator);
+                    Assert.False(filter.Contains(key1));
+                    Assert.False(filter.Contains(key2));
+                    Assert.Equal(0, filter.Count);
 
-                        Assert.True(filter.Add(key1));
-                        Assert.True(filter.Contains(key1));
-                        Assert.False(filter.Contains(key2));
-                        Assert.Equal(1, filter.Count);
+                    Assert.True(filter.Add(key1));
+                    Assert.True(filter.Contains(key1));
+                    Assert.False(filter.Contains(key2));
+                    Assert.Equal(1, filter.Count);
 
-                        Assert.False(filter.Add(key1));
-                        Assert.True(filter.Contains(key1));
-                        Assert.False(filter.Contains(key2));
-                        Assert.Equal(1, filter.Count);
+                    Assert.False(filter.Add(key1));
+                    Assert.True(filter.Contains(key1));
+                    Assert.False(filter.Contains(key2));
+                    Assert.Equal(1, filter.Count);
 
-                        Assert.True(filter.Add(key2));
-                        Assert.True(filter.Contains(key1));
-                        Assert.True(filter.Contains(key2));
-                        Assert.Equal(2, filter.Count);
+                    Assert.True(filter.Add(key2));
+                    Assert.True(filter.Contains(key1));
+                    Assert.True(filter.Contains(key2));
+                    Assert.Equal(2, filter.Count);
 
-                        Assert.False(filter.Add(key1));
-                        Assert.True(filter.Contains(key1));
-                        Assert.True(filter.Contains(key2));
-                        Assert.Equal(2, filter.Count);
-                    }
+                    Assert.False(filter.Add(key1));
+                    Assert.True(filter.Contains(key1));
+                    Assert.True(filter.Contains(key2));
+                    Assert.Equal(2, filter.Count);
 
                     tx.Commit();
                 }
@@ -70,13 +68,11 @@ namespace FastTests.Server.Documents.Indexing
                 {
                     var tree = tx.CreateTree("Filters");
 
-                    using (var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator))
-                    {
-                        Assert.True(filter.Add(key1));
-                        Assert.Equal(1, filter.Count);
+                    var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator);
+                    Assert.True(filter.Add(key1));
+                    Assert.Equal(1, filter.Count);
 
-                        filter.Flush();
-                    }
+                    filter.Flush();
 
                     tx.Commit();
                 }
@@ -85,11 +81,9 @@ namespace FastTests.Server.Documents.Indexing
                 {
                     var tree = tx.CreateTree("Filters");
 
-                    using (var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: false, allocator: context.Allocator))
-                    {
-                        Assert.False(filter.Add(key1));
-                        Assert.Equal(1, filter.Count);
-                    }
+                    var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: false, allocator: context.Allocator);
+                    Assert.False(filter.Add(key1));
+                    Assert.Equal(1, filter.Count);
                 }
             }
         }
@@ -106,15 +100,13 @@ namespace FastTests.Server.Documents.Indexing
                 {
                     var tree = tx.CreateTree("Filters");
 
-                    using (var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator))
-                    {
-                        Assert.True(filter.Add(key1));
-                        Assert.Equal(1, filter.Count);
-                        Assert.True(filter.Writable);
-                        Assert.False(filter.ReadOnly);
+                    var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator);
+                    Assert.True(filter.Add(key1));
+                    Assert.Equal(1, filter.Count);
+                    Assert.True(filter.Writable);
+                    Assert.False(filter.ReadOnly);
 
-                        filter.Flush();
-                    }
+                    filter.Flush();
 
                     tx.Commit();
                 }
@@ -123,18 +115,16 @@ namespace FastTests.Server.Documents.Indexing
                 {
                     var tree = tx.CreateTree("Filters");
 
-                    using (var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: false, allocator: context.Allocator))
-                    {
-                        Assert.False(filter.Writable);
+                    var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: false, allocator: context.Allocator);
+                    Assert.False(filter.Writable);
 
-                        Assert.False(filter.Add(key1));
-                        Assert.Equal(1, filter.Count);
-                        Assert.False(filter.Writable);
+                    Assert.False(filter.Add(key1));
+                    Assert.Equal(1, filter.Count);
+                    Assert.False(filter.Writable);
 
-                        Assert.True(filter.Add(key2));
-                        Assert.Equal(2, filter.Count);
-                        Assert.True(filter.Writable);
-                    }
+                    Assert.True(filter.Add(key2));
+                    Assert.Equal(2, filter.Count);
+                    Assert.True(filter.Writable);
                 }
             }
         }
@@ -149,25 +139,21 @@ namespace FastTests.Server.Documents.Indexing
                     var tree = context.Transaction.InnerTransaction.CreateTree("BloomFilters");
                     tree.Increment("Count64", 2);
 
-                    using (var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator))
-                    {
-                        Assert.False(filter.ReadOnly);
-                        filter.MakeReadOnly();
-                        Assert.True(filter.ReadOnly);
-                    }
+                    var filter = new CollectionOfBloomFilters.BloomFilter64(0, BloomFilterVersion.CurrentVersion, tree, writable: true, allocator: context.Allocator);
+                    Assert.False(filter.ReadOnly);
+                    filter.MakeReadOnly();
+                    Assert.True(filter.ReadOnly);
 
                     tx.Commit();
                 }
 
                 using (context.OpenWriteTransaction())
                 {
-                    using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                    {
-                        Assert.Equal(2, collection.Count);
+                    var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    Assert.Equal(2, collection.Count);
 
-                        Assert.True(collection[0].ReadOnly);
-                        Assert.False(collection[1].ReadOnly);
-                    }
+                    Assert.True(collection[0].ReadOnly);
+                    Assert.False(collection[1].ReadOnly);
                 }
             }
         }
@@ -179,28 +165,24 @@ namespace FastTests.Server.Documents.Indexing
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context))
+                    var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context);
+                    Assert.Equal(1, collection.Count);
+
+                    for (var i = 0; i < CollectionOfBloomFilters.BloomFilter32.MaxCapacity * 1.2; i++)
                     {
-                        Assert.Equal(1, collection.Count);
-
-                        for (var i = 0; i < CollectionOfBloomFilters.BloomFilter32.MaxCapacity * 1.2; i++)
-                        {
-                            var key = context.GetLazyString("orders/" + i);
-                            collection.Add(key);
-                        }
-
-                        Assert.Equal(2, collection.Count);
+                        var key = context.GetLazyString("orders/" + i);
+                        collection.Add(key);
                     }
+
+                    Assert.Equal(2, collection.Count);
 
                     tx.Commit();
                 }
 
                 using (context.OpenWriteTransaction())
                 {
-                    using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context))
-                    {
-                        Assert.Equal(2, collection.Count);
-                    }
+                    var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context);
+                    Assert.Equal(2, collection.Count);
                 }
             }
         }
@@ -212,14 +194,12 @@ namespace FastTests.Server.Documents.Indexing
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context))
-                    {
-                        Assert.Equal(1, collection.Count);
+                    var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context);
+                    Assert.Equal(1, collection.Count);
 
-                        collection.AddFilter(collection.CreateNewFilter(1, CollectionOfBloomFilters.Mode.X86)); // should not throw
+                    collection.AddFilter(collection.CreateNewFilter(1, CollectionOfBloomFilters.Mode.X86)); // should not throw
 
-                        Assert.Throws<InvalidOperationException>(() => collection.AddFilter(collection.CreateNewFilter(2, CollectionOfBloomFilters.Mode.X64)));
-                    }
+                    Assert.Throws<InvalidOperationException>(() => collection.AddFilter(collection.CreateNewFilter(2, CollectionOfBloomFilters.Mode.X64)));
                 }
             }
         }
@@ -231,30 +211,26 @@ namespace FastTests.Server.Documents.Indexing
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context))
+                    var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context);
+                    var i = 0;
+                    while (collection.Consumed == false)
                     {
-                        var i = 0;
-                        while (collection.Consumed == false)
-                        {
-                            var key = context.GetLazyString($"orders/{i++}");
-                            collection.Add(key);
-                        }
-
-                        Assert.Equal(20, collection.Count);
-                        collection.Flush();
-                        Assert.Equal(0, collection.Count);
+                        var key = context.GetLazyString($"orders/{i++}");
+                        collection.Add(key);
                     }
+
+                    Assert.Equal(20, collection.Count);
+                    collection.Flush();
+                    Assert.Equal(0, collection.Count);
 
                     tx.Commit();
                 }
 
                 using (context.OpenWriteTransaction())
                 {
-                    using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context))
-                    {
-                        Assert.Equal(0, collection.Count);
-                        Assert.True(collection.Consumed);
-                    }
+                    var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X86, context);
+                    Assert.Equal(0, collection.Count);
+                    Assert.True(collection.Consumed);
                 }
             }
         }

--- a/test/SlowTests/Core/Indexing/BloomFilters.cs
+++ b/test/SlowTests/Core/Indexing/BloomFilters.cs
@@ -53,11 +53,9 @@ namespace SlowTests.Core.Indexing
                 {
                     using (context.OpenWriteTransaction())
                     {
-                        using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                        {
-                            Assert.Equal(1, collection.Count);
-                            Assert.Equal(0, collection.CurrentFilterCount);
-                        }
+                        var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                        Assert.Equal(1, collection.Count);
+                        Assert.Equal(0, collection.CurrentFilterCount);
                     }
                 }
 
@@ -80,11 +78,9 @@ namespace SlowTests.Core.Indexing
                 {
                     using (context.OpenWriteTransaction())
                     {
-                        using (var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                        {
-                            Assert.Equal(1, collection.Count);
-                            Assert.Equal(10, collection.CurrentFilterCount);
-                        }
+                        var collection = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                        Assert.Equal(1, collection.Count);
+                        Assert.Equal(10, collection.CurrentFilterCount);
                     }
                 }
             }

--- a/test/StressTests/Issues/RavenDB_15780.cs
+++ b/test/StressTests/Issues/RavenDB_15780.cs
@@ -36,14 +36,12 @@ namespace StressTests.Issues
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    for (var i = 0; i < count; i++)
                     {
-                        for (var i = 0; i < count; i++)
-                        {
-                            var key = context.GetLazyString($"orders/{i}");
-                            if (filter.Add(key))
-                                added++;
-                        }
+                        var key = context.GetLazyString($"orders/{i}");
+                        if (filter.Add(key))
+                            added++;
                     }
                 }
 
@@ -73,14 +71,12 @@ namespace StressTests.Issues
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    for (var i = 0; i < count; i++)
                     {
-                        for (var i = 0; i < count; i++)
-                        {
-                            var key = context.GetLazyString($"orders/{i:D19}-A");
-                            if (filter.Add(key))
-                                added++;
-                        }
+                        var key = context.GetLazyString($"orders/{i:D19}-A");
+                        if (filter.Add(key))
+                            added++;
                     }
                 }
 
@@ -110,14 +106,12 @@ namespace StressTests.Issues
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    for (var i = 0; i < count; i++)
                     {
-                        for (var i = 0; i < count; i++)
-                        {
-                            var key = context.GetLazyString(Guid.NewGuid().ToString());
-                            if (filter.Add(key))
-                                added++;
-                        }
+                        var key = context.GetLazyString(Guid.NewGuid().ToString());
+                        if (filter.Add(key))
+                            added++;
                     }
                 }
 
@@ -133,50 +127,40 @@ namespace StressTests.Issues
             {
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                    {
-                        Assert.Equal(BloomFilterVersion.CurrentVersion, filter.Version);
-                    }
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    Assert.Equal(BloomFilterVersion.CurrentVersion, filter.Version);
 
                     tx.Commit();
                 }
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                    {
-                        Assert.Equal(BloomFilterVersion.CurrentVersion, filter.Version);
-                    }
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    Assert.Equal(BloomFilterVersion.CurrentVersion, filter.Version);
 
                     tx.Commit();
                 }
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                    {
-                        Assert.Equal(BloomFilterVersion.CurrentVersion, filter.Version);
-                    }
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    Assert.Equal(BloomFilterVersion.CurrentVersion, filter.Version);
                 }
 
                 SetVersion(context, BloomFilterVersion.BaseVersion);
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                    {
-                        Assert.Equal(BloomFilterVersion.BaseVersion, filter.Version);
-                    }
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    Assert.Equal(BloomFilterVersion.BaseVersion, filter.Version);
                 }
 
                 SetVersion(context, version: null);
 
                 using (var tx = context.OpenWriteTransaction())
                 {
-                    using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                    {
-                        Assert.Equal(BloomFilterVersion.BaseVersion, filter.Version);
-                    }
+                    var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                    Assert.Equal(BloomFilterVersion.BaseVersion, filter.Version);
                 }
             }
         }
@@ -197,10 +181,8 @@ namespace StressTests.Issues
 
             using (var tx = context.OpenWriteTransaction())
             {
-                using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                {
-                    Assert.Equal(version ?? BloomFilterVersion.BaseVersion, filter.Version);
-                }
+                var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
+                Assert.Equal(version ?? BloomFilterVersion.BaseVersion, filter.Version);
 
                 tx.Commit();
             }
@@ -210,9 +192,7 @@ namespace StressTests.Issues
         {
             using (var tx = context.OpenWriteTransaction())
             {
-                using (var filter = CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context))
-                {
-                }
+                CollectionOfBloomFilters.Load(CollectionOfBloomFilters.Mode.X64, context);
 
                 tx.Commit();
             }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26186/Extreme-object-count-34.5M-PagePosition-instances-held-by-IndexWriter

### Additional description

## TL;DR

Ran a memory test with 2 indexes:
* **1 map index** (1B documents, 1 entries)
* **1 map-reduce index** (1.4B documents, 10M entries)

**Test Conditions:** Indexing stopped, no document changes, several full GC cycles forced.

| State | Managed Heap | Objects | GC Pause |
| :--- | :--- | :--- | :--- |
| **Before** | 8.12 GB | 69M | ~553 ms |
| **After** | **430 MB** | **2.36M** | **~28 ms** |
| **Improvement** | **-7.69 GB (~94%)**| **-66.64M (~96%)** | **-525 ms (~95%)** |

> **Note:** The largest retained allocation before the fix was `PagePosition` - 48M objects, ~2 GB. Most of GC time was spent on Marking: 71.85% of GC time.

---

## Changes Introduced

### 1. Null `VoronStream._llt` on transaction dispose
Lucene caches `SegmentReader` objects in its `IndexReader`, and each `SegmentReader` holds `VoronBufferedInput`/`VoronIndexInput` instances which in turn reference a `VoronStream`. The `VoronStream` stores a reference to a `LowLevelTransaction` in order to read pages from Voron storage.

* **The Issue:** This cache is per-thread - different indexing/query threads hold different `LowLevelTransaction` instances. When a `VoronStream` is reused across transactions (via `UpdateCurrentTransaction`), the previous `LowLevelTransaction` has already been disposed. However, the `VoronStream` was still holding a strong reference to it, preventing GC collection. A `LowLevelTransaction` holds substantial internal structures (`PagePosition` entries, `Dictionary<long, PagePosition>`, `HashSet<long>`, and journal file references). The number of these objects scales with the indexing batch size. With many stale transactions retained across many `VoronStream` instances, this accumulated **~8 GB of retained managed memory**.
* **The Fix:** Introduced `SetLowLevelTransaction()` which subscribes to the transaction's `OnDispose` event and nulls out `_llt` when the transaction is disposed. This allows the GC to collect the disposed `LowLevelTransaction` and all its associated structures. On the next use, `UpdateCurrentTransaction` sets a fresh transaction.

<img width="693" height="1143" alt="image" src="https://github.com/user-attachments/assets/1a3b206e-0566-4f4c-9506-74b34596bea2" />
<img width="2214" height="233" alt="image" src="https://github.com/user-attachments/assets/3f0dfc3d-c2df-41f9-b41d-9d6f995afc02" />

### 2. Release bloom filters after indexing transaction
* **The Issue:** `CollectionOfBloomFilters` holds a reference to a Voron `Tree`, which in turn holds a `LowLevelTransaction`. When the index is idle or disabled, this reference keeps the transaction alive indefinitely.
* **The Fix:** Nulls out `_filters` at the end of `InitializeIndexingWork` (via `DisposableAction`) when the filters are not consumed. Since `_filters` is always reloaded at the start of each indexing transaction, this is safe. When filters are consumed, they are created with `tree: null`, so no transaction reference is held in that case.

### 3. Skip bloom filter initialization for Corax indexes
* **The Issue:** Bloom filters are only used by Lucene indexes to determine whether a document needs to be deleted before re-indexing. Corax handles this differently and does not use bloom filters.
* **The Fix:** `InitializeIndexingWork` now returns `null` early for non-Lucene search engines, avoiding unnecessary bloom filter loading.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
