### PR TITLE
[v6.2] RavenDB-26201 Setup wizard doesn't work offline

### DIFF
--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -1225,7 +1225,8 @@ namespace Raven.Server.Commercial
                     await DeleteAllExistingCertificates(serverStore);
                     
                     await serverStore.EnsureNotPassiveAsync(skipLicenseActivation: true);
-                    await serverStore.LicenseManager.ActivateAsync(setupInfo.License, RaftIdGenerator.DontCareId);
+                    if (setupInfo.License != null)
+                        await serverStore.LicenseManager.ActivateAsync(setupInfo.License, RaftIdGenerator.DontCareId);
 
                     serverStore.HasFixedPort = setupInfo.NodeSetupInfos[localNodeTag].Port != 0;
                 },

--- a/src/Raven.Studio/typescript/commands/wizard/registrationInfoCommand.ts
+++ b/src/Raven.Studio/typescript/commands/wizard/registrationInfoCommand.ts
@@ -19,7 +19,7 @@ class registrationInfoCommand extends commandBase {
             .done(result => task.resolve(result))
             .fail((response: JQueryXHR) => {
                 this.reportError("Failed to complete domain registration", response.responseText, response.statusText);
-                task.reject();
+                task.reject(response);
             });
         
         return task;

--- a/src/Raven.Studio/typescript/components/setupWizard/SetupWizard.stories.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/SetupWizard.stories.tsx
@@ -254,9 +254,11 @@ async function navigateToStep(
     }
 
     // Continue to SECURITY
-    continueButton = canvas.getByRole("button", { name: /Continue/ });
+    continueButton = await canvas.findByRole("button", { name: /Continue|Skip license/ });
     await waitFor(() => expect(continueButton).not.toBeDisabled());
-    await userEvent.click(continueButton);
+    await userEvent.click(continueButton, {
+        pointerEventsCheck: 0,
+    });
 
     if (targetStep === "Security") {
         return;

--- a/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
+++ b/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
@@ -5,6 +5,7 @@ import { ipAddressFormSchema } from "components/setupWizard/steps/SetupWizardNod
 export type SetupWizardSetupMethod = "newCluster" | "createPackage" | "usePackage";
 export type SetupWizardSecurityOption = "letsEncrypt" | "ownCertificate" | "none";
 export type LicenseTypeToGenerate = "community" | "developer";
+export type LicenseKeyStatus = "loading" | "valid" | "invalid" | "connection-error";
 
 const setupMethodStepSchema = yup.object({
     method: yup.string<SetupWizardSetupMethod>().nullable().required(),
@@ -71,9 +72,7 @@ const licenseKeyStepSchema = yup.object({
     verificationCode: yup.string(),
 
     //states
-    isLoadingKey: yup.boolean(),
-    isInvalidKey: yup.boolean(),
-    isConnectionError: yup.boolean(),
+    licenseStatus: yup.string<LicenseKeyStatus>().nullable(),
 });
 
 export const licenseKeySchema = yup.object().shape({

--- a/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
+++ b/src/Raven.Studio/typescript/components/setupWizard/setupWizardValidation.ts
@@ -73,6 +73,7 @@ const licenseKeyStepSchema = yup.object({
     //states
     isLoadingKey: yup.boolean(),
     isInvalidKey: yup.boolean(),
+    isConnectionError: yup.boolean(),
 });
 
 export const licenseKeySchema = yup.object().shape({

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardLicenseKeyStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardLicenseKeyStep.tsx
@@ -173,12 +173,12 @@ function LicenseKeyBadge() {
     const { control } = useFormContext<SetupWizardFormData>();
 
     const {
-        licenseKeyStep: { licenseInfo, isLoadingKey, isInvalidKey, isConnectionError },
+        licenseKeyStep: { licenseInfo, licenseStatus },
     } = useWatch({ control });
 
-    if (isLoadingKey) {
+    if (licenseStatus === "loading") {
         return (
-            <LazyLoad active={isLoadingKey}>
+            <LazyLoad active>
                 <Badge bg="secondary" pill className="position-absolute bottom-0 end-0 mb-3 me-3" style={{ zIndex: 5 }}>
                     Loading...
                 </Badge>
@@ -186,7 +186,7 @@ function LicenseKeyBadge() {
         );
     }
 
-    if (isInvalidKey) {
+    if (licenseStatus === "invalid") {
         return (
             <PopoverWithHoverWrapper
                 wrapperClassName="position-absolute bottom-0 end-0 mb-3 me-3"
@@ -201,7 +201,7 @@ function LicenseKeyBadge() {
         );
     }
 
-    if (isConnectionError) {
+    if (licenseStatus === "connection-error") {
         return (
             <PopoverWithHoverWrapper
                 wrapperClassName="position-absolute bottom-0 end-0 mb-3 me-3"
@@ -216,7 +216,7 @@ function LicenseKeyBadge() {
         );
     }
 
-    if (licenseInfo == null || licenseInfo.licenseType == null) {
+    if (licenseStatus !== "valid" || licenseInfo == null || licenseInfo.licenseType == null) {
         return null;
     }
 
@@ -410,8 +410,7 @@ function SkipLicenseVerificationConfirmModal(props: { close: () => void }) {
     const handleConfirm = () => {
         reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "skip-verification", "confirmed");
         setValue("licenseKeyStep.key", null);
-        setValue("licenseKeyStep.isInvalidKey", false);
-        setValue("licenseKeyStep.isConnectionError", false);
+        setValue("licenseKeyStep.licenseStatus", null);
         setValue("licenseKeyStep.licenseInfo", null);
         setValue("currentStep", "Security");
     };
@@ -681,7 +680,7 @@ export function SetupWizardLicenseKeyStepFooter() {
 
     const { licenseKeyStep } = useWatch({ control });
 
-    const { key, licenseTypeToGenerate, isInvalidKey, isConnectionError } = licenseKeyStep;
+    const { key, licenseTypeToGenerate, licenseStatus } = licenseKeyStep;
 
     const toDto = (licenseStepData: SetupWizardFormData["licenseKeyStep"]): SendFreeLicenseVerificationRequest => {
         if (!licenseStepData) {
@@ -705,18 +704,11 @@ export function SetupWizardLicenseKeyStepFooter() {
     };
     const asyncRegistrationInfo = useAsyncDebounce(
         async () => {
-            setValue("licenseKeyStep.isLoadingKey", true);
-            setValue("licenseKeyStep.isInvalidKey", false);
-            setValue("licenseKeyStep.isConnectionError", false);
+            setValue("licenseKeyStep.licenseStatus", "loading");
             setValue("licenseKeyStep.licenseInfo", null);
 
-            if (key == null) {
-                setValue("licenseKeyStep.isLoadingKey", false);
-                return;
-            }
-
             if (!key) {
-                setValue("licenseKeyStep.isLoadingKey", false);
+                setValue("licenseKeyStep.licenseStatus", null);
                 return;
             }
 
@@ -727,8 +719,7 @@ export function SetupWizardLicenseKeyStepFooter() {
                 await licenseKeySchema.validate(parsedKey);
             } catch {
                 reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "key-parse", "invalid");
-                setValue("licenseKeyStep.isInvalidKey", true);
-                setValue("licenseKeyStep.isLoadingKey", false);
+                setValue("licenseKeyStep.licenseStatus", "invalid");
                 return;
             }
 
@@ -751,25 +742,18 @@ export function SetupWizardLicenseKeyStepFooter() {
                         shouldDirty: true,
                     }
                 );
-                setValue("licenseKeyStep.isLoadingKey", false);
+                setValue("licenseKeyStep.licenseStatus", "valid");
             } catch (err) {
                 const message: string = (err as JQueryXHR)?.responseJSON?.Message;
-                
-                const isConnectionError = message?.includes("Failed to contact");
+                const isConnError = message?.includes("Failed to contact");
 
                 reportEvent(
                     setupWizardGA4Prefixes.licenseKeyStep,
                     "key-parse",
-                    isConnectionError ? "connection-error" : "invalid"
+                    isConnError ? "connection-error" : "invalid"
                 );
 
-                if (isConnectionError) {
-                    setValue("licenseKeyStep.isConnectionError", true);
-                } else {
-                    setValue("licenseKeyStep.isInvalidKey", true);
-                }
-
-                setValue("licenseKeyStep.isLoadingKey", false);
+                setValue("licenseKeyStep.licenseStatus", isConnError ? "connection-error" : "invalid");
                 setValue("licenseKeyStep.licenseInfo", null);
             }
         },
@@ -825,7 +809,7 @@ export function SetupWizardLicenseKeyStepFooter() {
     };
 
     const handleContinue = async () => {
-        if (key && !isInvalidKey && !isConnectionError) {
+        if (key && licenseStatus === "valid") {
             reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "continue", "with-key");
             setValue("currentStep", "Security");
         } else {
@@ -857,7 +841,7 @@ export function SetupWizardLicenseKeyStepFooter() {
                     onClick={handleContinue}
                     isSpinning={asyncRegistrationInfo.loading}
                 >
-                    {key && !isInvalidKey && !isConnectionError ? "Continue" : "Skip license"}
+                    {key && licenseStatus === "valid" ? "Continue" : "Skip license"}
                     <Icon icon="arrow-right" margin="ms-1" />
                 </ButtonWithSpinner>
             )}

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardLicenseKeyStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardLicenseKeyStep.tsx
@@ -33,6 +33,7 @@ import { setupWizardGA4Prefixes } from "components/setupWizard/utils/setupWizard
 import { setupWizardFormDefaultValues } from "components/setupWizard/utils/setupWizardFormDefaultValues";
 import classNames from "classnames";
 import LicenseType = Raven.Server.Commercial.LicenseType;
+import License = Raven.Server.Commercial.License;
 
 function scrollSetupWizardToTop() {
     const container = document.querySelector<HTMLElement>(".setup-wizard-main");
@@ -172,7 +173,7 @@ function LicenseKeyBadge() {
     const { control } = useFormContext<SetupWizardFormData>();
 
     const {
-        licenseKeyStep: { licenseInfo, isLoadingKey, isInvalidKey },
+        licenseKeyStep: { licenseInfo, isLoadingKey, isInvalidKey, isConnectionError },
     } = useWatch({ control });
 
     if (isLoadingKey) {
@@ -194,6 +195,21 @@ function LicenseKeyBadge() {
             >
                 <Badge bg="danger" pill>
                     Invalid
+                    <Icon icon="warning" margin="ms-2" />
+                </Badge>
+            </PopoverWithHoverWrapper>
+        );
+    }
+
+    if (isConnectionError) {
+        return (
+            <PopoverWithHoverWrapper
+                wrapperClassName="position-absolute bottom-0 end-0 mb-3 me-3"
+                targetStyle={{ zIndex: 5 }}
+                message="Cannot connect to the license server. Please try again later."
+            >
+                <Badge bg="danger" pill>
+                    Connection error
                     <Icon icon="warning" margin="ms-2" />
                 </Badge>
             </PopoverWithHoverWrapper>
@@ -393,6 +409,10 @@ function SkipLicenseVerificationConfirmModal(props: { close: () => void }) {
 
     const handleConfirm = () => {
         reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "skip-verification", "confirmed");
+        setValue("licenseKeyStep.key", null);
+        setValue("licenseKeyStep.isInvalidKey", false);
+        setValue("licenseKeyStep.isConnectionError", false);
+        setValue("licenseKeyStep.licenseInfo", null);
         setValue("currentStep", "Security");
     };
 
@@ -420,8 +440,6 @@ function SkipLicenseVerificationConfirmModal(props: { close: () => void }) {
                 applied
                 <br />
                 <Icon icon="check" color="success" /> Limited set of features
-                <br />
-                <Icon icon="check" color="success" /> Unsecure mode only (no HTTPS or certificates)
                 <br />
                 <Icon icon="check" color="success" /> Max of 1 node in cluster, 3 CPU cores, and 6 GB RAM memory usage
                 <p className="mt-3 mb-0">
@@ -663,7 +681,7 @@ export function SetupWizardLicenseKeyStepFooter() {
 
     const { licenseKeyStep } = useWatch({ control });
 
-    const { key, licenseTypeToGenerate, isInvalidKey } = licenseKeyStep;
+    const { key, licenseTypeToGenerate, isInvalidKey, isConnectionError } = licenseKeyStep;
 
     const toDto = (licenseStepData: SetupWizardFormData["licenseKeyStep"]): SendFreeLicenseVerificationRequest => {
         if (!licenseStepData) {
@@ -689,6 +707,7 @@ export function SetupWizardLicenseKeyStepFooter() {
         async () => {
             setValue("licenseKeyStep.isLoadingKey", true);
             setValue("licenseKeyStep.isInvalidKey", false);
+            setValue("licenseKeyStep.isConnectionError", false);
             setValue("licenseKeyStep.licenseInfo", null);
 
             if (key == null) {
@@ -701,10 +720,19 @@ export function SetupWizardLicenseKeyStepFooter() {
                 return;
             }
 
-            try {
-                const parsedKey = JSON.parse(key);
-                await licenseKeySchema.validate(parsedKey);
+            let parsedKey: License = null;
 
+            try {
+                parsedKey = JSON.parse(key);
+                await licenseKeySchema.validate(parsedKey);
+            } catch {
+                reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "key-parse", "invalid");
+                setValue("licenseKeyStep.isInvalidKey", true);
+                setValue("licenseKeyStep.isLoadingKey", false);
+                return;
+            }
+
+            try {
                 const info = await setupWizardService.registrationInfo(parsedKey);
 
                 reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "key-parse", "valid");
@@ -725,8 +753,22 @@ export function SetupWizardLicenseKeyStepFooter() {
                 );
                 setValue("licenseKeyStep.isLoadingKey", false);
             } catch (err) {
-                reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "key-parse", "invalid");
-                setValue("licenseKeyStep.isInvalidKey", true);
+                const message: string = (err as JQueryXHR)?.responseJSON?.Message;
+                
+                const isConnectionError = message?.includes("Failed to contact");
+
+                reportEvent(
+                    setupWizardGA4Prefixes.licenseKeyStep,
+                    "key-parse",
+                    isConnectionError ? "connection-error" : "invalid"
+                );
+
+                if (isConnectionError) {
+                    setValue("licenseKeyStep.isConnectionError", true);
+                } else {
+                    setValue("licenseKeyStep.isInvalidKey", true);
+                }
+
                 setValue("licenseKeyStep.isLoadingKey", false);
                 setValue("licenseKeyStep.licenseInfo", null);
             }
@@ -783,7 +825,7 @@ export function SetupWizardLicenseKeyStepFooter() {
     };
 
     const handleContinue = async () => {
-        if (key) {
+        if (key && !isInvalidKey && !isConnectionError) {
             reportEvent(setupWizardGA4Prefixes.licenseKeyStep, "continue", "with-key");
             setValue("currentStep", "Security");
         } else {
@@ -810,13 +852,13 @@ export function SetupWizardLicenseKeyStepFooter() {
                 </Button>
             ) : (
                 <ButtonWithSpinner
-                    disabled={isInvalidKey}
                     variant="primary"
                     className="rounded-pill"
                     onClick={handleContinue}
                     isSpinning={asyncRegistrationInfo.loading}
                 >
-                    Continue <Icon icon="arrow-right" margin="m-s1" />
+                    {key && !isInvalidKey && !isConnectionError ? "Continue" : "Skip license"}
+                    <Icon icon="arrow-right" margin="ms-1" />
                 </ButtonWithSpinner>
             )}
             {isLicenseSkipModalOpen && <SkipLicenseVerificationConfirmModal close={toggleIsLicenseSkipModalOpen} />}

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardNodeAddressStep.tsx
@@ -913,6 +913,7 @@ function AddAnotherNode({ onAddNode }: AddAnotherNodeProps) {
     const licenseKeyStep = getValues("licenseKeyStep");
     const nodeData = getValues("nodeAddressStep.nodes");
 
+    const hasLicense = !!licenseKeyStep?.licenseInfo;
     const maxClusterSize = licenseKeyStep?.licenseInfo?.maxClusterSize ?? setupWizardConstants.AGPL_MAX_CLUSTER_SIZE;
     const isMaxClusterNodes = maxClusterSize === nodeData?.length;
 
@@ -924,21 +925,41 @@ function AddAnotherNode({ onAddNode }: AddAnotherNodeProps) {
             )}
         >
             <ConditionalPopover
-                conditions={{
-                    isActive: isMaxClusterNodes,
-                    message: (
-                        <>
-                            <p className="mb-0">Your license doesn&apos;t allow more nodes in the cluster.</p>
-                            <hr className="my-2" />
-                            <span className="md-label">
-                                <Icon icon="link" /> See{" "}
-                                <a href="https://ravendb.net/buy" target="_blank">
-                                    licenses comparison <Icon icon="newtab" />
-                                </a>
-                            </span>
-                        </>
-                    ),
-                }}
+                conditions={[
+                    {
+                        isActive: !hasLicense,
+                        message: (
+                            <>
+                                <p className="mb-0">
+                                    Without a license you can only run a single-node cluster. Otherwise, go back to the{" "}
+                                    <b>License Key</b> step to provide a license and unlock multi-node clusters.
+                                </p>
+                                <hr className="my-2" />
+                                <span className="md-label">
+                                    <Icon icon="link" /> See{" "}
+                                    <a href="https://ravendb.net/buy" target="_blank">
+                                        licenses comparison <Icon icon="newtab" />
+                                    </a>
+                                </span>
+                            </>
+                        ),
+                    },
+                    {
+                        isActive: isMaxClusterNodes,
+                        message: (
+                            <>
+                                <p className="mb-0">Your license doesn&apos;t allow more nodes in the cluster.</p>
+                                <hr className="my-2" />
+                                <span className="md-label">
+                                    <Icon icon="link" /> See{" "}
+                                    <a href="https://ravendb.net/buy" target="_blank">
+                                        licenses comparison <Icon icon="newtab" />
+                                    </a>
+                                </span>
+                            </>
+                        ),
+                    },
+                ]}
             >
                 <Button
                     disabled={isMaxClusterNodes}

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSecurityStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSecurityStep.tsx
@@ -72,8 +72,8 @@ export function SetupWizardSecurityStep() {
                         isActive: isLetsEncryptDisabled,
                         message: (
                             <div>
-                                Let&#39;s Encrypt is not available without a license. Go back to the{" "}
-                                <b>License Key</b> step and insert an existing license or generate a free{" "}
+                                Let&#39;s Encrypt is not available without a license. Go back to the <b>License Key</b>{" "}
+                                step and insert an existing license or generate a free{" "}
                                 <Button
                                     variant="link"
                                     className="text-info p-0 text-decoration-underline"

--- a/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSecurityStep.tsx
+++ b/src/Raven.Studio/typescript/components/setupWizard/steps/SetupWizardSecurityStep.tsx
@@ -1,5 +1,5 @@
 import { useFormContext, useWatch } from "react-hook-form";
-import { SetupWizardFormData } from "../setupWizardValidation";
+import { LicenseTypeToGenerate, SetupWizardFormData } from "../setupWizardValidation";
 import { Icon } from "components/common/Icon";
 import SetupWizardClickableCard from "../partials/SetupWizardClickableCard";
 import Button from "react-bootstrap/Button";
@@ -25,17 +25,21 @@ export function SetupWizardSecurityStep() {
         licenseKeyStep: { key, licenseInfo },
     } = useWatch({ control });
 
+    const isLetsEncryptDisabled = !key;
+    const isSecureRecommended = !!key && licenseInfo?.licenseType !== "Developer";
+
+    const handleGoToGenerateLicense = (licenseType: LicenseTypeToGenerate) => {
+        reportEvent(setupWizardGA4Prefixes.securityStep, "go-to-generate-license", licenseType);
+        setValue("licenseKeyStep.licenseTypeToGenerate", licenseType);
+        setValue("securityStep", setupWizardFormDefaultValues["securityStep"]);
+        setValue("currentStep", "License key");
+    };
+
     useEffect(() => {
-        if (isSecureDisabled) {
-            setValue("securityStep.securityOption", "none");
-        }
         if (isSecureRecommended) {
             setValue("securityStep.securityOption", "letsEncrypt");
         }
     }, []);
-
-    const isSecureDisabled = !key;
-    const isSecureRecommended = !!key && licenseInfo?.licenseType !== "Developer";
 
     return (
         <div>
@@ -65,13 +69,27 @@ export function SetupWizardSecurityStep() {
                 <ConditionalPopover
                     className="w-100"
                     conditions={{
-                        isActive: isSecureDisabled,
+                        isActive: isLetsEncryptDisabled,
                         message: (
                             <div>
-                                Secure setup methods are not available without a license. If you&#39;d like to use one
-                                of the secure options, you can go back to <b>License Key</b> step and insert an existing
-                                license or generate a free <b className="text-info">Community</b> or{" "}
-                                <b className="text-developer">Developer</b> license.
+                                Let&#39;s Encrypt is not available without a license. Go back to the{" "}
+                                <b>License Key</b> step and insert an existing license or generate a free{" "}
+                                <Button
+                                    variant="link"
+                                    className="text-info p-0 text-decoration-underline"
+                                    onClick={() => handleGoToGenerateLicense("community")}
+                                >
+                                    Community
+                                </Button>{" "}
+                                or{" "}
+                                <Button
+                                    variant="link"
+                                    className="text-developer p-0 text-decoration-underline"
+                                    onClick={() => handleGoToGenerateLicense("developer")}
+                                >
+                                    Developer
+                                </Button>{" "}
+                                license to use this option.
                             </div>
                         ),
                     }}
@@ -88,7 +106,7 @@ export function SetupWizardSecurityStep() {
                             });
                             reportEvent(setupWizardGA4Prefixes.securityStep, "select-option", "letsEncrypt");
                         }}
-                        isDisabled={isSecureDisabled}
+                        isDisabled={isLetsEncryptDisabled}
                         popoverMessage={
                             <ul className="mb-0 ps-3">
                                 <li>
@@ -107,48 +125,32 @@ export function SetupWizardSecurityStep() {
                         }
                     />
                 </ConditionalPopover>
-                <ConditionalPopover
-                    className="w-100"
-                    conditions={{
-                        isActive: isSecureDisabled,
-                        message: (
-                            <div>
-                                Secure setup methods are not available without a license. If you&#39;d like to use one
-                                of the secure options, you can go back to <b>License Key</b> step and insert an existing
-                                license or generate a free <b className="text-info">Community</b> or{" "}
-                                <b className="text-developer">Developer</b> license.
-                            </div>
-                        ),
+                <SetupWizardClickableCard
+                    className="mt-2 w-100"
+                    icon="certificate"
+                    title="Provide your own certificate"
+                    description="Ideal for secure corporate setups with manual certificate management"
+                    isSelected={securityOption === "ownCertificate"}
+                    onClick={() => {
+                        setValue("securityStep.securityOption", "ownCertificate", {
+                            shouldDirty: true,
+                        });
+                        reportEvent(setupWizardGA4Prefixes.securityStep, "select-option", "ownCertificate");
                     }}
-                >
-                    <SetupWizardClickableCard
-                        className="mt-2 w-100"
-                        icon="certificate"
-                        title="Provide your own certificate"
-                        description="Ideal for secure corporate setups with manual certificate management"
-                        isSelected={securityOption === "ownCertificate"}
-                        onClick={() => {
-                            setValue("securityStep.securityOption", "ownCertificate", {
-                                shouldDirty: true,
-                            });
-                            reportEvent(setupWizardGA4Prefixes.securityStep, "select-option", "ownCertificate");
-                        }}
-                        isDisabled={isSecureDisabled}
-                        popoverMessage={
-                            <ul className="mb-0 ps-3">
-                                <li>
-                                    Use this when you need to provide a custom SSL/TLS certificate, often to comply with
-                                    corporate security policies or integrate with an internal certificate authority.
-                                </li>
-                                <li className="mt-1">
-                                    Recommended for <b>production environments</b> where certificates are managed
-                                    manually or by external infrastructure, and full control over certificate management
-                                    and trust configuration is required.
-                                </li>
-                            </ul>
-                        }
-                    />
-                </ConditionalPopover>
+                    popoverMessage={
+                        <ul className="mb-0 ps-3">
+                            <li>
+                                Use this when you need to provide a custom SSL/TLS certificate, often to comply with
+                                corporate security policies or integrate with an internal certificate authority.
+                            </li>
+                            <li className="mt-1">
+                                Recommended for <b>production environments</b> where certificates are managed manually
+                                or by external infrastructure, and full control over certificate management and trust
+                                configuration is required.
+                            </li>
+                        </ul>
+                    }
+                />
             </div>
             <div className="my-4">
                 <h5 className="mb-1">
@@ -193,13 +195,15 @@ export function SetupWizardSecurityStepFooter() {
 
     const {
         securityStep: { securityOption, isLetsEncryptAgreementAccepted },
-        licenseKeyStep: { licenseInfo },
+        licenseKeyStep: { key, licenseInfo },
     } = useWatch({ control });
 
-    const asyncGetLetsEncryptAgreement = useAsync(
-        () => setupWizardService.getLetsEncryptAgreement(licenseInfo.userDomainsWithIps.email[0] ?? ""),
-        []
-    );
+    const asyncGetLetsEncryptAgreement = useAsync(async () => {
+        if (!key) {
+            return null;
+        }
+        return setupWizardService.getLetsEncryptAgreement(licenseInfo?.userDomainsWithIps?.email?.[0] ?? "");
+    }, []);
 
     const handleBack = () => {
         reportEvent(setupWizardGA4Prefixes.securityStep, "back");

--- a/src/Raven.Studio/typescript/components/setupWizard/utils/setupWizardFormDefaultValues.ts
+++ b/src/Raven.Studio/typescript/components/setupWizard/utils/setupWizardFormDefaultValues.ts
@@ -19,6 +19,7 @@ export const setupWizardFormDefaultValues: SetupWizardFormData = {
         key: "",
         licenseInfo: null,
         licenseTypeToGenerate: null,
+        licenseStatus: null,
         firstName: "",
         lastName: "",
         email: "",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26201

### Additional description

<img width="661" height="324" alt="image" src="https://github.com/user-attachments/assets/9fdf91a0-0748-4661-b4f4-8e3b6c9086f6" />

<img width="1718" height="620" alt="image" src="https://github.com/user-attachments/assets/cc1d7e28-4851-4495-b6a6-7da0d85a4939" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
