### PR TITLE
RavenDB-26054 Allow throttling of Enforce Revisions Configuration

### DIFF
--- a/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
@@ -24,11 +24,29 @@ namespace Raven.Client.Documents.Operations.Revisions
         /// </summary>
         public sealed class Parameters : RevisionsOperationParameters
         {
+            private int? _maxOpsPerSecond;
+
             /// <summary>
             /// Gets or sets a value indicating whether to include force-created revisions.
             /// For more information, visit <a href="https://ravendb.net/docs/article-page/7.2/csharp/document-extensions/revisions/overview#force-revision-creation">here</a>.
             /// </summary>
             public bool IncludeForceCreated { get; set; } = false;
+
+            /// <summary>
+            /// Limits the number of revisions processed per second.
+            /// Use this to throttle the operation and reduce resource consumption on large datasets.
+            /// Default is <c>null</c> (no throttling).
+            /// </summary>
+            public int? MaxOpsPerSecond
+            {
+                get => _maxOpsPerSecond;
+                set
+                {
+                    if (value.HasValue && value.Value <= 0)
+                        throw new InvalidOperationException("MaxOpsPerSecond must be greater than 0");
+                    _maxOpsPerSecond = value;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Revisions/EnforceRevisionsConfigurationOperation.cs
@@ -33,7 +33,7 @@ namespace Raven.Client.Documents.Operations.Revisions
             public bool IncludeForceCreated { get; set; } = false;
 
             /// <summary>
-            /// Limits the number of revisions processed per second.
+            /// Limits the number of documents processed per second.
             /// Use this to throttle the operation and reduce resource consumption on large datasets.
             /// Default is <c>null</c> (no throttling).
             /// </summary>

--- a/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
+++ b/src/Raven.Server/Documents/Handlers/Admin/Processors/Revisions/AdminRevisionsHandlerProcessorForEnforceRevisionsConfiguration.cs
@@ -28,6 +28,6 @@ internal sealed class AdminRevisionsHandlerProcessorForEnforceRevisionsConfigura
 
     protected override Task<IOperationResult> ExecuteOperation(Action<IOperationProgress> onProgress, EnforceRevisionsConfigurationOperation.Parameters parameters, OperationCancelToken token)
     {
-        return RequestHandler.Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, parameters, token);
+        return RequestHandler.Database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress, parameters, parameters.MaxOpsPerSecond, token);
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1989,6 +1989,9 @@ namespace Raven.Server.Documents.Revisions
             // send initial progress
             parameters.OnProgress?.Invoke(result);
 
+            using (var rateGate = maxOpsPerSecond.HasValue
+                       ? new RateGate(maxOpsPerSecond.Value, TimeSpan.FromSeconds(1))
+                       : null)
             foreach (var collection in collections)
             {
                 // we need to reset the last scanned etag for each collection.
@@ -2004,14 +2007,11 @@ namespace Raven.Server.Documents.Revisions
             string collection, List<string> ids, Stopwatch sw,
             Func<List<string>, TOperationResult, OperationCancelToken, RateGate, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             TOperationResult result,
-            Parameters parameters, int? maxOpsPerSecond, OperationCancelToken token)
+            Parameters parameters, RateGate rateGate, OperationCancelToken token)
             where TOperationResult : OperationResult
         {
             var hasMore = true;
 
-            using (var rateGate = maxOpsPerSecond.HasValue
-                       ? new RateGate(maxOpsPerSecond.Value, TimeSpan.FromSeconds(1))
-                       : null)
             while (hasMore)
             {
                 hasMore = false;

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1948,7 +1948,7 @@ namespace Raven.Server.Documents.Revisions
         private async Task PerformRevisionsOperationAsync<TOperationResult>(
             Action<IOperationProgress> onProgress,
             TOperationResult result,
-            Func<List<string>, TOperationResult, OperationCancelToken, RateGate, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            Func<List<string>, TOperationResult, RateGate, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             RevisionsOperationParameters operationParameters,
             int? maxOpsPerSecond,
             OperationCancelToken token) where TOperationResult : OperationResult
@@ -2005,7 +2005,7 @@ namespace Raven.Server.Documents.Revisions
 
         private async Task PerformRevisionsOperationOnSingleCollectionAsync<TOperationResult>(
             string collection, List<string> ids, Stopwatch sw,
-            Func<List<string>, TOperationResult, OperationCancelToken, RateGate, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            Func<List<string>, TOperationResult, RateGate, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             TOperationResult result,
             Parameters parameters, RateGate rateGate, OperationCancelToken token)
             where TOperationResult : OperationResult
@@ -2065,12 +2065,12 @@ namespace Raven.Server.Documents.Revisions
                         while (moreWork)
                         {
                             token.ThrowIfCancellationRequested();
-                            var cmd = createCommand(ids, result, token, rateGate);
+                            var cmd = createCommand(ids, result, rateGate, token);
                             await _database.TxMerger.Enqueue(cmd);
                             moreWork = cmd.MoreWork || cmd.NeedWait;
 
                             if (cmd.NeedWait)
-                                rateGate?.WaitToProceed();
+                                await rateGate.WaitToProceedAsync();
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2062,12 +2062,12 @@ namespace Raven.Server.Documents.Revisions
                     if (ids.Count > 0)
                     {
                         var moreWork = true;
-                        while (moreWork || ids.Count > 0)
+                        while (moreWork)
                         {
                             token.ThrowIfCancellationRequested();
                             var cmd = createCommand(ids, result, token, rateGate);
                             await _database.TxMerger.Enqueue(cmd);
-                            moreWork = cmd.MoreWork;
+                            moreWork = cmd.MoreWork || cmd.NeedWait;
 
                             if (cmd.NeedWait)
                                 rateGate?.WaitToProceed();

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -30,6 +30,7 @@ using Sparrow.Server.Utils;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Exceptions;
+using Voron.Util.RateLimiting;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Revisions;
 using static Raven.Server.Documents.Schemas.Tombstones;
@@ -1917,7 +1918,8 @@ namespace Raven.Server.Documents.Revisions
 
         public async Task<IOperationResult> EnforceConfigurationAsync(Action<IOperationProgress> onProgress,
             EnforceRevisionsConfigurationOperation.Parameters parameters,
-            OperationCancelToken token)
+           int? maxOpsPerSecond,
+           OperationCancelToken token)
         {
             var result = new EnforceConfigurationResult();
             await PerformRevisionsOperationAsync(onProgress, result,
@@ -1956,8 +1958,9 @@ namespace Raven.Server.Documents.Revisions
         private async Task PerformRevisionsOperationAsync<TOperationResult>(
             Action<IOperationProgress> onProgress,
             TOperationResult result,
-            Func<List<string>, TOperationResult, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            Func<List<string>, TOperationResult, OperationCancelToken, RateGate, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             RevisionsOperationParameters operationParameters,
+            int? maxOpsPerSecond,
             OperationCancelToken token) where TOperationResult : OperationResult
         {
             var databaseName = _database.Name;
@@ -2009,12 +2012,16 @@ namespace Raven.Server.Documents.Revisions
 
         private async Task PerformRevisionsOperationOnSingleCollectionAsync<TOperationResult>(
             string collection, List<string> ids, Stopwatch sw,
-            Func<List<string>, TOperationResult, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            Func<List<string>, TOperationResult, OperationCancelToken, RateGate, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             TOperationResult result,
-            Parameters parameters, OperationCancelToken token)
+            Parameters parameters, int? maxOpsPerSecond, OperationCancelToken token)
             where TOperationResult : OperationResult
         {
             var hasMore = true;
+
+            using (var rateGate = maxOpsPerSecond.HasValue
+                       ? new RateGate(maxOpsPerSecond.Value, TimeSpan.FromSeconds(1))
+                       : null)
             while (hasMore)
             {
                 hasMore = false;
@@ -2027,8 +2034,8 @@ namespace Raven.Server.Documents.Revisions
                     {
                         if (GetRevisionsByCollection(ctx, collection, parameters.LastScannedEtag, out var revisions) == false)
                         {
-                            /*  there is no collection named like that, or that collection doesn't have any revisions, 
-                                but we won't throw here because this will fail the whole operation, 
+                            /*  there is no collection named like that, or that collection doesn't have any revisions,
+                                but we won't throw here because this will fail the whole operation,
                                 so we'll just skip this collection.
                              */
                             return;
@@ -2065,12 +2072,15 @@ namespace Raven.Server.Documents.Revisions
                     if (ids.Count > 0)
                     {
                         var moreWork = true;
-                        while (moreWork)
+                        while (moreWork || ids.Count > 0)
                         {
                             token.ThrowIfCancellationRequested();
-                            var cmd = createCommand(ids, result, token);
+                            var cmd = createCommand(ids, result, token, rateGate);
                             await _database.TxMerger.Enqueue(cmd);
                             moreWork = cmd.MoreWork;
+
+                            if (cmd.NeedWait)
+                                rateGate?.WaitToProceed();
                         }
                     }
                 }
@@ -2379,16 +2389,16 @@ namespace Raven.Server.Documents.Revisions
 
             collections ??= [null]; // revert all collections
 
-            foreach (var collection in collections)
-            {
-                var list = new List<Document>();
-            
+                foreach (var collection in collections)
+                {
+                    var list = new List<Document>();
+
                 await RevertRevisionsInternal(list, collection, parameters, onProgress, result, token);
 
                 var current = result.LastProcessedEtags.TryGetValue(databaseName, out var existing) ? existing : 0;
                 result.LastProcessedEtags[databaseName] = Math.Max(current, parameters.LastScannedEtag);
                 parameters.LastScannedEtag = etagBarrier;
-            }
+                }
 
             return result;
         }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -346,7 +346,7 @@ namespace Raven.Server.Documents.Revisions
             Debug.Assert(changeVector != null, "Change vector must be set");
             Debug.Assert(lastModifiedTicks != DateTime.MinValue.Ticks, "last modified ticks must be set");
 
-            if (IsExistingNewerTombstone(context, id, changeVector, flags, nonPersistentFlags, lastModifiedTicks)) 
+            if (IsExistingNewerTombstone(context, id, changeVector, flags, nonPersistentFlags, lastModifiedTicks))
                 return false;
 
             BlittableJsonReaderObject.AssertNoModifications(document, id, assertChildren: true);
@@ -1553,7 +1553,7 @@ namespace Raven.Server.Documents.Revisions
             if (nonPersistentFlags.Contain(NonPersistentDocumentFlags.SkipRevisionCreation))
                 return;
 
-            if (IsExistingNewerTombstone(context, id, changeVector, flags, nonPersistentFlags, lastModifiedTicks)) 
+            if (IsExistingNewerTombstone(context, id, changeVector, flags, nonPersistentFlags, lastModifiedTicks))
                 return;
 
             Debug.Assert(changeVector != null, "Change vector must be set");
@@ -1672,7 +1672,7 @@ namespace Raven.Server.Documents.Revisions
                 table.Set(tvb);
             }
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe ByteStringContext.InternalScope GetKeyPrefix(DocumentsOperationContext context, LazyStringValue lowerId, out Slice prefixSlice)
         {
@@ -1912,9 +1912,15 @@ namespace Raven.Server.Documents.Revisions
            OperationCancelToken token)
         {
             var result = new EnforceConfigurationResult();
-            await PerformRevisionsOperationAsync(onProgress, result,
-                (ids, res, tk) => new EnforceRevisionConfigurationCommand(this, ids, res, parameters.IncludeForceCreated, tk),
-                parameters, token);
+
+            using (var rateGate = maxOpsPerSecond.HasValue
+                       ? new RateGate(maxOpsPerSecond.Value, TimeSpan.FromSeconds(1))
+                       : null)
+            {
+                await PerformRevisionsOperationAsync(onProgress, result,
+                    (ids, res, tk) => new EnforceRevisionConfigurationCommand(this, ids, res, parameters.IncludeForceCreated, rateGate, tk),
+                    parameters, rateGate, token);
+            }
 
             return result;
         }
@@ -1925,8 +1931,8 @@ namespace Raven.Server.Documents.Revisions
         {
             var result = new AdoptOrphanedRevisionsResult();
             await PerformRevisionsOperationAsync(onProgress, result,
-                (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, tk),
-                parameters, token);
+                (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, null, tk),
+                parameters, rateGate: null, token);
 
             return result;
         }
@@ -1948,9 +1954,9 @@ namespace Raven.Server.Documents.Revisions
         private async Task PerformRevisionsOperationAsync<TOperationResult>(
             Action<IOperationProgress> onProgress,
             TOperationResult result,
-            Func<List<string>, TOperationResult, RateGate, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            Func<List<string>, TOperationResult, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             RevisionsOperationParameters operationParameters,
-            int? maxOpsPerSecond,
+            RateGate rateGate,
             OperationCancelToken token) where TOperationResult : OperationResult
         {
             var databaseName = _database.Name;
@@ -1989,13 +1995,10 @@ namespace Raven.Server.Documents.Revisions
             // send initial progress
             parameters.OnProgress?.Invoke(result);
 
-            using (var rateGate = maxOpsPerSecond.HasValue
-                       ? new RateGate(maxOpsPerSecond.Value, TimeSpan.FromSeconds(1))
-                       : null)
             foreach (var collection in collections)
             {
                 // we need to reset the last scanned etag for each collection.
-                await PerformRevisionsOperationOnSingleCollectionAsync(collection, ids, sw, createCommand, result, parameters, token);
+                await PerformRevisionsOperationOnSingleCollectionAsync(collection, ids, sw, createCommand, result, parameters, rateGate, token);
 
                 var previous = result.LastProcessedEtags.GetValueOrDefault(databaseName, 0);
                 result.LastProcessedEtags[databaseName] = Math.Max(previous, parameters.LastScannedEtag);
@@ -2005,7 +2008,7 @@ namespace Raven.Server.Documents.Revisions
 
         private async Task PerformRevisionsOperationOnSingleCollectionAsync<TOperationResult>(
             string collection, List<string> ids, Stopwatch sw,
-            Func<List<string>, TOperationResult, RateGate, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
+            Func<List<string>, TOperationResult, OperationCancelToken, RevisionsScanningOperationCommand<TOperationResult>> createCommand,
             TOperationResult result,
             Parameters parameters, RateGate rateGate, OperationCancelToken token)
             where TOperationResult : OperationResult
@@ -2065,7 +2068,7 @@ namespace Raven.Server.Documents.Revisions
                         while (moreWork)
                         {
                             token.ThrowIfCancellationRequested();
-                            var cmd = createCommand(ids, result, rateGate, token);
+                            var cmd = createCommand(ids, result, token);
                             await _database.TxMerger.Enqueue(cmd);
                             moreWork = cmd.MoreWork || cmd.NeedWait;
 
@@ -2379,16 +2382,16 @@ namespace Raven.Server.Documents.Revisions
 
             collections ??= [null]; // revert all collections
 
-                foreach (var collection in collections)
-                {
-                    var list = new List<Document>();
+            foreach (var collection in collections)
+            {
+                var list = new List<Document>();
 
                 await RevertRevisionsInternal(list, collection, parameters, onProgress, result, token);
 
                 var current = result.LastProcessedEtags.TryGetValue(databaseName, out var existing) ? existing : 0;
                 result.LastProcessedEtags[databaseName] = Math.Max(current, parameters.LastScannedEtag);
                 parameters.LastScannedEtag = etagBarrier;
-                }
+            }
 
             return result;
         }
@@ -2860,7 +2863,7 @@ namespace Raven.Server.Documents.Revisions
             {
                 if (table.ReadByKey(cv, out TableValueReader tvr) == false)
                     return null;
-                
+
                 return GetMetrics(table, tvr);
             }
         }
@@ -3048,7 +3051,7 @@ namespace Raven.Server.Documents.Revisions
                 throw new ArgumentException("Data size is invalid, possible corruption when parsing BlittableJsonReaderObject", nameof(size));
 
             BlittableJsonReaderObject.BlittableValidation(context, ptr, size);
-            
+
             var result = new Document
             {
                 StorageId = tvr.Id,

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1906,16 +1906,6 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
-        public Task<IOperationResult> EnforceConfigurationAsync(Action<IOperationProgress> onProgress, OperationCancelToken token)
-        {
-            return EnforceConfigurationAsync(onProgress, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, token);
-        }
-
-        public Task<IOperationResult> EnforceConfigurationAsync(Action<IOperationProgress> onProgress, bool includeForceCreated, OperationCancelToken token)
-        {
-            return EnforceConfigurationAsync(onProgress, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = includeForceCreated }, token);
-        }
-
         public async Task<IOperationResult> EnforceConfigurationAsync(Action<IOperationProgress> onProgress,
             EnforceRevisionsConfigurationOperation.Parameters parameters,
            int? maxOpsPerSecond,

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/AdoptOrphanedRevisionsCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/AdoptOrphanedRevisionsCommand.cs
@@ -3,6 +3,7 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Voron.Util.RateLimiting;
 
 namespace Raven.Server.Documents.TransactionMerger.Commands;
 internal class AdoptOrphanedRevisionsCommand : RevisionsScanningOperationCommand<AdoptOrphanedRevisionsResult>
@@ -11,7 +12,8 @@ internal class AdoptOrphanedRevisionsCommand : RevisionsScanningOperationCommand
         RevisionsStorage revisionsStorage,
         List<string> ids,
         AdoptOrphanedRevisionsResult result,
-        OperationCancelToken token) : base(revisionsStorage, ids, result, token)
+        RateGate rateGate,
+        OperationCancelToken token) : base(revisionsStorage, ids, result, rateGate, token)
     {
         MoreWork = false;
     }
@@ -46,7 +48,7 @@ internal class AdoptOrphanedRevisionsCommand : RevisionsScanningOperationCommand
         
         public AdoptOrphanedRevisionsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            return new AdoptOrphanedRevisionsCommand(_revisionsStorage, _ids, new AdoptOrphanedRevisionsResult(), OperationCancelToken.None);
+            return new AdoptOrphanedRevisionsCommand(_revisionsStorage, _ids, new AdoptOrphanedRevisionsResult(), null, OperationCancelToken.None);
         }
     }
 

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
@@ -3,6 +3,7 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Voron.Util.RateLimiting;
 
 namespace Raven.Server.Documents.TransactionMerger.Commands;
 
@@ -15,7 +16,8 @@ internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOpe
         List<string> ids,
         EnforceConfigurationResult result,
         bool includeForceCreated,
-        OperationCancelToken token) : base(revisionsStorage, ids, result, token)
+        OperationCancelToken token,
+        RateGate rateGate = null) : base(revisionsStorage, ids, result, token, rateGate)
     {
         _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration = includeForceCreated;
     }
@@ -23,9 +25,17 @@ internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOpe
     protected override long ExecuteCmd(DocumentsOperationContext context)
     {
         MoreWork = false;
+        NeedWait = false;
         for (int i = _ids.Count - 1; i >= 0; i--)
         {
             _token.ThrowIfCancellationRequested();
+
+            if (_rateGate != null && _rateGate.WaitToProceed(0) == false)
+            {
+                NeedWait = true;
+                break;
+            }
+
             var moreWork = false;
             _result.RemovedRevisions += (int)_revisionsStorage.EnforceConfigurationFor(context, _ids[i], _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration == false, ref moreWork);
             if (moreWork == false)

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/EnforceRevisionConfigurationCommand.cs
@@ -16,8 +16,8 @@ internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOpe
         List<string> ids,
         EnforceConfigurationResult result,
         bool includeForceCreated,
-        OperationCancelToken token,
-        RateGate rateGate = null) : base(revisionsStorage, ids, result, token, rateGate)
+        RateGate rateGate,
+        OperationCancelToken token) : base(revisionsStorage, ids, result, rateGate, token)
     {
         _includeForceCreatedRevisionsOnDeleteInCaseOfNoConfiguration = includeForceCreated;
     }
@@ -67,7 +67,7 @@ internal sealed class EnforceRevisionConfigurationCommand : RevisionsScanningOpe
 
         public EnforceRevisionConfigurationCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
         {
-            return new EnforceRevisionConfigurationCommand(_revisionsStorage, _ids, new EnforceConfigurationResult(), _includeForceCreated, OperationCancelToken.None);
+            return new EnforceRevisionConfigurationCommand(_revisionsStorage, _ids, new EnforceConfigurationResult(), _includeForceCreated, null, OperationCancelToken.None);
         }
     }
 }

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/RevisionsScanningOperationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/RevisionsScanningOperationCommand.cs
@@ -28,8 +28,8 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
             RevisionsStorage revisionsStorage,
             List<string> ids,
             TOperationResult result,
-            OperationCancelToken token,
-            RateGate rateGate = null)
+            RateGate rateGate,
+            OperationCancelToken token)
         {
             _revisionsStorage = revisionsStorage;
             _ids = ids;

--- a/src/Raven.Server/Documents/TransactionMerger/Commands/RevisionsScanningOperationCommand.cs
+++ b/src/Raven.Server/Documents/TransactionMerger/Commands/RevisionsScanningOperationCommand.cs
@@ -3,6 +3,7 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Server.Documents.Revisions;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
+using Voron.Util.RateLimiting;
 
 namespace Raven.Server.Documents.TransactionMerger.Commands
 {
@@ -11,11 +12,15 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
     {
         public bool MoreWork;
 
+        public bool NeedWait;
+
         protected readonly RevisionsStorage _revisionsStorage;
 
         protected readonly List<string> _ids;
 
         protected readonly OperationCancelToken _token;
+
+        protected readonly RateGate _rateGate;
 
         protected TOperationResult _result;
 
@@ -23,12 +28,14 @@ namespace Raven.Server.Documents.TransactionMerger.Commands
             RevisionsStorage revisionsStorage,
             List<string> ids,
             TOperationResult result,
-            OperationCancelToken token)
+            OperationCancelToken token,
+            RateGate rateGate = null)
         {
             _revisionsStorage = revisionsStorage;
             _ids = ids;
             _result = result;
             _token = token;
+            _rateGate = rateGate;
         }
     }
 }

--- a/src/Raven.Studio/typescript/commands/database/settings/enforceRevisionsConfigurationCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/settings/enforceRevisionsConfigurationCommand.ts
@@ -6,22 +6,25 @@ class enforceRevisionsConfigurationCommand extends commandBase {
     private readonly db: database | string;
     private readonly includeForceCreated: boolean;
     private readonly collections: string[];
-    
-    constructor(db: database | string, includeForceCreated = false, collections: string[] = null) {
+    private readonly maxOpsPerSecond: number;
+
+    constructor(db: database | string, includeForceCreated = false, collections: string[] = null, maxOpsPerSecond: number = null) {
         super();
-        
+
         this.db = db;
         this.includeForceCreated = includeForceCreated;
         this.collections = collections;
+        this.maxOpsPerSecond = maxOpsPerSecond;
     }
 
     execute(): JQueryPromise<operationIdDto> {
         const url = endpoints.databases.adminRevisions.adminRevisionsConfigEnforce;
-        
+
         const args:  Raven.Client.Documents.Operations.Revisions.EnforceRevisionsConfigurationOperation.Parameters = {
             IncludeForceCreated: this.includeForceCreated,
             Collections: this.collections ?? undefined,
-            ContinuationParameters: undefined
+            ContinuationParameters: undefined,
+            MaxOpsPerSecond: this.maxOpsPerSecond ?? undefined
         };
 
         return this.post<void>(url, JSON.stringify(args), this.db)

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -126,7 +126,7 @@ export default function DocumentRevisions() {
     });
 
     const asyncEnforceRevisionsConfiguration = useAsyncCallback(
-        async (includeForceCreated: boolean, collections: string[], maxOpsPerSecond: number) => {
+        async (includeForceCreated: boolean, collections: string[], maxOpsPerSecond: number | null) => {
             const dto = await databasesService.enforceRevisionsConfiguration(
                 databaseName,
                 includeForceCreated,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/DocumentRevisions.tsx
@@ -126,11 +126,12 @@ export default function DocumentRevisions() {
     });
 
     const asyncEnforceRevisionsConfiguration = useAsyncCallback(
-        async (includeForceCreated: boolean, collections: string[]) => {
+        async (includeForceCreated: boolean, collections: string[], maxOpsPerSecond: number) => {
             const dto = await databasesService.enforceRevisionsConfiguration(
                 databaseName,
                 includeForceCreated,
-                collections
+                collections,
+                maxOpsPerSecond
             );
 
             notificationCenter.instance.openDetailsForOperationById(

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
@@ -69,6 +69,7 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
                             type="number"
                             placeholder="No limit"
                             min={1}
+                            step={1}
                             {...register("maxOpsPerSecond", { valueAsNumber: true })}
                             isInvalid={!!formState.errors.maxOpsPerSecond}
                             disabled={formState.isSubmitting}
@@ -77,7 +78,7 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
                             {formState.errors.maxOpsPerSecond?.message}
                         </Form.Control.Feedback>
                         <Form.Text className="text-muted">
-                            Limits the number of revisions processed per second. Leave empty for no limit.
+                            Limits the number of documents processed per second. Leave empty for no limit.
                         </Form.Text>
                     </Form.Group>
                     <hr />
@@ -133,6 +134,7 @@ const schema = yup.object({
         .number()
         .nullable()
         .transform((value) => (isNaN(value) ? null : value))
+        .integer("Max operations per second must be a whole number")
         .min(1, "Max operations per second must be greater than 0"),
 });
 

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
@@ -7,10 +7,11 @@ import { SubmitHandler, useForm, useWatch } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { collectionsTrackerSelectors } from "components/common/shell/collectionsTrackerSlice";
 import FormCollectionsSelect from "components/common/FormCollectionsSelect";
-import { FormSwitch } from "components/common/Form";
+import { FormGroup, FormInput, FormSwitch, FormLabel } from "components/common/Form";
 import RichAlert from "components/common/RichAlert";
 import Button from "react-bootstrap/Button";
 import Modal from "components/common/Modal";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 
 interface EnforceConfigurationProps {
     toggle: () => void;
@@ -22,7 +23,7 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
 
     const allCollectionNames = useAppSelector(collectionsTrackerSelectors.collectionNames);
 
-    const { control, formState, setValue, handleSubmit, register } = useForm<FormData>({
+    const { control, formState, setValue, handleSubmit } = useForm<FormData>({
         resolver: formResolver,
         defaultValues: {
             isIncludeForceCreated: false,
@@ -63,25 +64,16 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
                     >
                         Include Force Created Revisions
                     </FormSwitch>
-                    <Form.Group className="mt-2">
-                        <Form.Label>Max operations per second</Form.Label>
-                        <Form.Control
-                            type="number"
-                            placeholder="No limit"
-                            min={1}
-                            step={1}
-                            {...register("maxOpsPerSecond", { valueAsNumber: true })}
-                            isInvalid={!!formState.errors.maxOpsPerSecond}
-                            disabled={formState.isSubmitting}
-                        />
-                        <Form.Control.Feedback type="invalid">
-                            {formState.errors.maxOpsPerSecond?.message}
-                        </Form.Control.Feedback>
-                        <Form.Text className="text-muted">
-                            Limits the number of documents processed per second. Leave empty for no limit.
-                        </Form.Text>
-                    </Form.Group>
-                    <hr />
+                    <FormGroup marginClass="m-0">
+                        <FormLabel>
+                            Max operations per second
+                            <PopoverWithHoverWrapper message="Limits the number of documents processed per second. Leave empty for no limit.">
+                                <Icon icon="info-new" margin="ms-1" />
+                            </PopoverWithHoverWrapper>
+                        </FormLabel>
+                        <FormInput type="number" placeholder="No limit" control={control} name="maxOpsPerSecond" />
+                    </FormGroup>
+                    <hr className="my-1" />
                     <p>
                         Clicking <strong>Enforce</strong> will enforce the current revision configuration definitions{" "}
                         <strong>on all existing revisions</strong> in the database per collection.
@@ -130,12 +122,7 @@ const schema = yup.object({
             is: false,
             then: (schema) => schema.min(1),
         }),
-    maxOpsPerSecond: yup
-        .number()
-        .nullable()
-        .transform((value) => (isNaN(value) ? null : value))
-        .integer("Max operations per second must be a whole number")
-        .min(1, "Max operations per second must be greater than 0"),
+    maxOpsPerSecond: yup.number().nullable().integer().min(1),
 });
 
 const formResolver = yupResolver(schema);

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
@@ -14,7 +14,7 @@ import Modal from "components/common/Modal";
 
 interface EnforceConfigurationProps {
     toggle: () => void;
-    onConfirm: (includeForceCreated: boolean, collections: string[], maxOpsPerSecond: number) => Promise<void>;
+    onConfirm: (includeForceCreated: boolean, collections: string[], maxOpsPerSecond: number | null) => Promise<void>;
 }
 
 export default function EnforceConfiguration(props: EnforceConfigurationProps) {

--- a/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/documentRevisions/EnforceConfiguration.tsx
@@ -14,7 +14,7 @@ import Modal from "components/common/Modal";
 
 interface EnforceConfigurationProps {
     toggle: () => void;
-    onConfirm: (includeForceCreated: boolean, collections: string[]) => Promise<void>;
+    onConfirm: (includeForceCreated: boolean, collections: string[], maxOpsPerSecond: number) => Promise<void>;
 }
 
 export default function EnforceConfiguration(props: EnforceConfigurationProps) {
@@ -22,12 +22,13 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
 
     const allCollectionNames = useAppSelector(collectionsTrackerSelectors.collectionNames);
 
-    const { control, formState, setValue, handleSubmit } = useForm<FormData>({
+    const { control, formState, setValue, handleSubmit, register } = useForm<FormData>({
         resolver: formResolver,
         defaultValues: {
             isIncludeForceCreated: false,
             isAllCollections: false,
             collections: [],
+            maxOpsPerSecond: null,
         },
     });
 
@@ -36,7 +37,7 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
     const onEnforce: SubmitHandler<FormData> = (formData) => {
         const formCollections = formData.isAllCollections ? null : formData.collections;
 
-        onConfirm(formData.isIncludeForceCreated, formCollections);
+        onConfirm(formData.isIncludeForceCreated, formCollections, formData.maxOpsPerSecond);
         toggle();
     };
 
@@ -62,6 +63,23 @@ export default function EnforceConfiguration(props: EnforceConfigurationProps) {
                     >
                         Include Force Created Revisions
                     </FormSwitch>
+                    <Form.Group className="mt-2">
+                        <Form.Label>Max operations per second</Form.Label>
+                        <Form.Control
+                            type="number"
+                            placeholder="No limit"
+                            min={1}
+                            {...register("maxOpsPerSecond", { valueAsNumber: true })}
+                            isInvalid={!!formState.errors.maxOpsPerSecond}
+                            disabled={formState.isSubmitting}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {formState.errors.maxOpsPerSecond?.message}
+                        </Form.Control.Feedback>
+                        <Form.Text className="text-muted">
+                            Limits the number of revisions processed per second. Leave empty for no limit.
+                        </Form.Text>
+                    </Form.Group>
                     <hr />
                     <p>
                         Clicking <strong>Enforce</strong> will enforce the current revision configuration definitions{" "}
@@ -111,6 +129,11 @@ const schema = yup.object({
             is: false,
             then: (schema) => schema.min(1),
         }),
+    maxOpsPerSecond: yup
+        .number()
+        .nullable()
+        .transform((value) => (isNaN(value) ? null : value))
+        .min(1, "Max operations per second must be greater than 0"),
 });
 
 const formResolver = yupResolver(schema);

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -207,18 +207,8 @@ export default class DatabasesService {
         return new saveRevisionsBinCleanerConfigurationCommand(...args).execute();
     }
 
-    async enforceRevisionsConfiguration(
-        databaseName: string,
-        includeForceCreated = false,
-        collections: string[] = null,
-        maxOpsPerSecond: number = null
-    ) {
-        return new enforceRevisionsConfigurationCommand(
-            databaseName,
-            includeForceCreated,
-            collections,
-            maxOpsPerSecond
-        ).execute();
+    async enforceRevisionsConfiguration(...args: ConstructorParameters<typeof enforceRevisionsConfigurationCommand>) {
+        return new enforceRevisionsConfigurationCommand(...args).execute();
     }
 
     async revertRevisions(databaseName: string, dto: Raven.Server.Documents.Revisions.RevertRevisionsRequest) {

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -210,9 +210,10 @@ export default class DatabasesService {
     async enforceRevisionsConfiguration(
         databaseName: string,
         includeForceCreated = false,
-        collections: string[] = null
+        collections: string[] = null,
+        maxOpsPerSecond: number = null
     ) {
-        return new enforceRevisionsConfigurationCommand(databaseName, includeForceCreated, collections).execute();
+        return new enforceRevisionsConfigurationCommand(databaseName, includeForceCreated, collections, maxOpsPerSecond).execute();
     }
 
     async revertRevisions(databaseName: string, dto: Raven.Server.Documents.Revisions.RevertRevisionsRequest) {

--- a/src/Raven.Studio/typescript/components/services/DatabasesService.ts
+++ b/src/Raven.Studio/typescript/components/services/DatabasesService.ts
@@ -213,7 +213,12 @@ export default class DatabasesService {
         collections: string[] = null,
         maxOpsPerSecond: number = null
     ) {
-        return new enforceRevisionsConfigurationCommand(databaseName, includeForceCreated, collections, maxOpsPerSecond).execute();
+        return new enforceRevisionsConfigurationCommand(
+            databaseName,
+            includeForceCreated,
+            collections,
+            maxOpsPerSecond
+        ).execute();
     }
 
     async revertRevisions(databaseName: string, dto: Raven.Server.Documents.Revisions.RevertRevisionsRequest) {

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -810,7 +810,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -831,7 +831,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -894,7 +894,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -910,7 +910,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -959,7 +959,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -810,7 +810,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -831,7 +831,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -894,7 +894,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -910,7 +910,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -959,7 +959,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
+++ b/test/FastTests/Server/Documents/Revisions/RevisionsTests.cs
@@ -810,7 +810,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -831,7 +831,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -894,7 +894,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -910,7 +910,7 @@ namespace FastTests.Server.Documents.Revisions
                 await RevisionsHelper.SetupRevisionsAsync(store, configuration: configuration);
 
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 for (int i = 0; i < 10; i++)
                 {
@@ -959,7 +959,7 @@ namespace FastTests.Server.Documents.Revisions
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
@@ -1259,7 +1259,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
-                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
             using (var s = hubStore.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
@@ -13,6 +13,7 @@ using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Documents.Operations.Replication;
+using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Documents.Smuggler;
@@ -1259,7 +1260,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
-                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
             using (var s = hubStore.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests.Issues/Issues/FilteredReplicationTests.cs
@@ -1259,7 +1259,7 @@ namespace SlowTests.Issues
             Assert.True(WaitForDocument<Propagation>(sinkStore1, "foo", x => x.Completed == true));
 
             using (var token = new OperationCancelToken(hubDb.Configuration.Databases.OperationTimeout.AsTimeSpan, hubDb.DatabaseShutdown, CancellationToken.None))
-                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                await hubDb.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
             using (var s = hubStore.OpenAsyncSession())
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-16961.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16961.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
                 var db = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
                 }
 
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
@@ -118,7 +118,7 @@ namespace SlowTests.Issues
                 var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
                 IOperationResult enforceResult;
                 using (var token = new OperationCancelToken(db1.Configuration.Databases.OperationTimeout.AsTimeSpan, db1.DatabaseShutdown, CancellationToken.None))
-                    enforceResult = await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    enforceResult = await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 var val = await WaitForValueAsync(() =>
                     {
@@ -207,7 +207,7 @@ namespace SlowTests.Issues
 
                 var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 await UpdateConflictResolver(store1, resolveToLatest: true);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-16961.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16961.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
                 var db = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
                 }
 
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
@@ -118,7 +118,7 @@ namespace SlowTests.Issues
                 var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
                 IOperationResult enforceResult;
                 using (var token = new OperationCancelToken(db1.Configuration.Databases.OperationTimeout.AsTimeSpan, db1.DatabaseShutdown, CancellationToken.None))
-                    enforceResult = await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    enforceResult = await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 var val = await WaitForValueAsync(() =>
                     {
@@ -207,7 +207,7 @@ namespace SlowTests.Issues
 
                 var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 await UpdateConflictResolver(store1, resolveToLatest: true);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-16961.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-16961.cs
@@ -52,7 +52,7 @@ namespace SlowTests.Issues
                 var db = await GetDocumentDatabaseInstanceForAsync(store, options.DatabaseMode, "users/1");
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
                 }
 
                 using (db.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
@@ -118,7 +118,7 @@ namespace SlowTests.Issues
                 var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
                 IOperationResult enforceResult;
                 using (var token = new OperationCancelToken(db1.Configuration.Databases.OperationTimeout.AsTimeSpan, db1.DatabaseShutdown, CancellationToken.None))
-                    enforceResult = await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    enforceResult = await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 var val = await WaitForValueAsync(() =>
                     {
@@ -207,7 +207,7 @@ namespace SlowTests.Issues
 
                 var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "users/1");
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 await UpdateConflictResolver(store1, resolveToLatest: true);
 

--- a/test/SlowTests.Issues/Issues/RavenDB-20425.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-20425.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Issues
         {
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
             using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated, token: token);
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated, collections: null, maxOpsPerSecond: null, token: token);
         }
 
         private async Task UpdateDoc(DocumentStore store, string docId)

--- a/test/SlowTests.Issues/Issues/RavenDB-20425.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-20425.cs
@@ -58,7 +58,7 @@ namespace SlowTests.Issues
         {
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
             using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated, collections: null, maxOpsPerSecond: null, token: token);
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = includeForceCreated }, maxOpsPerSecond: null, token);
         }
 
         private async Task UpdateDoc(DocumentStore store, string docId)

--- a/test/SlowTests.Issues/Issues/RavenDB-20846.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-20846.cs
@@ -87,7 +87,7 @@ public class RavenDB_20846 : ClusterTestBase
 
         var db = await Databases.GetDocumentDatabaseInstanceFor(store);
         using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false, Collections = new[] { "Users", "Products" } }, token);
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false, Collections = new[] { "Users", "Products" } }, maxOpsPerSecond: null, token);
 
         using (var session = store.OpenAsyncSession())
         {

--- a/test/SlowTests.Issues/Issues/RavenDB-21382.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21382.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Issues
             }
 
             using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
-                await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, false, token: token);
+                await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collections: null, maxOpsPerSecond: null, token: token);
 
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-21382.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21382.cs
@@ -63,7 +63,7 @@ namespace SlowTests.Issues
             }
 
             using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
-                await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: false, collections: null, maxOpsPerSecond: null, token: token);
+                await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false }, maxOpsPerSecond: null, token);
 
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB-21569.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21569.cs
@@ -54,7 +54,7 @@ public class RavenDB_21569 : RavenTestBase
         await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
 
         using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
-            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
         using (var session = store.OpenAsyncSession())
         {
@@ -99,7 +99,7 @@ public class RavenDB_21569 : RavenTestBase
         await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
 
         using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
-            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
         using (var session = store.OpenAsyncSession())
         {

--- a/test/SlowTests.Issues/Issues/RavenDB-21569.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-21569.cs
@@ -54,7 +54,7 @@ public class RavenDB_21569 : RavenTestBase
         await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
 
         using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
-            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, true, token: token);
+            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
         using (var session = store.OpenAsyncSession())
         {
@@ -99,7 +99,7 @@ public class RavenDB_21569 : RavenTestBase
         await RevisionsHelper.SetupRevisionsAsync(store, Server.ServerStore, configuration: configuration);
 
         using (var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown, CancellationToken.None))
-            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, true, token: token);
+            await database.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
         using (var session = store.OpenAsyncSession())
         {

--- a/test/SlowTests.Issues/Issues/RavenDB-23728.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-23728.cs
@@ -173,7 +173,7 @@ namespace SlowTests.Issues
             var db = await Databases.GetDocumentDatabaseInstanceFor(store);
             using (var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(timeout)))
             using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, cts.Token, db.DatabaseShutdown))
-                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false, Collections = collections?.ToArray() }, token);
+                await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false, Collections = collections?.ToArray() }, maxOpsPerSecond: null, token);
         }
 
         private class User

--- a/test/SlowTests.Issues/Issues/RavenDB_21780.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21780.cs
@@ -55,7 +55,7 @@ public class RavenDB_21780 : ClusterTestBase
         // enforce
         var db = await Databases.GetDocumentDatabaseInstanceFor(Server, store);
         using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true, Collections = new[] { "Users" } }, token);
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true, Collections = new[] { "Users" } }, maxOpsPerSecond: null, token);
 
 
         using (var session = store.OpenAsyncSession())

--- a/test/SlowTests.Issues/Issues/RavenDB_21934.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_21934.cs
@@ -64,7 +64,7 @@ public class RavenDB_21934 : RavenTestBase
 
         var db = await Databases.GetDocumentDatabaseInstanceFor(store);
         using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true, Collections = collections.ToArray() }, token);
+            await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true, Collections = collections.ToArray() }, maxOpsPerSecond: null, token);
 
         using (var session = store.OpenAsyncSession())
         {

--- a/test/SlowTests.Issues/Issues/RavenDB_26054.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26054.cs
@@ -7,7 +7,6 @@ using Raven.Client.Documents.Operations.Revisions;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace SlowTests.Issues
 {

--- a/test/SlowTests.Issues/Issues/RavenDB_26054.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26054.cs
@@ -17,11 +17,10 @@ namespace SlowTests.Issues
         {
         }
 
-        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
-        public async Task EnforceRevisionsConfigurationWithThrottling(Options options)
+        [RavenFact(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
+        public async Task EnforceRevisionsConfigurationWithThrottling()
         {
-            using (var store = GetDocumentStore(options))
+            using (var store = GetDocumentStore())
             {
                 await RevisionsHelper.SetupRevisionsAsync(store, modifyConfiguration: configuration =>
                     configuration.Collections["Users"].PurgeOnDelete = false);

--- a/test/SlowTests.Issues/Issues/RavenDB_26054.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26054.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Utils;
+using Raven.Client.Documents.Operations.Revisions;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26054 : RavenTestBase
+    {
+        public RavenDB_26054(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Revisions, LicenseRequired = true)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public async Task EnforceRevisionsConfigurationWithThrottling(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                await RevisionsHelper.SetupRevisionsAsync(store, modifyConfiguration: configuration =>
+                    configuration.Collections["Users"].PurgeOnDelete = false);
+
+                // Create 30 documents, each with 2 revisions (initial + 1 update)
+                for (int i = 0; i < 30; i++)
+                {
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new User { Name = $"User{i}" }, $"users/{i}");
+                        await session.SaveChangesAsync();
+                    }
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        var user = await session.LoadAsync<User>($"users/{i}");
+                        user.Name = $"User{i}_updated";
+                        await session.SaveChangesAsync();
+                    }
+                }
+
+                // Change config to keep max 1 revision
+                await RevisionsHelper.SetupRevisionsAsync(store, modifyConfiguration: configuration =>
+                {
+                    configuration.Collections["Users"].PurgeOnDelete = false;
+                    configuration.Collections["Users"].MinimumRevisionsToKeep = 1;
+                });
+
+                // Enforce with MaxOpsPerSecond = 10
+                var sw = Stopwatch.StartNew();
+                var result = await store.Operations.SendAsync(
+                    new EnforceRevisionsConfigurationOperation(new EnforceRevisionsConfigurationOperation.Parameters
+                    {
+                        MaxOpsPerSecond = 10
+                    }));
+                var operationResult = (EnforceConfigurationResult)await result.WaitForCompletionAsync();
+                sw.Stop();
+
+                // 30 doc IDs at 10/sec → should take > 1 second
+                Assert.True(sw.Elapsed > TimeSpan.FromSeconds(1),
+                    $"Expected operation to take more than 1 second due to throttling, but took {sw.Elapsed}");
+
+                Assert.Equal(30, operationResult.ScannedDocuments);
+                Assert.Equal(30, operationResult.RemovedRevisions);
+            }
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RravenDB-16949.cs
+++ b/test/SlowTests.Issues/Issues/RravenDB-16949.cs
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RravenDB-16949.cs
+++ b/test/SlowTests.Issues/Issues/RravenDB-16949.cs
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests.Issues/Issues/RravenDB-16949.cs
+++ b/test/SlowTests.Issues/Issues/RravenDB-16949.cs
@@ -227,7 +227,7 @@ namespace SlowTests.Issues
 
                 var db = await Databases.GetDocumentDatabaseInstanceFor(store);
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
                 WaitForUserToContinueTheTest(store);
                 using (var session = store.OpenAsyncSession())
                 {

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -307,7 +307,7 @@ namespace SlowTests.Server.Documents.Revisions
                 var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var dbName = db.Name;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 await EnsureReplicatingAsync(store1, store2);
 

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -307,7 +307,7 @@ namespace SlowTests.Server.Documents.Revisions
                 var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var dbName = db.Name;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
 
@@ -972,7 +972,7 @@ namespace SlowTests.Server.Documents.Revisions
                 EnforceConfigurationResult result;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, token: token);
+                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
                 }
 
                 Assert.Equal(11, result.ScannedRevisions);

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsReplication.cs
@@ -307,7 +307,7 @@ namespace SlowTests.Server.Documents.Revisions
                 var db = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var dbName = db.Name;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
-                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(_ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
 
@@ -972,7 +972,7 @@ namespace SlowTests.Server.Documents.Revisions
                 EnforceConfigurationResult result;
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
-                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                    result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
                 }
 
                 Assert.Equal(11, result.ScannedRevisions);

--- a/test/SlowTests/Server/Documents/Revisions/RevisionsStartFromEtagTests.cs
+++ b/test/SlowTests/Server/Documents/Revisions/RevisionsStartFromEtagTests.cs
@@ -77,7 +77,7 @@ namespace SlowTests.Server.Documents.Revisions
                                 EtagBarriers = new Dictionary<string, long> { [db.Name] = etagBarrier },
                                 NodeTags = new Dictionary<string, string> { [db.Name] = db.ServerStore.NodeTag }
                             }
-                        }, token);
+                        }, maxOpsPerSecond: null, token);
                 }
 
                 using (var session = store.OpenAsyncSession(new Raven.Client.Documents.Session.SessionOptions { NoCaching = true }))
@@ -753,7 +753,7 @@ namespace SlowTests.Server.Documents.Revisions
                 using (var token = new OperationCancelToken(db.Configuration.Databases.OperationTimeout.AsTimeSpan, db.DatabaseShutdown, CancellationToken.None))
                 {
                     result = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(
-                        _ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false }, token);
+                        _ => { }, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false }, maxOpsPerSecond: null, token);
                 }
 
                 Assert.Equal(1, result.ScannedDocuments);
@@ -806,7 +806,7 @@ namespace SlowTests.Server.Documents.Revisions
                             IncludeForceCreated = false,
                             Collections = new[] { "Companies" }
                         },
-                        token);
+                        maxOpsPerSecond: null, token);
                 }
 
                 Assert.True(firstResult.RemovedRevisions > 0, "First run should have trimmed Companies revisions");
@@ -842,7 +842,7 @@ namespace SlowTests.Server.Documents.Revisions
                                 NodeTags = new Dictionary<string, string>(firstResult.NodeTags)
                             }
                         },
-                        token);
+                        maxOpsPerSecond: null, token);
                 }
 
                 // The resumed run must have trimmed Users and Orders
@@ -1058,7 +1058,7 @@ namespace SlowTests.Server.Documents.Revisions
                     firstResult = (EnforceConfigurationResult)await db.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(
                         _ => { },
                         new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = false },
-                        token);
+                        maxOpsPerSecond: null, token);
                 }
 
                 Assert.True(firstResult.NodeTags.ContainsKey(store.Database), "NodeTags should contain an entry for the database");
@@ -1079,7 +1079,7 @@ namespace SlowTests.Server.Documents.Revisions
                                 NodeTags = new Dictionary<string, string>(firstResult.NodeTags)
                             }
                         },
-                        token);
+                        maxOpsPerSecond: null, token);
                 }
 
                 // Resume with wrong NodeTags — should throw InvalidOperationException
@@ -1098,7 +1098,7 @@ namespace SlowTests.Server.Documents.Revisions
                                 NodeTags = new Dictionary<string, string> { [store.Database] = "Z" } // fake node tag
                             }
                         },
-                        token);
+                        maxOpsPerSecond: null, token);
                 });
 
                 Assert.Contains("node 'Z'", ex.Message);

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -388,7 +388,7 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
-                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, token);
+                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -388,7 +388,7 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
-                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token);
+                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);

--- a/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
+++ b/test/SlowTests/Server/Replication/ReplicationOfConflicts.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Revisions;
 using Raven.Client.Exceptions.Documents;
 using Raven.Client.Http;
 using Raven.Server.Documents;
@@ -388,7 +389,7 @@ namespace SlowTests.Server.Replication
 
                 var db1 = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, "foo/bar");
                 var token = new OperationCancelToken(TimeSpan.FromSeconds(60), CancellationToken.None, CancellationToken.None);
-                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, includeForceCreated: true, collections: null, maxOpsPerSecond: null, token: token);
+                await db1.DocumentsStorage.RevisionsStorage.EnforceConfigurationAsync(onProgress: null, new EnforceRevisionsConfigurationOperation.Parameters { IncludeForceCreated = true }, maxOpsPerSecond: null, token);
 
                 await EnsureReplicatingAsync(store1, store2);
                 await EnsureReplicatingAsync(store2, store3);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26054

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
