### PR TITLE
RavenDB-26159 Use LRU for scanned ids to avoid unbounded list

### DIFF
--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -80,6 +80,8 @@ namespace Raven.Server.Documents
         private readonly ServerStore _serverStore;
         private readonly Action<LogMode, string> _addToInitLog;
         private readonly Logger _logger;
+        public Logger Logger => _logger;
+
         private readonly DisposeOnce<SingleAttempt> _disposeOnce;
         internal TestingStuff ForTestingPurposes;
 

--- a/src/Raven.Server/Documents/Operations/AbstractOperations.cs
+++ b/src/Raven.Server/Documents/Operations/AbstractOperations.cs
@@ -13,6 +13,7 @@ using Raven.Client.Util;
 using Raven.Server.Documents.Changes;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
+using Sparrow.Logging;
 using Sparrow.LowMemory;
 
 namespace Raven.Server.Documents.Operations;
@@ -30,9 +31,9 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
     {
         _changes = changes;
         _maxCompletedTaskLifeTime = maxCompletedTaskLifeTime;
-
         LowMemoryNotification.Instance.RegisterLowMemoryHandler(this);
     }
+    protected abstract Logger GetLogger();
 
     public abstract Task<IOperationResult> AddLocalOperation(
         long id,
@@ -85,6 +86,7 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
 
         void ContinuationFunction(Task<IOperationResult> taskResult)
         {
+            var logger = GetLogger();
             operationDescription.EndTime = SystemTime.UtcNow;
             
             if (operationState.PersistProgressOnFaultedStatus == false)
@@ -94,10 +96,14 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
             {
                 operationState.Result = null;
                 operationState.Status = OperationStatus.Canceled;
+                if (logger.IsInfoEnabled)
+                    logger.Info($"Operation {operationDescription.TaskType} with ID {operation.Id} was canceled.");
             }
             else if (taskResult.IsFaulted)
             {
                 var innerException = taskResult.Exception.ExtractSingleInnerException();
+                if (logger.IsInfoEnabled)
+                    logger.Info($"Operation {operationDescription.TaskType} with ID {operation.Id} faulted.", innerException);
 
                 var isConflict = innerException is DocumentConflictException or ConcurrencyException;
                 var status = isConflict ? HttpStatusCode.Conflict : HttpStatusCode.InternalServerError;
@@ -119,6 +125,8 @@ public abstract class AbstractOperations<TOperation> : ILowMemoryHandler
             {
                 operationState.Result = taskResult.Result;
                 operationState.Status = OperationStatus.Completed;
+                if (logger.IsInfoEnabled)
+                    logger.Info($"Operation {operationDescription.TaskType} with ID {operation.Id} completed successfully.");
             }
 
             if (Monitor.TryEnter(locker) == false)

--- a/src/Raven.Server/Documents/Operations/Operations.cs
+++ b/src/Raven.Server/Documents/Operations/Operations.cs
@@ -5,6 +5,7 @@ using Raven.Server.Documents.Changes;
 using Raven.Server.NotificationCenter;
 using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
+using Sparrow.Logging;
 using Sparrow.Platform;
 
 namespace Raven.Server.Documents.Operations
@@ -17,14 +18,21 @@ namespace Raven.Server.Documents.Operations
                 : TimeSpan.FromDays(2))
         {
         }
+
+        private Logger _logger;
+        protected override Logger GetLogger() => _logger ??= LoggingSource.Instance.GetLogger<ServerOperations>("Server");
     }
 
     public sealed class DatabaseOperations : Operations
     {
+        private readonly DocumentDatabase _database;
         public DatabaseOperations(DocumentDatabase database)
             : base(database.Name, database.ConfigurationStorage.OperationsStorage, database.NotificationCenter, database.Changes, database.Is32Bits ? TimeSpan.FromHours(12) : TimeSpan.FromDays(2))
         {
+            _database = database ?? throw new ArgumentNullException(nameof(database));
         }
+
+        protected override Logger GetLogger() => _database.Logger;
     }
 
     public abstract class Operations : AbstractOperations<Operation>

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1642,7 +1642,6 @@ namespace Raven.Server.Documents.Revisions
                     var etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr.Result.Reader);
                     if (etag > parameters.EtagBarrier)
                     {
-                        progressResult.Warn(id, "This document wouldn't be reverted, because it changed after the revert progress started.");
                         return null;
                     }
 
@@ -1771,20 +1770,9 @@ namespace Raven.Server.Documents.Revisions
             return result;
         }
 
-        public async Task<IOperationResult> AdoptOrphanedAsync(Action<IOperationProgress> onProgress,
-            OperationCancelToken token)
-        {
-            var result = new AdoptOrphanedRevisionsResult();
-            await PerformRevisionsOperationAsync(onProgress, result,
-                (ids, res, tk) => new AdoptOrphanedRevisionsCommand(this, ids, result, tk),
-                collections: null, token);
-
-            return result;
-        }
-
         private bool CanContinueBatch(List<string> idsToCheck, TimeSpan elapsed, JsonOperationContext context)
         {
-            if (idsToCheck.Count > 1024)
+            if (idsToCheck.Count > 4 * 1024)
                 return false;
 
             if (elapsed > MaxEnforceConfigurationSingleBatchTime)
@@ -1837,7 +1825,6 @@ namespace Raven.Server.Documents.Revisions
             {
                 await PerformRevisionsOperationOnSingleCollectionAsync(collection, ids, sw, createCommand, result, parameters, token);
             }
-
         }
 
         private async Task PerformRevisionsOperationOnSingleCollectionAsync<TOperationResult>(
@@ -2059,7 +2046,7 @@ namespace Raven.Server.Documents.Revisions
                 var changeVector = _documentsStorage.GetNewChangeVector(context, newEtag);
                 var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
 
-                var local = _documentsStorage.GetDocumentOrTombstone(context, lowerId, throwOnConflict: false);
+                var local = _documentsStorage.GetDocumentOrTombstone(context, lowerId, throwOnConflict: false, fields: DocumentFields.Default);
                 var deletedDoc = local.Document == null;
 
                 var configuration = GetRevisionsConfiguration(collectionName.Name, deleteRevisionsWhenNoCofiguration: true);
@@ -2173,13 +2160,13 @@ namespace Raven.Server.Documents.Revisions
             public DateTime MinimalDate;
             public long EtagBarrier;
             public long LastScannedEtag;
-            public readonly HashSet<string> ScannedIds = new HashSet<string>();
+            public readonly LruHashSet<string> ScannedIds = new LruHashSet<string>(64 * 1024);
             public Action<IOperationProgress> OnProgress;
         }
 
-        public async Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token)
+        public Task<IOperationResult> RevertRevisions(DateTime before, TimeSpan window, Action<IOperationProgress> onProgress, OperationCancelToken token)
         {
-            return await RevertRevisions(before, window, onProgress, collections: null, token);
+            return RevertRevisions(before, window, onProgress, collections: null, token);
         }
 
         public Task RevertDocumentsToRevisionsAsync(Dictionary<string, string> idToChangeVector, OperationCancelToken token)
@@ -2248,17 +2235,17 @@ namespace Raven.Server.Documents.Revisions
                 using (_database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext writeCtx))
                 {
                     hasMore = PrepareRevertedRevisions(writeCtx, parameters, result, list, collection, token);
-                    await WriteRevertedRevisions(list, token);
+                    await WriteRevertedRevisions(list, parameters, token);
                 }
             }
         }
 
-        private async Task WriteRevertedRevisions(List<Document> list, OperationCancelToken token)
+        private async Task WriteRevertedRevisions(List<Document> list, Parameters parameters, OperationCancelToken token)
         {
             if (list.Count == 0)
                 return;
 
-            await _database.TxMerger.Enqueue(new RevertDocumentsCommand(list, token));
+            await _database.TxMerger.Enqueue(new RevertDocumentsCommand(list, parameters.EtagBarrier, token));
 
             list.Clear();
         }
@@ -2391,20 +2378,20 @@ namespace Raven.Server.Documents.Revisions
         internal sealed class RevertDocumentsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
         {
             private readonly List<Document> _list;
+            private readonly long? _etagBarrier;
             private readonly Dictionary<string, string> _idToChangeVector;
             private readonly CancellationToken _token;
 
-            public RevertDocumentsCommand(List<Document> list, OperationCancelToken token)
+            public RevertDocumentsCommand(List<Document> list, long? etagBarrier, OperationCancelToken token)
             {
                 _list = list;
+                _etagBarrier = etagBarrier;
                 _token = token.Token;
             }
 
-            public RevertDocumentsCommand(Dictionary<string, string> idToChangeVector, OperationCancelToken token)
+            public RevertDocumentsCommand(Dictionary<string, string> idToChangeVector, OperationCancelToken token) : this(new List<Document>(), etagBarrier: null, token)
             {
                 _idToChangeVector = idToChangeVector;
-                _list = new List<Document>();
-                _token = token.Token;
             }
 
             protected override long ExecuteCmd(DocumentsOperationContext context)
@@ -2423,6 +2410,16 @@ namespace Raven.Server.Documents.Revisions
 
                 foreach (var document in _list)
                 {
+                    if (_etagBarrier.HasValue)
+                    {
+                        // this protects against ourselves, if we already reverted the document
+                        var current = documentsStorage.GetDocumentOrTombstone(context, document.Id, DocumentFields.Default, throwOnConflict: false);
+                        var currentEtag = current.Document?.Etag ?? current.Tombstone?.Etag ?? 0;
+                        var currentflags = current.Document?.Flags ?? current.Tombstone?.Flags ?? DocumentFlags.None;
+                        if (currentEtag > _etagBarrier.Value && currentflags.HasFlag(DocumentFlags.Reverted))
+                            continue;
+                    }
+
                     _token.ThrowIfCancellationRequested();
                     var flags = document.Flags.Strip(DocumentFlags.Revision | DocumentFlags.Conflicted | DocumentFlags.Resolved | DocumentFlags.FromClusterTransaction | DocumentFlags.FromReplication) | DocumentFlags.Reverted;
 
@@ -2504,22 +2501,24 @@ namespace Raven.Server.Documents.Revisions
 
             public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
             {
-                return new RevertDocumentsCommandDto(_list);
+                return new RevertDocumentsCommandDto(_list, _etagBarrier);
             }
         }
 
         internal sealed class RevertDocumentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, RevertDocumentsCommand>
         {
             public readonly List<Document> List;
+            private readonly long? _etagBarrier;
 
-            public RevertDocumentsCommandDto(List<Document> list)
+            public RevertDocumentsCommandDto(List<Document> list, long? etagBarrier)
             {
                 List = list;
+                _etagBarrier = etagBarrier;
             }
 
             public RevertDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                return new RevertDocumentsCommand(List, OperationCancelToken.None);
+                return new RevertDocumentsCommand(List, _etagBarrier, OperationCancelToken.None);
             }
         }
 

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2414,10 +2414,14 @@ namespace Raven.Server.Documents.Revisions
                     {
                         // this protects against ourselves, if we already reverted the document
                         var current = documentsStorage.GetDocumentOrTombstone(context, document.Id, DocumentFields.Default, throwOnConflict: false);
-                        var currentEtag = current.Document?.Etag ?? current.Tombstone?.Etag ?? 0;
-                        var currentflags = current.Document?.Flags ?? current.Tombstone?.Flags ?? DocumentFlags.None;
-                        if (currentEtag > _etagBarrier.Value && currentflags.HasFlag(DocumentFlags.Reverted))
-                            continue;
+                        using (current.Document)
+                        using (current.Tombstone)
+                        {
+                            var currentEtag = current.Document?.Etag ?? current.Tombstone?.Etag ?? 0;
+                            var currentFlags = current.Document?.Flags ?? current.Tombstone?.Flags ?? DocumentFlags.None;
+                            if (currentEtag > _etagBarrier.Value && currentFlags.HasFlag(DocumentFlags.Reverted))
+                                continue;
+                        }
                     }
 
                     _token.ThrowIfCancellationRequested();
@@ -2508,17 +2512,17 @@ namespace Raven.Server.Documents.Revisions
         internal sealed class RevertDocumentsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, RevertDocumentsCommand>
         {
             public readonly List<Document> List;
-            private readonly long? _etagBarrier;
+            public readonly long? EtagBarrier;
 
             public RevertDocumentsCommandDto(List<Document> list, long? etagBarrier)
             {
                 List = list;
-                _etagBarrier = etagBarrier;
+                EtagBarrier = etagBarrier;
             }
 
             public RevertDocumentsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
             {
-                return new RevertDocumentsCommand(List, _etagBarrier, OperationCancelToken.None);
+                return new RevertDocumentsCommand(List, EtagBarrier, OperationCancelToken.None);
             }
         }
 

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.Operations.cs
@@ -12,6 +12,7 @@ using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
 using Sparrow.Json;
+using Sparrow.Logging;
 using Sparrow.Platform;
 
 namespace Raven.Server.Documents.Sharding;
@@ -49,6 +50,8 @@ public partial class ShardedDatabaseContext
 
             base.RaiseNotifications(change, operation);
         }
+
+        protected override Logger GetLogger() => _context._logger;
 
         public override Task<IOperationResult> AddLocalOperation(
             long id,

--- a/src/Raven.Server/Utils/LruDictionary.cs
+++ b/src/Raven.Server/Utils/LruDictionary.cs
@@ -1,4 +1,6 @@
-﻿namespace Raven.Server.Utils;
+﻿using System;
+
+namespace Raven.Server.Utils;
 
 using System.Collections.Generic;
 
@@ -10,6 +12,9 @@ public sealed class LruDictionary<TKey, TValue> where TKey : notnull
 
     public LruDictionary(int maxCapacity)
     {
+        if (maxCapacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxCapacity), "Max capacity must be greater than zero.");
+
         _maxCapacity = maxCapacity;
         _cache = new Dictionary<TKey, (LinkedListNode<TKey> Node, TValue Value)>(maxCapacity);
         _list = new LinkedList<TKey>();

--- a/src/Raven.Server/Utils/LruHashSet.cs
+++ b/src/Raven.Server/Utils/LruHashSet.cs
@@ -1,0 +1,26 @@
+﻿namespace Raven.Server.Utils;
+
+public sealed class LruHashSet<TKey> where TKey : notnull
+{
+    private readonly LruDictionary<TKey, object> _cache;
+
+    public LruHashSet(int maxCapacity)
+    {
+        _cache = new LruDictionary<TKey, object>(maxCapacity);
+    }
+
+    public bool Contains(TKey key) => _cache.TryGetValue(key, out _);
+
+    public bool Add(TKey key)
+    {
+        if (_cache.TryGetValue(key, out _))
+        {
+            return false;
+        }
+
+        _cache[key] = null;
+        return true;
+    }
+
+    public void Clear() => _cache.Clear();
+}

--- a/test/SlowTests/Issues/RavenDB-21381.cs
+++ b/test/SlowTests/Issues/RavenDB-21381.cs
@@ -99,7 +99,7 @@ namespace SlowTests.Issues
 
             // Run AdoptOrphaned and assert that new 'Delete Revision' was created again for user1
             var token = new OperationCancelToken(database.Configuration.Databases.OperationTimeout.AsTimeSpan, database.DatabaseShutdown);
-            await database.DocumentsStorage.RevisionsStorage.AdoptOrphanedAsync(null, token);
+            await database.DocumentsStorage.RevisionsStorage.AdoptOrphanedAsync(onProgress: null, collections: null, token);
             using (var session = store.OpenAsyncSession())
             {
                 var user1RevCount = await session.Advanced.Revisions.GetCountForAsync(user1.Id);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26159

### Additional description

Use LRU for scanned ids to avoid unbounded list and OOM in large databases

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
