### PR TITLE
RavenDB-26091 Corax: Configurable NULL order in sorting

### DIFF
--- a/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
@@ -242,7 +242,7 @@ namespace Voron.Benchmark.Corax
             var ageField = FieldMetadata.Build(_ageSlice, default, 2, default, default);
             var ageTerm = _indexSearcher.StartWithQuery(ageField, _ageValueSlice);
             var andQuery = _indexSearcher.And(typeTerm, ageTerm);
-            var query = _indexSearcher.OrderBy(andQuery, new OrderMetadata(ageField, true, MatchCompareFieldType.Sequence), take: TakeSize);           
+            var query = _indexSearcher.OrderBy(andQuery, new OrderMetadata(ageField, true, MatchCompareFieldType.Sequence), nullFirst: true, take: TakeSize);           
 
             Span<long> ids = _ids;
             while (query.Fill(ids) != 0)

--- a/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
+++ b/bench/Voron.Benchmark/Corax/OrderByBenchmark.cs
@@ -242,7 +242,7 @@ namespace Voron.Benchmark.Corax
             var ageField = FieldMetadata.Build(_ageSlice, default, 2, default, default);
             var ageTerm = _indexSearcher.StartWithQuery(ageField, _ageValueSlice);
             var andQuery = _indexSearcher.And(typeTerm, ageTerm);
-            var query = _indexSearcher.OrderBy(andQuery, new OrderMetadata(ageField, true, MatchCompareFieldType.Sequence), nullFirst: true, take: TakeSize);           
+            var query = _indexSearcher.OrderBy(andQuery, new OrderMetadata(ageField, true, MatchCompareFieldType.Sequence, fieldHasNoTerms: false), nullFirst: true, take: TakeSize);           
 
             Span<long> ids = _ids;
             while (query.Fill(ids) != 0)

--- a/src/Corax/Querying/IndexSearcher.Sorting.cs
+++ b/src/Corax/Querying/IndexSearcher.Sorting.cs
@@ -10,10 +10,10 @@ public unsafe partial class IndexSearcher
 {
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public SortingMatch OrderBy<TInner>(in TInner set, OrderMetadata metadata, int take = Constants.IndexSearcher.TakeAll, in CancellationToken token = default)
+    public SortingMatch OrderBy<TInner>(in TInner set, OrderMetadata metadata, bool nullFirst, int take = Constants.IndexSearcher.TakeAll, in CancellationToken token = default)
         where TInner : IQueryMatch
     {
-        return SortingMatch.Create(new SortingMatch<TInner>(this,  set, metadata, token, take));
+        return SortingMatch.Create(new SortingMatch<TInner>(this,  set, metadata, token, nullFirst, take));
     }
     
         

--- a/src/Corax/Querying/IndexSearcher.Sorting.cs
+++ b/src/Corax/Querying/IndexSearcher.Sorting.cs
@@ -18,10 +18,10 @@ public unsafe partial class IndexSearcher
     
         
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public SortingMultiMatch OrderBy<TInner>(in TInner set, OrderMetadata[] metadata,
+    public SortingMultiMatch OrderBy<TInner>(in TInner set, OrderMetadata[] metadata, bool nullFirst,
         int take = Constants.IndexSearcher.TakeAll, in CancellationToken token = default)
         where TInner : IQueryMatch
     {
-        return SortingMultiMatch.Create(new SortingMultiMatch<TInner>(this,  set, metadata, take, token: token));
+        return SortingMultiMatch.Create(new SortingMultiMatch<TInner>(this,  set, metadata, nullFirst, take, token: token));
     }
 }

--- a/src/Corax/Querying/IndexSearcher.TermMatch.cs
+++ b/src/Corax/Querying/IndexSearcher.TermMatch.cs
@@ -241,7 +241,7 @@ public partial class IndexSearcher
         {
             if (termAsSpan.SequenceEqual(Constants.NullValueSpan))
             {
-                if (TryGetPostingListForNull(tree.Name, out containerId))
+                if (TryGetPostingListForNull(tree.Name, out containerId, out _))
                     return NumberOfDocumentsUnderSpecificTerm(containerId);
             }
             

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -57,6 +57,13 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private EntryIdPaginationSupportStatus? _entryIdPaginationSupportStatus;
 
     private long? _lastEntryId;
+    
+    /// <summary>
+    /// Used for testing purposes only.
+    /// </summary>
+    internal CoraxTestingConfiguration _testingConfiguration;
+
+    public void SetTestingConfiguration(CoraxTestingConfiguration testingConfiguration) => _testingConfiguration = testingConfiguration;
 
     
     public long LastEntryId

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -525,18 +525,20 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryGetPostingListForNonExisting(in FieldMetadata field, out long postingListId) => TryGetPostingListForNonExisting(field.FieldName, out postingListId);
+    internal bool TryGetPostingListForNonExisting(in FieldMetadata field, out long postingListId) => TryGetPostingListForNonExisting(field.FieldName, out postingListId, out _);
     
-    private bool TryGetPostingListForNonExisting(Slice name, out long postingListId)
+    internal bool TryGetPostingListForNonExisting(Slice name, out long postingListId, out long termContainerId)
     {
         InitNonExistingPostingList();
         var result = _nonExistingPostingListsTree?.ReadStructure<(long PostingListId, long TermContainerId)>(name);
         if (result == null)
         {
             postingListId = -1;
+            termContainerId = -1;
             return false;
         }
         postingListId = result.Value.PostingListId;
+        termContainerId = result.Value.TermContainerId;
         return true;
     }
     
@@ -550,18 +552,21 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal bool TryGetPostingListForNull(in FieldMetadata field, out long postingListId) => TryGetPostingListForNull(field.FieldName, out postingListId);
+    internal bool TryGetPostingListForNull(in FieldMetadata field, out long postingListId) => TryGetPostingListForNull(field.FieldName, out postingListId, out _);
     
-    private bool TryGetPostingListForNull(Slice name, out long postingListId)
+    internal bool TryGetPostingListForNull(Slice name, out long postingListId, out long termContainerId)
     {
         InitNullPostingList();
         var result = _nullPostingListsTree?.ReadStructure<(long PostingListId, long TermContainerId)>(name);
         if (result == null)
         {
             postingListId = -1;
+            termContainerId = -1;
             return false;
         }
+        
         postingListId = result.Value.PostingListId;
+        termContainerId = result.Value.TermContainerId;
         return true;
     }
 
@@ -575,17 +580,17 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IncludeNullMatch<TInner> IncludeNullMatch<TInner>(in FieldMetadata field, in TInner inner, bool forward)
+    public IncludeNullMatch<TInner> IncludeNullMatch<TInner>(in FieldMetadata field, in TInner inner, bool forward, bool nullFirsts)
         where TInner : IQueryMatch
     {
-        return new IncludeNullMatch<TInner>(this, inner, field, forward);
+        return new IncludeNullMatch<TInner>(this, inner, field, forward, nullFirsts);
     }
     
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IncludeNonExistingMatch<TInner> IncludeNonExistingMatch<TInner>(in FieldMetadata field, in TInner inner, bool forward)
+    public IncludeNonExistingMatch<TInner> IncludeNonExistingMatch<TInner>(in FieldMetadata field, in TInner inner, bool forward, bool nullFirsts)
         where TInner : IQueryMatch
     {
-        return new IncludeNonExistingMatch<TInner>(this, inner, field, forward);
+        return new IncludeNonExistingMatch<TInner>(this, inner, field, forward, nullFirsts);
     }
 
     public DeduplicationMatch<TInner> DeduplicationMatch<TInner>(in TInner inner, bool forceHashset = false) 

--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -30,13 +30,6 @@ namespace Corax.Querying;
 
 public sealed unsafe partial class IndexSearcher : IDisposable
 {
-    /// <summary>
-    /// Used for testing purposes only.
-    /// </summary>
-    private CoraxTestingConfiguration _testingConfiguration;
-
-    public void SetTestingConfiguration(CoraxTestingConfiguration testingConfiguration) => _testingConfiguration = testingConfiguration;
-    
     internal static readonly long BitmapMemoryRequiredThresholdInBytes = new Size(32, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);
     internal readonly Transaction _transaction;
     private Dictionary<string, Slice> _dynamicFieldNameMapping;

--- a/src/Corax/Querying/Matches/IncludeNonExistingMatch.cs
+++ b/src/Corax/Querying/Matches/IncludeNonExistingMatch.cs
@@ -12,12 +12,14 @@ public struct IncludeNonExistingMatch<TInner> : IQueryMatch
     where TInner : IQueryMatch
 {
     private readonly bool _forward;
+    private readonly bool _nullFirsts;
     private bool _hasLeftNonExisting;
     private bool _innerEnd = false;
     private PostingList.Iterator _postingListIterator;
-    public IncludeNonExistingMatch(Querying.IndexSearcher searcher, in TInner inner, in FieldMetadata field, bool forward)
+    public IncludeNonExistingMatch(Querying.IndexSearcher searcher, in TInner inner, in FieldMetadata field, bool forward, bool nullFirsts)
     {
         _forward = forward;
+        _nullFirsts = nullFirsts;
         _inner = inner;
         
         _hasLeftNonExisting = searcher.TryGetPostingListForNonExisting(in field, out var postingListId);
@@ -42,12 +44,14 @@ public struct IncludeNonExistingMatch<TInner> : IQueryMatch
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Fill(Span<long> matches)
     {
-        return _forward ? 
-            ForwardStreaming(matches) 
-            : BackwardStreaming(matches);
+        bool nullsFirst = _forward ? _nullFirsts : !_nullFirsts;
+        
+        return nullsFirst 
+            ? NullFirstStreaming(matches) 
+            : NullLastStreaming(matches);
     }
 
-    private int BackwardStreaming(Span<long> matches)
+    private int NullLastStreaming(Span<long> matches)
     {
         int read;
         if (_innerEnd == false)
@@ -62,7 +66,7 @@ public struct IncludeNonExistingMatch<TInner> : IQueryMatch
         return read;
     }
 
-    private int ForwardStreaming(Span<long> matches)
+    private int NullFirstStreaming(Span<long> matches)
     {
         if (FetchNonExisting(matches, out int read))
         {

--- a/src/Corax/Querying/Matches/IncludeNullMatch.cs
+++ b/src/Corax/Querying/Matches/IncludeNullMatch.cs
@@ -12,12 +12,14 @@ public struct IncludeNullMatch<TInner> : IQueryMatch
 where TInner : IQueryMatch
 {
     private readonly bool _forward;
+    private readonly bool _nullFirsts;
     private bool _hasLeftNulls;
     private bool _innerEnd = false;
     private PostingList.Iterator _postingListIterator;
-    public IncludeNullMatch(Querying.IndexSearcher searcher, in TInner inner, in FieldMetadata field, bool forward)
+    public IncludeNullMatch(Querying.IndexSearcher searcher, in TInner inner, in FieldMetadata field, bool forward, bool nullFirsts)
     {
         _forward = forward;
+        _nullFirsts = nullFirsts;
         _inner = inner;
         
         _hasLeftNulls = searcher.TryGetPostingListForNull(in field, out var postingListId);
@@ -42,12 +44,14 @@ where TInner : IQueryMatch
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Fill(Span<long> matches)
     {
-        return _forward ? 
-            ForwardStreaming(matches) 
-            : BackwardStreaming(matches);
+        bool nullsFirst = _forward ? _nullFirsts : !_nullFirsts;
+        
+        return nullsFirst 
+            ? NullFirstStreaming(matches) 
+            : NullLastStreaming(matches);
     }
 
-    private int BackwardStreaming(Span<long> matches)
+    private int NullLastStreaming(Span<long> matches)
     {
         int read;
         if (_innerEnd == false)
@@ -62,7 +66,7 @@ where TInner : IQueryMatch
         return read;
     }
 
-    private int ForwardStreaming(Span<long> matches)
+    private int NullFirstStreaming(Span<long> matches)
     {
         if (FetchNulls(matches, out int read))
         {

--- a/src/Corax/Querying/Matches/SortingMatches/CompactKeyComparer.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/CompactKeyComparer.cs
@@ -5,18 +5,18 @@ namespace Corax.Querying.Matches.SortingMatches;
 
 public static unsafe class CompactKeyComparer
 {
-    public static int Compare(UnmanagedSpan xItem, UnmanagedSpan yItem, bool nullFirst)
+    public static int Compare(UnmanagedSpan xItem, UnmanagedSpan yItem, int nullResult)
     {
         if (yItem.Address == null)
         {
             if (xItem.Address == null)
                 return 0;
 
-            return nullFirst ? 1 : -1;
+            return nullResult;
         }
 
         if (xItem.Address == null)
-            return nullFirst ? -1 : 1;
+            return -nullResult;
         
         var match = Memory.Compare(xItem.Address + 1, yItem.Address + 1, Math.Min(xItem.Length - 1, yItem.Length - 1));
         if (match != 0)

--- a/src/Corax/Querying/Matches/SortingMatches/CompactKeyComparer.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/CompactKeyComparer.cs
@@ -5,15 +5,19 @@ namespace Corax.Querying.Matches.SortingMatches;
 
 public static unsafe class CompactKeyComparer
 {
-    public static int Compare(UnmanagedSpan xItem, UnmanagedSpan yItem)
+    public static int Compare(UnmanagedSpan xItem, UnmanagedSpan yItem, bool nullFirst)
     {
         if (yItem.Address == null)
         {
-            return xItem.Address == null ? 0 : 1;
+            if (xItem.Address == null)
+                return 0;
+
+            return nullFirst ? 1 : -1;
         }
 
         if (xItem.Address == null)
-            return -1;
+            return nullFirst ? -1 : 1;
+        
         var match = Memory.Compare(xItem.Address + 1, yItem.Address + 1, Math.Min(xItem.Length - 1, yItem.Length - 1));
         if (match != 0)
             return match;

--- a/src/Corax/Querying/Matches/SortingMatches/HeapSorterBuilder.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/HeapSorterBuilder.cs
@@ -35,7 +35,7 @@ internal static class HeapSorterBuilder
 
 
     public static unsafe TextualMaxHeapSorter<SkipSecondaryComparer> BuildSingleAlphanumericalSorter(Span<int> documents, Span<ByteString> terms,
-        ByteStringContext allocator, bool descending)
+        ByteStringContext allocator, bool descending, bool nullFirst)
     {
         static int CompareAlphanumericalAscending(ref TextualMaxHeapSorter<SkipSecondaryComparer> sorter, ReadOnlySpan<byte> termA, int posA, ReadOnlySpan<byte> termB,
             int posB)
@@ -50,12 +50,12 @@ internal static class HeapSorterBuilder
         }
 
         var sorter = new TextualMaxHeapSorter<SkipSecondaryComparer>();
-        sorter.Init(documents, terms, allocator, descending, descending ? &CompareAlphanumericalDescending : &CompareAlphanumericalAscending, default);
+        sorter.Init(documents, terms, allocator, descending, descending ? &CompareAlphanumericalDescending : &CompareAlphanumericalAscending, default, nullFirst);
         return sorter;
     }
 
     public static unsafe TextualMaxHeapSorter<TSecondaryCmp> BuildCompoundAlphanumericalSorter<TSecondaryCmp>(Span<int> documents, Span<ByteString> terms,
-        ByteStringContext allocator, bool descending, TSecondaryCmp secondaryCmp) where TSecondaryCmp : IComparer<int>
+        ByteStringContext allocator, bool descending, TSecondaryCmp secondaryCmp, bool nullFirst) where TSecondaryCmp : IComparer<int>
     {
         static int CompareAlphanumericalAscending(ref TextualMaxHeapSorter<TSecondaryCmp> sorter, ReadOnlySpan<byte> termA, int posA, ReadOnlySpan<byte> termB, int posB)
         {
@@ -71,7 +71,7 @@ internal static class HeapSorterBuilder
         }
 
         var sorter = new TextualMaxHeapSorter<TSecondaryCmp>();
-        sorter.Init(documents, terms, allocator, descending, descending ? &CompareAlphanumericalDescending : &CompareAlphanumericalAscending, secondaryCmp);
+        sorter.Init(documents, terms, allocator, descending, descending ? &CompareAlphanumericalDescending : &CompareAlphanumericalAscending, secondaryCmp, nullFirst);
         return sorter;
     }
 

--- a/src/Corax/Querying/Matches/SortingMatches/HeapSorterBuilder.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/HeapSorterBuilder.cs
@@ -8,12 +8,12 @@ namespace Corax.Querying.Matches.SortingMatches;
 internal static class HeapSorterBuilder
 {
     public static unsafe NumericalMaxHeapSorter<UnmanagedSpan, TSecondaryComparer> BuildCompoundCompactKeySorter<TSecondaryComparer>(Span<int> documents,
-        Span<UnmanagedSpan> terms, bool descending, TSecondaryComparer secondaryCmp)
+        Span<UnmanagedSpan> terms, bool descending, TSecondaryComparer secondaryCmp, bool nullFirst)
         where TSecondaryComparer : IComparer<int>
     {
         static int Ascending(ref NumericalMaxHeapSorter<UnmanagedSpan, TSecondaryComparer> sorter, UnmanagedSpan termA, int posA, UnmanagedSpan termB, int posB)
         {
-            var cmp = CompactKeyComparer.Compare(termA, termB);
+            var cmp = CompactKeyComparer.Compare(termA, termB, sorter._nullFirst);
             return cmp == 0 ? 
                 sorter.SecondaryComparer.Compare(posA, posB) 
                 : cmp;
@@ -22,14 +22,14 @@ internal static class HeapSorterBuilder
         static int Descending(ref NumericalMaxHeapSorter<UnmanagedSpan, TSecondaryComparer> sorter, UnmanagedSpan termA, int posA, UnmanagedSpan termB, int posB)
         {
             //In first comparer we control the order of parameters, however secondary comparer (and it's inners have to be wrapped in Descending<>)
-            var cmp = CompactKeyComparer.Compare(termB, termA);
+            var cmp = CompactKeyComparer.Compare(termB, termA, sorter._nullFirst);
             return cmp == 0 ? 
                 sorter.SecondaryComparer.Compare(posA, posB) 
                 : cmp;
         }
 
         var sorter = new NumericalMaxHeapSorter<UnmanagedSpan, TSecondaryComparer>();
-        sorter.Init(documents, terms, null, descending, descending ? &Descending : &Ascending, secondaryCmp);
+        sorter.Init(documents, terms, null, descending, descending ? &Descending : &Ascending, secondaryCmp, nullFirst);
         return sorter;
     }
 
@@ -76,7 +76,7 @@ internal static class HeapSorterBuilder
     }
 
     public static unsafe NumericalMaxHeapSorter<TTermType, SkipSecondaryComparer> BuildSingleNumericalSorter<TTermType>(Span<int> documents, Span<TTermType> terms,
-        bool descending) where TTermType : unmanaged, IComparable
+        bool descending, bool nullFirst) where TTermType : unmanaged, IComparable
     {
         static int Ascending(ref NumericalMaxHeapSorter<TTermType, SkipSecondaryComparer> sorter, TTermType termA, int posA, TTermType termB, int posB)
         {
@@ -89,12 +89,12 @@ internal static class HeapSorterBuilder
         }
 
         var sorter = new NumericalMaxHeapSorter<TTermType, SkipSecondaryComparer>();
-        sorter.Init(documents, terms, null, descending, descending ? &Descending : &Ascending, default);
+        sorter.Init(documents, terms, null, descending, descending ? &Descending : &Ascending, default, nullFirst);
         return sorter;
     }
 
     public static unsafe NumericalMaxHeapSorter<TTermType, TSecondaryCmp> BuildCompoundNumericalSorter<TTermType, TSecondaryCmp>(Span<int> documents,
-        Span<TTermType> terms, bool descending, TSecondaryCmp secondaryCmp)
+        Span<TTermType> terms, bool descending, TSecondaryCmp secondaryCmp, bool nullFirst)
         where TSecondaryCmp : IComparer<int>
         where TTermType : unmanaged, IComparable
     {
@@ -115,7 +115,7 @@ internal static class HeapSorterBuilder
         }
 
         var sorter = new NumericalMaxHeapSorter<TTermType, TSecondaryCmp>();
-        sorter.Init(documents, terms, null, descending, descending ? &Descending : &Ascending, secondaryCmp);
+        sorter.Init(documents, terms, null, descending, descending ? &Descending : &Ascending, secondaryCmp, nullFirst);
         return sorter;
     }
 

--- a/src/Corax/Querying/Matches/SortingMatches/HeapSorterBuilder.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/HeapSorterBuilder.cs
@@ -13,7 +13,7 @@ internal static class HeapSorterBuilder
     {
         static int Ascending(ref NumericalMaxHeapSorter<UnmanagedSpan, TSecondaryComparer> sorter, UnmanagedSpan termA, int posA, UnmanagedSpan termB, int posB)
         {
-            var cmp = CompactKeyComparer.Compare(termA, termB, sorter._nullFirst);
+            var cmp = CompactKeyComparer.Compare(termA, termB, sorter._nullResult);
             return cmp == 0 ? 
                 sorter.SecondaryComparer.Compare(posA, posB) 
                 : cmp;
@@ -22,7 +22,7 @@ internal static class HeapSorterBuilder
         static int Descending(ref NumericalMaxHeapSorter<UnmanagedSpan, TSecondaryComparer> sorter, UnmanagedSpan termA, int posA, UnmanagedSpan termB, int posB)
         {
             //In first comparer we control the order of parameters, however secondary comparer (and it's inners have to be wrapped in Descending<>)
-            var cmp = CompactKeyComparer.Compare(termB, termA, sorter._nullFirst);
+            var cmp = CompactKeyComparer.Compare(termB, termA, sorter._nullResult);
             return cmp == 0 ? 
                 sorter.SecondaryComparer.Compare(posA, posB) 
                 : cmp;

--- a/src/Corax/Querying/Matches/SortingMatches/NumericalMaxHeapSorter.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/NumericalMaxHeapSorter.cs
@@ -23,6 +23,7 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
     private Span<int> _documents;
 
     internal bool _nullFirst;
+    internal int _nullResult;
     private Span<TTermType> _terms;
     
     private int _heapSize;
@@ -42,6 +43,7 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
         delegate*<ref NumericalMaxHeapSorter<TTermType, TSecondaryComparer>, TTermType, int, TTermType, int, int> compare, TSecondaryComparer secondaryCmp, bool nullFirst)
     {
         _nullFirst = nullFirst;
+        _nullResult = nullFirst ? 1 : -1;
         IsDescending = descending;
         _documents = documents;
         _terms = terms;
@@ -51,10 +53,10 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
     }
 
     /// <summary>
-    /// Insert new document to the heap
+    /// Insert a new document to the heap
     /// </summary>
-    /// <param name="document">Index of document in batchResult</param>
-    /// <param name="newTerm">term from document</param>
+    /// <param name="document">Index of a document in batchResult</param>
+    /// <param name="newTerm">term from a document</param>
     public void Insert(int document, TTermType newTerm)
     {
         if (_heapSize < _heapCapacity)

--- a/src/Corax/Querying/Matches/SortingMatches/NumericalMaxHeapSorter.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/NumericalMaxHeapSorter.cs
@@ -22,6 +22,7 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
     /// <summary>Values are indexes of documents inside batchResult, not the documents themselves.</summary>
     private Span<int> _documents;
 
+    internal bool _nullFirst;
     private Span<TTermType> _terms;
     
     private int _heapSize;
@@ -38,8 +39,9 @@ internal unsafe ref struct NumericalMaxHeapSorter<TTermType, TSecondaryComparer>
     private delegate*<ref NumericalMaxHeapSorter<TTermType, TSecondaryComparer>, TTermType, int, TTermType, int, int> _compare;
 
     public void Init(Span<int> documents, Span<TTermType> terms, ByteStringContext allocator, bool descending,
-        delegate*<ref NumericalMaxHeapSorter<TTermType, TSecondaryComparer>, TTermType, int, TTermType, int, int> compare, TSecondaryComparer secondaryCmp)
+        delegate*<ref NumericalMaxHeapSorter<TTermType, TSecondaryComparer>, TTermType, int, TTermType, int, int> compare, TSecondaryComparer secondaryCmp, bool nullFirst)
     {
+        _nullFirst = nullFirst;
         IsDescending = descending;
         _documents = documents;
         _terms = terms;

--- a/src/Corax/Querying/Matches/SortingMatches/SortingHelpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingHelpers.cs
@@ -9,6 +9,14 @@ namespace Corax.Querying.Matches.SortingMatches;
 internal static class SortingHelpers
 {
     public const long InvalidTermId = -1;
+    
+    /// <summary>
+    /// There are textual values for fields that are either null or do not exist. However, since we want to specifically control the order of the nulls,
+    /// we need to rewrite them and put them inside a specific "bucket". Since we do not want to compare literals all the time, we will replace them with an UnmanagedSpan where the address is a null pointer.
+    /// </summary>
+    public const long MissingTermId = long.MinValue;
+    
+    
     public static void ReplaceNullAndNonExistingTermIds(Span<long> buffer, long nonExistingTermId, long nullTermId, long replaceWith)
     {
         if (nonExistingTermId == InvalidTermId && nullTermId == InvalidTermId)
@@ -21,18 +29,15 @@ internal static class SortingHelpers
             var N = Vector512<long>.Count;
             var nonExistingVector = Vector512.Create(nonExistingTermId);
             var nullVector = Vector512.Create(nullTermId);
-                
+            var replaceWithVector = Vector512.Create(replaceWith);
             for (; idX + N <= buffer.Length; idX += N)
             {
                 var currentMask = Vector512.LoadUnsafe(ref Unsafe.Add(ref bufferRef, idX));
-                if (Vector512.EqualsAny(currentMask, nullVector) || Vector512.EqualsAny(currentMask, nonExistingVector))
-                {
-                    for (int i = 0; i < N; i++)
-                    {
-                        if (buffer[idX + i] == nonExistingTermId || buffer[idX + i] == nullTermId)
-                            buffer[idX + i] = replaceWith;
-                    }
-                }
+                var isNull = Vector512.Equals(currentMask, nullVector);
+                var isNonExisting = Vector512.Equals(currentMask, nonExistingVector);
+                var combinedMask = isNull | isNonExisting;
+                var result = Vector512.ConditionalSelect(combinedMask, replaceWithVector, currentMask);
+                result.StoreUnsafe(ref Unsafe.Add(ref bufferRef, idX));
             }
                 
         }

--- a/src/Corax/Querying/Matches/SortingMatches/SortingHelpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingHelpers.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using Sparrow;
+
+namespace Corax.Querying.Matches.SortingMatches;
+
+internal static class SortingHelpers
+{
+    public const long InvalidTermId = -1;
+    public static void ReplaceNullAndNonExistingTermIds(Span<long> buffer, long nonExistingTermId, long nullTermId, long replaceWith)
+    {
+        if (nonExistingTermId == InvalidTermId && nullTermId == InvalidTermId)
+            return;
+        
+        int idX = 0;
+        ref var bufferRef = ref MemoryMarshal.GetReference(buffer);
+        if (AdvInstructionSet.IsAcceleratedVector512)
+        {
+            var N = Vector512<long>.Count;
+            var nonExistingVector = Vector512.Create(nonExistingTermId);
+            var nullVector = Vector512.Create(nullTermId);
+                
+            for (; idX + N <= buffer.Length; idX += N)
+            {
+                var currentMask = Vector512.LoadUnsafe(ref Unsafe.Add(ref bufferRef, idX));
+                if (Vector512.EqualsAny(currentMask, nullVector) || Vector512.EqualsAny(currentMask, nonExistingVector))
+                {
+                    for (int i = 0; i < N; i++)
+                    {
+                        if (buffer[idX + i] == nonExistingTermId || buffer[idX + i] == nullTermId)
+                            buffer[idX + i] = replaceWith;
+                    }
+                }
+            }
+                
+        }
+            
+        for (; idX < buffer.Length; idX++)
+        {
+            if (buffer[idX] == nonExistingTermId || buffer[idX] == nullTermId)
+                buffer[idX] = replaceWith;
+        }
+    }
+}

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -11,6 +11,7 @@ using Sparrow;
 using Sparrow.Server;
 using Sparrow.Server.Utils.VxSort;
 using Voron;
+using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Impl;
@@ -165,6 +166,8 @@ unsafe partial struct SortingMatch<TInner>
 
     private struct EntryComparerByTerm : IEntryComparer, IComparer<UnmanagedSpan>
     {
+        private long NonExistingTermContainerId;
+        private long NullTermContainerId;
         private CompactKeyComparer _cmpTerm;
         private Lookup<Int64LookupKey> _lookup;
 
@@ -173,7 +176,10 @@ unsafe partial struct SortingMatch<TInner>
         public void Init(ref SortingMatch<TInner> match)
         {
             _lookup = match._searcher.EntriesToTermsReader(match._orderMetadata.Field.FieldName);
+            match._searcher.TryGetPostingListForNull(match._orderMetadata.Field.FieldName, out _, out NullTermContainerId);
+            match._searcher.TryGetPostingListForNonExisting(match._orderMetadata.Field.FieldName, out _, out NonExistingTermContainerId);
         }
+
 
         public void SortBatch(ref SortingMatch<TInner> match, LowLevelTransaction llt, PageLocator pageLocator, Span<long> batchResults, Span<long> batchTermIds,
             UnmanagedSpan* batchTerms,
@@ -187,9 +193,31 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
+            int nullOrEmpties = 0;
+            if (NullTermContainerId != -1 || NonExistingTermContainerId != -1)
+            {
+                for (int i = 0; i < batchTermIds.Length; i++)
+                {
+                    if (batchTermIds[i] == NullTermContainerId || batchTermIds[i] == NonExistingTermContainerId)
+                    {
+                        batchTermIds[i] = long.MinValue;
+                        nullOrEmpties++;
+                    }
+                }
+            }
+                
+            
+            var terms = new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length);
+            Container.GetAll(llt, batchTermIds, terms, long.MinValue, pageLocator);
+
+            
             var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending);
             var indexes = SortByTerms(ref match, batchTermIds, batchTerms, descending, indirectComparer);
+            
+            // In our sort
+            
+            
+            
             for (int i = 0; i < indexes.Length; i++)
             {
                 int bIdx = indexes[i];
@@ -247,7 +275,9 @@ unsafe partial struct SortingMatch<TInner>
                 }
                 else
                 {
-                    l = -1 >>> 16; // effectively move to the end
+                    l = match._nullFirst 
+                        ? 0 
+                        : -1 >>> 16;
                 }
 
                 l = BinaryPrimitives.ReverseEndianness(l) >>> 1;
@@ -348,8 +378,9 @@ unsafe partial struct SortingMatch<TInner>
                 match._results.AddRange(batchResults);
                 return;
             }
-
-            _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
+            
+            var missingValue = match._nullFirst ? long.MinValue : long.MaxValue;
+            _lookup.GetFor(batchResults, batchTermIds, missingValue);
             match._cancellationToken.ThrowIfCancellationRequested();
             var heapSize = Math.Min(match._take, batchResults.Length);
             heapSize = heapSize <= 0 ? batchResults.Length : heapSize;
@@ -383,7 +414,8 @@ unsafe partial struct SortingMatch<TInner>
                 return;
             }
 
-            _lookup.GetFor(batchResults, batchTermIds, BitConverter.DoubleToInt64Bits(double.MinValue));
+            var missingValue = match._nullFirst ? double.MinValue : double.MaxValue;
+            _lookup.GetFor(batchResults, batchTermIds, BitConverter.DoubleToInt64Bits(missingValue));
             match._cancellationToken.ThrowIfCancellationRequested();
             var heapSize = Math.Min(match._take, batchResults.Length);
             heapSize = heapSize <= 0 ? batchResults.Length : heapSize;
@@ -506,7 +538,15 @@ unsafe partial struct SortingMatch<TInner>
                 SpatialResult distance; 
                 if (_reader.TryGetSpatialPoint(batchResults[i], out var coords) == false)
                 {
-                    distance = new SpatialResult() { Distance = descending ? double.MinValue : double.MaxValue, Latitude = Double.NaN, Longitude = Double.NaN };
+                    var distanceForMissing = (Descending: descending, NullFirst: match._nullFirst)
+                        switch
+                        {
+                            (Descending: true, NullFirst: true) => double.MinValue,
+                            (Descending: false, NullFirst: true) => double.MaxValue,
+                            (Descending: false, NullFirst: false) => double.MaxValue,
+                            (Descending: true, NullFirst: false) => double.MinValue,
+                        };
+                    distance = new SpatialResult() { Distance = distanceForMissing, Latitude = Double.NaN, Longitude = Double.NaN };
                 }
                 else
                 {

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -11,7 +11,6 @@ using Sparrow;
 using Sparrow.Server;
 using Sparrow.Server.Utils.VxSort;
 using Voron;
-using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Impl;
@@ -195,19 +194,15 @@ unsafe partial struct SortingMatch<TInner>
             }
 
             match._cancellationToken.ThrowIfCancellationRequested();
-            _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, long.MinValue);
+            _lookup.GetFor(batchResults, batchTermIds, SortingHelpers.MissingTermId);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, SortingHelpers.MissingTermId);
             
             var terms = new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length);
-            Container.GetAll(llt, batchTermIds, terms, long.MinValue, pageLocator);
+            Container.GetAll(llt, batchTermIds, terms, SortingHelpers.MissingTermId, pageLocator);
 
             
             var indirectComparer = new IndirectComparer<CompactKeyComparer>(batchTerms, new CompactKeyComparer(), descending);
             var indexes = SortByTerms(ref match, batchTermIds, batchTerms, descending, indirectComparer);
-            
-            // In our sort
-            
-            
             
             for (int i = 0; i < indexes.Length; i++)
             {
@@ -256,6 +251,9 @@ unsafe partial struct SortingMatch<TInner>
             where TComparer : struct, IComparer<long>
         {
             Debug.Assert(buffer.Length < (1 << 15), "buffer.Length < (1<<15)");
+            var nullValue = match._nullFirst
+                ? 0
+                : -1 >>> 16;
             for (int i = 0; i < buffer.Length; i++)
             {
                 long l = 0;
@@ -266,9 +264,7 @@ unsafe partial struct SortingMatch<TInner>
                 }
                 else
                 {
-                    l = match._nullFirst 
-                        ? 0 
-                        : -1 >>> 16;
+                    l = nullValue;
                 }
 
                 l = BinaryPrimitives.ReverseEndianness(l) >>> 1;
@@ -475,9 +471,9 @@ unsafe partial struct SortingMatch<TInner>
             }
 
             match._cancellationToken.ThrowIfCancellationRequested();
-            _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, long.MinValue);
-            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
+            _lookup.GetFor(batchResults, batchTermIds, SortingHelpers.MissingTermId);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, SortingHelpers.MissingTermId);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), SortingHelpers.MissingTermId, pageLocator);
 
             var heapCapacity = _take == -1 ? batchResults.Length : Math.Min(_take, batchResults.Length);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(heapCapacity)];
@@ -503,6 +499,7 @@ unsafe partial struct SortingMatch<TInner>
             
 
             heap.Fill(batchResults, ref match._results, ref match._scoresResults, Span<float>.Empty, nullIndexes);
+            nullIndexes.Dispose();
         }
         
         public int Compare(UnmanagedSpan x, UnmanagedSpan y)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -15,6 +15,7 @@ using Voron.Data.CompactTrees;
 using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Impl;
+using Voron.Util;
 
 namespace Corax.Querying.Matches.SortingMatches;
 
@@ -438,6 +439,8 @@ unsafe partial struct SortingMatch<TInner>
 
     private struct EntryComparerByTermAlphaNumeric : IEntryComparer, IComparer<UnmanagedSpan>
     {
+        public long NonExistingTermContainerId;
+        public long NullTermContainerId;
         private TermsReader _reader;
         private long _dictionaryId;
         private Lookup<Int64LookupKey> _lookup;
@@ -452,10 +455,15 @@ unsafe partial struct SortingMatch<TInner>
             _lookup = match._searcher.EntriesToTermsReader(match._orderMetadata.Field.FieldName);
             _take = match._take;
             _allocator = match._searcher.Allocator;
+            if (match._searcher.TryGetPostingListForNull(match._orderMetadata.Field.FieldName, out _, out NullTermContainerId) == false)
+                NullTermContainerId = SortingHelpers.InvalidTermId;
+            if (match._searcher.TryGetPostingListForNonExisting(match._orderMetadata.Field.FieldName, out _, out NonExistingTermContainerId) == false)
+                NonExistingTermContainerId = SortingHelpers.InvalidTermId;
         }
 
-  
-        
+
+
+
         public void SortBatch(ref SortingMatch<TInner> match, LowLevelTransaction llt, PageLocator pageLocator, Span<long> batchResults, Span<long> batchTermIds,
             UnmanagedSpan* batchTerms,
             bool descending = false)
@@ -468,17 +476,33 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, long.MinValue);
             Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
+
             var heapCapacity = _take == -1 ? batchResults.Length : Math.Min(_take, batchResults.Length);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(heapCapacity)];
 
             using var _ = _allocator.Allocate(heapCapacity, out Span<ByteString> terms);
 
-            var heap = HeapSorterBuilder.BuildSingleAlphanumericalSorter(documents, terms, _allocator, descending);
+            var heap = HeapSorterBuilder.BuildSingleAlphanumericalSorter(documents, terms, _allocator, descending, match._nullFirst);
+            ContextBoundNativeList<int> nullIndexes = default;
+            
             for (int i = 0; i < batchTermIds.Length; i++)
+            {
+                var term = batchTerms[i];
+                if (term.Address == null)
+                {
+                    if (nullIndexes.HasContext == false)
+                        nullIndexes = new ContextBoundNativeList<int>(_allocator);
+                    nullIndexes.Add(i);
+                    continue;
+                }
+                
                 heap.Insert(i, _reader.GetDecodedTerm(_dictionaryId, batchTerms[i]));
+            }
+            
 
-            heap.Fill(batchResults, ref match._results, ref match._scoresResults, Span<float>.Empty);
+            heap.Fill(batchResults, ref match._results, ref match._scoresResults, Span<float>.Empty, nullIndexes);
         }
         
         public int Compare(UnmanagedSpan x, UnmanagedSpan y)

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.Comparers.cs
@@ -103,7 +103,7 @@ unsafe partial struct SortingMatch<TInner>
             heapSize = heapSize < 0 ? batchResults.Length : heapSize;
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[(batchTermIds.Length)..];
             using var _ = llt.Allocator.Allocate(heapSize, out Span<float> terms);
-            var heapSorter = HeapSorterBuilder.BuildSingleNumericalSorter(indexes.Slice(0, heapSize), terms, descending == false);
+            var heapSorter = HeapSorterBuilder.BuildSingleNumericalSorter(indexes.Slice(0, heapSize), terms, descending == false, match._nullFirst);
             
             
             for (int i = 0; i < batchTermIds.Length; i++)
@@ -176,8 +176,10 @@ unsafe partial struct SortingMatch<TInner>
         public void Init(ref SortingMatch<TInner> match)
         {
             _lookup = match._searcher.EntriesToTermsReader(match._orderMetadata.Field.FieldName);
-            match._searcher.TryGetPostingListForNull(match._orderMetadata.Field.FieldName, out _, out NullTermContainerId);
-            match._searcher.TryGetPostingListForNonExisting(match._orderMetadata.Field.FieldName, out _, out NonExistingTermContainerId);
+            if (match._searcher.TryGetPostingListForNull(match._orderMetadata.Field.FieldName, out _, out NullTermContainerId) == false)
+                NullTermContainerId = SortingHelpers.InvalidTermId;
+            if (match._searcher.TryGetPostingListForNonExisting(match._orderMetadata.Field.FieldName, out _, out NonExistingTermContainerId) == false)
+                NonExistingTermContainerId = SortingHelpers.InvalidTermId;
         }
 
 
@@ -193,19 +195,7 @@ unsafe partial struct SortingMatch<TInner>
 
             match._cancellationToken.ThrowIfCancellationRequested();
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            int nullOrEmpties = 0;
-            if (NullTermContainerId != -1 || NonExistingTermContainerId != -1)
-            {
-                for (int i = 0; i < batchTermIds.Length; i++)
-                {
-                    if (batchTermIds[i] == NullTermContainerId || batchTermIds[i] == NonExistingTermContainerId)
-                    {
-                        batchTermIds[i] = long.MinValue;
-                        nullOrEmpties++;
-                    }
-                }
-            }
-                
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, NonExistingTermContainerId, NullTermContainerId, long.MinValue);
             
             var terms = new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length);
             Container.GetAll(llt, batchTermIds, terms, long.MinValue, pageLocator);
@@ -386,7 +376,7 @@ unsafe partial struct SortingMatch<TInner>
             heapSize = heapSize <= 0 ? batchResults.Length : heapSize;
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             using var _ = llt.Allocator.Allocate(heapSize, out Span<long> terms);
-            var sorter = HeapSorterBuilder.BuildSingleNumericalSorter(indexes.Slice(0, heapSize), terms, descending);
+            var sorter = HeapSorterBuilder.BuildSingleNumericalSorter(indexes.Slice(0, heapSize), terms, descending, match._nullFirst);
 
             for (var i = 0; i < batchResults.Length; ++i)
                 sorter.Insert(i, batchTermIds[i]);
@@ -421,7 +411,7 @@ unsafe partial struct SortingMatch<TInner>
             heapSize = heapSize <= 0 ? batchResults.Length : heapSize;
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             using var _ = llt.Allocator.Allocate(heapSize, out Span<double> terms);
-            var sorter = HeapSorterBuilder.BuildSingleNumericalSorter(indexes.Slice(0, heapSize), terms, descending);
+            var sorter = HeapSorterBuilder.BuildSingleNumericalSorter(indexes.Slice(0, heapSize), terms, descending, match._nullFirst);
 
             for (var i = 0; i < batchResults.Length; ++i)
                 sorter.Insert(i, BitConverter.Int64BitsToDouble(batchTermIds[i]));
@@ -531,22 +521,14 @@ unsafe partial struct SortingMatch<TInner>
             using var _ = llt.Allocator.Allocate(heapSize, out Span<SpatialResult> terms);
 
 
-            var heapSorter = HeapSorterBuilder.BuildSingleNumericalSorter<SpatialResult>(indexes.Slice(0, heapSize), terms, descending);
+            var heapSorter = HeapSorterBuilder.BuildSingleNumericalSorter<SpatialResult>(indexes.Slice(0, heapSize), terms, descending, match._nullFirst);
             
             for (int i = 0; i < batchResults.Length; i++)
             {
                 SpatialResult distance; 
                 if (_reader.TryGetSpatialPoint(batchResults[i], out var coords) == false)
                 {
-                    var distanceForMissing = (Descending: descending, NullFirst: match._nullFirst)
-                        switch
-                        {
-                            (Descending: true, NullFirst: true) => double.MinValue,
-                            (Descending: false, NullFirst: true) => double.MaxValue,
-                            (Descending: false, NullFirst: false) => double.MaxValue,
-                            (Descending: true, NullFirst: false) => double.MinValue,
-                        };
-                    distance = new SpatialResult() { Distance = distanceForMissing, Latitude = Double.NaN, Longitude = Double.NaN };
+                    distance = new SpatialResult() { Distance = match._nullFirst ? double.MinValue : double.MaxValue, Latitude = Double.NaN, Longitude = Double.NaN };
                 }
                 else
                 {

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Corax.Indexing;
+using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
@@ -200,12 +201,14 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                 return 0;
 
             const int IndexSortingThreshold = 4096;
+            var forceUsingOnlyIndex = match._searcher._testingConfiguration is { ForceSortingUsingIndex: true };
+
             if (typeof(TDirection) == typeof(RandomDirection))
             {
                 SortByRandom(ref match, allMatches);
             }
-            else if (typeof(TDirection) == typeof(NoIterationOptimization) || 
-                match.TotalResults < IndexSortingThreshold)
+            else if (forceUsingOnlyIndex == false && (typeof(TDirection) == typeof(NoIterationOptimization) ||
+                      match.TotalResults < IndexSortingThreshold))
             {
                 SortResults<TEntryComparer>(ref match, allMatches);
             }
@@ -262,6 +265,8 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
         private TDirection _termsIt;
         private readonly long _min;
         private readonly long _max;
+        private readonly bool _nullFirst;
+        private readonly bool _isForward;
         private readonly Querying.IndexSearcher _searcher;
         private readonly LowLevelTransaction _llt;
 
@@ -276,12 +281,18 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
         private readonly PageLocator _pageLocator;
         private bool _hasSmallListReader;
 
+        private long _nonExistingPostingListId;
+        private bool _nonExistingPostingListRead;
+        private long _nullPostingListId;
+        private bool _nullPostingListRead;
 
-        public SortedIndexReader(LowLevelTransaction llt, Querying.IndexSearcher searcher, TDirection it, long min, long max)
+        public SortedIndexReader(LowLevelTransaction llt, Querying.IndexSearcher searcher, TDirection it, FieldMetadata metadata, long min, long max, bool nullFirst, bool isForward)
         {
             _termsIt = it;
             _min = min;
             _max = max;
+            _nullFirst = nullFirst;
+            _isForward = isForward;
             _termsIt.Reset();
             _llt = llt;
             _searcher = searcher;
@@ -294,6 +305,9 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             _containerItemsScope = llt.Allocator.Allocate(BufferSize * sizeof(UnmanagedSpan), out bs);
             _containerItems = (UnmanagedSpan*)bs.Ptr;
             _pageLocator = llt.PageLocator;
+
+            _nonExistingPostingListRead = searcher.TryGetPostingListForNonExisting(metadata, out _nonExistingPostingListId) == false;
+            _nullPostingListRead = searcher.TryGetPostingListForNull(metadata, out _nullPostingListId) == false;
         }
 
 
@@ -365,9 +379,21 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
             _smallPostListIds.Clear();
             _bufferIdx = 0;
             _bufferCount = 0;
-            _bufferCount = _termsIt.Fill(new Span<long>(_itBuffer, BufferSize));
+            
+            bool nullsFirst = _isForward ? _nullFirst : !_nullFirst;
+            var buffer = new Span<long>(_itBuffer, BufferSize);
+            if (nullsFirst)
+                LoadNonExistingAndNullIntoBuffer(buffer);
+            
+            
+            _bufferCount += _termsIt.Fill(buffer.Slice(_bufferCount));
             if (_bufferCount == 0)
-                return;
+            {
+                if (nullsFirst || (_nonExistingPostingListRead && _nullPostingListRead))
+                    return;
+                
+                LoadNonExistingAndNullIntoBuffer(buffer);
+            }
             
             for (int i = 0; i < _bufferCount; i++)
             {
@@ -384,6 +410,25 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                 return;
 
             Container.GetAll(_llt, _smallPostListIds.ToSpan(), new Span<UnmanagedSpan>(_containerItems, _smallPostListIds.Count), long.MinValue, _pageLocator);
+
+            
+        }
+        
+        void LoadNonExistingAndNullIntoBuffer(Span<long> buffer)
+        {
+            if (_nonExistingPostingListRead == false)
+            {
+                buffer[_bufferCount] = _nonExistingPostingListId;
+                _nonExistingPostingListRead = true;
+                _bufferCount += 1;
+            }
+                
+            if (_nullPostingListRead == false)
+            {
+                buffer[_bufferCount] = _nullPostingListId;
+                _nullPostingListRead = true;
+                _bufferCount += 1;
+            }
         }
 
         private void ReadLargePostingList(Span<long> sortedIds, ref int currentIdx)
@@ -438,10 +483,11 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
 
         var totalRead = 0;
         var reader = GetReader(ref match, allMatches[0], allMatches[^1]);
+        var forceUsingOnlyIndex = match._searcher._testingConfiguration is { ForceSortingUsingIndex: true };
         while (match._results.Count < maxResults)
         {
             match._cancellationToken.ThrowIfCancellationRequested();
-            if (totalRead > allMatches.Length * 2)
+            if (forceUsingOnlyIndex == false && totalRead > allMatches.Length * 2)
             {
                 // We may have _already_ matched some items, in which case they show up as negative 
                 // numbers in the matches (since we want to filter them), we need to pass the matches to the 
@@ -504,21 +550,21 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
                 typeof(TDirection) == typeof(Lookup<CompactTree.CompactKeyLookup>.BackwardIterator))
             {
                 var termsTree = match._searcher.GetTermsFor(entryCmp.GetSortFieldName(ref match));
-                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.IterateValues<TDirection>(), min, max);
+                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.IterateValues<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending);
             }
 
             if (typeof(TDirection) == typeof(Lookup<Int64LookupKey>.ForwardIterator) ||
                 typeof(TDirection) == typeof(Lookup<Int64LookupKey>.BackwardIterator))
             {
                 var termsTree = match._searcher.GetLongTermsFor(entryCmp.GetSortFieldName(ref match));
-                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), min, max);
+                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending);
             }
 
             if (typeof(TDirection) == typeof(Lookup<DoubleLookupKey>.ForwardIterator) ||
                 typeof(TDirection) == typeof(Lookup<DoubleLookupKey>.BackwardIterator))
             {
                 var termsTree = match._searcher.GetDoubleTermsFor(entryCmp.GetSortFieldName(ref match));
-                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), min, max);
+                return new SortedIndexReader<TDirection>(llt, match._searcher, termsTree.Iterate<TDirection>(), match._orderMetadata.Field, min, max, match._nullFirst, match._orderMetadata.Ascending);
             }
 
             throw new NotSupportedException(typeof(TDirection).FullName);

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMatch.cs
@@ -31,6 +31,7 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
     private TInner _inner;
     private readonly OrderMetadata _orderMetadata;
     private readonly CancellationToken _cancellationToken;
+    private readonly bool _nullFirst;
     private readonly delegate*<ref SortingMatch<TInner>, Span<long>, int> _fillFunc;
     private readonly int _take;
     private const int NotStarted = -1;
@@ -48,12 +49,13 @@ public unsafe partial struct SortingMatch<TInner> : IQueryMatch
     
     public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
     
-    public SortingMatch(IndexSearcher searcher, in TInner inner, OrderMetadata orderMetadata, in CancellationToken cancellationToken, int take = -1)
+    public SortingMatch(IndexSearcher searcher, in TInner inner, OrderMetadata orderMetadata, in CancellationToken cancellationToken, bool nullFirst, int take = -1)
     {
         _searcher = searcher;
         _inner = inner;
         _orderMetadata = orderMetadata;
         _cancellationToken = cancellationToken;
+        _nullFirst = nullFirst;
         _take = take;
         _alreadyReadIdx = 0;
         _results = new ContextBoundNativeList<long>(searcher.Allocator);

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -207,7 +207,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         private UnmanagedSpan<long> _batchResults;
         private int _comparerId;
         private TermsReader _termsReader;
-        private bool _nullFirst;
+        private int _nullResult;
         private long _nullTermContainerId;
         private long _nonExistingTermContainerId;
         
@@ -221,7 +221,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             _lookup = match._searcher.EntriesToTermsReader(fieldName);
             _batchResults = batchResults;
             _termsReader = match._searcher.TermsReaderFor(fieldName);
-            _nullFirst = match._nullFirst;
+            _nullResult = match._nullFirst ? 1 : -1;
             
             if (match._searcher.TryGetPostingListForNull(fieldName, out _, out _nullTermContainerId) == false)
                 _nullTermContainerId = -1;
@@ -241,9 +241,9 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 return;
             }
             
-            _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, _nonExistingTermContainerId, _nullTermContainerId, long.MinValue);
-            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
+            _lookup.GetFor(batchResults, batchTermIds, SortingHelpers.MissingTermId);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, _nonExistingTermContainerId, _nullTermContainerId, SortingHelpers.MissingTermId);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), SortingHelpers.MissingTermId, pageLocator);
             match._token.ThrowIfCancellationRequested();
 
             var heapSize = Math.Min(match._take, batchResults.Length);
@@ -261,7 +261,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
         public int Compare(UnmanagedSpan x, UnmanagedSpan y)
         {
-            return CompactKeyComparer.Compare(x, y, _nullFirst);
+            return CompactKeyComparer.Compare(x, y, _nullResult);
         }
 
         public int Compare(int x, int y)
@@ -269,7 +269,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             var termX = _termsReader.GetTerm(_batchResults[x], nullTermId: _nullTermContainerId, nonExistingTermId: _nonExistingTermContainerId);
             var termY = _termsReader.GetTerm(_batchResults[y], nullTermId: _nullTermContainerId, nonExistingTermId: _nonExistingTermContainerId);
             
-            return CompactKeyComparer.Compare(termX, termY, _nullFirst);
+            return CompactKeyComparer.Compare(termX, termY, _nullResult);
         }
     }
 
@@ -497,9 +497,9 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 return;
             }
 
-            _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
-            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, _nonExistingTermContainerId, _nullTermContainerId, long.MinValue);
-            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
+            _lookup.GetFor(batchResults, batchTermIds, SortingHelpers.MissingTermId);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, _nonExistingTermContainerId, _nullTermContainerId, SortingHelpers.MissingTermId);
+            Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), SortingHelpers.MissingTermId, pageLocator);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             for (int i = 0; i < batchTermIds.Length; i++)
                 documents[i] = i;
@@ -524,7 +524,6 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             heapSorter.Fill(batchResults, ref match._results, ref match._scoresResults, match._secondaryScoreBuffer, nullIndexes);
-            
             nullIndexes.Dispose();
         }
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -15,6 +15,7 @@ using Voron;
 using Voron.Data.Containers;
 using Voron.Data.Lookups;
 using Voron.Impl;
+using Voron.Util;
 
 namespace Corax.Querying.Matches.SortingMatches;
 
@@ -462,16 +463,26 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         private UnmanagedSpan<long> _batchResults;
         private int _comparerId;
         private ByteStringContext _allocator;
+        private long _nullTermContainerId;
+        private long _nonExistingTermContainerId;
+        private bool _nullFirst;
+
         public Slice GetSortFieldName(ref SortingMultiMatch<TInner> match) => match._orderMetadata[_comparerId].Field.FieldName;
 
         public void Init(ref SortingMultiMatch<TInner> match, UnmanagedSpan<long> batchResults, int comparerId)
         {
             _comparerId = comparerId;
-            _reader = match._searcher.TermsReaderFor(match._orderMetadata[_comparerId].Field.FieldName);
-            _dictionaryId = match._searcher.GetDictionaryIdFor(match._orderMetadata[_comparerId].Field.FieldName);
-            _lookup = match._searcher.EntriesToTermsReader(match._orderMetadata[_comparerId].Field.FieldName);
+            var fieldName = match._orderMetadata[_comparerId].Field.FieldName;
+            _reader = match._searcher.TermsReaderFor(fieldName);
+            _dictionaryId = match._searcher.GetDictionaryIdFor(fieldName);
+            _lookup = match._searcher.EntriesToTermsReader(fieldName);
             _batchResults = batchResults;
             _allocator = match._searcher.Allocator;
+            _nullFirst = match._nullFirst;
+            if (match._searcher.TryGetPostingListForNull(fieldName, out _, out _nullTermContainerId) == false)
+                _nullTermContainerId = SortingHelpers.InvalidTermId;
+            if (match._searcher.TryGetPostingListForNonExisting(fieldName, out _, out _nonExistingTermContainerId) == false)
+                _nonExistingTermContainerId = SortingHelpers.InvalidTermId;
         }
 
         public void SortBatch<TComparer2, TComparer3>(ref SortingMultiMatch<TInner> match, LowLevelTransaction llt, PageLocator pageLocator,
@@ -487,6 +498,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             }
 
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, _nonExistingTermContainerId, _nullTermContainerId, long.MinValue);
             Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             var documents = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             for (int i = 0; i < batchTermIds.Length; i++)
@@ -495,14 +507,27 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             var heapCapacity = match._take == -1 ? batchResults.Length : Math.Min(match._take, batchResults.Length);
             using var _ = _allocator.Allocate(heapCapacity, out Span<ByteString> terms);
             var secondaryComparers = new IndirectComparer2<TComparer2, TComparer3>(ref match, comparer2, comparer3);
-            var heapSorter = HeapSorterBuilder.BuildCompoundAlphanumericalSorter(documents.Slice(0, heapCapacity), terms, _allocator, orderMetadata[0].Ascending == false, secondaryComparers);
-           
-            for (int i = 0; i < batchTermIds.Length; i++)
-                heapSorter.Insert(i, _reader.GetDecodedTerm(_dictionaryId, batchTerms[i]));
+            var heapSorter = HeapSorterBuilder.BuildCompoundAlphanumericalSorter(documents.Slice(0, heapCapacity), terms, _allocator, orderMetadata[0].Ascending == false, secondaryComparers, match._nullFirst);
 
-            heapSorter.Fill(batchResults, ref match._results, ref match._scoresResults, match._secondaryScoreBuffer);
+            ContextBoundNativeList<int> nullIndexes = default;
+            for (int i = 0; i < batchTermIds.Length; i++)
+            {
+                var term = batchTerms[i];
+                if (term.Address == null)
+                {
+                    if (nullIndexes.HasContext == false)
+                        nullIndexes = new ContextBoundNativeList<int>(_allocator);
+                    nullIndexes.Add(i);
+                    continue;
+                }
+                heapSorter.Insert(i, _reader.GetDecodedTerm(_dictionaryId, batchTerms[i]));
+            }
+
+            heapSorter.Fill(batchResults, ref match._results, ref match._scoresResults, match._secondaryScoreBuffer, nullIndexes);
+            
+            nullIndexes.Dispose();
         }
-        
+
         public int Compare(UnmanagedSpan x, UnmanagedSpan y)
         {
             throw new NotSupportedException($"Method `{nameof(Compare)} for `{nameof(UnmanagedSpan)}` should never be used.");
@@ -510,6 +535,34 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
         public int Compare(int x, int y)
         {
+            if (_lookup == null)
+                return 0;
+
+            Span<long> buffer = [_batchResults[x], _batchResults[y], -1, -1];
+            var swap = buffer[0] > buffer[1];
+            if (swap) 
+                buffer[..2].Reverse();
+            _lookup.GetFor(buffer[..2], buffer[2..], long.MinValue);
+            
+            if (swap) 
+                buffer[2..].Reverse();
+            
+            if (buffer[2] == _nullTermContainerId || buffer[2] == _nonExistingTermContainerId)
+                buffer[2] = long.MinValue;
+            if (buffer[3] == _nullTermContainerId || buffer[3] == _nonExistingTermContainerId)
+                buffer[3] = long.MinValue;
+
+            var xIsNull = buffer[2] == long.MinValue;
+            var yIsNull = buffer[3] == long.MinValue;
+
+            if (xIsNull || yIsNull)
+            {
+                if (xIsNull && yIsNull) return 0;
+                return _nullFirst 
+                    ? (xIsNull ? -1 : 1) 
+                    : (xIsNull ? 1 : -1);
+            }
+
             _reader.GetDecodedTermsByIds(_dictionaryId, _batchResults[x], out var xTerm, _batchResults[y], out var yTerm);
             return AlphanumericalComparer.Instance.Compare(xTerm, yTerm);
         }

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -206,14 +206,26 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         private UnmanagedSpan<long> _batchResults;
         private int _comparerId;
         private TermsReader _termsReader;
+        private bool _nullFirst;
+        private long _nullTermContainerId;
+        private long _nonExistingTermContainerId;
+        
         public Slice GetSortFieldName(ref SortingMultiMatch<TInner> match) => match._orderMetadata[_comparerId].Field.FieldName;
 
+        
         public void Init(ref SortingMultiMatch<TInner> match, UnmanagedSpan<long> batchResults, int comparerId)
         {
             _comparerId = comparerId;
-            _lookup = match._searcher.EntriesToTermsReader(match._orderMetadata[_comparerId].Field.FieldName);
+            var fieldName = match._orderMetadata[_comparerId].Field.FieldName;
+            _lookup = match._searcher.EntriesToTermsReader(fieldName);
             _batchResults = batchResults;
-            _termsReader = match._searcher.TermsReaderFor(match._orderMetadata[_comparerId].Field.FieldName);
+            _termsReader = match._searcher.TermsReaderFor(fieldName);
+            _nullFirst = match._nullFirst;
+            
+            if (match._searcher.TryGetPostingListForNull(fieldName, out _, out _nullTermContainerId) == false)
+                _nullTermContainerId = -1;
+            if (match._searcher.TryGetPostingListForNonExisting(fieldName, out _, out _nonExistingTermContainerId) == false)
+                _nonExistingTermContainerId = -1;
         }
 
         public void SortBatch<TComparer2, TComparer3>(ref SortingMultiMatch<TInner> match, LowLevelTransaction llt, PageLocator pageLocator,
@@ -227,18 +239,18 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 match._results.AddRange(batchResults);
                 return;
             }
-
+            
             _lookup.GetFor(batchResults, batchTermIds, long.MinValue);
+            SortingHelpers.ReplaceNullAndNonExistingTermIds(batchTermIds, _nonExistingTermContainerId, _nullTermContainerId, long.MinValue);
             Container.GetAll(llt, batchTermIds, new Span<UnmanagedSpan>(batchTerms, batchTermIds.Length), long.MinValue, pageLocator);
             match._token.ThrowIfCancellationRequested();
-            bool isDescending = orderMetadata[0].Ascending == false;
 
             var heapSize = Math.Min(match._take, batchResults.Length);
             heapSize = heapSize < 0 ? batchResults.Length : heapSize;
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
-            var secondaryComparer = new SortingMultiMatch<TInner>.IndirectComparer2<TComparer2, TComparer3>(ref match, comparer2, comparer3);
+            var secondaryComparer = new IndirectComparer2<TComparer2, TComparer3>(ref match, comparer2, comparer3);
             using var _ = llt.Allocator.Allocate(heapSize, out Span<UnmanagedSpan> terms);
-            var sorter = HeapSorterBuilder.BuildCompoundCompactKeySorter(indexes.Slice(0, heapSize), terms, orderMetadata[0].Ascending == false, secondaryComparer);
+            var sorter = HeapSorterBuilder.BuildCompoundCompactKeySorter(indexes.Slice(0, heapSize), terms, orderMetadata[0].Ascending == false, secondaryComparer, match._nullFirst);
            
             for (int i = 0; i < indexes.Length; i++)
                 sorter.Insert(i, batchTerms[i]);
@@ -246,102 +258,9 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             sorter.Fill(batchResults, ref match._results, ref match._scoresResults, match._secondaryScoreBuffer);
         }
 
-        private static void MaybeBreakTies<TComparer>(Span<long> buffer, TComparer tieBreaker) 
-            where TComparer : struct, IComparer<long>
-        {
-            // We may have ties, have to resolve that before we can continue
-            for (int i = 1; i < buffer.Length; i++)
-            {
-                var x = buffer[i - 1];
-                var y = buffer[i];
-
-                x >>= 15;
-                y >>= 15;
-                if (x != y)
-                    continue;
-
-                // we have a match on the prefix, need to figure out where it ends hopefully this is rare
-                int end = i;
-                for (; end < buffer.Length; end++)
-                {
-                    y = buffer[end];
-                    y >>= 15;
-                    if (x != y)
-                        break;
-                }
-
-                buffer[(i - 1)..end].Sort(tieBreaker);
-                i = end;
-            }
-        }
-
-        private static Span<int> SortByTerms<TComparer>(ref SortingMultiMatch<TInner> match, Span<long> buffer, UnmanagedSpan* batchTerms,
-            TComparer tieBreaker)
-            where TComparer : struct, IComparer<long>, IComparer<int>
-        {
-            if (buffer.Length > SortingMatch.SortBatchSize)
-            {
-                return SortDirectly(buffer, tieBreaker);
-            }
-
-            Debug.Assert(buffer.Length < (1<<15),"buffer.Length < (1<<15)");
-            
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                long l = 0;
-                if (batchTerms[i].Address != null)
-                {
-                    Memory.Copy(&l, batchTerms[i].Address + 1 /* skip metadata byte */,
-                        Math.Min(6, batchTerms[i].Length - 1));
-                }
-                else
-                {
-                    l = -1 >>> 16; // effectively move to the end
-                }
-
-                l = BinaryPrimitives.ReverseEndianness(l) >>> 1;
-                long sortKey = l | (uint)i;
-                
-                buffer[i] = sortKey;
-            }
-
-            Sort.Run(buffer);
-            MaybeBreakTies(buffer, tieBreaker);
-
-            return ExtractIndexes(buffer);
-        }
-        
-        private static Span<int> SortDirectly<TComparer>(Span<long> buffer, TComparer tieBreaker)
-            where TComparer : struct, IComparer<int>
-        {
-            // note - we reuse the memory
-            var indexes = MemoryMarshal.Cast<long, int>(buffer)[..(buffer.Length)];
-            for (int i = 0; i < indexes.Length; i++)
-            {
-                indexes[i] = i;
-            }
-            indexes.Sort(tieBreaker);
-
-            return indexes;
-        }
-
-        private static Span<int> ExtractIndexes(Span<long> buffer)
-        {
-            // note - we reuse the memory
-            var indexes = MemoryMarshal.Cast<long, int>(buffer)[..(buffer.Length)];
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                var sortKey = buffer[i];
-                var idx = (ushort)sortKey & 0x7FFF;
-                indexes[i] = idx;
-            }
-
-            return indexes;
-        }
-
         public int Compare(UnmanagedSpan x, UnmanagedSpan y)
         {
-            return CompactKeyComparer.Compare(x, y);
+            return CompactKeyComparer.Compare(x, y, _nullFirst);
         }
 
         public int Compare(int x, int y)
@@ -355,7 +274,8 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         private Lookup<Int64LookupKey> _lookup;
         private UnmanagedSpan<long> _batchResults;
         private int _comparerId;
-
+        private long _missingValue;
+        
         public Slice GetSortFieldName(ref SortingMultiMatch<TInner> match)
         {
             IndexFieldsMappingBuilder.GetFieldNameForLongs(match._searcher.Allocator, match._orderMetadata[_comparerId].Field.FieldName, out var lngName);
@@ -367,6 +287,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             _comparerId = comparerId;
             _lookup = match._searcher.EntriesToTermsReader(GetSortFieldName(ref match));
             _batchResults = batchResults;
+            _missingValue = match._nullFirst ? long.MinValue : long.MaxValue;
         }
 
         public void SortBatch<TComparer2, TComparer3>(ref SortingMultiMatch<TInner> match, LowLevelTransaction llt, PageLocator pageLocator,
@@ -381,7 +302,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 return;
             }
             // load terms for documents
-            _lookup.GetFor(batchResults, batchTermIds, BitConverter.DoubleToInt64Bits(double.MinValue));
+            _lookup.GetFor(batchResults, batchTermIds, _missingValue);
 
             var heapSize = Math.Min(match._take, batchResults.Length);
             heapSize = heapSize < 0 ? batchResults.Length : heapSize;
@@ -389,7 +310,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             using var _ = llt.Allocator.Allocate(heapSize, out Span<long> terms);
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             var secondaryComparer = new IndirectComparer2<TComparer2, TComparer3>(ref match, comparer2, comparer3);
-            var heapSorter = HeapSorterBuilder.BuildCompoundNumericalSorter(indexes.Slice(0, heapSize), terms, orderMetadata[0].Ascending == false, secondaryComparer);
+            var heapSorter = HeapSorterBuilder.BuildCompoundNumericalSorter(indexes.Slice(0, heapSize), terms, orderMetadata[0].Ascending == false, secondaryComparer, match._nullFirst);
                 
             for (int i = 0; i < indexes.Length; i++)
                 heapSorter.Insert(i, batchTermIds[i]);
@@ -412,7 +333,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             if (swap)
                 buffer[..2].Reverse();
             
-            _lookup.GetFor(buffer[..2], buffer[2..], long.MinValue);
+            _lookup.GetFor(buffer[..2], buffer[2..], _missingValue);
             if (swap) // In the case when we swapped the keys (since the lookup requires a sorted list as input), we have to swap the values before comparison to maintain the original order.
                 buffer[2..].Reverse();
             
@@ -455,6 +376,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
     private struct EntryComparerByDouble : IEntryComparer, IComparer<UnmanagedSpan>
     {
+        private long _missingValue;
         private int _comparerId;
         private Lookup<Int64LookupKey> _lookup;
         private UnmanagedSpan<long> _batchResults;
@@ -471,7 +393,8 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 return;
             }
             // load terms for documents
-            _lookup.GetFor(batchResults, batchTermIds, BitConverter.DoubleToInt64Bits(double.MinValue));
+            
+            _lookup.GetFor(batchResults, batchTermIds, _missingValue);
 
             var heapSize = Math.Min(match._take, batchResults.Length);
             heapSize = heapSize < 0 ? batchResults.Length : heapSize;
@@ -479,7 +402,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             using var _ = llt.Allocator.Allocate(heapSize, out Span<double> terms);
             var indexes = MemoryMarshal.Cast<long, int>(batchTermIds)[..(batchTermIds.Length)];
             var secondaryComparer = new IndirectComparer2<TComparer2, TComparer3>(ref match, comparer2, comparer3);
-            var heapSorter = HeapSorterBuilder.BuildCompoundNumericalSorter(indexes.Slice(0, heapSize), terms, orderMetadata[0].Ascending == false, secondaryComparer);
+            var heapSorter = HeapSorterBuilder.BuildCompoundNumericalSorter(indexes.Slice(0, heapSize), terms, orderMetadata[0].Ascending == false, secondaryComparer, match._nullFirst);
                 
             for (int i = 0; i < indexes.Length; i++)
                 heapSorter.Insert(i, BitConverter.Int64BitsToDouble(batchTermIds[i]));
@@ -498,6 +421,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             _comparerId = comparerId;
             _lookup = match._searcher.EntriesToTermsReader(GetSortFieldName(ref match));
             _batchResults = batchResults;
+            _missingValue = BitConverter.DoubleToInt64Bits(match._nullFirst ? double.MinValue : double.MaxValue);
         }
 
         public int Compare(UnmanagedSpan x, UnmanagedSpan y)
@@ -516,7 +440,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             if (swap)
                 buffer.Slice(0, 2).Reverse();
             
-            _lookup.GetFor(buffer[..2], buffer[2..], BitConverter.DoubleToInt64Bits(double.MinValue));
+            _lookup.GetFor(buffer[..2], buffer[2..], _missingValue);
             
             // In the case when we swapped the keys (since the lookup requires a sorted list as input), we have to swap the values before comparison to maintain the original order.
             if (swap)
@@ -596,6 +520,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
         private double _round;
         private int _comparerId;
         private UnmanagedSpan<long> _batchResults;
+        private double _missingValueForInnerSorter;
         
         public Slice GetSortFieldName(ref SortingMultiMatch<TInner> match) => match._orderMetadata[_comparerId].Field.FieldName;
 
@@ -607,6 +532,11 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             _units = match._orderMetadata[_comparerId].Units;
             _round = match._orderMetadata[_comparerId].Round;
             _reader = match._searcher.SpatialReader(match._orderMetadata[_comparerId].Field.FieldName);
+
+            if (comparerId > 0)
+            {
+                _missingValueForInnerSorter = match._nullFirst ? double.MinValue : double.MaxValue;
+            }
         }
 
         public void SortBatch<TComparer2, TComparer3>(ref SortingMultiMatch<TInner> match, LowLevelTransaction llt, PageLocator pageLocator,
@@ -629,7 +559,7 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
             using var _ = llt.Allocator.Allocate(heapSize, out Span<SpatialResult> terms);
 
 
-            var heapSorter = HeapSorterBuilder.BuildSingleNumericalSorter<SpatialResult>(indexes.Slice(0, heapSize), terms, descending);
+            var heapSorter = HeapSorterBuilder.BuildSingleNumericalSorter<SpatialResult>(indexes.Slice(0, heapSize), terms, descending, match._nullFirst);
             
 
 
@@ -638,7 +568,8 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
                 SpatialResult distance; 
                 if (_reader.TryGetSpatialPoint(batchResults[i], out var coords) == false)
                 {
-                    distance = new SpatialResult() { Distance = descending ? double.MinValue : double.MaxValue, Latitude = Double.NaN, Longitude = Double.NaN };
+                    var distanceForMissing = match._nullFirst ? double.MinValue : double.MaxValue;
+                    distance = new SpatialResult() { Distance = distanceForMissing, Latitude = Double.NaN, Longitude = Double.NaN };
                 }
                 else
                 {
@@ -667,11 +598,11 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
             double xDistance =
                 _reader.TryGetSpatialPoint(_batchResults[x], out var coords) == false 
-                ? double.MaxValue 
+                ? _missingValueForInnerSorter 
                 : SpatialUtils.GetGeoDistance(coords, _center, _round, _units);
 
             double yDistance = _reader.TryGetSpatialPoint(_batchResults[y], out coords) == false 
-                ? double.MaxValue 
+                ? _missingValueForInnerSorter
                 : SpatialUtils.GetGeoDistance(coords, _center, _round, _units);
 
             return xDistance.CompareTo(yDistance);

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Comparers.cs
@@ -265,7 +265,10 @@ public unsafe partial struct SortingMultiMatch<TInner> : IQueryMatch
 
         public int Compare(int x, int y)
         {
-            return _termsReader.Compare(_batchResults[x], _batchResults[y]);
+            var termX = _termsReader.GetTerm(_batchResults[x], nullTermId: _nullTermContainerId, nonExistingTermId: _nonExistingTermContainerId);
+            var termY = _termsReader.GetTerm(_batchResults[y], nullTermId: _nullTermContainerId, nonExistingTermId: _nonExistingTermContainerId);
+            
+            return CompactKeyComparer.Compare(termX, termY, _nullFirst);
         }
     }
 

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using Sparrow;

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.Helpers.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using Sparrow;

--- a/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/SortingMultiMatch.cs
@@ -22,6 +22,7 @@ public unsafe partial struct SortingMultiMatch<TInner>
     private readonly IndexSearcher _searcher;
     private TInner _inner;
     private readonly OrderMetadata[] _orderMetadata;
+    private readonly bool _nullFirst;
     private readonly delegate*<ref SortingMultiMatch<TInner>, Span<long>, int> _fillFunc;
     private readonly IEntryComparer[] _nextComparers;
     private readonly int _take;
@@ -46,11 +47,12 @@ public unsafe partial struct SortingMultiMatch<TInner>
     public long TotalResults;
     public SkipSortingResult AttemptToSkipSorting() => throw new NotSupportedException();
 
-    public SortingMultiMatch(IndexSearcher searcher, in TInner inner, OrderMetadata[] orderMetadata, int take = -1, in CancellationToken token = default)
+    public SortingMultiMatch(IndexSearcher searcher, in TInner inner, OrderMetadata[] orderMetadata, bool nullFirst, int take = -1, in CancellationToken token = default)
     {
         _searcher = searcher;
         _inner = inner;
         _orderMetadata = orderMetadata;
+        _nullFirst = nullFirst;
         _take = take;
         _token = token;
         _alreadyReadIdx = 0;

--- a/src/Corax/Querying/Matches/SortingMatches/TextualMaxHeapSorter.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/TextualMaxHeapSorter.cs
@@ -29,6 +29,7 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
     private ByteStringContext _allocator;
     public bool IsDescending;
     public TSecondaryComparer SecondaryComparer;
+    internal bool _nullFirst;
 
 
     /// <summary>
@@ -39,8 +40,9 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
     private delegate*<ref TextualMaxHeapSorter<TSecondaryComparer>, ReadOnlySpan<byte>, int, ReadOnlySpan<byte>, int, int> _compare;
 
     public void Init(Span<int> documents, Span<ByteString> terms, ByteStringContext allocator, bool descending,
-        delegate*<ref TextualMaxHeapSorter<TSecondaryComparer>, ReadOnlySpan<byte>, int, ReadOnlySpan<byte>, int, int> compare, TSecondaryComparer secondaryCmp)
+        delegate*<ref TextualMaxHeapSorter<TSecondaryComparer>, ReadOnlySpan<byte>, int, ReadOnlySpan<byte>, int, int> compare, TSecondaryComparer secondaryCmp, bool nullFirst)
     {
+        _nullFirst = nullFirst;
         IsDescending = descending;
         _allocator = allocator;
         _documents = documents;
@@ -155,18 +157,35 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
     /// <param name="results">Destination of sorted results</param>
     /// <param name="scoreDestination">Destination of scores (sorted)</param>
     /// <param name="scores">An array with scores associated with batchResults</param>
-    public void Fill(Span<long> batchResults, ref ContextBoundNativeList<long> results, ref ContextBoundNativeList<float> scoreDestination, Span<float> scores)
+    /// <param name="nullIndexes">Positions in batchResults that have null terms and were excluded from the heap</param>
+    public void Fill(Span<long> batchResults, ref ContextBoundNativeList<long> results, ref ContextBoundNativeList<float> scoreDestination, Span<float> scores, ContextBoundNativeList<int> nullIndexes)
     {
         ValidateMaxHeapStructure();
-        var start = results.Count;
-        results.EnsureCapacityFor(_heapSize);
-        int documentsToReturn = _heapSize;
+        
+        int nullCount = nullIndexes.HasContext ? nullIndexes.Count : 0;
+        int startNullLength = 0;
 
+        var writeNullFirst = nullCount > 0
+                                    && (IsDescending && _nullFirst == false // null last, but we're sorting descending 
+                                        || (IsDescending == false && _nullFirst)); //ascending, null first
+        
+        if (writeNullFirst)
+        {
+            // HeapCapacity is the official limit what Fill should return.
+            var nullsToWrite = Math.Min(nullCount, _heapCapacity); // We could have more nulls than we can write. Let's write as much as we can.
+            AppendNulls(batchResults, ref results, ref scoreDestination, scores, nullIndexes, nullsToWrite);
+            startNullLength = nullsToWrite;
+            
+            if (startNullLength == _heapCapacity)
+                return; // We filled the limit with nulls. We're done.
+        }
+        
         var exposeScore = scoreDestination.HasContext && scores.IsEmpty == false;
         if (exposeScore)
             scoreDestination.EnsureCapacityFor(_heapSize);
         
-        while (documentsToReturn > 0)
+        results.EnsureCapacityFor(_heapSize);
+        while (_heapSize > 0)
         {
             results.AddUnsafe(batchResults[_documents[0]]);
             
@@ -174,10 +193,7 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
                 scoreDestination.AddUnsafe(scores[_documents[0]]);
             
             RemoveMax();
-            documentsToReturn--;
         }
-
-        Debug.Assert(_heapSize == 0, "_heapSize == 0");
         
         // When we sort a max-heap by repeatedly extracting the maximum value (at index 0), the result is in reverse order (locally - in the heap).
         // Note that we're not dealing with all documents, but only up to heapSize.
@@ -185,10 +201,46 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
         // (which is the minimum in the case of descending sorting) to decide if a document
         // should replace the max element in the heap (and then find the new maximum).
         // Reversing the elements is done via Span<T>.Reverse, which is a vectorized operation.
-        results.ToSpan().Slice(start).Reverse();
+        // When nulls were prepended, skip over them so they remain at the front.
+        results.ToSpan().Slice(startNullLength).Reverse();
         if (exposeScore)
-            scoreDestination.ToSpan().Slice(start).Reverse();
+            scoreDestination.ToSpan().Slice(startNullLength).Reverse();
+
+        if (writeNullFirst)
+        {
+            //We've max-heap. Internal comparer controls Descending/Ascending. We had to take out all elements from heap to reverse them, however,
+            // we still need to respect the count. So let's shrink it to the official limit.
+            results.Shrink(_heapCapacity);
+            if (exposeScore)
+                scoreDestination.Shrink(_heapCapacity); 
+        } 
+        else if (nullCount > 0 && results.Count < _heapCapacity) // We need to write nulls at the end, and we still have space for doing it. If we don't have enough space, it means we've been paging, and we're in the "middle" page.
+        {
+            AppendNulls(batchResults, ref results, ref scoreDestination, scores, nullIndexes, Math.Min(_heapCapacity - results.Count, nullCount));
+        }
     }
+
+    private void AppendNulls(Span<long> batchResults, ref ContextBoundNativeList<long> results,
+        ref ContextBoundNativeList<float> scoreDestination, Span<float> scores,
+        ContextBoundNativeList<int> nullIndexes, int nullCount)
+    {
+        if (typeof(TSecondaryComparer) != typeof(HeapSorterBuilder.SkipSecondaryComparer))
+            nullIndexes.ToSpan().Sort(SecondaryComparer);
+
+        var exposeScore = scoreDestination.HasContext && scores.IsEmpty == false;
+        results.EnsureCapacityFor(nullCount);
+        if (exposeScore)
+            scoreDestination.EnsureCapacityFor(nullCount);
+
+        var nullSpan = nullIndexes.ToSpan();
+        for (int i = 0; i < nullCount; i++)
+        {
+            results.AddUnsafe(batchResults[nullSpan[i]]);
+            if (exposeScore)
+                scoreDestination.AddUnsafe(scores[nullSpan[i]]);
+        }
+    }
+
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int Parent(int idX) => (idX - 1) / 2;

--- a/src/Corax/Querying/Matches/SortingMatches/TextualMaxHeapSorter.cs
+++ b/src/Corax/Querying/Matches/SortingMatches/TextualMaxHeapSorter.cs
@@ -160,6 +160,7 @@ internal unsafe ref struct TextualMaxHeapSorter<TSecondaryComparer> where TSecon
     /// <param name="nullIndexes">Positions in batchResults that have null terms and were excluded from the heap</param>
     public void Fill(Span<long> batchResults, ref ContextBoundNativeList<long> results, ref ContextBoundNativeList<float> scoreDestination, Span<float> scores, ContextBoundNativeList<int> nullIndexes)
     {
+        Debug.Assert(results.Count == 0, "Results should be empty");
         ValidateMaxHeapStructure();
         
         int nullCount = nullIndexes.HasContext ? nullIndexes.Count : 0;

--- a/src/Corax/Querying/TermsReader.cs
+++ b/src/Corax/Querying/TermsReader.cs
@@ -172,7 +172,8 @@ public unsafe struct TermsReader : IDisposable
         term = scope.Key.Decoded();
     }
 
-    private UnmanagedSpan GetTerm(long entryId)
+
+    public UnmanagedSpan GetTerm(long entryId, long nullTermId = -1, long nonExistingTermId = -1)
     {
         var idx = (uint)Hashing.Mix(entryId) % CacheSize;
         ref (long Key, UnmanagedSpan Value) cache = ref _cache[idx];
@@ -183,6 +184,13 @@ public unsafe struct TermsReader : IDisposable
         }
 
         var hasValue = _lookup.TryGetValue(entryId, out var termId);
+        if (hasValue && (termId == nullTermId || termId == nonExistingTermId))
+        {
+            cache = (entryId, default);
+            return default;
+        }
+        
+        
         UnmanagedSpan term = UnmanagedSpan.Empty;
         if (hasValue)
         {
@@ -193,28 +201,7 @@ public unsafe struct TermsReader : IDisposable
         cache = (entryId, term);
         return term;
     }
-
-    public int Compare(long x, long y)
-    {
-        var xItem = GetTerm(x);
-        var yItem = GetTerm(y);
-
-        if (yItem.Address == null)
-        {
-            return xItem.Address == null ? 0 : 1;
-        }
-
-        if (xItem.Address == null)
-            return -1;
-
-        var match = Memory.CompareInline(xItem.Address + 1, yItem.Address + 1, Math.Min(xItem.Length - 1, yItem.Length - 1));
-        if (match != 0)
-            return match;
-        var xItemLengthInBits = (xItem.Length - 1) * 8 - (xItem.Address[0] >> 4);
-        var yItemLengthInBits = (yItem.Length - 1) * 8 - (yItem.Address[0] >> 4);
-        return xItemLengthInBits - yItemLengthInBits;
-    }
-
+    
     public void Dispose()
     {
         _pagesToPrefetch.Dispose();

--- a/src/Corax/Utils/CoraxTestingConfiguration.cs
+++ b/src/Corax/Utils/CoraxTestingConfiguration.cs
@@ -4,4 +4,5 @@ public class CoraxTestingConfiguration
 {
     public bool DisableVectorSearchScanning { get; set; }
     public bool IsAccelerated { get; set; } = true;
+    public bool ForceSortingUsingIndex;
 }

--- a/src/Corax/Utils/OrderMetadata.cs
+++ b/src/Corax/Utils/OrderMetadata.cs
@@ -16,6 +16,7 @@ public readonly struct OrderMetadata
     public readonly double Round;
     public readonly SpatialUnits Units;
     public readonly int RandomSeed;
+    public readonly bool FieldHasNoTerms;
 
     public override string ToString()
     {
@@ -58,7 +59,7 @@ public readonly struct OrderMetadata
 
     }
 
-    public OrderMetadata(in FieldMetadata field, bool ascending, MatchCompareFieldType fieldType)
+    public OrderMetadata(in FieldMetadata field, bool ascending, MatchCompareFieldType fieldType, bool fieldHasNoTerms)
     {
         Unsafe.SkipInit(out HasBoost);
         Unsafe.SkipInit(out Point);
@@ -69,9 +70,10 @@ public readonly struct OrderMetadata
         Field = field;
         Ascending = ascending;
         FieldType = fieldType;
+        FieldHasNoTerms = fieldHasNoTerms;
     }
 
-    public OrderMetadata(in FieldMetadata field, bool ascending, MatchCompareFieldType fieldType, IPoint point, double round, SpatialUnits units)
+    public OrderMetadata(in FieldMetadata field, bool ascending, MatchCompareFieldType fieldType, IPoint point, double round, SpatialUnits units, bool fieldHasNoTerms)
     {
         Unsafe.SkipInit(out HasBoost);  
         Unsafe.SkipInit(out RandomSeed);
@@ -82,5 +84,6 @@ public readonly struct OrderMetadata
         Round = round;
         Point = point;
         Units = units;
+        FieldHasNoTerms = fieldHasNoTerms;
     }
 }

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -671,6 +671,12 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery { get; protected set; }
         
+        [Description("Corax: nulls are lowest values in ascending sorting.")]
+        [DefaultValue(true)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.Querying.Corax.NullFirst", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public bool NullFirst { get; protected set; }
+        
         protected override void ValidateProperty(PropertyInfo property)
         {
             base.ValidateProperty(property);

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -671,7 +671,7 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public bool UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery { get; protected set; }
         
-        [Description("Corax: nulls are lowest values in ascending sorting.")]
+        [Description("Corax: Null values appear first when sorting in ascending order.")]
         [DefaultValue(true)]
         [IndexUpdateType(IndexUpdateType.Refresh)]
         [ConfigurationEntry("Indexing.Querying.Corax.NullFirst", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -98,6 +98,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
 
         private TermsReader _documentIdReader;
 
+        public override bool IsSharded => false;
 
         public CoraxIndexReadOperation(Index index, RavenLogger logger, Transaction readTransaction, QueryBuilderFactories queryBuilderFactories, IndexFieldsMapping fieldsMapping, IndexQueryServerSide query) : base(index, logger, queryBuilderFactories, query)
         {

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1398,7 +1398,7 @@ public static partial class CoraxQueryBuilder
             case 1:
                 return indexSearcher.OrderBy(match, orderMetadata[0], builderParameters.Index.Configuration.NullFirst, take, builderParameters.Token);
             default:
-                return indexSearcher.OrderBy(match, orderMetadata, take, builderParameters.Token);
+                return indexSearcher.OrderBy(match, orderMetadata, builderParameters.Index.Configuration.NullFirst, take, builderParameters.Token);
         }
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -183,7 +183,7 @@ public static partial class CoraxQueryBuilder
             IQueryMatch coraxQuery;
             var metadata = builderParameters.Query.Metadata;
             var indexSearcher = builderParameters.IndexSearcher;
-            sortMetadata = GetSortMetadata(builderParameters);
+            sortMetadata = GetSortMetadata(builderParameters, out var hasEmptySortingMatches);
             var streamingOptimization = new StreamingOptimization(indexSearcher, sortMetadata, builderParameters.HasBoost);
             
             if (metadata.Query.Where is not null)
@@ -240,7 +240,7 @@ public static partial class CoraxQueryBuilder
                 // In the case of ordering by multiple fields, we still want to benefit from the streaming
                 // optimization, but we have to sort again anyway, this ensure that this happens
                 if (streamingOptimization.SkipOrderByClause == false || sortMetadata.Length > 1)
-                    coraxQuery = OrderBy(builderParameters, coraxQuery, sortMetadata);
+                    coraxQuery = OrderBy(builderParameters, coraxQuery, sortMetadata, hasEmptySortingMatches);
             }
 
             // The parser already throws parse exception if there is a syntax error.
@@ -1246,8 +1246,9 @@ public static partial class CoraxQueryBuilder
         }
     }
 
-    public static OrderMetadata[] GetSortMetadata(Parameters builderParameters)
+    public static OrderMetadata[] GetSortMetadata(Parameters builderParameters, out bool hasEmpty)
     {
+        hasEmpty = false;
         var query = builderParameters.Query;
         var index = builderParameters.Index;
         var getSpatialField = builderParameters.Factories?.GetSpatialFieldFactory;
@@ -1255,7 +1256,9 @@ public static partial class CoraxQueryBuilder
         var queryMapping = builderParameters.FieldsToFetch;
         var allocator = builderParameters.Allocator;
         if (query.PageSize == 0) // no need to sort when counting only
+        {
             return null;
+        }
 
         var orderByFields = query.Metadata.OrderBy;
 
@@ -1285,6 +1288,8 @@ public static partial class CoraxQueryBuilder
 
         foreach (var field in orderByFields)
         {
+            
+            
             if (field.OrderingType == OrderByFieldType.Random)
             {
                 var seed = field.Arguments is { Length: > 0 } ?
@@ -1306,10 +1311,15 @@ public static partial class CoraxQueryBuilder
 
             var fieldMetadata = QueryBuilderHelper.GetFieldIdForOrderBy(allocator, field.Name, index, builderParameters.HasDynamics,
                 builderParameters.DynamicFields, indexMapping, queryMapping, false);
-
-            if (builderParameters.IndexSearcher.GetTermAmountInField(fieldMetadata) == 0)
-                continue;
-
+            
+            bool fieldIsEmpty = builderParameters.IndexSearcher.GetTermAmountInField(fieldMetadata) == 0;
+            if (fieldIsEmpty)
+            {
+                if (builderParameters.IndexReadOperation.IsSharded == false)
+                    continue;
+                hasEmpty = true;
+            }
+            
             if (field.OrderingType == OrderByFieldType.Distance)
             {
                 var spatialField = getSpatialField(field.Name);
@@ -1353,7 +1363,7 @@ public static partial class CoraxQueryBuilder
                 sortArray[sortIndex++] = new OrderMetadata(fieldMetadata, field.Ascending, MatchCompareFieldType.Spatial, point, roundTo,
                     spatialField.Units is SpatialUnits.Kilometers
                         ? global::Corax.Utils.Spatial.SpatialUnits.Kilometers
-                        : global::Corax.Utils.Spatial.SpatialUnits.Miles);
+                        : global::Corax.Utils.Spatial.SpatialUnits.Miles, fieldIsEmpty);
                 continue;
             }
 
@@ -1370,27 +1380,46 @@ public static partial class CoraxQueryBuilder
                 case OrderByFieldType.Custom:
                     throw new NotSupportedInCoraxException($"{nameof(Corax)} doesn't support Custom OrderBy.");
                 case OrderByFieldType.AlphaNumeric:
-                    sortArray[sortIndex++] = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Alphanumeric);
+                    sortArray[sortIndex++] = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Alphanumeric, fieldIsEmpty);
                     continue;
                 case OrderByFieldType.Long:
-                    temporaryOrder = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Integer);
+                    temporaryOrder = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Integer, fieldIsEmpty);
                     break;
                 case OrderByFieldType.Double:
-                    temporaryOrder = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Floating);
+                    temporaryOrder = new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Floating, fieldIsEmpty);
                     break;
             }
 
-            sortArray[sortIndex++] = temporaryOrder ?? new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Sequence);
+            sortArray[sortIndex++] = temporaryOrder ?? new OrderMetadata(metadataField, field.Ascending, MatchCompareFieldType.Sequence, fieldIsEmpty);
         }
 
         return sortArray[0..sortIndex];
     }
 
-    private static IQueryMatch OrderBy(Parameters builderParameters, IQueryMatch match, in OrderMetadata[] orderMetadata)
+    private static IQueryMatch OrderBy(Parameters builderParameters, IQueryMatch match, in OrderMetadata[] orderMetadataSource, bool hasEmptySortingMatches)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
         var indexSearcher = builderParameters.IndexSearcher;
         var take = builderParameters.Take;
+        OrderMetadata[] orderMetadata = null;
+        if (hasEmptySortingMatches == false)
+            orderMetadata = orderMetadataSource;
+        else
+        {
+            var currentIdx = 0;
+            foreach (var orderMetadataItem in orderMetadataSource)
+            {
+                if (orderMetadataItem.FieldHasNoTerms)
+                    continue;
+                
+                orderMetadata ??= new OrderMetadata[orderMetadataSource.Length];
+                orderMetadata[currentIdx++] = orderMetadataItem;
+                
+            }
+
+            orderMetadata = currentIdx == 0 ? [] : orderMetadata![..currentIdx];
+        }
+  
         switch (orderMetadata.Length)
         {
             case 0:

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -184,8 +184,8 @@ public static partial class CoraxQueryBuilder
             var metadata = builderParameters.Query.Metadata;
             var indexSearcher = builderParameters.IndexSearcher;
             sortMetadata = GetSortMetadata(builderParameters);
-            var streamingOptimization = new StreamingOptimization(indexSearcher, sortMetadata, builderParameters.HasBoost);
-
+            var streamingOptimization = new StreamingOptimization(indexSearcher, sortMetadata, builderParameters.HasBoost, builderParameters.Index.Configuration.NullFirst);
+            
             if (metadata.Query.Where is not null)
             {
                 coraxQuery = ToCoraxQuery(builderParameters, metadata.Query.Where,  ref streamingOptimization);
@@ -215,13 +215,13 @@ public static partial class CoraxQueryBuilder
                     _ => throw new ArgumentOutOfRangeException("Already checked the FieldType, but was: " + sortBy.FieldType)
                 };
 
-                var queryWithNullMatches = indexSearcher.IncludeNullMatch(in sortBy.Field, betweenQuery, sortBy.Ascending);
+                var queryWithNullMatches = indexSearcher.IncludeNullMatch(in sortBy.Field, betweenQuery, sortBy.Ascending, builderParameters.Index.Configuration.NullFirst);
 
                 var indexVersion = builderParameters.Index.Definition.Version;
 
                 if (IndexDefinitionBaseServerSide.IndexVersion.IsNonExistingPostingListSupported(indexVersion))
                 {
-                    var queryWithNullAndNonExistingMatches = indexSearcher.IncludeNonExistingMatch(in sortBy.Field, queryWithNullMatches, sortBy.Ascending);
+                    var queryWithNullAndNonExistingMatches = indexSearcher.IncludeNonExistingMatch(in sortBy.Field, queryWithNullMatches, sortBy.Ascending, builderParameters.Index.Configuration.NullFirst);
                     coraxQuery = queryWithNullAndNonExistingMatches;
                 }
 
@@ -1396,7 +1396,7 @@ public static partial class CoraxQueryBuilder
             case 0:
                 return match;
             case 1:
-                return indexSearcher.OrderBy(match, orderMetadata[0], take, builderParameters.Token);
+                return indexSearcher.OrderBy(match, orderMetadata[0], builderParameters.Index.Configuration.NullFirst, take, builderParameters.Token);
             default:
                 return indexSearcher.OrderBy(match, orderMetadata, take, builderParameters.Token);
         }

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -184,7 +184,7 @@ public static partial class CoraxQueryBuilder
             var metadata = builderParameters.Query.Metadata;
             var indexSearcher = builderParameters.IndexSearcher;
             sortMetadata = GetSortMetadata(builderParameters);
-            var streamingOptimization = new StreamingOptimization(indexSearcher, sortMetadata, builderParameters.HasBoost, builderParameters.Index.Configuration.NullFirst);
+            var streamingOptimization = new StreamingOptimization(indexSearcher, sortMetadata, builderParameters.HasBoost);
             
             if (metadata.Query.Where is not null)
             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/IndexReadOperationBase.cs
@@ -19,6 +19,7 @@ namespace Raven.Server.Documents.Indexes.Persistence
 {
     public abstract class IndexReadOperationBase : IndexOperationBase
     {
+        public abstract bool IsSharded { get; }
         protected readonly QueryBuilderFactories QueryBuilderFactories;
         private readonly MemoryInfo _memoryInfo;
         private static readonly long ThresholdForMemoryUsageLoggingInBytes = new Size(512, SizeUnit.Megabytes).GetValue(SizeUnit.Bytes);

--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexReadOperation.cs
@@ -66,6 +66,8 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
         private static readonly LuceneCleaner _luceneCleaner;
 
+        public override bool IsSharded => false;
+        
         static LuceneIndexReadOperation()
         {
             _luceneCleaner = new LuceneCleaner();

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -25,6 +25,8 @@ namespace Raven.Server.Documents.Indexes.Sharding.Persistence.Corax;
 
 public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
 {
+    public override bool IsSharded => true;
+
     public ShardedCoraxIndexReadOperation(Index index, RavenLogger logger, Transaction readTransaction, QueryBuilderFactories queryBuilderFactories,
         IndexFieldsMapping fieldsMapping, IndexQueryServerSide query) : base(index, logger, readTransaction, queryBuilderFactories, fieldsMapping, query)
     {
@@ -98,30 +100,36 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
             switch (orderByField.OrderingType)
             {
                 case OrderByFieldType.Long:
-                    long l = long.MaxValue;
+                    long? l = null;
                     while (reader.FindNext(fieldRootPage))
                     {
-                        l = long.Min(l, reader.CurrentLong);
+                        if (reader.IsNull || reader.IsNonExisting)
+                            continue;
+                        l = l.HasValue ? long.Min(l.Value, reader.CurrentLong) : reader.CurrentLong;
                     }
+                    
                     result.AddLongOrderByField(l);
                     break;
                 case OrderByFieldType.Double:
-                    double d = double.MaxValue;
+                    double? d = null;
                     while (reader.FindNext(fieldRootPage))
                     {
-                        d = double.Min(d, reader.CurrentDouble);
+                        if (reader.IsNull || reader.IsNonExisting)
+                            continue;
+                        d = d.HasValue ? double.Min(d.Value, reader.CurrentDouble) : reader.CurrentDouble;
                     }
                     result.AddDoubleOrderByField(d);
                     break;
                 case OrderByFieldType.Distance:
                 {
-                    double m = double.MaxValue;
+                    double? m = null;
                     while (reader.FindNextSpatial(fieldRootPage))
                     {
+                        if (reader.IsNull || reader.IsNonExisting)
+                            continue;
                         var coordinates = (reader.Latitude, reader.Longitude);
-                     
                         var distance = SpatialUtils.GetGeoDistance(in coordinates, (orderByFieldMetadata.Point.X, orderByFieldMetadata.Point.Y), orderByFieldMetadata.Round, orderByFieldMetadata.Units);
-                        m = double.Min(m, distance);
+                        m = m.HasValue ? double.Min(m.Value, distance) : distance;
                     }
 
                     result.AddDoubleOrderByField(m);

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Lucene/ShardedLuceneIndexReadOperation.cs
@@ -16,6 +16,8 @@ namespace Raven.Server.Documents.Indexes.Sharding.Persistence.Lucene;
 
 public sealed class ShardedLuceneIndexReadOperation : LuceneIndexReadOperation
 {
+    public override bool IsSharded => true;
+
     public ShardedLuceneIndexReadOperation(Index index, LuceneVoronDirectory directory, LuceneIndexSearcherHolder searcherHolder,
         QueryBuilderFactories queryBuilderFactories, Transaction readTransaction, IndexQueryServerSide query) : base(index, directory, searcherHolder,
         queryBuilderFactories, readTransaction, query)

--- a/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Raven.Client;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Documents.Queries.AST;
@@ -15,12 +16,16 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
 {
     private readonly OrderByField[] _orderByFields;
     private readonly bool _extractFromData;
+    private readonly bool _nullFirst;
+    private readonly bool _acceptMissingValues;
     private readonly Random[] _randoms;
 
-    public DocumentsComparer(OrderByField[] orderByFields, bool extractFromData, bool hasOrderByRandom)
+    public DocumentsComparer(OrderByField[] orderByFields, bool extractFromData, bool hasOrderByRandom, bool nullFirst, bool acceptMissingValues)
     {
         _orderByFields = orderByFields;
         _extractFromData = extractFromData;
+        _nullFirst = nullFirst;
+        _acceptMissingValues = acceptMissingValues;
         _randoms = hasOrderByRandom == false
             ? null
             : GetRandom(_orderByFields);
@@ -66,12 +71,36 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
                 {
                     var xVal = GetString(x, order.Name, index);
                     var yVal = GetString(y, order.Name, index);
+
+                    if (_acceptMissingValues && (xVal == null || yVal == null))
+                    {
+                        if (xVal == null && yVal == null)
+                            return 0;
+                        
+                        if (yVal == null)
+                            return _nullFirst ? 1 : -1;
+                        
+                        return _nullFirst ? -1 : 1;
+                    }
+                    
                     return string.Compare(xVal, yVal, StringComparison.OrdinalIgnoreCase);
                 }
             case OrderByFieldType.Long:
                 {
                     var hasX = TryGetLongValue(x, order.Name, index, out long xLng);
                     var hasY = TryGetLongValue(y, order.Name, index, out long yLng);
+                    
+                    if (_acceptMissingValues && (hasX == false || hasY == false))
+                    {
+                        if (hasX == false && hasY == false)
+                            return 0;
+                        
+                        if (hasY == false)
+                            return _nullFirst ? 1 : -1;
+                        
+                        return _nullFirst ? -1 : 1;
+                    }
+                    
                     if (hasX == false && hasY == false)
                         return 0;
                     if (hasX == false)
@@ -85,6 +114,18 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
                 {
                     var hasX = TryGetDoubleValue(x, order.Name, index, out double xDbl);
                     var hasY = TryGetDoubleValue(y, order.Name, index, out double yDbl);
+                    
+                    if (_acceptMissingValues && (hasX == false || hasY == false))
+                    {
+                        if (hasX == false && hasY == false)
+                            return 0;
+                        
+                        if (hasY == false)
+                            return _nullFirst ? 1 : -1;
+                        
+                        return _nullFirst ? -1 : 1;
+                    }
+                    
                     if (hasX == false && hasY == false)
                         return 0;
                     if (hasX == false)
@@ -97,6 +138,18 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
                 {
                     var xVal = GetString(x, order.Name, index);
                     var yVal = GetString(y, order.Name, index);
+                    
+                    if (_acceptMissingValues && (xVal == null || yVal == null))
+                    {
+                        if (xVal == null && yVal == null)
+                            return 0;
+                        
+                        if (yVal == null)
+                            return _nullFirst ? 1 : -1;
+                        
+                        return _nullFirst ? -1 : 1;
+                    }
+                    
                     if (xVal == null && yVal == null)
                         return 0;
                     if (xVal == null)
@@ -125,10 +178,20 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
         }
 
         if (blittable.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
+        {
+            if (_acceptMissingValues)
+                return null;
+            
             ThrowIfCannotFindMetadata(blittable);
+        }
 
         if (metadata.TryGet(Constants.Documents.Metadata.Sharding.Querying.OrderByFields, out BlittableJsonReaderArray orderByFields) == false)
+        {
+            if (_acceptMissingValues)
+                return null;
+            
             ThrowIfCannotFindOrderByFields(metadata);
+        }
 
         return orderByFields[index]?.ToString();
     }
@@ -141,12 +204,34 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
         }
 
         if (blittable.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
+        {
+            if (_acceptMissingValues)
+            {
+                value = 0;
+                return false;
+            }
+            
             ThrowIfCannotFindMetadata(blittable);
+        }
 
         if (metadata.TryGet(Constants.Documents.Metadata.Sharding.Querying.OrderByFields, out BlittableJsonReaderArray orderByFields) == false)
+        {
+            if (_acceptMissingValues)
+            {
+                value = 0;
+                return false;
+            }
             ThrowIfCannotFindOrderByFields(metadata);
+        }
 
         var arrayValue = orderByFields[index];
+
+        if (arrayValue is null)
+        {
+            value = 0;
+            return false;
+        }
+        
         if (arrayValue is long v)
         {
             value = v;
@@ -166,12 +251,33 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
         }
 
         if (blittable.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
+        {
+            if (_acceptMissingValues)
+            {
+                value = 0;
+                return false;
+            }
             ThrowIfCannotFindMetadata(blittable);
+        }
 
         if (metadata.TryGet(Constants.Documents.Metadata.Sharding.Querying.OrderByFields, out BlittableJsonReaderArray orderByFields) == false)
+        {
+            if (_acceptMissingValues)
+            {
+                value = 0;
+                return false;
+            }
             ThrowIfCannotFindOrderByFields(metadata);
+        }
 
         var arrayValue = orderByFields[index];
+        
+        if (arrayValue is null)
+        {
+            value = 0;
+            return false;
+        }
+        
         if (arrayValue is LazyNumberValue lnv)
         {
             value = lnv.ToDouble(CultureInfo.InvariantCulture);
@@ -205,5 +311,30 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
     private static void ThrowIfNotExpectedType(string expectedType, object actualValue)
     {
         throw new InvalidOperationException($"Expected to get type: {expectedType} but got: {actualValue} of type: {actualValue.GetType()}");
+    }
+    
+    public static void RetrieveConfigurationForDocumentsComparer(ShardedDatabaseContext databaseContext, string indexName, out bool nullFirst, out bool acceptMissing)
+    {
+        if (indexName == null)
+            goto Default;
+        
+        var index = databaseContext.Indexes.GetIndex(indexName);
+        if (index == null)
+            goto Default;
+
+        var searchEngine = index.Type.IsAuto() 
+            ? index.Configuration.AutoIndexingEngineType 
+            : index.Configuration.StaticIndexingEngineType;
+        
+        if (searchEngine == SearchEngineType.Lucene)
+            goto Default;
+
+        nullFirst = index.Configuration.NullFirst;
+        acceptMissing = true;
+        return;
+        
+        Default:
+        nullFirst = true;
+        acceptMissing = false;
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
@@ -315,26 +315,24 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
     
     public static void RetrieveConfigurationForDocumentsComparer(ShardedDatabaseContext databaseContext, string indexName, out bool nullFirst, out bool acceptMissing)
     {
+        nullFirst = true;
+        acceptMissing = false;
+
         if (indexName == null)
-            goto Default;
-        
+            return;
+    
         var index = databaseContext.Indexes.GetIndex(indexName);
         if (index == null)
-            goto Default;
+            return;
 
         var searchEngine = index.Type.IsAuto() 
             ? index.Configuration.AutoIndexingEngineType 
             : index.Configuration.StaticIndexingEngineType;
-        
+    
         if (searchEngine == SearchEngineType.Lucene)
-            goto Default;
+            return;
 
         nullFirst = index.Configuration.NullFirst;
         acceptMissing = true;
-        return;
-        
-        Default:
-        nullFirst = true;
-        acceptMissing = false;
     }
 }

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Streaming/ShardedStreamingHandlerProcessorForGetStreamQuery.cs
@@ -142,7 +142,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
     {
         private readonly HttpContext _httpContext;
         private readonly Func<(JsonOperationContext, IDisposable)> _allocateJsonContext;
-        private readonly IComparer<BlittableJsonReaderObject> _comparer;
+        private readonly Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> _comparerCreator;
         private readonly Dictionary<int, PostQueryStreamCommand> _queryStreamCommands;
         private readonly IndexQueryServerSide _query;
         private readonly ShardedDatabaseContext _databaseContext;
@@ -153,14 +153,13 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
         private readonly long _take;
         private readonly CancellationToken _token;
 
-        public ShardedStreamQueryOperation(HttpContext httpContext, Func<(JsonOperationContext, IDisposable)> allocateJsonContext,
-            IComparer<BlittableJsonReaderObject> comparer, Dictionary<int, PostQueryStreamCommand> queryStreamCommands,
+        public ShardedStreamQueryOperation(HttpContext httpContext, Func<(JsonOperationContext, IDisposable)> allocateJsonContext,Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> comparerCreator, Dictionary<int, PostQueryStreamCommand> queryStreamCommands,
             IndexQueryServerSide query, ShardedDatabaseContext databaseContext, List<OrderByField> groupByFields,
             bool isProjectionFromMapReduceIndex, TransactionOperationContext context, CancellationToken token)
         {
             _httpContext = httpContext;
             _allocateJsonContext = allocateJsonContext;
-            _comparer = comparer;
+            _comparerCreator = comparerCreator;
             _queryStreamCommands = queryStreamCommands;
             _query = query;
             _databaseContext = databaseContext;
@@ -183,9 +182,7 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
         {
             var queryStats = new StreamQueryStatistics();
 
-            var mergedEnumerator = _groupByFields != null
-                ? new ShardedMapReduceStreamingEnumerator(_query, _databaseContext, _groupByFields, _isProjectionFromMapReduceIndex, queryStats, _context, _token)
-                : new MergedEnumerator<BlittableJsonReaderObject>(_comparer);
+            MergedEnumerator<BlittableJsonReaderObject> mergedEnumerator = null;
 
             foreach (var streamResult in results.Values)
             {
@@ -202,8 +199,16 @@ namespace Raven.Server.Documents.Sharding.Handlers.Processors.Streaming
                     queryStats.IndexTimestamp = qs.IndexTimestamp;
                 }
 
+                mergedEnumerator ??= _groupByFields != null
+                    ? new ShardedMapReduceStreamingEnumerator(_query, _databaseContext, _groupByFields, _isProjectionFromMapReduceIndex, queryStats, _context, _token)
+                    : new MergedEnumerator<BlittableJsonReaderObject>(_comparerCreator(_databaseContext, queryStats.IndexName, _query));
+                
                 mergedEnumerator.AddEnumerator(enumerator);
             }
+            
+            mergedEnumerator ??= _groupByFields != null
+                ? new ShardedMapReduceStreamingEnumerator(_query, _databaseContext, _groupByFields, _isProjectionFromMapReduceIndex, queryStats, _context, _token)
+                : new MergedEnumerator<BlittableJsonReaderObject>(_comparerCreator(_databaseContext, _query.Metadata.IndexName, _query));
 
             return new ShardedStreamQueryResult(mergedEnumerator, _skip, _take, queryStats);
         }

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/AbstractShardedQueryOperation.cs
@@ -44,6 +44,8 @@ public abstract class AbstractShardedQueryOperation<TCombinedResult, TResult, TI
     }
 
     public HttpRequest HttpRequest { get => _requestHandler.HttpContext.Request; }
+    
+    protected ShardedDatabaseContext DatabaseContext => _requestHandler.DatabaseContext;
 
     public string ExpectedEtag { get; }
 

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedIndexEntriesQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedIndexEntriesQueryOperation.cs
@@ -19,18 +19,18 @@ namespace Raven.Server.Documents.Sharding.Operations.Queries;
 public sealed class ShardedIndexEntriesQueryOperation : AbstractShardedQueryOperation<ShardedIndexEntriesQueryResult, BlittableJsonReaderObject, BlittableJsonReaderObject>
 {
     private readonly IndexQueryServerSide _query;
-    private readonly IComparer<BlittableJsonReaderObject> _sortingComparer;
+    private readonly Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> _sortingComparerCreator;
 
     public ShardedIndexEntriesQueryOperation([NotNull] IndexQueryServerSide query,
         TransactionOperationContext context,
         ShardedDatabaseRequestHandler requestHandler,
         Dictionary<int, ShardedQueryCommand> queryCommands,
-        [NotNull] IComparer<BlittableJsonReaderObject> sortingComparer,
+        [NotNull] Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> sortingComparerCreator,
         string expectedEtag)
         : base(query.Metadata, queryCommands, context, requestHandler, expectedEtag)
     {
         _query = query ?? throw new ArgumentNullException(nameof(query));
-        _sortingComparer = sortingComparer ?? throw new ArgumentNullException(nameof(sortingComparer));
+        _sortingComparerCreator = sortingComparerCreator ?? throw new ArgumentNullException(nameof(sortingComparerCreator));
     }
 
     public bool FromStudio => HttpRequest.IsFromStudio();
@@ -52,7 +52,7 @@ public sealed class ShardedIndexEntriesQueryOperation : AbstractShardedQueryOper
         }
 
         // all the results from each command are already ordered
-        using (var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(_sortingComparer))
+        using (var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(_sortingComparerCreator(DatabaseContext, result.IndexName, _query)))
         {
             foreach (var (shardNumber, cmdResult) in results)
             {

--- a/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
+++ b/src/Raven.Server/Documents/Sharding/Operations/Queries/ShardedQueryOperation.cs
@@ -24,7 +24,7 @@ public sealed class ShardedQueryOperation : AbstractShardedQueryOperation<Sharde
 {
     private readonly IndexQueryServerSide _query;
     private readonly bool _isDistinctQuery;
-    private readonly IComparer<BlittableJsonReaderObject> _sortingComparer;
+    private readonly Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> _sortingComparerCreator;
     private readonly HashSet<int> _alreadySeenProjections;
     private HashSet<string> _timeSeriesFieldNames;
 
@@ -33,12 +33,12 @@ public sealed class ShardedQueryOperation : AbstractShardedQueryOperation<Sharde
         TransactionOperationContext context,
         ShardedDatabaseRequestHandler requestHandler,
         Dictionary<int, ShardedQueryCommand> queryCommands,
-        [NotNull] IComparer<BlittableJsonReaderObject> sortingComparer,
+        [NotNull] Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> sortingComparerCreator,
         string expectedEtag)
         : base(query.Metadata, queryCommands, context, requestHandler, expectedEtag)
     {
         _query = query ?? throw new ArgumentNullException(nameof(query));
-        _sortingComparer = sortingComparer ?? throw new ArgumentNullException(nameof(sortingComparer));
+        _sortingComparerCreator = sortingComparerCreator ?? throw new ArgumentNullException(nameof(sortingComparerCreator));
 
         if (query.Metadata.IsDistinct && isProjectionFromMapReduceIndex == false)
         {
@@ -154,7 +154,8 @@ public sealed class ShardedQueryOperation : AbstractShardedQueryOperation<Sharde
             result.TimeSeriesFields = _timeSeriesFieldNames.ToList();
 
         // all the results from each command are already ordered
-        using (var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(_sortingComparer))
+        var comparer = _sortingComparerCreator(DatabaseContext, result.IndexName, _query);
+        using (var mergedEnumerator = new MergedEnumerator<BlittableJsonReaderObject>(comparer))
         {
             foreach (var (shardNumber, cmdResult) in results)
             {

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -835,7 +835,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         }
     }
 
-    protected IComparer<BlittableJsonReaderObject> GetComparer(IndexQueryServerSide query)
+    protected IComparer<BlittableJsonReaderObject> ComparerCreator(ShardedDatabaseContext databaseContext, string indexName, IndexQueryServerSide query)
     {
         var queryType = GetQueryType();
 
@@ -846,7 +846,10 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             return ConstantComparer.Instance;
 
         if (query.Metadata.OrderBy?.Length > 0)
-            return new DocumentsComparer(query.Metadata.OrderBy, extractFromData: queryType == QueryType.IndexEntries, query.Metadata.HasOrderByRandom);
+        {
+            DocumentsComparer.RetrieveConfigurationForDocumentsComparer(databaseContext, indexName, out var nullFirst, out var acceptMissing);
+            return new DocumentsComparer(query.Metadata.OrderBy, extractFromData: queryType == QueryType.IndexEntries, query.Metadata.HasOrderByRandom, nullFirst, acceptMissing);
+        }
 
         if (queryType == QueryType.IndexEntries)
             return ConstantComparer.Instance;

--- a/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/IndexEntries/ShardedIndexEntriesQueryProcessor.cs
@@ -27,11 +27,9 @@ public sealed class ShardedIndexEntriesQueryProcessor : ShardedQueryProcessorBas
 
     public override async Task<ShardedIndexEntriesQueryResult> ExecuteShardedOperations(QueryTimingsScope scope)
     {
-        var documentsComparer = GetComparer(Query);
-
         var commands = GetOperationCommands(scope: null);
 
-        var operation = new ShardedIndexEntriesQueryOperation(Query, Context, RequestHandler, commands, documentsComparer, ExistingResultEtag?.ToString());
+        var operation = new ShardedIndexEntriesQueryOperation(Query, Context, RequestHandler, commands, ComparerCreator, ExistingResultEtag?.ToString());
         int[] shards = GetShardNumbers(commands);
         var shardedReadResult = await RequestHandler.ShardExecutor.ExecuteParallelForShardsAsync(shards, operation, Token);
 

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedMapReduceStreamingEnumerator.cs
@@ -50,7 +50,7 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
         StreamQueryStatistics queryStats,
         TransactionOperationContext context,
         CancellationToken token)
-        : base(new DocumentsComparer(reduceKeys.ToArray(), extractFromData: true, hasOrderByRandom: false))
+        : base(CreateComparer(reduceKeys, databaseContext, queryStats))
     {
         _query = query;
         _databaseContext = databaseContext;
@@ -61,6 +61,12 @@ public class ShardedMapReduceStreamingEnumerator : MergedEnumerator<BlittableJso
 
         if (query.Metadata.Query.Filter != null)
             _queryFilter = new ShardedQueryFilter(query, new ShardedQueryResult(), queryTimings: null, _databaseContext.Indexes.ScriptRunnerCache, _context);
+    }
+
+    private static DocumentsComparer CreateComparer(List<OrderByField> reduceKeys, ShardedDatabaseContext databaseContext, StreamQueryStatistics queryStats)
+    {
+        DocumentsComparer.RetrieveConfigurationForDocumentsComparer(databaseContext, queryStats.IndexName, out var nullFirst, out var acceptMissing);
+        return new DocumentsComparer(reduceKeys.ToArray(), extractFromData: true, hasOrderByRandom: false, nullFirst, acceptMissing);
     }
 
     public override bool MoveNext()

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessor.cs
@@ -42,7 +42,6 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
     {
         using (var queryScope = scope?.For(nameof(QueryTimingsScope.Names.Query)))
         {
-            var documentsComparer = GetComparer(Query);
             ShardedQueryOperation operation;
             ShardedReadResult<ShardedQueryResult> shardedReadResult;
 
@@ -50,7 +49,7 @@ public sealed class ShardedQueryProcessor : ShardedQueryProcessorBase<ShardedQue
             {
                 var commands = GetOperationCommands(executeScope);
 
-                operation = new ShardedQueryOperation(Query, IsProjectionFromMapReduceIndex, Context, RequestHandler, commands, documentsComparer, ExistingResultEtag?.ToString());
+                operation = new ShardedQueryOperation(Query, IsProjectionFromMapReduceIndex, Context, RequestHandler, commands, ComparerCreator, ExistingResultEtag?.ToString());
                 int[] shards = GetShardNumbers(commands);
                 shardedReadResult = await RequestHandler.ShardExecutor.ExecuteParallelForShardsAsync(shards, operation, Token);
             }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryProcessorBase.cs
@@ -91,8 +91,10 @@ public abstract class ShardedQueryProcessorBase<TCombinedResult> : AbstractShard
             var orderByFields = Query.Metadata.CachedOrderBy ?? Query.Metadata.OrderBy;
             if (orderByFields?.Length > 0)
             {
+                DocumentsComparer.RetrieveConfigurationForDocumentsComparer(RequestHandler.DatabaseContext, result.IndexName, out var nullFirst, out bool acceptMissing);
+                
                 // apply ordering after the re-reduce of a map-reduce index
-                result.Results.Sort(new DocumentsComparer(orderByFields, extractFromData: true, Query.Metadata.HasOrderByRandom));
+                result.Results.Sort(new DocumentsComparer(orderByFields, extractFromData: true, Query.Metadata.HasOrderByRandom, nullFirst, acceptMissing));
             }
         }
     }

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryResultDocument.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryResultDocument.cs
@@ -22,24 +22,30 @@ public sealed class ShardedQueryResultDocument : Document
         });
     }
 
-    public void AddLongOrderByField(long value)
+    public void AddLongOrderByField(long? value)
     {
-        OrderByFields.Add(new OrderByField
-        {
-            OrderType = OrderByFieldType.Long,
-            LongValue = value
-        });
+        var orderField = value.HasValue ?
+            new OrderByField
+            {
+                OrderType = OrderByFieldType.Long,
+                LongValue = value.Value
+            } : new OrderByField(){OrderType = OrderByFieldType.Long, IsNull = true};
+        
+        OrderByFields.Add(orderField);
     }
 
-    public void AddDoubleOrderByField(double value)
+    public void AddDoubleOrderByField(double? value)
     {
-        OrderByFields.Add(new OrderByField
-        {
-            OrderType = OrderByFieldType.Double,
-            DoubleValue = value
-        });
+        var orderField = value.HasValue ?
+            new OrderByField
+            {
+                OrderType = OrderByFieldType.Double,
+                DoubleValue = value.Value
+            } : new OrderByField(){OrderType = OrderByFieldType.Double, IsNull = true};
+        
+        OrderByFields.Add(orderField);
     }
-
+    
     public static ShardedQueryResultDocument From(Document doc)
     {
         return new ShardedQueryResultDocument
@@ -62,6 +68,7 @@ public sealed class ShardedQueryResultDocument : Document
 
     public struct OrderByField
     {
+        public bool IsNull;
         public OrderByFieldType OrderType;
         public string StringValue;
         public long LongValue;

--- a/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/ShardedQueryStreamProcessor.cs
@@ -77,10 +77,11 @@ namespace Raven.Server.Documents.Sharding.Queries
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Handle continuation token in streaming");
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Missing scope usage");
 
-            var documentsComparer = string.IsNullOrEmpty(_debug) ? GetComparer(Query) : ConstantComparer.Instance;
+            Func<ShardedDatabaseContext, string, IndexQueryServerSide, IComparer<BlittableJsonReaderObject>> documentsComparer = string.IsNullOrEmpty(_debug) 
+                ? ComparerCreator
+                : (_, _, _) => ConstantComparer.Instance;
 
             var commands = GetOperationCommands(null);
-
             var op = new ShardedStreamQueryOperation(RequestHandler.HttpContext, () =>
             {
                 IDisposable returnToContextPool = RequestHandler.ContextPool.AllocateOperationContext(out JsonOperationContext ctx);

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -2453,6 +2453,13 @@ namespace Raven.Server.Json
                             writer.WriteComma();
 
                         firstOrderByField = false;
+
+                        if (orderByField.IsNull)
+                        {
+                            writer.WriteNull();
+                            continue;
+                        }
+                        
                         switch (orderByField.OrderType)
                         {
                             case OrderByFieldType.Long:

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -56,6 +56,7 @@ class configurationItem {
         "Indexing.ElapsedSinceQueriedPersistIntervalInMin",
         "Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery",
         "Indexing.Corax.VectorSearch.VectorSearchScanningThreshold"
+        "Indexing.Querying.Corax.NullFirst"
         
         // "Indexing.Static.SearchEngineType" - ignoring as we have dedicated widget to set that
         /*

--- a/test/FastTests/Corax/BoostingQuery.cs
+++ b/test/FastTests/Corax/BoostingQuery.cs
@@ -69,7 +69,7 @@ namespace FastTests.Corax
                 var contentMatch = searcher.TermQuery(searcher.FieldMetadataBuilder("Content1", hasBoost: true), "1");
                 var orMatch = searcher.Or(boostedStartWithMatch, contentMatch);
                 var boostedOrMatch = searcher.Boost(orMatch, 10);
-                var orderByScore = searcher.OrderBy(boostedOrMatch, new OrderMetadata(true, MatchCompareFieldType.Score));
+                var orderByScore = searcher.OrderBy(boostedOrMatch, new OrderMetadata(true, MatchCompareFieldType.Score), nullFirst: true);
                 Span<long> ids = stackalloc long[2048];
                 int read = orderByScore.Fill(ids);
                 ids = ids.Slice(0, read);
@@ -106,7 +106,7 @@ namespace FastTests.Corax
                     searcher.InQuery(contentMetadata, new() {"1", "2", "3"})
                     , 10);
 
-                match = searcher.OrderBy(match,new OrderMetadata(true, MatchCompareFieldType.Score));
+                match = searcher.OrderBy(match,new OrderMetadata(true, MatchCompareFieldType.Score), nullFirst: true);
                 Span<long> ids = stackalloc long[amount];
                 var read = match.Fill(ids);
                 List<string> result = new();
@@ -146,7 +146,7 @@ namespace FastTests.Corax
                 var boostedOrMatch = searcher.Boost(orMatch, 10);
                 var contentMatch2 = searcher.TermQuery("Content1", "2", hasBoost: true);
                 var orMatch2 = searcher.Or(contentMatch2, boostedOrMatch);
-                var sortedMatch = searcher.OrderBy(orMatch2, new OrderMetadata(true, MatchCompareFieldType.Score));
+                var sortedMatch = searcher.OrderBy(orMatch2, new OrderMetadata(true, MatchCompareFieldType.Score), nullFirst: true);
 
                 Span<long> ids = stackalloc long[2048];
                 int read = sortedMatch.Fill(ids);
@@ -185,7 +185,7 @@ namespace FastTests.Corax
                 var boostedOrMatch = searcher.Boost(orMatch, 10);
                 var contentMatch2 = searcher.TermQuery("Content1", "2", hasBoost: true);
                 var orMatch2 = searcher.Or(contentMatch2, boostedOrMatch);
-                var sortedMatch = searcher.OrderBy(orMatch2, new OrderMetadata(true, MatchCompareFieldType.Score), 4);
+                var sortedMatch = searcher.OrderBy(orMatch2, new OrderMetadata(true, MatchCompareFieldType.Score), nullFirst: true, 4);
 
                 // TODO: Check what happens in OrderBy statements when the buffer is too small. 
                 Span<long> ids = stackalloc long[1024];
@@ -230,7 +230,7 @@ namespace FastTests.Corax
 
                 var orMatch = searcher.Or(boostedContent0, boostedContent1);
                 var boostedOrMatch = searcher.Boost(orMatch, 10);
-                var sortedMatch = searcher.OrderBy(boostedOrMatch,new OrderMetadata(true,MatchCompareFieldType.Score));
+                var sortedMatch = searcher.OrderBy(boostedOrMatch,new OrderMetadata(true,MatchCompareFieldType.Score), nullFirst: true);
 
                 Span<long> ids = stackalloc long[1024];
                 var read = sortedMatch.Fill(ids);
@@ -274,7 +274,7 @@ namespace FastTests.Corax
             var contentMetadata = searcher.FieldMetadataBuilder("Content1", hasBoost: true);
             {
                 var query = searcher.OrderBy(searcher.InQuery(contentMetadata, new List<string>() {"0", "1"})
-                    ,new OrderMetadata(true,MatchCompareFieldType.Score));
+                    ,new OrderMetadata(true,MatchCompareFieldType.Score), nullFirst: true);
 
                 Span<long> ids = stackalloc long[1024];
                 var read = query.Fill(ids);
@@ -356,7 +356,7 @@ namespace FastTests.Corax
             var contentMetadata = searcher.FieldMetadataBuilder("Content1", Content1, hasBoost: true);
             {
                 var query = searcher.InQuery(contentMetadata, new List<string>() {"0", "1", "2", "3"});
-                var sortedMatch = searcher.OrderBy(query,new OrderMetadata(true,MatchCompareFieldType.Score));
+                var sortedMatch = searcher.OrderBy(query,new OrderMetadata(true,MatchCompareFieldType.Score), nullFirst: true);
 
                 Span<long> ids = stackalloc long[1024];
                 var read = sortedMatch.Fill(ids);

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -196,7 +196,7 @@ public class FacetIndexingRepro : StorageTest
             {
                 var searcher = new IndexSearcher(rtx, fields);
                 var field = FieldMetadata.Build(fields.GetByFieldId(i).FieldName, default, i, default, default);
-                var sort = searcher.OrderBy(searcher.AllEntries(), new OrderMetadata(field, true, MatchCompareFieldType.Sequence));
+                var sort = searcher.OrderBy(searcher.AllEntries(), new OrderMetadata(field, true, MatchCompareFieldType.Sequence), nullFirst: true);
                 while (sort.Fill(matches) != 0)
                 {
                 }

--- a/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
+++ b/test/FastTests/Corax/Bugs/FacetIndexingRepro.cs
@@ -196,7 +196,7 @@ public class FacetIndexingRepro : StorageTest
             {
                 var searcher = new IndexSearcher(rtx, fields);
                 var field = FieldMetadata.Build(fields.GetByFieldId(i).FieldName, default, i, default, default);
-                var sort = searcher.OrderBy(searcher.AllEntries(), new OrderMetadata(field, true, MatchCompareFieldType.Sequence), nullFirst: true);
+                var sort = searcher.OrderBy(searcher.AllEntries(), new OrderMetadata(field, true, MatchCompareFieldType.Sequence, fieldHasNoTerms: false), nullFirst: true);
                 while (sort.Fill(matches) != 0)
                 {
                 }

--- a/test/FastTests/Corax/CompactTreeTests.cs
+++ b/test/FastTests/Corax/CompactTreeTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron.Data.CompactTrees;

--- a/test/FastTests/Corax/CompactTreeTests.cs
+++ b/test/FastTests/Corax/CompactTreeTests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text;
 using FastTests.Voron;
 using Tests.Infrastructure;
 using Voron.Data.CompactTrees;
@@ -220,7 +222,106 @@ public class CompactTreeTests(ITestOutputHelper output) : StorageTest(output)
             Assert.Equal(1898, value);
         }
     }
+    
+    [RavenFact(RavenTestCategory.Voron)]
+    public void TestSeekForBackwardIteratorUsingMultiplePagesDouble()
+    {
+        using (var wtx = Env.WriteTransaction())
+        {
+            var tree = wtx.LookupFor<DoubleLookupKey>("test");
 
+            for (int i = 0; i < 5_000; i += 2)
+            {
+                tree.Add(new DoubleLookupKey(i), i);
+            }
+            
+            wtx.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var tree = rtx.LookupFor<DoubleLookupKey>("test");
+            
+            // 4998 4996 ... 2 0
+            var it = tree.Iterate<Lookup<DoubleLookupKey>.BackwardIterator>();
+
+            var numberOfPages = tree.AllPages().Count;
+            
+            Assert.Equal(5, numberOfPages);
+
+            bool moveNext;
+            long value;
+            
+            it.Reset();
+            it.Seek<DoubleLookupKey>(2);
+            moveNext = it.MoveNext(out value);
+            Assert.True(moveNext);
+            Assert.Equal(2, value);
+            
+            it.Reset();
+            it.Seek<DoubleLookupKey>(1900);
+            moveNext = it.MoveNext(out value);
+            Assert.True(moveNext);
+            Assert.Equal(1900, value);
+            
+            it.Reset();
+            it.Seek<DoubleLookupKey>(3);
+            moveNext = it.MoveNext(out value);
+            Assert.True(moveNext);
+            Assert.Equal(2, value);
+            
+            it.Reset();
+            it.Seek<DoubleLookupKey>(1899);
+            moveNext = it.MoveNext(out value);
+            Assert.True(moveNext);
+            Assert.Equal(1898, value);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void TestIterateValuesStringBackward()
+    {
+        List<(string, long)> order = new();
+        using (var wtx = Env.WriteTransaction())
+        {
+            var tree = wtx.CompactTreeFor("test");
+
+            for (int i = 0; i < 5_000; i += 1)
+            {
+                var str = $"{i:000000}";
+                order.Add((str, i));
+                tree.Add(str, i);
+            }
+            
+            wtx.Commit();
+        }
+
+        using (var rtx = Env.ReadTransaction())
+        {
+            var tree = rtx.CompactTreeFor("test");
+            
+            // 4998 4996 ... 2 0
+            var backwardIterator = tree.IterateValues<Lookup<CompactTree.CompactKeyLookup>.BackwardIterator>();
+            backwardIterator.Reset();
+
+            Span<long> values = stackalloc long[16];
+            while (backwardIterator.Fill(values) is var read and > 0)
+            {
+                var toCheck = values[..read];
+
+                for (int i = 0; i < read; i++)
+                {
+                    var current = toCheck[i];
+                    var expected = order[^1];
+                    Assert.Equal(expected.Item2, current);
+                    order.RemoveAt(order.Count - 1);
+                }
+            }
+            
+            Assert.Empty(order);
+        }
+    }
+    
     [RavenFact(RavenTestCategory.Voron)]
     public void CanProperlyResetIterator()
     {

--- a/test/FastTests/Corax/CoraxCrud.cs
+++ b/test/FastTests/Corax/CoraxCrud.cs
@@ -114,7 +114,7 @@ public class CoraxCrud : StorageTest
             using var indexSearcher = new IndexSearcher(Env, fields);
             
             var match = indexSearcher.TermQuery("Content", "oren", hasBoost: true);
-            var sort = indexSearcher.OrderBy(match, new OrderMetadata(true, MatchCompareFieldType.Score));
+            var sort = indexSearcher.OrderBy(match, new OrderMetadata(true, MatchCompareFieldType.Score), nullFirst: true);
             Assert.Equal(2, sort.Fill(ids));
             Assert.Equal("users/2", indexSearcher.TermsReaderFor("Id").GetTermFor(ids[0]));
             Assert.Equal("users/1", indexSearcher.TermsReaderFor("Id").GetTermFor(ids[1]));

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -11,6 +11,7 @@ using Corax.Mappings;
 using Corax.Pipeline;
 using Corax.Querying.Matches;
 using Corax.Querying.Matches.Meta;
+using Corax.Querying.Matches.SortingMatches;
 using Corax.Querying.Matches.SortingMatches.Meta;
 using Corax.Utils;
 using FastTests.Voron;
@@ -116,14 +117,13 @@ namespace FastTests.Corax
                 var term0 = entry1.Content.OrderBy(x => x).First();
                 var term1 = entry2.Content.OrderBy(x => x).First();
                 
-                
-                var cmp = reader.Compare(ids[0], ids[1]);
+                var cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[0]), reader.GetTerm(ids[1]), true);
                 Assert.Equal(string.Compare(term0, term1, StringComparison.Ordinal),Math.Sign(cmp));
-                cmp = reader.Compare(ids[1], ids[0]);
+                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[1]), reader.GetTerm(ids[0]), true);
                 Assert.Equal(string.Compare(term1, term0, StringComparison.Ordinal), Math.Sign(cmp));
-                cmp = reader.Compare(ids[0], ids[0]);
+                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[0]), reader.GetTerm(ids[0]), true);
                 Assert.Equal(string.Compare(term0, term0, StringComparison.Ordinal), Math.Sign(cmp));
-                cmp = reader.Compare(ids[1], ids[1]);
+                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[1]), reader.GetTerm(ids[1]), true);
                 Assert.Equal(string.Compare(term1, term1, StringComparison.Ordinal), Math.Sign(cmp));
             }
         }

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -116,14 +116,15 @@ namespace FastTests.Corax
 
                 var term0 = entry1.Content.OrderBy(x => x).First();
                 var term1 = entry2.Content.OrderBy(x => x).First();
-                
-                var cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[0]), reader.GetTerm(ids[1]), true);
+
+                var nullResults = -1;
+                var cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[0]), reader.GetTerm(ids[1]), nullResults);
                 Assert.Equal(string.Compare(term0, term1, StringComparison.Ordinal),Math.Sign(cmp));
-                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[1]), reader.GetTerm(ids[0]), true);
+                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[1]), reader.GetTerm(ids[0]), nullResults);
                 Assert.Equal(string.Compare(term1, term0, StringComparison.Ordinal), Math.Sign(cmp));
-                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[0]), reader.GetTerm(ids[0]), true);
+                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[0]), reader.GetTerm(ids[0]), nullResults);
                 Assert.Equal(string.Compare(term0, term0, StringComparison.Ordinal), Math.Sign(cmp));
-                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[1]), reader.GetTerm(ids[1]), true);
+                cmp = CompactKeyComparer.Compare(reader.GetTerm(ids[1]), reader.GetTerm(ids[1]), nullResults);
                 Assert.Equal(string.Compare(term1, term1, StringComparison.Ordinal), Math.Sign(cmp));
             }
         }

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -937,7 +937,7 @@ namespace FastTests.Corax
 
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
             var contentMetadata = searcher.FieldMetadataBuilder("Content", ContentIndex);
-            OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence);
+            OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence, fieldHasNoTerms: false);
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
                 var match = searcher.OrderBy(match1, orderMetadata, take: 16, nullFirst: true);
@@ -962,7 +962,7 @@ namespace FastTests.Corax
 
             using var searcher = new IndexSearcher(Env, CreateKnownFields(Allocator));
             var contentMetadata = searcher.FieldMetadataBuilder("Content", ContentIndex);
-            OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence);
+            OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence, fieldHasNoTerms: false);
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
                 var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);
@@ -1027,7 +1027,7 @@ namespace FastTests.Corax
 
             using var searcher = new IndexSearcher(Env, CreateKnownFields(bsc));
             var contentMetadata = searcher.FieldMetadataBuilder("Content", ContentIndex);
-            OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence);
+            OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence, fieldHasNoTerms: false);
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
                 var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);

--- a/test/FastTests/Corax/IndexSearcher.cs
+++ b/test/FastTests/Corax/IndexSearcher.cs
@@ -940,7 +940,7 @@ namespace FastTests.Corax
             OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence);
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
-                var match = searcher.OrderBy(match1, orderMetadata, take: 16);
+                var match = searcher.OrderBy(match1, orderMetadata, take: 16, nullFirst: true);
 
                 Span<long> ids = stackalloc long[16];
                 Assert.Equal(3, match.Fill(ids));
@@ -965,7 +965,7 @@ namespace FastTests.Corax
             OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence);
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
-                var match = searcher.OrderBy(match1, orderMetadata);
+                var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);
 
                 Span<long> ids = stackalloc long[2];
                 Assert.Equal(2, match.Fill(ids));
@@ -1030,7 +1030,7 @@ namespace FastTests.Corax
             OrderMetadata orderMetadata = new OrderMetadata(contentMetadata, true, MatchCompareFieldType.Sequence);
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
-                var match = searcher.OrderBy(match1, orderMetadata);
+                var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);
 
                 Span<long> ids = stackalloc long[16];
                 Assert.Equal(3, match.Fill(ids));
@@ -1046,7 +1046,7 @@ namespace FastTests.Corax
 
             {
                 var match1 = searcher.StartWithQuery("Id", "e");
-                var match = searcher.OrderBy(match1, orderMetadata, take: 16);
+                var match = searcher.OrderBy(match1, orderMetadata, take: 16, nullFirst: true);
 
                 Span<long> ids1 = stackalloc long[2];
                 Assert.Equal(2, match.Fill(ids1));

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -39,7 +39,7 @@ namespace FastTests.Corax
                 var concat = searcher.And(allEntries, match1);
 
                 var match = searcher.OrderBy(concat,
-                    new OrderMetadata(searcher.FieldMetadataBuilder("Content", ContentId), false, MatchCompareFieldType.Integer));
+                    new OrderMetadata(searcher.FieldMetadataBuilder("Content", ContentId), false, MatchCompareFieldType.Integer), nullFirst: true);
 
                 List<string> sortedByCorax = new();
                 Span<long> ids = stackalloc long[2048];

--- a/test/FastTests/Corax/OrderBySorting.cs
+++ b/test/FastTests/Corax/OrderBySorting.cs
@@ -39,7 +39,7 @@ namespace FastTests.Corax
                 var concat = searcher.And(allEntries, match1);
 
                 var match = searcher.OrderBy(concat,
-                    new OrderMetadata(searcher.FieldMetadataBuilder("Content", ContentId), false, MatchCompareFieldType.Integer), nullFirst: true);
+                    new OrderMetadata(searcher.FieldMetadataBuilder("Content", ContentId), false, MatchCompareFieldType.Integer, fieldHasNoTerms: false), nullFirst: true);
 
                 List<string> sortedByCorax = new();
                 Span<long> ids = stackalloc long[2048];

--- a/test/FastTests/Corax/RavenDB_22561.cs
+++ b/test/FastTests/Corax/RavenDB_22561.cs
@@ -40,8 +40,6 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
 
         random.Shuffle(table);
 
-        var positions = Enumerable.Range(0, size).Select(x => (long)x).ToArray();
-
         for (int pageSize = (size / 10); pageSize <= size; pageSize += (size / 10))
         {
             var indexes = new int[pageSize].AsSpan();
@@ -52,7 +50,7 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
                 sorter.Insert(docPos, table[docPos]);
 
             ContextBoundNativeList<long> result = new ContextBoundNativeList<long>(bsc);
-            sorter.Fill(positions, ref result, ref _scorePlaceHolder, Span<float>.Empty);
+            sorter.Fill(table, ref result, ref _scorePlaceHolder, Span<float>.Empty);
             Assert.Equal(table.OrderBy(x => x).Take(pageSize).ToArray().AsSpan(), result.ToSpan());
             result.Dispose();
         }

--- a/test/FastTests/Corax/RavenDB_22561.cs
+++ b/test/FastTests/Corax/RavenDB_22561.cs
@@ -44,7 +44,7 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
         {
             var indexes = new int[pageSize].AsSpan();
             var terms = new long[pageSize].AsSpan();
-            var sorter = global::Corax.Querying.Matches.SortingMatches.HeapSorterBuilder.BuildSingleNumericalSorter(indexes, terms, false);
+            var sorter = global::Corax.Querying.Matches.SortingMatches.HeapSorterBuilder.BuildSingleNumericalSorter(indexes, terms, false, nullFirst: true);
 
             for (var docPos = 0; docPos < size; ++docPos)
                 sorter.Insert(docPos, table[docPos]);
@@ -79,7 +79,7 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
             var indexes = new int[pageSize].AsSpan();
             var terms = new long[pageSize].AsSpan();
             var sorter = global::Corax.Querying.Matches.SortingMatches.HeapSorterBuilder.BuildCompoundNumericalSorter(indexes, terms, false,
-                new TestLongComparable(secondTable));
+                new TestLongComparable(secondTable), nullFirst: true);
 
             for (var docPos = 0; docPos < size; ++docPos)
                 sorter.Insert(docPos, table[docPos]);

--- a/test/FastTests/Corax/RavenDB_22561.cs
+++ b/test/FastTests/Corax/RavenDB_22561.cs
@@ -40,6 +40,8 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
 
         random.Shuffle(table);
 
+        var positions = Enumerable.Range(0, size).Select(x => (long)x).ToArray();
+
         for (int pageSize = (size / 10); pageSize <= size; pageSize += (size / 10))
         {
             var indexes = new int[pageSize].AsSpan();
@@ -50,7 +52,7 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
                 sorter.Insert(docPos, table[docPos]);
 
             ContextBoundNativeList<long> result = new ContextBoundNativeList<long>(bsc);
-            sorter.Fill(table, ref result, ref _scorePlaceHolder, Span<float>.Empty);
+            sorter.Fill(positions, ref result, ref _scorePlaceHolder, Span<float>.Empty);
             Assert.Equal(table.OrderBy(x => x).Take(pageSize).ToArray().AsSpan(), result.ToSpan());
             result.Dispose();
         }
@@ -100,6 +102,53 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void CanHeapSortNullPagingString(bool nullFirst, bool descending)
+    {
+        string[] expectedOrder = (nullFirst, descending) switch
+        {
+            (true, false) => [null, null, "aaa", "bbb", "ccc"],
+            (true, true) => ["ccc", "bbb", "aaa", null, null],
+            (false, false) => ["aaa", "bbb", "ccc", null, null],
+            (false, true) => [null, null, "ccc", "bbb", "aaa"],
+        };
+
+        string[] sourceData = [null, null, "aaa", "bbb", "ccc"];
+        int totalSize = sourceData.Length;
+        var positions = Enumerable.Range(0, totalSize).Select(x => (long)x).ToArray();
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+
+        for (int take = 1; take <= expectedOrder.Length; take++)
+        {
+            var indexes = new int[take].AsSpan();
+            var terms = new ByteString[take].AsSpan();
+            var sorter = global::Corax.Querying.Matches.SortingMatches.HeapSorterBuilder
+                .BuildSingleAlphanumericalSorter(indexes, terms, bsc, descending, nullFirst);
+
+            var nullIndexes = new ContextBoundNativeList<int>(bsc);
+            for (int docPos = 0; docPos < totalSize; ++docPos)
+            {
+                if (sourceData[docPos] == null)
+                    nullIndexes.Add(docPos);
+                else
+                    sorter.Insert(docPos, Encodings.Utf8.GetBytes(sourceData[docPos]));
+            }
+
+            ContextBoundNativeList<long> result = new(bsc);
+            sorter.Fill(positions, ref result, ref _scorePlaceHolder, Span<float>.Empty, nullIndexes);
+
+            var actual = result.ToSpan().ToArray().Select(pos => sourceData[(int)pos]).ToArray();
+            Assert.Equal(expectedOrder.Take(take), actual);
+
+            result.Dispose();
+            nullIndexes.Dispose();
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
     [InlineDataWithRandomSeed(100)]
     [InlineDataWithRandomSeed(1_000)]
     [InlineDataWithRandomSeed(10_000)]
@@ -121,13 +170,13 @@ public class RavenDB_22561_LLT : NoDisposalNeeded
         {
             var indexes = new int[pageSize].AsSpan();
             var terms = new ByteString[pageSize].AsSpan();
-            var sorter = global::Corax.Querying.Matches.SortingMatches.HeapSorterBuilder.BuildSingleAlphanumericalSorter(indexes, terms, bsc, false);
+            var sorter = global::Corax.Querying.Matches.SortingMatches.HeapSorterBuilder.BuildSingleAlphanumericalSorter(indexes, terms, bsc, false, true);
 
             for (var docPos = 0; docPos < size; ++docPos)
                 sorter.Insert(docPos, Encodings.Utf8.GetBytes(sourceData[docPos]));
 
             ContextBoundNativeList<long> result = new ContextBoundNativeList<long>(bsc);
-            sorter.Fill(positions, ref result, ref _scorePlaceHolder, Span<float>.Empty);
+            sorter.Fill(positions, ref result, ref _scorePlaceHolder, Span<float>.Empty, default);
 
             var expectedOrder = sourceData.OrderBy(x => x, AlphaNumericFieldComparator.StringAlphanumComparer.Instance).Take(pageSize).ToArray();
             List<string> orderFromSorter = new();

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -85,6 +85,7 @@ namespace FastTests.Issues
                 "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
                 "Indexing.ElapsedSinceQueriedPersistIntervalInMin",
                 "Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery",
+                "Indexing.Querying.Corax.NullFirst",
                 
                 "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",

--- a/test/SlowTests/Corax/Bugs/RavenDB-25410.cs
+++ b/test/SlowTests/Corax/Bugs/RavenDB-25410.cs
@@ -56,7 +56,7 @@ public class RavenDB_25410(ITestOutputHelper output) : StorageTest(output)
             IQueryMatch sortingMatch;
             if (multiSort)
             {
-                var q = indexSearcher.OrderBy(dummyMatch, [new OrderMetadata(true, MatchCompareFieldType.Score), new OrderMetadata(mapping.GetByFieldId(0).Metadata, true, MatchCompareFieldType.Sequence)]);
+                var q = indexSearcher.OrderBy(dummyMatch, [new OrderMetadata(true, MatchCompareFieldType.Score), new OrderMetadata(mapping.GetByFieldId(0).Metadata, true, MatchCompareFieldType.Sequence)], nullFirst: true);
                 q.SetSortingDataTransfer(transfer);
                 sortingMatch = q;
             }

--- a/test/SlowTests/Corax/Bugs/RavenDB-25410.cs
+++ b/test/SlowTests/Corax/Bugs/RavenDB-25410.cs
@@ -62,7 +62,7 @@ public class RavenDB_25410(ITestOutputHelper output) : StorageTest(output)
             }
             else
             {
-                var q = indexSearcher.OrderBy(dummyMatch, new OrderMetadata(true, MatchCompareFieldType.Score));
+                var q = indexSearcher.OrderBy(dummyMatch, new OrderMetadata(true, MatchCompareFieldType.Score), nullFirst: true);
                 q.SetScoreAndDistanceBuffer(transfer);
                 sortingMatch = q;
             }

--- a/test/SlowTests/Corax/Bugs/RavenDB-25410.cs
+++ b/test/SlowTests/Corax/Bugs/RavenDB-25410.cs
@@ -56,7 +56,7 @@ public class RavenDB_25410(ITestOutputHelper output) : StorageTest(output)
             IQueryMatch sortingMatch;
             if (multiSort)
             {
-                var q = indexSearcher.OrderBy(dummyMatch, [new OrderMetadata(true, MatchCompareFieldType.Score), new OrderMetadata(mapping.GetByFieldId(0).Metadata, true, MatchCompareFieldType.Sequence)], nullFirst: true);
+                var q = indexSearcher.OrderBy(dummyMatch, [new OrderMetadata(true, MatchCompareFieldType.Score), new OrderMetadata(mapping.GetByFieldId(0).Metadata, true, MatchCompareFieldType.Sequence, fieldHasNoTerms: false)], nullFirst: true);
                 q.SetSortingDataTransfer(transfer);
                 sortingMatch = q;
             }

--- a/test/SlowTests/Corax/RavenDB-23453.cs
+++ b/test/SlowTests/Corax/RavenDB-23453.cs
@@ -97,21 +97,21 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, random: random);
                 IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
-                query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
             }
             {
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
-                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
 
             {
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 16, isExact, false, random: random);
-                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultsWithoutFilterQuery = EvaluateQuery(indexSearcher, ref query);
             }
 
@@ -185,7 +185,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 400, isExact, false, random: random);
                 IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
-                query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
             }
             {
@@ -193,7 +193,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
-                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
 
@@ -201,7 +201,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, random: random);
-                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultsWithoutFilterQuery = EvaluateQuery(indexSearcher, ref query);
             }
 
@@ -231,7 +231,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
-                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
 
@@ -291,7 +291,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
                 var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 16, isExact, false, betweenQuery, shouldScan ? 1024 : 0, random: random);
-                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)]);
+                var query = indexSearcher.OrderBy(vecSearch, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultsFromFilteredQuery = EvaluateQuery(indexSearcher, ref query);
             }
 

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -1,0 +1,776 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Queries.Timings;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingStringAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingStringStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderBy(x => x.Name)
+            .ToList();
+
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("Name", root.Parameters["FieldName"]);
+            Assert.Equal("True", root.Parameters["Ascending"]);
+            Assert.Equal("Sequence", root.Parameters["FieldType"]);
+
+            Assert.Equal(1, root.Children.Count);
+
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
+
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("a", queryResults[2].Name);
+            Assert.Equal("b", queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Equal("a", queryResults[0].Name);
+            Assert.Equal("b", queryResults[1].Name);
+            Assert.Null(queryResults[2].Name);
+            Assert.Null(queryResults[3].Name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingIntAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingIntStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderBy(x => x.IntValue, OrderingType.Long)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("IntValue", root.Parameters["FieldName"]);
+            Assert.Equal("True", root.Parameters["Ascending"]);
+            Assert.Equal("Integer", root.Parameters["FieldType"]);
+
+            Assert.Equal(1, root.Children.Count);
+
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
+
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(1, queryResults[2].IntValue);
+            Assert.Equal(2, queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Equal(1, queryResults[0].IntValue);
+            Assert.Equal(2, queryResults[1].IntValue);
+            Assert.Null(queryResults[2].IntValue);
+            Assert.Null(queryResults[3].IntValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingDoubleAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingDoubleStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderBy(x => x.DoubleValue, OrderingType.Double)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
+            Assert.Equal("True", root.Parameters["Ascending"]);
+            Assert.Equal("Floating", root.Parameters["FieldType"]);
+
+            Assert.Equal(1, root.Children.Count);
+
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
+
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(1, queryResults[2].DoubleValue);
+            Assert.Equal(2, queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Equal(1, queryResults[0].DoubleValue);
+            Assert.Equal(2, queryResults[1].DoubleValue);
+            Assert.Null(queryResults[2].DoubleValue);
+            Assert.Null(queryResults[3].DoubleValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        // StartsWith query can use streaming optimization - no runtime sorting needed
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .OrderBy(x => x.Name)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            // Streaming optimization should be applied - root should NOT be SortingMatch
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("a", queryResults[2].Name);
+            Assert.Equal("b", queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Equal("a", queryResults[0].Name);
+            Assert.Equal("b", queryResults[1].Name);
+            Assert.Null(queryResults[2].Name);
+            Assert.Null(queryResults[3].Name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        // Range query can use streaming optimization - no runtime sorting needed
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .OrderBy(x => x.IntValue, OrderingType.Long)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            // Streaming optimization should be applied - root should NOT be SortingMatch
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(1, queryResults[2].IntValue);
+            Assert.Equal(2, queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Equal(1, queryResults[0].IntValue);
+            Assert.Equal(2, queryResults[1].IntValue);
+            Assert.Null(queryResults[2].IntValue);
+            Assert.Null(queryResults[3].IntValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        // Range query can use streaming optimization - no runtime sorting needed
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .OrderBy(x => x.DoubleValue, OrderingType.Double)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            // Streaming optimization should be applied - root should NOT be SortingMatch
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(1, queryResults[2].DoubleValue);
+            Assert.Equal(2, queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Equal(1, queryResults[0].DoubleValue);
+            Assert.Equal(2, queryResults[1].DoubleValue);
+            Assert.Null(queryResults[2].DoubleValue);
+            Assert.Null(queryResults[3].DoubleValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderByDescending(x => x.Name)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("Name", root.Parameters["FieldName"]);
+            Assert.Equal("False", root.Parameters["Ascending"]);
+            Assert.Equal("Sequence", root.Parameters["FieldType"]);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("b", queryResults[2].Name);
+            Assert.Equal("a", queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Equal("b", queryResults[0].Name);
+            Assert.Equal("a", queryResults[1].Name);
+            Assert.Null(queryResults[2].Name);
+            Assert.Null(queryResults[3].Name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderByDescending(x => x.IntValue, OrderingType.Long)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("IntValue", root.Parameters["FieldName"]);
+            Assert.Equal("False", root.Parameters["Ascending"]);
+            Assert.Equal("Integer", root.Parameters["FieldType"]);
+
+            Assert.Equal(1, root.Children.Count);
+
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
+
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(2, queryResults[2].IntValue);
+            Assert.Equal(1, queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Equal(2, queryResults[0].IntValue);
+            Assert.Equal(1, queryResults[1].IntValue);
+            Assert.Null(queryResults[2].IntValue);
+            Assert.Null(queryResults[3].IntValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
+            Assert.Equal("False", root.Parameters["Ascending"]);
+            Assert.Equal("Floating", root.Parameters["FieldType"]);
+
+            Assert.Equal(1, root.Children.Count);
+
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
+
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(2, queryResults[2].DoubleValue);
+            Assert.Equal(1, queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Equal(2, queryResults[0].DoubleValue);
+            Assert.Equal(1, queryResults[1].DoubleValue);
+            Assert.Null(queryResults[2].DoubleValue);
+            Assert.Null(queryResults[3].DoubleValue);
+        }
+    }
+
+    // Streaming Descending tests - data is fetched directly from BTree without runtime sorting
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .OrderByDescending(x => x.Name)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("b", queryResults[2].Name);
+            Assert.Equal("a", queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Equal("b", queryResults[0].Name);
+            Assert.Equal("a", queryResults[1].Name);
+            Assert.Null(queryResults[2].Name);
+            Assert.Null(queryResults[3].Name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .OrderByDescending(x => x.IntValue, OrderingType.Long)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(2, queryResults[2].IntValue);
+            Assert.Equal(1, queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Equal(2, queryResults[0].IntValue);
+            Assert.Equal(1, queryResults[1].IntValue);
+            Assert.Null(queryResults[2].IntValue);
+            Assert.Null(queryResults[3].IntValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+
+    private void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    {
+        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
+        using var session = store.OpenSession();
+
+        var queryResults = queryCreator(session)
+            .Timings(out var timings)
+            .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+            .ToList();
+
+        if (options.DatabaseMode is RavenDatabaseMode.Single)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(2, queryResults[2].DoubleValue);
+            Assert.Equal(1, queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Equal(2, queryResults[0].DoubleValue);
+            Assert.Equal(1, queryResults[1].DoubleValue);
+            Assert.Null(queryResults[2].DoubleValue);
+            Assert.Null(queryResults[3].DoubleValue);
+        }
+    }
+
+    private DocumentStore CreateDocumentsAndIndexes(Options options, bool nullFirst, bool autoIndexes, bool testNonExistsing)
+    {
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.NullFirst)] = nullFirst.ToString();
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = "Corax";
+        };
+
+        var store = GetDocumentStore(options);
+
+
+        using var session = store.OpenSession();
+
+
+        var nullDocument = new Document { Name = null, DoubleValue = null, IntValue = null, ToIgnore = nameof(Document.ToIgnore) };
+        var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, ToIgnore = nameof(Document.ToIgnore) };
+        var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, ToIgnore = nameof(Document.ToIgnore) };
+        var nonExistingFields = new Document() { Name = null, DoubleValue = null, IntValue = null, ToIgnore = nameof(Document.ToIgnore) };
+        session.Store(nullDocument);
+        session.Store(oneDocument);
+        session.Store(twoDocument);
+        session.Store(nonExistingFields);
+        session.SaveChanges();
+
+        if (testNonExistsing)
+        {
+            var operation = store.Operations.Send(new PatchByQueryOperation(
+                $@"from Documents where 
+id() == '{nonExistingFields.Id}' 
+update {{
+    delete(this['Name']);
+    delete(this['DoubleValue']);
+    delete(this['IntValue']);
+}}"));
+            operation.WaitForCompletion();
+        }
+
+        if (autoIndexes == false)
+        {
+            new DocumentIndex().Execute(store);
+        }
+        else
+        {
+            // ignore value, create an autoindex
+            var _ = session.Query<Document>()
+                .Count(x => (x.Name == "1" || x.DoubleValue > 0 || x.IntValue > 0 || x.ToIgnore == null));
+        }
+
+        Indexes.WaitForIndexing(store);
+
+        return store;
+    }
+
+    private class Document
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int? IntValue { get; set; }
+        public double? DoubleValue { get; set; }
+        public string ToIgnore { get; set; }
+    }
+
+    private class DocumentIndex : AbstractIndexCreationTask<Document>
+    {
+        public DocumentIndex()
+        {
+            Map = docs => from doc in docs select new { doc.Name, doc.IntValue, doc.DoubleValue, doc.ToIgnore };
+        }
+    }
+}

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -18,16 +18,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingStringAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingStringStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -84,16 +84,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingIntAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingIntStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -149,16 +149,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingDoubleAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingDoubleStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -214,16 +214,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -266,16 +266,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -318,16 +318,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -370,16 +370,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -393,6 +393,7 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
             .WhereExists(x => x.Id)
             .OrderByDescending(x => x.Name)
             .ToList();
+
 
         if (options.DatabaseMode is RavenDatabaseMode.Single)
         {
@@ -408,33 +409,33 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         if (nullFirst)
         {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("b", queryResults[2].Name);
-            Assert.Equal("a", queryResults[3].Name);
-        }
-        else
-        {
             Assert.Equal("b", queryResults[0].Name);
             Assert.Equal("a", queryResults[1].Name);
             Assert.Null(queryResults[2].Name);
             Assert.Null(queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("b", queryResults[2].Name);
+            Assert.Equal("a", queryResults[3].Name);
         }
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -473,33 +474,33 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         if (nullFirst)
         {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(2, queryResults[2].IntValue);
-            Assert.Equal(1, queryResults[3].IntValue);
-        }
-        else
-        {
             Assert.Equal(2, queryResults[0].IntValue);
             Assert.Equal(1, queryResults[1].IntValue);
             Assert.Null(queryResults[2].IntValue);
             Assert.Null(queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(2, queryResults[2].IntValue);
+            Assert.Equal(1, queryResults[3].IntValue);
         }
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -538,17 +539,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         if (nullFirst)
         {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(2, queryResults[2].DoubleValue);
-            Assert.Equal(1, queryResults[3].DoubleValue);
-        }
-        else
-        {
             Assert.Equal(2, queryResults[0].DoubleValue);
             Assert.Equal(1, queryResults[1].DoubleValue);
             Assert.Null(queryResults[2].DoubleValue);
             Assert.Null(queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(2, queryResults[2].DoubleValue);
+            Assert.Equal(1, queryResults[3].DoubleValue);
         }
     }
 
@@ -557,16 +558,16 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -590,33 +591,33 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         if (nullFirst)
         {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("b", queryResults[2].Name);
-            Assert.Equal("a", queryResults[3].Name);
-        }
-        else
-        {
             Assert.Equal("b", queryResults[0].Name);
             Assert.Equal("a", queryResults[1].Name);
             Assert.Null(queryResults[2].Name);
             Assert.Null(queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("b", queryResults[2].Name);
+            Assert.Equal("a", queryResults[3].Name);
         }
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -640,33 +641,33 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         if (nullFirst)
         {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(2, queryResults[2].IntValue);
-            Assert.Equal(1, queryResults[3].IntValue);
-        }
-        else
-        {
             Assert.Equal(2, queryResults[0].IntValue);
             Assert.Equal(1, queryResults[1].IntValue);
             Assert.Null(queryResults[2].IntValue);
             Assert.Null(queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(2, queryResults[2].IntValue);
+            Assert.Equal(1, queryResults[3].IntValue);
         }
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
     public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
         CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
 
@@ -690,17 +691,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         if (nullFirst)
         {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(2, queryResults[2].DoubleValue);
-            Assert.Equal(1, queryResults[3].DoubleValue);
-        }
-        else
-        {
             Assert.Equal(2, queryResults[0].DoubleValue);
             Assert.Equal(1, queryResults[1].DoubleValue);
             Assert.Null(queryResults[2].DoubleValue);
             Assert.Null(queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(2, queryResults[2].DoubleValue);
+            Assert.Equal(1, queryResults[3].DoubleValue);
         }
     }
 

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -19,13 +19,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingStringAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex: true, session => session.Advanced.AsyncDocumentQuery<Document>());
+        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingStringStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
@@ -80,13 +84,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingIntAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingIntStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
@@ -140,13 +148,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingDoubleAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingDoubleStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
@@ -197,20 +209,20 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
 
         var queryResults = await queryCreator(session)
@@ -240,20 +252,20 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
 
         var queryResults = await queryCreator(session)
@@ -283,20 +295,20 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
 
         var queryResults = await queryCreator(session)
@@ -327,13 +339,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
@@ -376,13 +392,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
@@ -434,13 +454,17 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
         CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
@@ -492,20 +516,20 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
 
         var queryResults = await queryCreator(session)
@@ -535,20 +559,20 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
 
         var queryResults = await queryCreator(session)
@@ -578,20 +602,20 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
 
         var queryResults = await queryCreator(session)
@@ -620,6 +644,97 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingSpatialAutoIndex(Options options, bool nullFirst, bool ascending) => await
+        CanChangeOrderOfTheNullsWhenSortingSpatialBase(options, nullFirst, testNonExisting: true, autoIndex: true, ascending);
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingSpatialStaticIndex(Options options, bool nullFirst, bool ascending) => await
+        CanChangeOrderOfTheNullsWhenSortingSpatialBase(options, nullFirst, testNonExisting: true, autoIndex: false, ascending);
+
+    private async Task CanChangeOrderOfTheNullsWhenSortingSpatialBase(Options options, bool nullFirst, bool testNonExisting, bool autoIndex, bool ascending)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, autoIndex, testNonExisting, forceSortUsingIndex: false);
+        using var session = store.OpenAsyncSession();
+        WaitForUserToContinueTheTest(store);
+        var orderClause = ascending ? "" : " desc";
+        var rql = autoIndex 
+            ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)) {orderClause}"
+            : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}";
+
+        rql += " include timings()";
+        QueryTimings timings;
+        var queryResults = await session.Advanced.AsyncRawQuery<Document>(rql).Timings(out timings).ToListAsync();
+
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.Equal("SortingMatch", root.Operation);
+        Assert.Contains("FieldName", root.Parameters);
+        Assert.Equal(autoIndex ? "spatial.point(Location.Latitude, Location.Longitude)": "Location", root.Parameters["FieldName"]);
+        Assert.Equal(ascending ? "True" : "False", root.Parameters["Ascending"]);
+        Assert.Equal("Spatial", root.Parameters["FieldType"]);
+        Assert.Equal("Pt(x=0.0,y=0.0)", root.Parameters["Point"]);
+        Assert.Equal("Kilometers", root.Parameters["Units"]);
+
+        Assert.Equal(1, root.Children.Count);
+
+        var secondLevel = root.Children[0];
+        Assert.Equal("MultiTermMatch", secondLevel.Operation);
+        Assert.Equal(1, secondLevel.Children.Count);
+
+        var thirdLevel = secondLevel.Children[0];
+        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+        Assert.Empty(thirdLevel.Children);
+
+        Assert.Equal(4, queryResults.Count);
+
+        switch (ascending, nullFirst)
+        {
+            case (ascending: true, nullFirst: true):
+                Assert.Null(queryResults[0].Location);
+                Assert.Null(queryResults[1].Location);
+                Assert.Equal(expected: 10, actual: queryResults[2].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[2].Location.Longitude);
+                Assert.Equal(expected: 20, actual: queryResults[3].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[3].Location.Longitude);
+                break;
+            
+            case (ascending: true, nullFirst: false):
+                Assert.Equal(expected: 10, actual: queryResults[0].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[0].Location.Longitude);
+                Assert.Equal(expected: 20, actual: queryResults[1].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[1].Location.Longitude);
+                Assert.Null(queryResults[2].Location);
+                Assert.Null(queryResults[3].Location);
+                break;
+            
+            case (ascending: false, nullFirst: true):
+                Assert.Equal(expected: 20, actual: queryResults[0].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[0].Location.Longitude);
+                Assert.Equal(expected: 10, actual: queryResults[1].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[1].Location.Longitude);
+                Assert.Null(queryResults[2].Location);
+                Assert.Null(queryResults[3].Location);
+                break;
+            
+            case (ascending: false, nullFirst: false):
+                Assert.Null(queryResults[0].Location);
+                Assert.Null(queryResults[1].Location);
+                Assert.Equal(expected: 20, actual: queryResults[2].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[2].Location.Longitude);
+                Assert.Equal(expected: 10, actual: queryResults[3].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[3].Location.Longitude);
+                break;
+        }
+    }
+    
     private async Task<DocumentStore> CreateDocumentsAndIndexes(Options options, bool nullFirst, bool autoIndexes, bool testNonExisting, bool forceSortUsingIndex)
     {
         options.ModifyDatabaseRecord += record =>
@@ -634,10 +749,10 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         using var session = store.OpenAsyncSession();
 
 
-        var nullDocument = new Document { Name = null, DoubleValue = null, IntValue = null, ToIgnore = nameof(Document.ToIgnore) };
-        var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, ToIgnore = nameof(Document.ToIgnore) };
-        var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, ToIgnore = nameof(Document.ToIgnore) };
-        var nonExistingFields = new Document() { Name = null, DoubleValue = null, IntValue = null, ToIgnore = nameof(Document.ToIgnore) };
+        var nullDocument = new Document { Name = null, DoubleValue = null, IntValue = null, Location = null, ToIgnore = nameof(Document.ToIgnore) };
+        var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, Location = new(){Latitude = 10, Longitude = 10}, ToIgnore = nameof(Document.ToIgnore) };
+        var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, Location = new(){Latitude = 20, Longitude = 20}, ToIgnore = nameof(Document.ToIgnore) };
+        var nonExistingFields = new Document() { Name = null, DoubleValue = null, IntValue = null, Location = null, ToIgnore = nameof(Document.ToIgnore) };
         await session.StoreAsync(nullDocument);
         await session.StoreAsync(oneDocument);
         await session.StoreAsync(twoDocument);
@@ -653,6 +768,7 @@ update {{
     delete(this['Name']);
     delete(this['DoubleValue']);
     delete(this['IntValue']);
+    delete(this['Location']);
 }}"));
             await operation.WaitForCompletionAsync();
         }
@@ -667,8 +783,11 @@ update {{
         else
         {
             // ignore value, create an autoindex
-            var _ = await session.Query<Document>().Statistics(out var stats)
-                .CountAsync(x => (x.Name == "1" || x.DoubleValue > 0 || x.IntValue > 0 || x.ToIgnore == null));
+            var _ = await session.Query<Document>()
+                .Statistics(out var stats)
+                .Where(x => x.Name == "1" || x.DoubleValue > 0 || x.IntValue > 0 || x.ToIgnore == null)
+                .Spatial(x => x.Point(doc => doc.Location.Latitude, doc => doc.Location.Longitude), f => f.WithinRadius(1000, 0, 0))
+                .ToListAsync();
             indexName = stats.IndexName;
         }
 
@@ -691,13 +810,27 @@ update {{
         public int? IntValue { get; set; }
         public double? DoubleValue { get; set; }
         public string ToIgnore { get; set; }
+        public Geo Location { get; set; }
+    }
+
+    private class Geo
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
     }
 
     private class DocumentIndex : AbstractIndexCreationTask<Document>
     {
         public DocumentIndex()
         {
-            Map = docs => from doc in docs select new { doc.Name, doc.IntValue, doc.DoubleValue, doc.ToIgnore };
+            Map = docs => from doc in docs select new
+            {
+                doc.Name, 
+                doc.IntValue, 
+                doc.DoubleValue, 
+                doc.ToIgnore,
+                Location = doc.Location == null ? null : CreateSpatialField(doc.Location.Latitude, doc.Location.Longitude)
+            };
         }
     }
 }

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
+using Corax.Utils;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
@@ -16,35 +18,30 @@ namespace SlowTests.Corax;
 public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingStringAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingStringAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex: true, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingStringStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingStringStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .WhereExists(x => x.Id)
             .OrderBy(x => x.Name)
-            .ToList();
+            .ToListAsync();
 
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
+      
             var root = (QueryInspectionNode)timings.QueryPlan;
             Assert.Equal("SortingMatch", root.Operation);
             Assert.Contains("FieldName", root.Parameters);
@@ -61,7 +58,7 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
             var thirdLevel = secondLevel.Children[0];
             Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
             Assert.Empty(thirdLevel.Children);
-        }
+        
 
         Assert.Equal(4, queryResults.Count);
 
@@ -82,34 +79,29 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingIntAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingIntAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingIntStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingIntStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .WhereExists(x => x.Id)
             .OrderBy(x => x.IntValue, OrderingType.Long)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
+
             var root = (QueryInspectionNode)timings.QueryPlan;
             Assert.Equal("SortingMatch", root.Operation);
             Assert.Contains("FieldName", root.Parameters);
@@ -126,7 +118,7 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
             var thirdLevel = secondLevel.Children[0];
             Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
             Assert.Empty(thirdLevel.Children);
-        }
+        
 
         Assert.Equal(4, queryResults.Count);
 
@@ -147,51 +139,44 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingDoubleAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingDoubleStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .WhereExists(x => x.Id)
             .OrderBy(x => x.DoubleValue, OrderingType.Double)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.Equal("SortingMatch", root.Operation);
-            Assert.Contains("FieldName", root.Parameters);
-            Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
-            Assert.Equal("True", root.Parameters["Ascending"]);
-            Assert.Equal("Floating", root.Parameters["FieldType"]);
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.Equal("SortingMatch", root.Operation);
+        Assert.Contains("FieldName", root.Parameters);
+        Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
+        Assert.Equal("True", root.Parameters["Ascending"]);
+        Assert.Equal("Floating", root.Parameters["FieldType"]);
 
-            Assert.Equal(1, root.Children.Count);
+        Assert.Equal(1, root.Children.Count);
 
-            var secondLevel = root.Children[0];
-            Assert.Equal("MultiTermMatch", secondLevel.Operation);
-            Assert.Equal(1, secondLevel.Children.Count);
+        var secondLevel = root.Children[0];
+        Assert.Equal("MultiTermMatch", secondLevel.Operation);
+        Assert.Equal(1, secondLevel.Children.Count);
 
-            var thirdLevel = secondLevel.Children[0];
-            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-            Assert.Empty(thirdLevel.Children);
-        }
+        var thirdLevel = secondLevel.Children[0];
+        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+        Assert.Empty(thirdLevel.Children);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -212,38 +197,29 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        // StartsWith query can use streaming optimization - no runtime sorting needed
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .OrderBy(x => x.Name)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            // Streaming optimization should be applied - root should NOT be SortingMatch
-            Assert.NotEqual("SortingMatch", root.Operation);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -264,38 +240,29 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        // Range query can use streaming optimization - no runtime sorting needed
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .OrderBy(x => x.IntValue, OrderingType.Long)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            // Streaming optimization should be applied - root should NOT be SortingMatch
-            Assert.NotEqual("SortingMatch", root.Operation);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -316,38 +283,29 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        // Range query can use streaming optimization - no runtime sorting needed
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .OrderBy(x => x.DoubleValue, OrderingType.Double)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            // Streaming optimization should be applied - root should NOT be SortingMatch
-            Assert.NotEqual("SortingMatch", root.Operation);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -368,42 +326,35 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .WhereExists(x => x.Id)
             .OrderByDescending(x => x.Name)
-            .ToList();
+            .ToListAsync();
 
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.Equal("SortingMatch", root.Operation);
-            Assert.Contains("FieldName", root.Parameters);
-            Assert.Equal("Name", root.Parameters["FieldName"]);
-            Assert.Equal("False", root.Parameters["Ascending"]);
-            Assert.Equal("Sequence", root.Parameters["FieldType"]);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.Equal("SortingMatch", root.Operation);
+        Assert.Contains("FieldName", root.Parameters);
+        Assert.Equal("Name", root.Parameters["FieldName"]);
+        Assert.Equal("False", root.Parameters["Ascending"]);
+        Assert.Equal("Sequence", root.Parameters["FieldType"]);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -424,51 +375,44 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .WhereExists(x => x.Id)
             .OrderByDescending(x => x.IntValue, OrderingType.Long)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.Equal("SortingMatch", root.Operation);
-            Assert.Contains("FieldName", root.Parameters);
-            Assert.Equal("IntValue", root.Parameters["FieldName"]);
-            Assert.Equal("False", root.Parameters["Ascending"]);
-            Assert.Equal("Integer", root.Parameters["FieldType"]);
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.Equal("SortingMatch", root.Operation);
+        Assert.Contains("FieldName", root.Parameters);
+        Assert.Equal("IntValue", root.Parameters["FieldName"]);
+        Assert.Equal("False", root.Parameters["Ascending"]);
+        Assert.Equal("Integer", root.Parameters["FieldType"]);
 
-            Assert.Equal(1, root.Children.Count);
+        Assert.Equal(1, root.Children.Count);
 
-            var secondLevel = root.Children[0];
-            Assert.Equal("MultiTermMatch", secondLevel.Operation);
-            Assert.Equal(1, secondLevel.Children.Count);
+        var secondLevel = root.Children[0];
+        Assert.Equal("MultiTermMatch", secondLevel.Operation);
+        Assert.Equal(1, secondLevel.Children.Count);
 
-            var thirdLevel = secondLevel.Children[0];
-            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-            Assert.Empty(thirdLevel.Children);
-        }
+        var thirdLevel = secondLevel.Children[0];
+        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+        Assert.Empty(thirdLevel.Children);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -489,51 +433,44 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .WhereExists(x => x.Id)
             .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.Equal("SortingMatch", root.Operation);
-            Assert.Contains("FieldName", root.Parameters);
-            Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
-            Assert.Equal("False", root.Parameters["Ascending"]);
-            Assert.Equal("Floating", root.Parameters["FieldType"]);
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.Equal("SortingMatch", root.Operation);
+        Assert.Contains("FieldName", root.Parameters);
+        Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
+        Assert.Equal("False", root.Parameters["Ascending"]);
+        Assert.Equal("Floating", root.Parameters["FieldType"]);
 
-            Assert.Equal(1, root.Children.Count);
+        Assert.Equal(1, root.Children.Count);
 
-            var secondLevel = root.Children[0];
-            Assert.Equal("MultiTermMatch", secondLevel.Operation);
-            Assert.Equal(1, secondLevel.Children.Count);
+        var secondLevel = root.Children[0];
+        Assert.Equal("MultiTermMatch", secondLevel.Operation);
+        Assert.Equal(1, secondLevel.Children.Count);
 
-            var thirdLevel = secondLevel.Children[0];
-            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-            Assert.Empty(thirdLevel.Children);
-        }
+        var thirdLevel = secondLevel.Children[0];
+        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+        Assert.Empty(thirdLevel.Children);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -553,39 +490,31 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
-    // Streaming Descending tests - data is fetched directly from BTree without runtime sorting
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .OrderByDescending(x => x.Name)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.NotEqual("SortingMatch", root.Operation);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -606,36 +535,29 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .OrderByDescending(x => x.IntValue, OrderingType.Long)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.NotEqual("SortingMatch", root.Operation);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -656,36 +578,29 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting, true, session => session.Advanced.DocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Single, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [false, false], Skip = "Sharding")]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded, Data = [true, false], Skip = "Sharding")]
-    public void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool testNonExisting) =>
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting, false, session => session.Advanced.DocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
+        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private void CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IDocumentSession, IDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
-        using var store = CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting);
-        using var session = store.OpenSession();
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var session = store.OpenAsyncSession();
 
-        var queryResults = queryCreator(session)
+        var queryResults = await queryCreator(session)
             .Timings(out var timings)
             .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
-            .ToList();
+            .ToListAsync();
 
-        if (options.DatabaseMode is RavenDatabaseMode.Single)
-        {
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.NotEqual("SortingMatch", root.Operation);
-        }
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
@@ -705,7 +620,7 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
-    private DocumentStore CreateDocumentsAndIndexes(Options options, bool nullFirst, bool autoIndexes, bool testNonExistsing)
+    private async Task<DocumentStore> CreateDocumentsAndIndexes(Options options, bool nullFirst, bool autoIndexes, bool testNonExisting, bool forceSortUsingIndex)
     {
         options.ModifyDatabaseRecord += record =>
         {
@@ -716,22 +631,22 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var store = GetDocumentStore(options);
 
 
-        using var session = store.OpenSession();
+        using var session = store.OpenAsyncSession();
 
 
         var nullDocument = new Document { Name = null, DoubleValue = null, IntValue = null, ToIgnore = nameof(Document.ToIgnore) };
         var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, ToIgnore = nameof(Document.ToIgnore) };
         var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, ToIgnore = nameof(Document.ToIgnore) };
         var nonExistingFields = new Document() { Name = null, DoubleValue = null, IntValue = null, ToIgnore = nameof(Document.ToIgnore) };
-        session.Store(nullDocument);
-        session.Store(oneDocument);
-        session.Store(twoDocument);
-        session.Store(nonExistingFields);
-        session.SaveChanges();
+        await session.StoreAsync(nullDocument);
+        await session.StoreAsync(oneDocument);
+        await session.StoreAsync(twoDocument);
+        await session.StoreAsync(nonExistingFields);
+        await session.SaveChangesAsync();
 
-        if (testNonExistsing)
+        if (testNonExisting)
         {
-            var operation = store.Operations.Send(new PatchByQueryOperation(
+            var operation = await store.Operations.SendAsync(new PatchByQueryOperation(
                 $@"from Documents where 
 id() == '{nonExistingFields.Id}' 
 update {{
@@ -739,21 +654,32 @@ update {{
     delete(this['DoubleValue']);
     delete(this['IntValue']);
 }}"));
-            operation.WaitForCompletion();
+            await operation.WaitForCompletionAsync();
         }
 
+        string indexName;
         if (autoIndexes == false)
         {
-            new DocumentIndex().Execute(store);
+            var index = new DocumentIndex();
+            await index.ExecuteAsync(store);
+            indexName = index.IndexName;
         }
         else
         {
             // ignore value, create an autoindex
-            var _ = session.Query<Document>()
-                .Count(x => (x.Name == "1" || x.DoubleValue > 0 || x.IntValue > 0 || x.ToIgnore == null));
+            var _ = await session.Query<Document>().Statistics(out var stats)
+                .CountAsync(x => (x.Name == "1" || x.DoubleValue > 0 || x.IntValue > 0 || x.ToIgnore == null));
+            indexName = stats.IndexName;
         }
 
-        Indexes.WaitForIndexing(store);
+        await Indexes.WaitForIndexingAsync(store);
+
+        if (forceSortUsingIndex)
+        {
+            var db = await GetDatabase(store.Database);
+            var indexInstance = db.IndexStore.GetIndex(indexName);
+            indexInstance.ForTestingPurposesOnly().CoraxConfiguration = new CoraxTestingConfiguration() { ForceSortingUsingIndex = true };
+        }
 
         return store;
     }

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -18,24 +18,23 @@ namespace SlowTests.Corax;
 
 public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 {
-
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingString(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool forceSortUsingIndex)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex);
@@ -44,23 +43,25 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
             .ToListAsync();
 
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.Equal("SortingMatch", root.Operation);
-        Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal("Name", root.Parameters["FieldName"]);
-        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
-        Assert.Equal("Sequence", root.Parameters["FieldType"]);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("Name", root.Parameters["FieldName"]);
+            Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+            Assert.Equal("Sequence", root.Parameters["FieldType"]);
 
-        Assert.Equal(1, root.Children.Count);
+            Assert.Equal(1, root.Children.Count);
 
-        var secondLevel = root.Children[0];
-        Assert.Equal("MultiTermMatch", secondLevel.Operation);
-        Assert.Equal(1, secondLevel.Children.Count);
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
 
-        var thirdLevel = secondLevel.Children[0];
-        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-        Assert.Empty(thirdLevel.Children);
-
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -109,21 +110,21 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingInt(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool forceSortUsingIndex)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex);
@@ -131,22 +132,25 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.Equal("SortingMatch", root.Operation);
-        Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal("IntValue", root.Parameters["FieldName"]);
-        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
-        Assert.Equal("Integer", root.Parameters["FieldType"]);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("IntValue", root.Parameters["FieldName"]);
+            Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+            Assert.Equal("Integer", root.Parameters["FieldType"]);
 
-        Assert.Equal(1, root.Children.Count);
+            Assert.Equal(1, root.Children.Count);
 
-        var secondLevel = root.Children[0];
-        Assert.Equal("MultiTermMatch", secondLevel.Operation);
-        Assert.Equal(1, secondLevel.Children.Count);
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
 
-        var thirdLevel = secondLevel.Children[0];
-        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-        Assert.Empty(thirdLevel.Children);
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -195,21 +199,21 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingDouble(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool forceSortUsingIndex)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex);
@@ -217,22 +221,25 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.Equal("SortingMatch", root.Operation);
-        Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
-        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
-        Assert.Equal("Floating", root.Parameters["FieldType"]);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
+            Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+            Assert.Equal("Floating", root.Parameters["FieldType"]);
 
-        Assert.Equal(1, root.Children.Count);
+            Assert.Equal(1, root.Children.Count);
 
-        var secondLevel = root.Children[0];
-        Assert.Equal("MultiTermMatch", secondLevel.Operation);
-        Assert.Equal(1, secondLevel.Children.Count);
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
 
-        var thirdLevel = secondLevel.Children[0];
-        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-        Assert.Empty(thirdLevel.Children);
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -280,14 +287,14 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenStreamingSortingString(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
@@ -295,8 +302,11 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.NotEqual("SortingMatch", root.Operation);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -343,14 +353,14 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenStreamingSortingInt(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
@@ -358,8 +368,11 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.NotEqual("SortingMatch", root.Operation);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -406,14 +419,14 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDouble(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
@@ -421,8 +434,11 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.NotEqual("SortingMatch", root.Operation);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.NotEqual("SortingMatch", root.Operation);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -469,14 +485,14 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
     
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingAlphaNumeric(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
@@ -484,22 +500,25 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.Equal("SortingMatch", root.Operation);
-        Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal("Name", root.Parameters["FieldName"]);
-        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
-        Assert.Equal("Alphanumeric", root.Parameters["FieldType"]);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal("Name", root.Parameters["FieldName"]);
+            Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+            Assert.Equal("Alphanumeric", root.Parameters["FieldType"]);
 
-        Assert.Equal(1, root.Children.Count);
+            Assert.Equal(1, root.Children.Count);
 
-        var secondLevel = root.Children[0];
-        Assert.Equal("MultiTermMatch", secondLevel.Operation);
-        Assert.Equal(1, secondLevel.Children.Count);
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
 
-        var thirdLevel = secondLevel.Children[0];
-        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-        Assert.Empty(thirdLevel.Children);
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -547,14 +566,14 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
     }
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenSortingSpatial(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
@@ -568,24 +587,27 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         rql += " include timings()";
         var queryResults = await session.Advanced.AsyncRawQuery<Document>(rql).Timings(out var timings).ToListAsync();
 
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.Equal("SortingMatch", root.Operation);
-        Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal(isAutoIndex ? "spatial.point(Location.Latitude, Location.Longitude)" : "Location", root.Parameters["FieldName"]);
-        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
-        Assert.Equal("Spatial", root.Parameters["FieldType"]);
-        Assert.Equal("Pt(x=0.0,y=0.0)", root.Parameters["Point"]);
-        Assert.Equal("Kilometers", root.Parameters["Units"]);
+        if (options.DatabaseMode != RavenDatabaseMode.Sharded)
+        {
+            var root = (QueryInspectionNode)timings.QueryPlan;
+            Assert.Equal("SortingMatch", root.Operation);
+            Assert.Contains("FieldName", root.Parameters);
+            Assert.Equal(isAutoIndex ? "spatial.point(Location.Latitude, Location.Longitude)" : "Location", root.Parameters["FieldName"]);
+            Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+            Assert.Equal("Spatial", root.Parameters["FieldType"]);
+            Assert.Equal("Pt(x=0.0,y=0.0)", root.Parameters["Point"]);
+            Assert.Equal("Kilometers", root.Parameters["Units"]);
 
-        Assert.Equal(1, root.Children.Count);
+            Assert.Equal(1, root.Children.Count);
 
-        var secondLevel = root.Children[0];
-        Assert.Equal("MultiTermMatch", secondLevel.Operation);
-        Assert.Equal(1, secondLevel.Children.Count);
+            var secondLevel = root.Children[0];
+            Assert.Equal("MultiTermMatch", secondLevel.Operation);
+            Assert.Equal(1, secondLevel.Children.Count);
 
-        var thirdLevel = secondLevel.Children[0];
-        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-        Assert.Empty(thirdLevel.Children);
+            var thirdLevel = secondLevel.Children[0];
+            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+            Assert.Empty(thirdLevel.Children);
+        }
 
         Assert.Equal(4, queryResults.Count);
 
@@ -631,8 +653,8 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false])]
     public async Task AlphanumericalNullPagingTest(Options options, bool nullFirst)
     {
         options.ModifyDatabaseRecord += record =>
@@ -812,6 +834,7 @@ update {{
 
         if (forceSortUsingIndex)
         {
+            Assert.NotEqual(RavenDatabaseMode.Sharded, options.DatabaseMode);
             var db = await GetDatabase(store.Database);
             var indexInstance = db.IndexStore.GetIndex(indexName);
             indexInstance.ForTestingPurposesOnly().CoraxConfiguration = new CoraxTestingConfiguration() { ForceSortingUsingIndex = true };

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Corax.Utils;
@@ -17,168 +18,38 @@ namespace SlowTests.Corax;
 
 public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingStringAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingStringStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingStringBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingString(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool forceSortUsingIndex)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex);
         using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderBy(x => x.Name)
+        var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
-
-      
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.Equal("SortingMatch", root.Operation);
-            Assert.Contains("FieldName", root.Parameters);
-            Assert.Equal("Name", root.Parameters["FieldName"]);
-            Assert.Equal("True", root.Parameters["Ascending"]);
-            Assert.Equal("Sequence", root.Parameters["FieldType"]);
-
-            Assert.Equal(1, root.Children.Count);
-
-            var secondLevel = root.Children[0];
-            Assert.Equal("MultiTermMatch", secondLevel.Operation);
-            Assert.Equal(1, secondLevel.Children.Count);
-
-            var thirdLevel = secondLevel.Children[0];
-            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-            Assert.Empty(thirdLevel.Children);
-        
-
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("a", queryResults[2].Name);
-            Assert.Equal("b", queryResults[3].Name);
-        }
-        else
-        {
-            Assert.Equal("a", queryResults[0].Name);
-            Assert.Equal("b", queryResults[1].Name);
-            Assert.Null(queryResults[2].Name);
-            Assert.Null(queryResults[3].Name);
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingIntAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingIntStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingIntBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderBy(x => x.IntValue, OrderingType.Long)
-            .ToListAsync();
-
-
-            var root = (QueryInspectionNode)timings.QueryPlan;
-            Assert.Equal("SortingMatch", root.Operation);
-            Assert.Contains("FieldName", root.Parameters);
-            Assert.Equal("IntValue", root.Parameters["FieldName"]);
-            Assert.Equal("True", root.Parameters["Ascending"]);
-            Assert.Equal("Integer", root.Parameters["FieldType"]);
-
-            Assert.Equal(1, root.Children.Count);
-
-            var secondLevel = root.Children[0];
-            Assert.Equal("MultiTermMatch", secondLevel.Operation);
-            Assert.Equal(1, secondLevel.Children.Count);
-
-            var thirdLevel = secondLevel.Children[0];
-            Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
-            Assert.Empty(thirdLevel.Children);
-        
-
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(1, queryResults[2].IntValue);
-            Assert.Equal(2, queryResults[3].IntValue);
-        }
-        else
-        {
-            Assert.Equal(1, queryResults[0].IntValue);
-            Assert.Equal(2, queryResults[1].IntValue);
-            Assert.Null(queryResults[2].IntValue);
-            Assert.Null(queryResults[3].IntValue);
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingDoubleBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderBy(x => x.DoubleValue, OrderingType.Double)
-            .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
         Assert.Equal("SortingMatch", root.Operation);
         Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
-        Assert.Equal("True", root.Parameters["Ascending"]);
-        Assert.Equal("Floating", root.Parameters["FieldType"]);
+        Assert.Equal("Name", root.Parameters["FieldName"]);
+        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+        Assert.Equal("Sequence", root.Parameters["FieldType"]);
 
         Assert.Equal(1, root.Children.Count);
 
@@ -190,238 +61,81 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
         Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
         Assert.Empty(thirdLevel.Children);
 
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(1, queryResults[2].DoubleValue);
-            Assert.Equal(2, queryResults[3].DoubleValue);
-        }
-        else
-        {
-            Assert.Equal(1, queryResults[0].DoubleValue);
-            Assert.Equal(2, queryResults[1].DoubleValue);
-            Assert.Null(queryResults[2].DoubleValue);
-            Assert.Null(queryResults[3].DoubleValue);
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .OrderBy(x => x.Name)
-            .ToListAsync();
-
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.NotEqual("SortingMatch", root.Operation);
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("a", queryResults[2].Name);
-            Assert.Equal("b", queryResults[3].Name);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("a", queryResults[2].Name);
+                Assert.Equal("b", queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal("b", queryResults[0].Name);
+                Assert.Equal("a", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal("a", queryResults[0].Name);
+                Assert.Equal("b", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("b", queryResults[2].Name);
+                Assert.Equal("a", queryResults[3].Name);
+                break;
         }
-        else
+        
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
         {
-            Assert.Equal("a", queryResults[0].Name);
-            Assert.Equal("b", queryResults[1].Name);
-            Assert.Null(queryResults[2].Name);
-            Assert.Null(queryResults[3].Name);
-        }
-    }
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .OrderBy(x => x.IntValue, OrderingType.Long)
-            .ToListAsync();
-
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.NotEqual("SortingMatch", root.Operation);
-
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(1, queryResults[2].IntValue);
-            Assert.Equal(2, queryResults[3].IntValue);
-        }
-        else
-        {
-            Assert.Equal(1, queryResults[0].IntValue);
-            Assert.Equal(2, queryResults[1].IntValue);
-            Assert.Null(queryResults[2].IntValue);
-            Assert.Null(queryResults[3].IntValue);
+            query = query.WhereExists(x => x.Id);
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.Name)
+                : query.OrderByDescending(x => x.Name);
+            return query;
         }
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingInt(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool forceSortUsingIndex)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex);
         using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .OrderBy(x => x.DoubleValue, OrderingType.Double)
-            .ToListAsync();
-
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.NotEqual("SortingMatch", root.Operation);
-
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(1, queryResults[2].DoubleValue);
-            Assert.Equal(2, queryResults[3].DoubleValue);
-        }
-        else
-        {
-            Assert.Equal(1, queryResults[0].DoubleValue);
-            Assert.Equal(2, queryResults[1].DoubleValue);
-            Assert.Null(queryResults[2].DoubleValue);
-            Assert.Null(queryResults[3].DoubleValue);
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderByDescending(x => x.Name)
-            .ToListAsync();
-
-
-        var root = (QueryInspectionNode)timings.QueryPlan;
-        Assert.Equal("SortingMatch", root.Operation);
-        Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal("Name", root.Parameters["FieldName"]);
-        Assert.Equal("False", root.Parameters["Ascending"]);
-        Assert.Equal("Sequence", root.Parameters["FieldType"]);
-
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Equal("b", queryResults[0].Name);
-            Assert.Equal("a", queryResults[1].Name);
-            Assert.Null(queryResults[2].Name);
-            Assert.Null(queryResults[3].Name);
-        }
-        else
-        {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("b", queryResults[2].Name);
-            Assert.Equal("a", queryResults[3].Name);
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderByDescending(x => x.IntValue, OrderingType.Long)
+        var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
         Assert.Equal("SortingMatch", root.Operation);
         Assert.Contains("FieldName", root.Parameters);
         Assert.Equal("IntValue", root.Parameters["FieldName"]);
-        Assert.Equal("False", root.Parameters["Ascending"]);
+        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
         Assert.Equal("Integer", root.Parameters["FieldType"]);
 
         Assert.Equal(1, root.Children.Count);
@@ -436,54 +150,78 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Equal(2, queryResults[0].IntValue);
-            Assert.Equal(1, queryResults[1].IntValue);
-            Assert.Null(queryResults[2].IntValue);
-            Assert.Null(queryResults[3].IntValue);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].IntValue);
+                Assert.Null(queryResults[1].IntValue);
+                Assert.Equal(1, queryResults[2].IntValue);
+                Assert.Equal(2, queryResults[3].IntValue);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal(2, queryResults[0].IntValue);
+                Assert.Equal(1, queryResults[1].IntValue);
+                Assert.Null(queryResults[2].IntValue);
+                Assert.Null(queryResults[3].IntValue);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal(1, queryResults[0].IntValue);
+                Assert.Equal(2, queryResults[1].IntValue);
+                Assert.Null(queryResults[2].IntValue);
+                Assert.Null(queryResults[3].IntValue);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].IntValue);
+                Assert.Null(queryResults[1].IntValue);
+                Assert.Equal(2, queryResults[2].IntValue);
+                Assert.Equal(1, queryResults[3].IntValue);
+                break;
         }
-        else
+
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
         {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(2, queryResults[2].IntValue);
-            Assert.Equal(1, queryResults[3].IntValue);
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
+
+            query = query.WhereExists(x => x.Id);
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.IntValue, OrderingType.Long)
+                : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
+            return query;
         }
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool forceSortUsingIndex) => await
-        CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, forceSortUsingIndex, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, bool forceSortUsingIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingDouble(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool forceSortUsingIndex)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex);
         using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+        var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
         Assert.Equal("SortingMatch", root.Operation);
         Assert.Contains("FieldName", root.Parameters);
         Assert.Equal("DoubleValue", root.Parameters["FieldName"]);
-        Assert.Equal("False", root.Parameters["Ascending"]);
+        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
         Assert.Equal("Floating", root.Parameters["FieldType"]);
 
         Assert.Equal(1, root.Children.Count);
@@ -498,43 +236,63 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Equal(2, queryResults[0].DoubleValue);
-            Assert.Equal(1, queryResults[1].DoubleValue);
-            Assert.Null(queryResults[2].DoubleValue);
-            Assert.Null(queryResults[3].DoubleValue);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].DoubleValue);
+                Assert.Null(queryResults[1].DoubleValue);
+                Assert.Equal(1, queryResults[2].DoubleValue);
+                Assert.Equal(2, queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal(2, queryResults[0].DoubleValue);
+                Assert.Equal(1, queryResults[1].DoubleValue);
+                Assert.Null(queryResults[2].DoubleValue);
+                Assert.Null(queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal(1, queryResults[0].DoubleValue);
+                Assert.Equal(2, queryResults[1].DoubleValue);
+                Assert.Null(queryResults[2].DoubleValue);
+                Assert.Null(queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].DoubleValue);
+                Assert.Null(queryResults[1].DoubleValue);
+                Assert.Equal(2, queryResults[2].DoubleValue);
+                Assert.Equal(1, queryResults[3].DoubleValue);
+                break;
         }
-        else
+
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
         {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(2, queryResults[2].DoubleValue);
-            Assert.Equal(1, queryResults[3].DoubleValue);
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
+
+            query = query.WhereExists(x => x.Id);
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.DoubleValue, OrderingType.Double)
+                : query.OrderByDescending(x => x.DoubleValue, OrderingType.Double);
+            return query;
         }
     }
 
-
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingStringDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingString(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .OrderByDescending(x => x.Name)
+        var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
@@ -542,42 +300,62 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Equal("b", queryResults[0].Name);
-            Assert.Equal("a", queryResults[1].Name);
-            Assert.Null(queryResults[2].Name);
-            Assert.Null(queryResults[3].Name);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("a", queryResults[2].Name);
+                Assert.Equal("b", queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal("b", queryResults[0].Name);
+                Assert.Equal("a", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal("a", queryResults[0].Name);
+                Assert.Equal("b", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("b", queryResults[2].Name);
+                Assert.Equal("a", queryResults[3].Name);
+                break;
         }
-        else
+
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
         {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("b", queryResults[2].Name);
-            Assert.Equal("a", queryResults[3].Name);
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
+
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.Name)
+                : query.OrderByDescending(x => x.Name);
+            return query;
         }
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingIntDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingInt(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .OrderByDescending(x => x.IntValue, OrderingType.Long)
+        var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
@@ -585,42 +363,62 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Equal(2, queryResults[0].IntValue);
-            Assert.Equal(1, queryResults[1].IntValue);
-            Assert.Null(queryResults[2].IntValue);
-            Assert.Null(queryResults[3].IntValue);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].IntValue);
+                Assert.Null(queryResults[1].IntValue);
+                Assert.Equal(1, queryResults[2].IntValue);
+                Assert.Equal(2, queryResults[3].IntValue);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal(2, queryResults[0].IntValue);
+                Assert.Equal(1, queryResults[1].IntValue);
+                Assert.Null(queryResults[2].IntValue);
+                Assert.Null(queryResults[3].IntValue);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal(1, queryResults[0].IntValue);
+                Assert.Equal(2, queryResults[1].IntValue);
+                Assert.Null(queryResults[2].IntValue);
+                Assert.Null(queryResults[3].IntValue);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].IntValue);
+                Assert.Null(queryResults[1].IntValue);
+                Assert.Equal(2, queryResults[2].IntValue);
+                Assert.Equal(1, queryResults[3].IntValue);
+                break;
         }
-        else
+
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
         {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(2, queryResults[2].IntValue);
-            Assert.Equal(1, queryResults[3].IntValue);
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
+
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.IntValue, OrderingType.Long)
+                : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
+            return query;
         }
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, true, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(options, nullFirst, testNonExisting: true, false, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenStreamingSortingDoubleDescendingBase(Options options, bool nullFirst, bool testNonExisting, bool isAutoIndex, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenStreamingSortingDouble(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, testNonExisting, forceSortUsingIndex: false);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
-
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+        var queryResults = await CreateQuery(out var timings)
             .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
@@ -628,57 +426,153 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Equal(2, queryResults[0].DoubleValue);
-            Assert.Equal(1, queryResults[1].DoubleValue);
-            Assert.Null(queryResults[2].DoubleValue);
-            Assert.Null(queryResults[3].DoubleValue);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].DoubleValue);
+                Assert.Null(queryResults[1].DoubleValue);
+                Assert.Equal(1, queryResults[2].DoubleValue);
+                Assert.Equal(2, queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal(2, queryResults[0].DoubleValue);
+                Assert.Equal(1, queryResults[1].DoubleValue);
+                Assert.Null(queryResults[2].DoubleValue);
+                Assert.Null(queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal(1, queryResults[0].DoubleValue);
+                Assert.Equal(2, queryResults[1].DoubleValue);
+                Assert.Null(queryResults[2].DoubleValue);
+                Assert.Null(queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].DoubleValue);
+                Assert.Null(queryResults[1].DoubleValue);
+                Assert.Equal(2, queryResults[2].DoubleValue);
+                Assert.Equal(1, queryResults[3].DoubleValue);
+                break;
         }
-        else
+
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
         {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(2, queryResults[2].DoubleValue);
-            Assert.Equal(1, queryResults[3].DoubleValue);
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
+
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.DoubleValue, OrderingType.Double)
+                : query.OrderByDescending(x => x.DoubleValue, OrderingType.Double);
+            return query;
         }
     }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingSpatialAutoIndex(Options options, bool nullFirst, bool ascending) => await
-        CanChangeOrderOfTheNullsWhenSortingSpatialBase(options, nullFirst, testNonExisting: true, autoIndex: true, ascending);
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenSortingSpatialStaticIndex(Options options, bool nullFirst, bool ascending) => await
-        CanChangeOrderOfTheNullsWhenSortingSpatialBase(options, nullFirst, testNonExisting: true, autoIndex: false, ascending);
-
-    private async Task CanChangeOrderOfTheNullsWhenSortingSpatialBase(Options options, bool nullFirst, bool testNonExisting, bool autoIndex, bool ascending)
+    
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingAlphaNumeric(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, autoIndex, testNonExisting, forceSortUsingIndex: false);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
         using var session = store.OpenAsyncSession();
-        WaitForUserToContinueTheTest(store);
-        var orderClause = ascending ? "" : " desc";
-        var rql = autoIndex 
-            ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)) {orderClause}"
-            : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}";
-
-        rql += " include timings()";
-        QueryTimings timings;
-        var queryResults = await session.Advanced.AsyncRawQuery<Document>(rql).Timings(out timings).ToListAsync();
+        var queryResults = await CreateQuery(out var timings)
+            .ToListAsync();
 
         var root = (QueryInspectionNode)timings.QueryPlan;
         Assert.Equal("SortingMatch", root.Operation);
         Assert.Contains("FieldName", root.Parameters);
-        Assert.Equal(autoIndex ? "spatial.point(Location.Latitude, Location.Longitude)": "Location", root.Parameters["FieldName"]);
-        Assert.Equal(ascending ? "True" : "False", root.Parameters["Ascending"]);
+        Assert.Equal("Name", root.Parameters["FieldName"]);
+        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
+        Assert.Equal("Alphanumeric", root.Parameters["FieldType"]);
+
+        Assert.Equal(1, root.Children.Count);
+
+        var secondLevel = root.Children[0];
+        Assert.Equal("MultiTermMatch", secondLevel.Operation);
+        Assert.Equal(1, secondLevel.Children.Count);
+
+        var thirdLevel = secondLevel.Children[0];
+        Assert.Equal("ExistsTermProvider", thirdLevel.Operation);
+        Assert.Empty(thirdLevel.Children);
+
+        Assert.Equal(4, queryResults.Count);
+
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
+        {
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("a", queryResults[2].Name);
+                Assert.Equal("b", queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal("b", queryResults[0].Name);
+                Assert.Equal("a", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal("a", queryResults[0].Name);
+                Assert.Equal("b", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("b", queryResults[2].Name);
+                Assert.Equal("a", queryResults[3].Name);
+                break;
+        }
+
+        IAsyncDocumentQuery<Document> CreateQuery(out QueryTimings timings)
+        {
+            IAsyncDocumentQuery<Document> query = isAutoIndex
+                ? session.Advanced.AsyncDocumentQuery<Document>()
+                : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
+
+            query = query.WhereExists(x => x.Id);
+            query = query.Timings(out timings);
+            query = isAscending
+                ? query.OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+                : query.OrderByDescending(x => x.Name, OrderingType.AlphaNumeric);
+            return query;
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenSortingSpatial(Options options, bool nullFirst, bool isAutoIndex, bool isAscending)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex, true, forceSortUsingIndex: false);
+        using var session = store.OpenAsyncSession();
+        WaitForUserToContinueTheTest(store);
+        var orderClause = isAscending ? "" : " desc";
+        var rql = isAutoIndex
+            ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)) {orderClause}"
+            : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}";
+
+        rql += " include timings()";
+        var queryResults = await session.Advanced.AsyncRawQuery<Document>(rql).Timings(out var timings).ToListAsync();
+
+        var root = (QueryInspectionNode)timings.QueryPlan;
+        Assert.Equal("SortingMatch", root.Operation);
+        Assert.Contains("FieldName", root.Parameters);
+        Assert.Equal(isAutoIndex ? "spatial.point(Location.Latitude, Location.Longitude)" : "Location", root.Parameters["FieldName"]);
+        Assert.Equal(isAscending.ToString(), root.Parameters["Ascending"]);
         Assert.Equal("Spatial", root.Parameters["FieldType"]);
         Assert.Equal("Pt(x=0.0,y=0.0)", root.Parameters["Point"]);
         Assert.Equal("Kilometers", root.Parameters["Units"]);
@@ -695,9 +589,9 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
         Assert.Equal(4, queryResults.Count);
 
-        switch (ascending, nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            case (ascending: true, nullFirst: true):
+            case (IsAscending: true, NullFirst: true):
                 Assert.Null(queryResults[0].Location);
                 Assert.Null(queryResults[1].Location);
                 Assert.Equal(expected: 10, actual: queryResults[2].Location.Latitude);
@@ -705,8 +599,8 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
                 Assert.Equal(expected: 20, actual: queryResults[3].Location.Latitude);
                 Assert.Equal(expected: 20, actual: queryResults[3].Location.Longitude);
                 break;
-            
-            case (ascending: true, nullFirst: false):
+
+            case (IsAscending: true, NullFirst: false):
                 Assert.Equal(expected: 10, actual: queryResults[0].Location.Latitude);
                 Assert.Equal(expected: 10, actual: queryResults[0].Location.Longitude);
                 Assert.Equal(expected: 20, actual: queryResults[1].Location.Latitude);
@@ -714,8 +608,8 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
                 Assert.Null(queryResults[2].Location);
                 Assert.Null(queryResults[3].Location);
                 break;
-            
-            case (ascending: false, nullFirst: true):
+
+            case (IsAscending: false, NullFirst: true):
                 Assert.Equal(expected: 20, actual: queryResults[0].Location.Latitude);
                 Assert.Equal(expected: 20, actual: queryResults[0].Location.Longitude);
                 Assert.Equal(expected: 10, actual: queryResults[1].Location.Latitude);
@@ -723,8 +617,8 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
                 Assert.Null(queryResults[2].Location);
                 Assert.Null(queryResults[3].Location);
                 break;
-            
-            case (ascending: false, nullFirst: false):
+
+            case (IsAscending: false, NullFirst: false):
                 Assert.Null(queryResults[0].Location);
                 Assert.Null(queryResults[1].Location);
                 Assert.Equal(expected: 20, actual: queryResults[2].Location.Latitude);
@@ -734,7 +628,130 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
                 break;
         }
     }
+
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task AlphanumericalNullPagingTest(Options options, bool nullFirst)
+    {
+        options.ModifyDatabaseRecord += record =>
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.NullFirst)] = nullFirst.ToString();
+
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenAsyncSession();
+        await session.StoreAsync(new Document { Name = null, ToIgnore = nameof(Document.ToIgnore) });
+        await session.StoreAsync(new Document { Name = null, ToIgnore = nameof(Document.ToIgnore) });
+        await session.StoreAsync(new Document { Name = "aaa", ToIgnore = nameof(Document.ToIgnore) });
+        await session.StoreAsync(new Document { Name = "bbb", ToIgnore = nameof(Document.ToIgnore) });
+        await session.StoreAsync(new Document { Name = "ccc", ToIgnore = nameof(Document.ToIgnore) });
+        await session.SaveChangesAsync();
+
+        var result = await session.Query<Document>().Customize(x => x.WaitForNonStaleResults())
+            .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+            .ToListAsync();
+
+        Assert.Equal(5, result.Count);
+        if (nullFirst)
+        {
+            Assert.Null(result[0].Name);
+            Assert.Null(result[1].Name);
+            Assert.Equal("aaa", result[2].Name);
+            Assert.Equal("bbb", result[3].Name);
+            Assert.Equal("ccc", result[4].Name);
+        }
+        else
+        {
+            Assert.Equal("aaa", result[0].Name);
+            Assert.Equal("bbb", result[1].Name);
+            Assert.Equal("ccc", result[2].Name);
+            Assert.Null(result[3].Name);
+            Assert.Null(result[4].Name);
+        }
+
+        result = await session.Query<Document>()
+            .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+            .Take(1)
+            .ToListAsync();
+        Assert.Equal(1, result.Count);
+        if (nullFirst)
+            Assert.Null(result[0].Name);
+        else
+            Assert.Equal("aaa", result[0].Name);
+
+        result = await session.Query<Document>()
+            .OrderBy(x => x.Name, OrderingType.AlphaNumeric)
+            .Skip(3)
+            .Take(1)
+            .ToListAsync();
+        Assert.Equal(1, result.Count);
+        if (nullFirst)
+            Assert.Equal("bbb", result[0].Name);
+        else
+            Assert.Null(result[0].Name);
+
+        result = await session.Query<Document>()
+            .OrderByDescending(x => x.Name, OrderingType.AlphaNumeric)
+            .Skip(3)
+            .Take(10)
+            .ToListAsync();
+        Assert.Equal(2, result.Count);
+        if (nullFirst)
+        {
+            Assert.Null(result[0].Name);
+            Assert.Null(result[1].Name);
+        }
+        else
+        {
+            Assert.Equal("bbb", result[0].Name);
+            Assert.Equal("aaa", result[1].Name);
+        }
+        
+        result = await session.Query<Document>()
+            .OrderByDescending(x => x.Name, OrderingType.AlphaNumeric)
+            .ToListAsync();
+
+        Assert.Equal(5, result.Count);
+        if (nullFirst)
+        {
+            Assert.Equal("ccc", result[0].Name);
+            Assert.Equal("bbb", result[1].Name);
+            Assert.Equal("aaa", result[2].Name);
+            Assert.Null(result[3].Name);
+            Assert.Null(result[4].Name);
+        }
+        else
+        {
+            Assert.Null(result[0].Name);
+            Assert.Null(result[1].Name);
+            Assert.Equal("ccc", result[2].Name);
+            Assert.Equal("bbb", result[3].Name);
+            Assert.Equal("aaa", result[4].Name);
+        }
+
+        result = await session.Query<Document>()
+            .OrderByDescending(x => x.Name, OrderingType.AlphaNumeric)
+            .Take(1)
+            .ToListAsync();
+        Assert.Equal(1, result.Count);
+        if (nullFirst)
+            Assert.Equal("ccc", result[0].Name);
+        else
+            Assert.Null(result[0].Name);
+
+        result = await session.Query<Document>()
+            .OrderByDescending(x => x.Name, OrderingType.AlphaNumeric)
+            .Skip(3)
+            .Take(1)
+            .ToListAsync();
+        Assert.Equal(1, result.Count);
+        if (nullFirst)
+            Assert.Null(result[0].Name);
+        else
+            Assert.Equal("bbb", result[0].Name);
+    }
     
+
     private async Task<DocumentStore> CreateDocumentsAndIndexes(Options options, bool nullFirst, bool autoIndexes, bool testNonExisting, bool forceSortUsingIndex)
     {
         options.ModifyDatabaseRecord += record =>
@@ -750,8 +767,8 @@ public class RavenDB_26091(ITestOutputHelper output) : RavenTestBase(output)
 
 
         var nullDocument = new Document { Name = null, DoubleValue = null, IntValue = null, Location = null, ToIgnore = nameof(Document.ToIgnore) };
-        var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, Location = new(){Latitude = 10, Longitude = 10}, ToIgnore = nameof(Document.ToIgnore) };
-        var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, Location = new(){Latitude = 20, Longitude = 20}, ToIgnore = nameof(Document.ToIgnore) };
+        var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, Location = new() { Latitude = 10, Longitude = 10 }, ToIgnore = nameof(Document.ToIgnore) };
+        var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, Location = new() { Latitude = 20, Longitude = 20 }, ToIgnore = nameof(Document.ToIgnore) };
         var nonExistingFields = new Document() { Name = null, DoubleValue = null, IntValue = null, Location = null, ToIgnore = nameof(Document.ToIgnore) };
         await session.StoreAsync(nullDocument);
         await session.StoreAsync(oneDocument);
@@ -823,14 +840,15 @@ update {{
     {
         public DocumentIndex()
         {
-            Map = docs => from doc in docs select new
-            {
-                doc.Name, 
-                doc.IntValue, 
-                doc.DoubleValue, 
-                doc.ToIgnore,
-                Location = doc.Location == null ? null : CreateSpatialField(doc.Location.Latitude, doc.Location.Longitude)
-            };
+            Map = docs => from doc in docs
+                select new
+                {
+                    doc.Name,
+                    doc.IntValue,
+                    doc.DoubleValue,
+                    doc.ToIgnore,
+                    Location = doc.Location == null ? null : CreateSpatialField(doc.Location.Latitude, doc.Location.Longitude)
+                };
         }
     }
 }

--- a/test/SlowTests/Corax/RavenDB-26091.cs
+++ b/test/SlowTests/Corax/RavenDB-26091.cs
@@ -13,6 +13,7 @@ using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
 
 namespace SlowTests.Corax;
 

--- a/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
+++ b/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
@@ -1,0 +1,421 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Corax;
+
+public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
+        using var session = store.OpenAsyncSession();
+
+        var queryResults = await queryCreator(session)
+            .WhereExists(x => x.Id)
+            .OrderBy(x => x.Name)
+            .OrderBy(x => x.ToIgnore)
+            .ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("a", queryResults[2].Name);
+            Assert.Equal("b", queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Equal("a", queryResults[0].Name);
+            Assert.Equal("b", queryResults[1].Name);
+            Assert.Null(queryResults[2].Name);
+            Assert.Null(queryResults[3].Name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
+        using var session = store.OpenAsyncSession();
+
+        var queryResults = await queryCreator(session)
+            .WhereExists(x => x.Id)
+            .OrderBy(x => x.IntValue, OrderingType.Long)
+            .OrderBy(x => x.ToIgnore)
+            .ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(1, queryResults[2].IntValue);
+            Assert.Equal(2, queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Equal(1, queryResults[0].IntValue);
+            Assert.Equal(2, queryResults[1].IntValue);
+            Assert.Null(queryResults[2].IntValue);
+            Assert.Null(queryResults[3].IntValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
+        using var session = store.OpenAsyncSession();
+
+        var queryResults = await queryCreator(session)
+            .WhereExists(x => x.Id)
+            .OrderBy(x => x.DoubleValue, OrderingType.Double)
+            .OrderBy(x => x.ToIgnore)
+            .ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(1, queryResults[2].DoubleValue);
+            Assert.Equal(2, queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Equal(1, queryResults[0].DoubleValue);
+            Assert.Equal(2, queryResults[1].DoubleValue);
+            Assert.Null(queryResults[2].DoubleValue);
+            Assert.Null(queryResults[3].DoubleValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
+        using var session = store.OpenAsyncSession();
+
+        var queryResults = await queryCreator(session)
+            .WhereExists(x => x.Id)
+            .OrderByDescending(x => x.Name)
+            .OrderBy(x => x.ToIgnore)
+            .ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Equal("b", queryResults[0].Name);
+            Assert.Equal("a", queryResults[1].Name);
+            Assert.Null(queryResults[2].Name);
+            Assert.Null(queryResults[3].Name);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].Name);
+            Assert.Null(queryResults[1].Name);
+            Assert.Equal("b", queryResults[2].Name);
+            Assert.Equal("a", queryResults[3].Name);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    //[RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
+        using var session = store.OpenAsyncSession();
+
+        var queryResults = await queryCreator(session)
+            .WhereExists(x => x.Id)
+            .OrderByDescending(x => x.IntValue, OrderingType.Long)
+            .OrderBy(x => x.ToIgnore)
+            .ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Equal(2, queryResults[0].IntValue);
+            Assert.Equal(1, queryResults[1].IntValue);
+            Assert.Null(queryResults[2].IntValue);
+            Assert.Null(queryResults[3].IntValue);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].IntValue);
+            Assert.Null(queryResults[1].IntValue);
+            Assert.Equal(2, queryResults[2].IntValue);
+            Assert.Equal(1, queryResults[3].IntValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingAutoIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingStaticIndex(Options options, bool nullFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
+        using var session = store.OpenAsyncSession();
+
+        var queryResults = await queryCreator(session)
+            .Timings(out var timings)
+            .WhereExists(x => x.Id)
+            .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+            .OrderBy(x => x.ToIgnore)
+            .ToListAsync();
+
+
+        var qp = timings;
+        Assert.Equal(4, queryResults.Count);
+
+        if (nullFirst)
+        {
+            Assert.Equal(2, queryResults[0].DoubleValue);
+            Assert.Equal(1, queryResults[1].DoubleValue);
+            Assert.Null(queryResults[2].DoubleValue);
+            Assert.Null(queryResults[3].DoubleValue);
+        }
+        else
+        {
+            Assert.Null(queryResults[0].DoubleValue);
+            Assert.Null(queryResults[1].DoubleValue);
+            Assert.Equal(2, queryResults[2].DoubleValue);
+            Assert.Equal(1, queryResults[3].DoubleValue);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialAutoIndex(Options options, bool nullFirst, bool ascending) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: true, ascending);
+
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialStaticIndex(Options options, bool nullFirst, bool ascending) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: false, ascending);
+
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(Options options, bool nullFirst, bool autoIndex, bool ascending)
+    {
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, autoIndex);
+        using var session = store.OpenAsyncSession();
+        
+        var orderClause = ascending ? "" : " desc";
+        var rql = autoIndex 
+            ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)) {orderClause}, ToIgnore"
+            : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}, ToIgnore";
+
+        rql += " include timings()";
+        var queryResults = await session.Advanced.AsyncRawQuery<Document>(rql).ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        switch (ascending, nullFirst)
+        {
+            case (ascending: true, nullFirst: true):
+                Assert.Null(queryResults[0].Location);
+                Assert.Null(queryResults[1].Location);
+                Assert.Equal(expected: 10, actual: queryResults[2].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[2].Location.Longitude);
+                Assert.Equal(expected: 20, actual: queryResults[3].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[3].Location.Longitude);
+                break;
+            
+            case (ascending: true, nullFirst: false):
+                Assert.Equal(expected: 10, actual: queryResults[0].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[0].Location.Longitude);
+                Assert.Equal(expected: 20, actual: queryResults[1].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[1].Location.Longitude);
+                Assert.Null(queryResults[2].Location);
+                Assert.Null(queryResults[3].Location);
+                break;
+            
+            case (ascending: false, nullFirst: true):
+                Assert.Equal(expected: 20, actual: queryResults[0].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[0].Location.Longitude);
+                Assert.Equal(expected: 10, actual: queryResults[1].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[1].Location.Longitude);
+                Assert.Null(queryResults[2].Location);
+                Assert.Null(queryResults[3].Location);
+                break;
+            
+            case (ascending: false, nullFirst: false):
+                Assert.Null(queryResults[0].Location);
+                Assert.Null(queryResults[1].Location);
+                Assert.Equal(expected: 20, actual: queryResults[2].Location.Latitude);
+                Assert.Equal(expected: 20, actual: queryResults[2].Location.Longitude);
+                Assert.Equal(expected: 10, actual: queryResults[3].Location.Latitude);
+                Assert.Equal(expected: 10, actual: queryResults[3].Location.Longitude);
+                break;
+        }
+    }
+
+    private async Task<DocumentStore> CreateDocumentsAndIndexes(Options options, bool nullFirst, bool autoIndex = false)
+    {
+        options.ModifyDatabaseRecord += record =>
+        {
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.NullFirst)] = nullFirst.ToString();
+            record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = "Corax";
+        };
+
+        var store = GetDocumentStore(options);
+
+        using var session = store.OpenAsyncSession();
+
+        var nullDocument = new Document { Name = null, DoubleValue = null, IntValue = null, Location = null, ToIgnore = nameof(Document.ToIgnore) };
+        var oneDocument = new Document { Name = "a", DoubleValue = 1, IntValue = 1, Location = new Geo { Latitude = 10, Longitude = 10 }, ToIgnore = nameof(Document.ToIgnore) };
+        var twoDocument = new Document { Name = "b", DoubleValue = 2, IntValue = 2, Location = new Geo { Latitude = 20, Longitude = 20 }, ToIgnore = nameof(Document.ToIgnore) };
+        var nonExistingFields = new Document { Name = null, DoubleValue = null, IntValue = null, Location = null, ToIgnore = nameof(Document.ToIgnore) };
+        await session.StoreAsync(nullDocument);
+        await session.StoreAsync(oneDocument);
+        await session.StoreAsync(twoDocument);
+        await session.StoreAsync(nonExistingFields);
+        await session.SaveChangesAsync();
+
+        var operation = await store.Operations.SendAsync(new PatchByQueryOperation(
+            $@"from Documents where 
+id() == '{nonExistingFields.Id}' 
+update {{
+    delete(this['Name']);
+    delete(this['DoubleValue']);
+    delete(this['IntValue']);
+    delete(this['Location']);
+}}"));
+        await operation.WaitForCompletionAsync();
+
+        if (autoIndex == false)
+        {
+            var index = new DocumentIndex();
+            await index.ExecuteAsync(store);
+        }
+        else
+        {
+            // Create an autoindex
+            var _ = await session.Query<Document>()
+                .Statistics(out var stats)
+                .Where(x => x.Name == "1" || x.DoubleValue > 0 || x.IntValue > 0 || x.ToIgnore == null)
+                .Spatial(x => x.Point(doc => doc.Location.Latitude, doc => doc.Location.Longitude), f => f.WithinRadius(1000, 0, 0))
+                .ToListAsync();
+        }
+
+        await Indexes.WaitForIndexingAsync(store);
+
+        return store;
+    }
+
+    private class Document
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public int? IntValue { get; set; }
+        public double? DoubleValue { get; set; }
+        public string ToIgnore { get; set; }
+        public Geo Location { get; set; }
+    }
+
+    private class Geo
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+    }
+
+    private class DocumentIndex : AbstractIndexCreationTask<Document>
+    {
+        public DocumentIndex()
+        {
+            Map = docs => from doc in docs select new 
+            { 
+                doc.Name, 
+                doc.IntValue, 
+                doc.DoubleValue, 
+                doc.ToIgnore,
+                Location = doc.Location == null ? null : CreateSpatialField(doc.Location.Latitude, doc.Location.Longitude)
+            };
+        }
+    }
+}

--- a/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
+++ b/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
@@ -15,353 +15,320 @@ namespace SlowTests.Corax;
 
 public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingString(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = fieldFirst
-            ? await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.Name)
-                .OrderBy(x => x.ToIgnore)
-                .ToListAsync()
-            : await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.ToIgnore)
-                .OrderBy(x => x.Name)
-                .ToListAsync();
+        IAsyncDocumentQuery<Document> query = isAutoIndex
+            ? session.Advanced.AsyncDocumentQuery<Document>()
+            : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
 
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
+        query = query.WhereExists(x => x.Id);
+        if (fieldFirst)
         {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("a", queryResults[2].Name);
-            Assert.Equal("b", queryResults[3].Name);
+            query = isAscending ? query.OrderBy(x => x.Name) : query.OrderByDescending(x => x.Name);
+            query = query.OrderBy(x => x.ToIgnore);
         }
         else
         {
-            Assert.Equal("a", queryResults[0].Name);
-            Assert.Equal("b", queryResults[1].Name);
-            Assert.Null(queryResults[2].Name);
-            Assert.Null(queryResults[3].Name);
+            query = query.OrderBy(x => x.ToIgnore);
+            query = isAscending ? query.OrderBy(x => x.Name) : query.OrderByDescending(x => x.Name);
+        }
+        var queryResults = await query.ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
+        {
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("a", queryResults[2].Name);
+                Assert.Equal("b", queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal("b", queryResults[0].Name);
+                Assert.Equal("a", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal("a", queryResults[0].Name);
+                Assert.Equal("b", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("b", queryResults[2].Name);
+                Assert.Equal("a", queryResults[3].Name);
+                break;
         }
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingInt(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = fieldFirst
-            ? await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.IntValue, OrderingType.Long)
-                .OrderBy(x => x.ToIgnore)
-                .ToListAsync()
-            : await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.ToIgnore)
-                .OrderBy(x => x.IntValue, OrderingType.Long)
-                .ToListAsync();
+        IAsyncDocumentQuery<Document> query = isAutoIndex
+            ? session.Advanced.AsyncDocumentQuery<Document>()
+            : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
 
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
+        query = query.WhereExists(x => x.Id);
+        if (fieldFirst)
         {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(1, queryResults[2].IntValue);
-            Assert.Equal(2, queryResults[3].IntValue);
+            query = isAscending ? query.OrderBy(x => x.IntValue, OrderingType.Long) : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
+            query = query.OrderBy(x => x.ToIgnore);
         }
         else
         {
-            Assert.Equal(1, queryResults[0].IntValue);
-            Assert.Equal(2, queryResults[1].IntValue);
-            Assert.Null(queryResults[2].IntValue);
-            Assert.Null(queryResults[3].IntValue);
+            query = query.OrderBy(x => x.ToIgnore);
+            query = isAscending ? query.OrderBy(x => x.IntValue, OrderingType.Long) : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
+        }
+        var queryResults = await query.ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
+        {
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].IntValue);
+                Assert.Null(queryResults[1].IntValue);
+                Assert.Equal(1, queryResults[2].IntValue);
+                Assert.Equal(2, queryResults[3].IntValue);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal(2, queryResults[0].IntValue);
+                Assert.Equal(1, queryResults[1].IntValue);
+                Assert.Null(queryResults[2].IntValue);
+                Assert.Null(queryResults[3].IntValue);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal(1, queryResults[0].IntValue);
+                Assert.Equal(2, queryResults[1].IntValue);
+                Assert.Null(queryResults[2].IntValue);
+                Assert.Null(queryResults[3].IntValue);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].IntValue);
+                Assert.Null(queryResults[1].IntValue);
+                Assert.Equal(2, queryResults[2].IntValue);
+                Assert.Equal(1, queryResults[3].IntValue);
+                break;
         }
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDouble(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = fieldFirst
-            ? await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.DoubleValue, OrderingType.Double)
-                .OrderBy(x => x.ToIgnore)
-                .ToListAsync()
-            : await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.ToIgnore)
-                .OrderBy(x => x.DoubleValue, OrderingType.Double)
-                .ToListAsync();
+        IAsyncDocumentQuery<Document> query = isAutoIndex
+            ? session.Advanced.AsyncDocumentQuery<Document>()
+            : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
 
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
+        query = query.WhereExists(x => x.Id);
+        if (fieldFirst)
         {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(1, queryResults[2].DoubleValue);
-            Assert.Equal(2, queryResults[3].DoubleValue);
+            query = isAscending ? query.OrderBy(x => x.DoubleValue, OrderingType.Double) : query.OrderByDescending(x => x.DoubleValue, OrderingType.Double);
+            query = query.OrderBy(x => x.ToIgnore);
         }
         else
         {
-            Assert.Equal(1, queryResults[0].DoubleValue);
-            Assert.Equal(2, queryResults[1].DoubleValue);
-            Assert.Null(queryResults[2].DoubleValue);
-            Assert.Null(queryResults[3].DoubleValue);
+            query = query.OrderBy(x => x.ToIgnore);
+            query = isAscending ? query.OrderBy(x => x.DoubleValue, OrderingType.Double) : query.OrderByDescending(x => x.DoubleValue, OrderingType.Double);
+        }
+        var queryResults = await query.ToListAsync();
+
+        Assert.Equal(4, queryResults.Count);
+
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
+        {
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].DoubleValue);
+                Assert.Null(queryResults[1].DoubleValue);
+                Assert.Equal(1, queryResults[2].DoubleValue);
+                Assert.Equal(2, queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal(2, queryResults[0].DoubleValue);
+                Assert.Equal(1, queryResults[1].DoubleValue);
+                Assert.Null(queryResults[2].DoubleValue);
+                Assert.Null(queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal(1, queryResults[0].DoubleValue);
+                Assert.Equal(2, queryResults[1].DoubleValue);
+                Assert.Null(queryResults[2].DoubleValue);
+                Assert.Null(queryResults[3].DoubleValue);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].DoubleValue);
+                Assert.Null(queryResults[1].DoubleValue);
+                Assert.Equal(2, queryResults[2].DoubleValue);
+                Assert.Equal(1, queryResults[3].DoubleValue);
+                break;
         }
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingAlphaNumeric(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = fieldFirst
-            ? await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderByDescending(x => x.Name)
-                .OrderBy(x => x.ToIgnore)
-                .ToListAsync()
-            : await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.ToIgnore)
-                .OrderByDescending(x => x.Name)
-                .ToListAsync();
+        IAsyncDocumentQuery<Document> query = isAutoIndex
+            ? session.Advanced.AsyncDocumentQuery<Document>()
+            : session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>();
 
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
+        query = query.WhereExists(x => x.Id);
+        if (fieldFirst)
         {
-            Assert.Equal("b", queryResults[0].Name);
-            Assert.Equal("a", queryResults[1].Name);
-            Assert.Null(queryResults[2].Name);
-            Assert.Null(queryResults[3].Name);
+            query = isAscending ? query.OrderBy(x => x.Name, OrderingType.AlphaNumeric) : query.OrderByDescending(x => x.Name, OrderingType.AlphaNumeric);
+            query = query.OrderBy(x => x.ToIgnore);
         }
         else
         {
-            Assert.Null(queryResults[0].Name);
-            Assert.Null(queryResults[1].Name);
-            Assert.Equal("b", queryResults[2].Name);
-            Assert.Equal("a", queryResults[3].Name);
+            query = query.OrderBy(x => x.ToIgnore);
+            query = isAscending ? query.OrderBy(x => x.Name, OrderingType.AlphaNumeric) : query.OrderByDescending(x => x.Name, OrderingType.AlphaNumeric);
         }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = fieldFirst
-            ? await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderByDescending(x => x.IntValue, OrderingType.Long)
-                .OrderBy(x => x.ToIgnore)
-                .ToListAsync()
-            : await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.ToIgnore)
-                .OrderByDescending(x => x.IntValue, OrderingType.Long)
-                .ToListAsync();
+        var queryResults = await query.ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
 
-        if (nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            Assert.Equal(2, queryResults[0].IntValue);
-            Assert.Equal(1, queryResults[1].IntValue);
-            Assert.Null(queryResults[2].IntValue);
-            Assert.Null(queryResults[3].IntValue);
-        }
-        else
-        {
-            Assert.Null(queryResults[0].IntValue);
-            Assert.Null(queryResults[1].IntValue);
-            Assert.Equal(2, queryResults[2].IntValue);
-            Assert.Equal(1, queryResults[3].IntValue);
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
-    {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst);
-        using var session = store.OpenAsyncSession();
-
-        var queryResults = fieldFirst
-            ? await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
-                .OrderBy(x => x.ToIgnore)
-                .ToListAsync()
-            : await queryCreator(session)
-                .WhereExists(x => x.Id)
-                .OrderBy(x => x.ToIgnore)
-                .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
-                .ToListAsync();
-
-        Assert.Equal(4, queryResults.Count);
-
-        if (nullFirst)
-        {
-            Assert.Equal(2, queryResults[0].DoubleValue);
-            Assert.Equal(1, queryResults[1].DoubleValue);
-            Assert.Null(queryResults[2].DoubleValue);
-            Assert.Null(queryResults[3].DoubleValue);
-        }
-        else
-        {
-            Assert.Null(queryResults[0].DoubleValue);
-            Assert.Null(queryResults[1].DoubleValue);
-            Assert.Equal(2, queryResults[2].DoubleValue);
-            Assert.Equal(1, queryResults[3].DoubleValue);
+            case (IsAscending: true, NullFirst: true):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("a", queryResults[2].Name);
+                Assert.Equal("b", queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: true):
+                Assert.Equal("b", queryResults[0].Name);
+                Assert.Equal("a", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: true, NullFirst: false):
+                Assert.Equal("a", queryResults[0].Name);
+                Assert.Equal("b", queryResults[1].Name);
+                Assert.Null(queryResults[2].Name);
+                Assert.Null(queryResults[3].Name);
+                break;
+            case (IsAscending: false, NullFirst: false):
+                Assert.Null(queryResults[0].Name);
+                Assert.Null(queryResults[1].Name);
+                Assert.Equal("b", queryResults[2].Name);
+                Assert.Equal("a", queryResults[3].Name);
+                break;
         }
     }
 
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialAutoIndex(Options options, bool nullFirst, bool ascending, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: true, ascending, fieldFirst);
-
-    [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialStaticIndex(Options options, bool nullFirst, bool ascending, bool fieldFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: false, ascending, fieldFirst);
-
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(Options options, bool nullFirst, bool autoIndex, bool ascending, bool fieldFirst)
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatial(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
-        using var store = await CreateDocumentsAndIndexes(options, nullFirst, autoIndex);
+        using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex);
         using var session = store.OpenAsyncSession();
 
-        var orderClause = ascending ? "" : " desc";
+        var orderClause = isAscending ? "" : " desc";
         string rql;
 
         if (fieldFirst)
         {
-            rql = autoIndex
+            rql = isAutoIndex
                 ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)){orderClause}, ToIgnore"
                 : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}, ToIgnore";
         }
         else
         {
-            rql = autoIndex
+            rql = isAutoIndex
                 ? $"from Documents where exists(ToIgnore) order by ToIgnore, spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)){orderClause}"
                 : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by ToIgnore, spatial.distance(Location, spatial.point(0,0)){orderClause}";
         }
@@ -370,9 +337,9 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
 
         Assert.Equal(4, queryResults.Count);
 
-        switch (ascending, nullFirst)
+        switch (IsAscending: isAscending, NullFirst: nullFirst)
         {
-            case (ascending: true, nullFirst: true):
+            case (IsAscending: true, NullFirst: true):
                 Assert.Null(queryResults[0].Location);
                 Assert.Null(queryResults[1].Location);
                 Assert.Equal(expected: 10, actual: queryResults[2].Location.Latitude);
@@ -381,7 +348,7 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
                 Assert.Equal(expected: 20, actual: queryResults[3].Location.Longitude);
                 break;
 
-            case (ascending: true, nullFirst: false):
+            case (IsAscending: true, NullFirst: false):
                 Assert.Equal(expected: 10, actual: queryResults[0].Location.Latitude);
                 Assert.Equal(expected: 10, actual: queryResults[0].Location.Longitude);
                 Assert.Equal(expected: 20, actual: queryResults[1].Location.Latitude);
@@ -390,7 +357,7 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
                 Assert.Null(queryResults[3].Location);
                 break;
 
-            case (ascending: false, nullFirst: true):
+            case (IsAscending: false, NullFirst: true):
                 Assert.Equal(expected: 20, actual: queryResults[0].Location.Latitude);
                 Assert.Equal(expected: 20, actual: queryResults[0].Location.Longitude);
                 Assert.Equal(expected: 10, actual: queryResults[1].Location.Latitude);
@@ -399,7 +366,7 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
                 Assert.Null(queryResults[3].Location);
                 break;
 
-            case (ascending: false, nullFirst: false):
+            case (IsAscending: false, NullFirst: false):
                 Assert.Null(queryResults[0].Location);
                 Assert.Null(queryResults[1].Location);
                 Assert.Equal(expected: 20, actual: queryResults[2].Location.Latitude);

--- a/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
+++ b/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
@@ -16,27 +16,37 @@ namespace SlowTests.Corax;
 public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = await queryCreator(session)
-            .WhereExists(x => x.Id)
-            .OrderBy(x => x.Name)
-            .OrderBy(x => x.ToIgnore)
-            .ToListAsync();
+        var queryResults = fieldFirst
+            ? await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.Name)
+                .OrderBy(x => x.ToIgnore)
+                .ToListAsync()
+            : await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.ToIgnore)
+                .OrderBy(x => x.Name)
+                .ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
 
@@ -57,27 +67,37 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = await queryCreator(session)
-            .WhereExists(x => x.Id)
-            .OrderBy(x => x.IntValue, OrderingType.Long)
-            .OrderBy(x => x.ToIgnore)
-            .ToListAsync();
+        var queryResults = fieldFirst
+            ? await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.IntValue, OrderingType.Long)
+                .OrderBy(x => x.ToIgnore)
+                .ToListAsync()
+            : await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.ToIgnore)
+                .OrderBy(x => x.IntValue, OrderingType.Long)
+                .ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
 
@@ -98,27 +118,37 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = await queryCreator(session)
-            .WhereExists(x => x.Id)
-            .OrderBy(x => x.DoubleValue, OrderingType.Double)
-            .OrderBy(x => x.ToIgnore)
-            .ToListAsync();
+        var queryResults = fieldFirst
+            ? await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.DoubleValue, OrderingType.Double)
+                .OrderBy(x => x.ToIgnore)
+                .ToListAsync()
+            : await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.ToIgnore)
+                .OrderBy(x => x.DoubleValue, OrderingType.Double)
+                .ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
 
@@ -139,27 +169,37 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingStringDescendingBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = await queryCreator(session)
-            .WhereExists(x => x.Id)
-            .OrderByDescending(x => x.Name)
-            .OrderBy(x => x.ToIgnore)
-            .ToListAsync();
+        var queryResults = fieldFirst
+            ? await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderByDescending(x => x.Name)
+                .OrderBy(x => x.ToIgnore)
+                .ToListAsync()
+            : await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.ToIgnore)
+                .OrderByDescending(x => x.Name)
+                .ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
 
@@ -180,27 +220,37 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    //[RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingIntDescendingBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = await queryCreator(session)
-            .WhereExists(x => x.Id)
-            .OrderByDescending(x => x.IntValue, OrderingType.Long)
-            .OrderBy(x => x.ToIgnore)
-            .ToListAsync();
+        var queryResults = fieldFirst
+            ? await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderByDescending(x => x.IntValue, OrderingType.Long)
+                .OrderBy(x => x.ToIgnore)
+                .ToListAsync()
+            : await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.ToIgnore)
+                .OrderByDescending(x => x.IntValue, OrderingType.Long)
+                .ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
 
@@ -221,31 +271,38 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingAutoIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingAutoIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document>());
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingStaticIndex(Options options, bool nullFirst) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingStaticIndex(Options options, bool nullFirst, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(options, nullFirst, fieldFirst, session => session.Advanced.AsyncDocumentQuery<Document, DocumentIndex>());
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(Options options, bool nullFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDoubleDescendingBase(Options options, bool nullFirst, bool fieldFirst, Func<IAsyncDocumentSession, IAsyncDocumentQuery<Document>> queryCreator)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
         using var session = store.OpenAsyncSession();
 
-        var queryResults = await queryCreator(session)
-            .Timings(out var timings)
-            .WhereExists(x => x.Id)
-            .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
-            .OrderBy(x => x.ToIgnore)
-            .ToListAsync();
+        var queryResults = fieldFirst
+            ? await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+                .OrderBy(x => x.ToIgnore)
+                .ToListAsync()
+            : await queryCreator(session)
+                .WhereExists(x => x.Id)
+                .OrderBy(x => x.ToIgnore)
+                .OrderByDescending(x => x.DoubleValue, OrderingType.Double)
+                .ToListAsync();
 
-
-        var qp = timings;
         Assert.Equal(4, queryResults.Count);
 
         if (nullFirst)
@@ -265,32 +322,50 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialAutoIndex(Options options, bool nullFirst, bool ascending) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: true, ascending);
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialAutoIndex(Options options, bool nullFirst, bool ascending, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: true, ascending, fieldFirst);
 
     [RavenTheory(RavenTestCategory.Corax)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false])]
-    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialStaticIndex(Options options, bool nullFirst, bool ascending) => await
-        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: false, ascending);
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false])]
+    public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialStaticIndex(Options options, bool nullFirst, bool ascending, bool fieldFirst) => await
+        CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(options, nullFirst, autoIndex: false, ascending, fieldFirst);
 
-    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(Options options, bool nullFirst, bool autoIndex, bool ascending)
+    private async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatialBase(Options options, bool nullFirst, bool autoIndex, bool ascending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, autoIndex);
         using var session = store.OpenAsyncSession();
-        
-        var orderClause = ascending ? "" : " desc";
-        var rql = autoIndex 
-            ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)) {orderClause}, ToIgnore"
-            : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}, ToIgnore";
 
-        rql += " include timings()";
+        var orderClause = ascending ? "" : " desc";
+        string rql;
+
+        if (fieldFirst)
+        {
+            rql = autoIndex
+                ? $"from Documents where exists(ToIgnore) order by spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)){orderClause}, ToIgnore"
+                : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by spatial.distance(Location, spatial.point(0,0)){orderClause}, ToIgnore";
+        }
+        else
+        {
+            rql = autoIndex
+                ? $"from Documents where exists(ToIgnore) order by ToIgnore, spatial.distance(spatial.point(Location.Latitude, Location.Longitude), spatial.point(0,0)){orderClause}"
+                : $"from index '{new DocumentIndex().IndexName}' where exists(ToIgnore) order by ToIgnore, spatial.distance(Location, spatial.point(0,0)){orderClause}";
+        }
+
         var queryResults = await session.Advanced.AsyncRawQuery<Document>(rql).ToListAsync();
 
         Assert.Equal(4, queryResults.Count);
@@ -305,7 +380,7 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
                 Assert.Equal(expected: 20, actual: queryResults[3].Location.Latitude);
                 Assert.Equal(expected: 20, actual: queryResults[3].Location.Longitude);
                 break;
-            
+
             case (ascending: true, nullFirst: false):
                 Assert.Equal(expected: 10, actual: queryResults[0].Location.Latitude);
                 Assert.Equal(expected: 10, actual: queryResults[0].Location.Longitude);
@@ -314,7 +389,7 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
                 Assert.Null(queryResults[2].Location);
                 Assert.Null(queryResults[3].Location);
                 break;
-            
+
             case (ascending: false, nullFirst: true):
                 Assert.Equal(expected: 20, actual: queryResults[0].Location.Latitude);
                 Assert.Equal(expected: 20, actual: queryResults[0].Location.Longitude);
@@ -323,7 +398,7 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
                 Assert.Null(queryResults[2].Location);
                 Assert.Null(queryResults[3].Location);
                 break;
-            
+
             case (ascending: false, nullFirst: false):
                 Assert.Null(queryResults[0].Location);
                 Assert.Null(queryResults[1].Location);
@@ -408,14 +483,15 @@ update {{
     {
         public DocumentIndex()
         {
-            Map = docs => from doc in docs select new 
-            { 
-                doc.Name, 
-                doc.IntValue, 
-                doc.DoubleValue, 
-                doc.ToIgnore,
-                Location = doc.Location == null ? null : CreateSpatialField(doc.Location.Latitude, doc.Location.Longitude)
-            };
+            Map = docs => from doc in docs
+                select new
+                {
+                    doc.Name,
+                    doc.IntValue,
+                    doc.DoubleValue,
+                    doc.ToIgnore,
+                    Location = doc.Location == null ? null : CreateSpatialField(doc.Location.Latitude, doc.Location.Longitude)
+                };
         }
     }
 }

--- a/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
+++ b/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
@@ -9,6 +9,7 @@ using Raven.Server.Config;
 using Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
+using ITestOutputHelper = Xunit.ITestOutputHelper;
 
 namespace SlowTests.Corax;
 

--- a/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
+++ b/test/SlowTests/Corax/RavenDB_26091_MultiSorting.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
@@ -16,22 +15,22 @@ namespace SlowTests.Corax;
 public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingString(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
@@ -86,22 +85,22 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingInt(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
@@ -114,13 +113,17 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
         query = query.WhereExists(x => x.Id);
         if (fieldFirst)
         {
-            query = isAscending ? query.OrderBy(x => x.IntValue, OrderingType.Long) : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
+            query = isAscending 
+                ? query.OrderBy(x => x.IntValue, OrderingType.Long) 
+                : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
             query = query.OrderBy(x => x.ToIgnore);
         }
         else
         {
             query = query.OrderBy(x => x.ToIgnore);
-            query = isAscending ? query.OrderBy(x => x.IntValue, OrderingType.Long) : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
+            query = isAscending 
+                ? query.OrderBy(x => x.IntValue, OrderingType.Long) 
+                : query.OrderByDescending(x => x.IntValue, OrderingType.Long);
         }
         var queryResults = await query.ToListAsync();
 
@@ -156,22 +159,22 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingDouble(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
@@ -226,22 +229,22 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingAlphaNumeric(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst);
@@ -296,22 +299,22 @@ public class RavenDB_26091_MultiSorting(ITestOutputHelper output) : RavenTestBas
     }
 
     [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [true, false, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, true, false, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, true, false])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, true])]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, Data = [false, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [true, false, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, true, false, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, true, false])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, true])]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All, Data = [false, false, false, false])]
     public async Task CanChangeOrderOfTheNullsWhenMultiFieldSortingSpatial(Options options, bool nullFirst, bool isAutoIndex, bool isAscending, bool fieldFirst)
     {
         using var store = await CreateDocumentsAndIndexes(options, nullFirst, isAutoIndex);

--- a/test/StressTests/Corax/OrderByMultiSorting.cs
+++ b/test/StressTests/Corax/OrderByMultiSorting.cs
@@ -45,8 +45,8 @@ namespace StressTests.Corax
                 var match1 = searcher.AllEntries();
                 var orderMetadata = new OrderMetadata[2]
                 {
-                    new(searcher.FieldMetadataBuilder("Content1", Content1), false, MatchCompareFieldType.Integer),
-                    new(searcher.FieldMetadataBuilder("Content2", Content2), true, MatchCompareFieldType.Integer)
+                    new(searcher.FieldMetadataBuilder("Content1", Content1), false, MatchCompareFieldType.Integer, fieldHasNoTerms: false),
+                    new(searcher.FieldMetadataBuilder("Content2", Content2), true, MatchCompareFieldType.Integer, fieldHasNoTerms: false)
                 };
                 
                 var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);
@@ -85,8 +85,8 @@ namespace StressTests.Corax
                 var match1 = searcher.AllEntries();
                 var orderMetadata = new OrderMetadata[2]
                 {
-                    new(searcher.FieldMetadataBuilder("Content1", Content1), true, MatchCompareFieldType.Integer),
-                    new(searcher.FieldMetadataBuilder("Content2", Content2), false, MatchCompareFieldType.Integer)
+                    new(searcher.FieldMetadataBuilder("Content1", Content1), true, MatchCompareFieldType.Integer, fieldHasNoTerms: false),
+                    new(searcher.FieldMetadataBuilder("Content2", Content2), false, MatchCompareFieldType.Integer, fieldHasNoTerms: false)
                 };
 
                 var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);

--- a/test/StressTests/Corax/OrderByMultiSorting.cs
+++ b/test/StressTests/Corax/OrderByMultiSorting.cs
@@ -49,7 +49,7 @@ namespace StressTests.Corax
                     new(searcher.FieldMetadataBuilder("Content2", Content2), true, MatchCompareFieldType.Integer)
                 };
                 
-                var match = searcher.OrderBy(match1, orderMetadata);
+                var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);
 
                 List<string> sortedByCorax = new();
                 Span<long> ids = _buffer;
@@ -89,7 +89,7 @@ namespace StressTests.Corax
                     new(searcher.FieldMetadataBuilder("Content2", Content2), false, MatchCompareFieldType.Integer)
                 };
 
-                var match = searcher.OrderBy(match1, orderMetadata);
+                var match = searcher.OrderBy(match1, orderMetadata, nullFirst: true);
 
                 List<string> sortedByCorax = new();
                 Span<long> ids = _buffer;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26091
### Additional description

Allows configuring NULL order in sorting via configuration option.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
