### PR TITLE
RavenDB-25962 Add DeleteAgent method to the Client API

### DIFF
--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -91,6 +91,26 @@ public class AiOperations
     }
 
     /// <summary>
+    /// Asynchronously deletes an AI agent from the database.
+    /// </summary>
+    /// <param name="agentId">The ID of the AI agent to delete.</param>
+    /// <returns>The result of the delete operation.</returns>
+    public Task<AiAgentConfigurationResult> DeleteAgentAsync(string agentId, CancellationToken token = default)
+    {
+        return _executor.SendAsync(new DeleteAiAgentOperation(agentId), token);
+    }
+
+    /// <summary>
+    /// Deletes an AI agent from the database.
+    /// </summary>
+    /// <param name="agentId">The ID of the AI agent to delete.</param>
+    /// <returns>The result of the delete operation.</returns>
+    public AiAgentConfigurationResult DeleteAgent(string agentId)
+    {
+        return AsyncHelpers.RunSync(() => DeleteAgentAsync(agentId));
+    }
+
+    /// <summary>
     /// Retrieves the AI agent configuration for a specific agent asynchronously.
     /// </summary>
     /// <param name="agentId">The ID of the AI agent to retrieve.</param>

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25962.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25962.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25962 : RavenTestBase
+    {
+        public RavenDB_25962(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanDeleteAiAgent(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agent = new AiAgentConfiguration("test-agent", config.ConnectionStringName,
+                "You are a test agent.");
+            agent.Identifier = "test-agent";
+
+            var createResult = await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance);
+
+            // verify agent was created
+            var agentFromServer = await store.AI.GetAgentAsync(createResult.Identifier);
+            Assert.NotNull(agentFromServer);
+
+            // delete agent
+            var deleteResult = await store.AI.DeleteAgentAsync(createResult.Identifier);
+            Assert.NotNull(deleteResult);
+
+            // verify agent is gone
+            var agents = await store.AI.GetAgentsAsync();
+            Assert.Empty(agents.AiAgents);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25962

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
