### PR TITLE
RavenDB-26080 Setup Wizard: Remove Chrome-specific text from other browsers

### DIFF
--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardFinishStep.tsx
@@ -884,6 +884,7 @@ function CertInstallationConfirm({ onCancel, onConfirm }: CertInstallationConfir
     const { reportEvent } = useEventsCollector();
 
     const browser = genUtils.getBrowser();
+    const [activeTab, setActiveTab] = useState(browser);
     const docsLink = useRavenLink({
         hash: "VD4R8E",
     });
@@ -899,7 +900,11 @@ function CertInstallationConfirm({ onCancel, onConfirm }: CertInstallationConfir
                     <NumberedListItem stepKey={1}>
                         <h4>Recognize certificate in your browser</h4>
                         <div className="browser-tab-container">
-                            <Tab.Container id="summary-tabs" defaultActiveKey={browser}>
+                            <Tab.Container
+                                id="summary-tabs"
+                                activeKey={activeTab}
+                                onSelect={(key: Browser) => setActiveTab(key)}
+                            >
                                 <Nav className="mb-2">
                                     <Nav.Item className="flex-grow">
                                         <Nav.Link eventKey="Chrome" className="chrome-tab">
@@ -965,11 +970,13 @@ function CertInstallationConfirm({ onCancel, onConfirm }: CertInstallationConfir
                             Once you proceed with restart, pick your newly installed certificate from the list of
                             available certificates.
                         </p>
-                        <p className="mb-0">
-                            If Chrome doesn’t let you choose a certificate and instead you get a RavenDB authentication
-                            error, please try again in the Incognito mode (or close all instances of Chrome). It can
-                            happen because the browser caches the client certificates.
-                        </p>
+                        {activeTab === "Chrome" && (
+                            <p className="mb-0">
+                                If Chrome doesn&apos;t let you choose a certificate and instead you get a RavenDB
+                                authentication error, please try again in the Incognito mode (or close all instances of
+                                Chrome). It can happen because the browser caches the client certificates.
+                            </p>
+                        )}
                     </NumberedListItem>
                 </NumberedList>
             </Modal.Body>


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26080

### Additional description

<img width="848" height="486" alt="image" src="https://github.com/user-attachments/assets/20ec7cef-0b2c-49a4-8970-97ce19a5975a" />

<img width="854" height="540" alt="image" src="https://github.com/user-attachments/assets/edb776c1-bbd6-4f85-a237-1f83a68818aa" />


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
