### PR TITLE
RavenDB-25470 Add ToggleTaskStateCommand to license limit check

### DIFF
--- a/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.License.cs
@@ -1268,6 +1268,9 @@ public sealed partial class ClusterStateMachine
                 case OngoingTaskType.QueueEtl:
                     AssertQueueEtlLicenseLimits(databaseRecord, licenseStatus, context);
                     break;
+                case OngoingTaskType.SnowflakeEtl:
+                    AssertSnowflakeEtl(databaseRecord, licenseStatus, context);
+                    break;
                 case OngoingTaskType.Backup:
                     AssertPeriodicBackupLicenseLimits(databaseRecord, licenseStatus, context);
                     break;
@@ -1279,6 +1282,12 @@ public sealed partial class ClusterStateMachine
                     break;
                 case OngoingTaskType.QueueSink:
                     AssertQueueSink(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.EmbeddingsGeneration:
+                    AssertEmbeddingsGeneration(databaseRecord, licenseStatus, context);
+                    break;
+                case OngoingTaskType.GenAi:
+                    AssertGenAi(databaseRecord, licenseStatus, context);
                     break;
                 default:
                     return;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25470

### Additional description
Added license limit check for ToggleTaskStateCommand

https://github.com/ravendb/ravendb/pull/22292

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
