### PR TITLE
RavenDB-26179

### DIFF
--- a/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ETL/AddEtlCommand.cs
@@ -44,7 +44,7 @@ namespace Raven.Server.ServerWide.Commands.ETL
 
         public override void FillJson(DynamicJsonValue json)
         {
-            json[nameof(Configuration)] = TypeConverter.ToBlittableSupportedType(Configuration);
+            json[nameof(Configuration)] = Configuration.ToJson();
         }
     }
 

--- a/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
+++ b/test/SlowTests/Server/Documents/AI/GenAi/Issues/RavenDB_25808.cs
@@ -40,7 +40,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             config.Collection = "Posts";
             config.GenAiTransformation = new GenAiTransformation { Script = "ai.genContext({ Text: this.Body });" };
             config.Identifier = "posts-translation-v1-to-v2";
-            config.Version = 0;
+            config.Version = null;
             config.SampleObject = sampleObjectV1;
 
 
@@ -71,6 +71,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
                 Assert.True(doc.TryGet(Constants.Documents.Metadata.Key, out Sparrow.Json.BlittableJsonReaderObject metadata));
                 Assert.True(metadata.TryGet(Constants.Documents.Metadata.GenAiHashes, out Sparrow.Json.BlittableJsonReaderObject hashesSection));
                 Assert.True(hashesSection.TryGet(config.Identifier, out Sparrow.Json.BlittableJsonReaderArray hashesArray));
+                Assert.NotNull(hashesArray);
 
                 originalHash = hashesArray.Last().ToString();
             }
@@ -94,8 +95,9 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
 
             config.SampleObject = sampleObjectV2;
 
-            //simulating older client cause the HashVersion is configured to None.
-            store.Maintenance.Send(new UpdateGenAiOperation(taskId, config)); // task will be re-enabled
+            var baselineUtc = DateTime.UtcNow;
+            //simulating older client cause the Version is configured to Null.
+            await store.Maintenance.SendAsync(new UpdateGenAiOperation(taskId, config)); // task will be re-enabled
 
             // ---- DIAGNOSTIC ASSERTION ----
             // Verify the server actually bumped the version to WithSampleObject BEFORE waiting for ETL.
@@ -105,7 +107,6 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             Assert.Equal(GenAiConfiguration.WithSampleObject, genAiTaskInfo.Configuration.Version);
 
             // ---- Touch doc without changing context (Body stays same) ----
-            var baselineUtc = DateTime.UtcNow;
             etlDone = Etl.WaitForEtlToComplete(store);
 
             using (var session = store.OpenSession())
@@ -219,7 +220,7 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
             await store.Maintenance.SendAsync(new ToggleOngoingTaskStateOperation(taskId, OngoingTaskType.GenAi, disable: true));
             await AssertWaitForTrueAsync(() => Task.FromResult(etlProcess.IsRunning == false));
 
-            store.Maintenance.Send(new UpdateGenAiOperation(taskId, config));
+            await store.Maintenance.SendAsync(new UpdateGenAiOperation(taskId, config));
 
             // ---- Touch doc without changing context (Body stays same) ----
             var baselineUtc = DateTime.UtcNow;
@@ -278,6 +279,40 @@ namespace SlowTests.Server.Documents.AI.GenAi.Issues
                 Assert.NotNull(finalGenAiTaskInfo);
                 Assert.Equal(null, finalGenAiTaskInfo.Configuration.Version);
             }
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ShouldBumpIntoV2InCaseOfAddGenAiOperation(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            // ---- Initial task config (V1) ----
+            var sampleObjectV1 = JsonConvert.SerializeObject(new
+            {
+                Translation = "translated text"
+            });
+
+            var schema = ChatCompletionClient.GetSchemaFromSampleObject(sampleObjectV1);
+
+            config.Prompt = "Translate this text to Polish";
+            config.JsonSchema = schema;
+            config.UpdateScript = "this.TextInPolish = $output.Translation;";
+            config.Collection = "Posts";
+            config.GenAiTransformation = new GenAiTransformation
+            {
+                Script = "ai.genContext({ Text: this.Body });"
+            };
+            config.Identifier = "posts-translation-v1-to-v2";
+            config.Version = null;
+
+            await store.Maintenance.SendAsync(new AddGenAiOperation(config));
+            var taskInfo = await store.Maintenance.SendAsync(new GetOngoingTaskInfoOperation(config.Name, OngoingTaskType.GenAi));
+
+            var genAiTaskInfo = taskInfo as Raven.Client.Documents.Operations.OngoingTasks.GenAi;
+            Assert.NotNull(genAiTaskInfo);
+            Assert.Equal(GenAiConfiguration.WithSampleObject, genAiTaskInfo.Configuration.Version);
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26179/SlowTests.Server.Documents.AI.GenAi.Issues.RavenDB25808.ShouldResendWhenExistingTaskIsV1AndSampleObjectChangedBumpsToV2options

### Additional description

Adjusted the point at which the baseline is captured to avoid a race condition in the test.
Also fixed JSON deserialization to prevent null values, since `TypeConverter` does not properly handle internal types.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
