### PR TITLE
RavenDB-26214 - UI is stuck at processing Time Series Deleted Ranges

### DIFF
--- a/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
+++ b/src/Raven.Client/Documents/Smuggler/SmugglerProgressBase.cs
@@ -424,7 +424,7 @@ public abstract class SmugglerProgressBase : IOperationProgress
 
         public override string ToString()
         {
-            return $"Skipped: {SkippedCount}. {base.ToString()}";
+            return $"Skipped: {SkippedCount:#,#;;0}. {base.ToString()}";
         }
     }
 
@@ -442,7 +442,7 @@ public abstract class SmugglerProgressBase : IOperationProgress
         public override string ToString()
         {
             if (SkippedCount > 0)
-                return $"Skipped: {SkippedCount}. {base.ToString()}";
+                return $"Skipped: {SkippedCount:#,#;;0}. {base.ToString()}";
 
             return base.ToString();
         }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1312,7 +1312,8 @@ namespace Raven.Server.Documents
                     CompareExchangeCount = ServerStore.Cluster.GetNumberOfCompareExchange(transactionContext, DocumentsStorage.DocumentDatabase.Name),
                     CompareExchangeTombstonesCount = ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(transactionContext, DocumentsStorage.DocumentDatabase.Name),
                     IdentitiesCount = ServerStore.Cluster.GetNumberOfIdentities(transactionContext, DocumentsStorage.DocumentDatabase.Name),
-                    TimeSeriesSegmentsCount = DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegments(documentsContext)
+                    TimeSeriesSegmentsCount = DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesSegments(documentsContext),
+                    TimeSeriesDeletedRangesCount = DocumentsStorage.TimeSeriesStorage.GetNumberOfTimeSeriesDeletedRanges(documentsContext)
                 };
             }
         }

--- a/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/BackupTask.cs
@@ -786,6 +786,8 @@ namespace Raven.Server.Documents.PeriodicBackup
 
             BackupResult.TimeSeries.Processed = true;
             BackupResult.TimeSeries.ReadCount = databaseSummary.TimeSeriesSegmentsCount;
+            BackupResult.TimeSeriesDeletedRanges.Processed = true;
+            BackupResult.TimeSeriesDeletedRanges.ReadCount = databaseSummary.TimeSeriesDeletedRangesCount;
         }
 
         protected void AddInfo(string message)

--- a/src/Raven.Server/Documents/PeriodicBackup/DatabaseSummary.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/DatabaseSummary.cs
@@ -19,5 +19,7 @@ namespace Raven.Server.Documents.PeriodicBackup
         public long IdentitiesCount { get; set; }
 
         public long TimeSeriesSegmentsCount { get; set; }
+
+        public long TimeSeriesDeletedRangesCount { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -65,6 +65,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
             Result.CompareExchangeTombstones.ReadCount += summary.CompareExchangeTombstonesCount;
             Result.Identities.ReadCount += summary.IdentitiesCount;
             Result.TimeSeries.ReadCount += summary.TimeSeriesSegmentsCount;
+            Result.TimeSeriesDeletedRanges.ReadCount += summary.TimeSeriesDeletedRangesCount;
 
             Result.AddInfo($"Successfully restored {Result.SnapshotRestore.ReadCount} files during snapshot restore, took: {_sw.ElapsedMilliseconds:#,#;;0}ms");
             Progress.Invoke(Result.Progress);

--- a/src/Raven.Server/SqlMigration/Model/MigrationResult.cs
+++ b/src/Raven.Server/SqlMigration/Model/MigrationResult.cs
@@ -142,9 +142,9 @@ namespace Raven.Server.SqlMigration.Model
 
         public override string ToString()
         {
-            return $"Skipped: {SkippedCount}. " +
-                   $"Read: {ReadCount}. " +
-                   $"Errored: {ErroredCount}.";
+            return $"Skipped: {SkippedCount:#,#;;0}. " +
+                   $"Read: {ReadCount:#,#;;0}. " +
+                   $"Errored: {ErroredCount:#,#;;0}.";
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26214/UI-is-stuck-at-processing-Time-Series-Deleted-Ranges

### Additional description

Set the `TimeSeriesDeletedRanges` as processed during a snapshot backup and restore.

<img width="587" height="412" alt="image" src="https://github.com/user-attachments/assets/3330ff00-b754-40a2-adf5-6542d747ed97" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
