### PR TITLE
RavenDB-26100 - print stacktrace in TcpConnectionOptions finalizer for debug

### DIFF
--- a/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
+++ b/src/Raven.Server/Documents/TcpHandlers/TcpConnectionOptions.cs
@@ -19,6 +19,9 @@ namespace Raven.Server.Documents.TcpHandlers
 {
     public sealed class TcpConnectionOptions : IDisposable
     {
+#if !RELEASE
+        private readonly string _allocationStackTrace = Environment.StackTrace;
+#endif
         private static long _sequence;
 
         private MeterMetric _bytesReceivedMetric;
@@ -151,7 +154,7 @@ namespace Raven.Server.Documents.TcpHandlers
 #if !RELEASE
         ~TcpConnectionOptions()
         {
-            throw new LowMemoryException($"Detected a leak on TcpConnectionOptions ('{ToString()}') when running the finalizer.");
+            throw new LowMemoryException($"Detected a leak on TcpConnectionOptions ('{ToString()}') when running the finalizer. Allocated at:{Environment.NewLine}{_allocationStackTrace}");
         }
 #endif
 


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26100

### Additional description

This pull request introduces an improvement to the `TcpConnectionOptions` class for non-release builds. The main change is the addition of stack trace information to help developers identify where leaked instances were allocated.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
