### PR TITLE
RavenDB-26141 RQL Assistant: ai.task() support

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/AbstractStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.AI;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.Processors.Studio;
+
+internal abstract class AbstractStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks<TRequestHandler, TOperationContext> : AbstractDatabaseHandlerProcessor<TRequestHandler, TOperationContext>
+    where TOperationContext : JsonOperationContext
+    where TRequestHandler : AbstractDatabaseRequestHandler<TOperationContext>
+{
+    internal AbstractStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks([NotNull] TRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out TOperationContext context))
+        {
+            var grouped = GetResults(context);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+                var firstCollection = true;
+                foreach (var (collection, tasks) in grouped)
+                {
+                    if (firstCollection == false)
+                        writer.WriteComma();
+                    firstCollection = false;
+
+                    writer.WritePropertyName(collection);
+                    writer.WriteStartObject();
+
+                    var firstTask = true;
+                    foreach (var (taskName, paths) in tasks)
+                    {
+                        if (firstTask == false)
+                            writer.WriteComma();
+                        firstTask = false;
+
+                        writer.WritePropertyName(taskName);
+                        writer.WriteArrayValue(paths);
+                    }
+
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndObject();
+            }
+        }
+    }
+
+    protected abstract IEnumerable<EmbeddingsGenerationConfiguration> GetEmbeddingsTasks(TOperationContext context);
+
+    private Dictionary<string, Dictionary<string, IEnumerable<string>>> GetResults(TOperationContext context)
+    {
+        return GetEmbeddingsTasks(context)
+            .GroupBy(x => x.Collection)
+            .ToDictionary(
+                g => g.Key,
+                g => g.ToDictionary(
+                    x => x.Identifier,
+                    x => (IEnumerable<string>)(x.EmbeddingsPathConfigurations?.Select(p => p.Path) ?? Enumerable.Empty<string>())
+                )
+            );
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.ServerWide.Context;

--- a/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Studio/StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.Processors.Studio;
+
+internal class StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks([NotNull] DatabaseRequestHandler requestHandler)
+    : AbstractStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks<DatabaseRequestHandler, DocumentsOperationContext>(requestHandler)
+{
+    protected override IEnumerable<EmbeddingsGenerationConfiguration> GetEmbeddingsTasks(DocumentsOperationContext context)
+    {
+        return context
+            .DocumentDatabase
+            .ReadDatabaseRecord()
+            .EmbeddingsGenerations;
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Server.Documents.Handlers.Processors.Studio;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Sharding.Handlers.Processors.Studio;
+
+internal class ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks([NotNull] ShardedDatabaseRequestHandler requestHandler)
+    : AbstractStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks<ShardedDatabaseRequestHandler, TransactionOperationContext>(requestHandler)
+{
+    protected override IEnumerable<EmbeddingsGenerationConfiguration> GetEmbeddingsTasks(TransactionOperationContext context)
+    {
+        return RequestHandler
+            .DatabaseContext
+            .DatabaseRecord
+            .EmbeddingsGenerations;
+    }
+}

--- a/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/Processors/Studio/ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Server.Documents.Handlers.Processors.Studio;

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedStudioQueryingAssistantHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedStudioQueryingAssistantHandler.cs
@@ -6,7 +6,7 @@ namespace Raven.Server.Documents.Sharding.Handlers;
 
 public class ShardedStudioQueryingAssistantHandler : ShardedDatabaseRequestHandler
 {
-    [RavenShardedAction("/databases/*/studio/tasks/embeddinggenerationtasks", "GET")]
+    [RavenShardedAction("/databases/*/studio/tasks/embeddings", "GET")]
     public async Task GetEmbeddingGenerationTasks()
     {
         using (var processor = new ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks(this))

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedStudioQueryingAssistantHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedStudioQueryingAssistantHandler.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Raven.Server.Documents.Sharding.Handlers.Processors.Studio;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Documents.Sharding.Handlers;
+
+public class ShardedStudioQueryingAssistantHandler : ShardedDatabaseRequestHandler
+{
+    [RavenShardedAction("/databases/*/studio/tasks/embeddinggenerationtasks", "GET")]
+    public async Task GetEmbeddingGenerationTasks()
+    {
+        using (var processor = new ShardedStudioQueryingAssistantProcessorForEmbeddingsGenerationTasks(this))
+            await processor.ExecuteAsync();
+    }
+}

--- a/src/Raven.Server/Web/Studio/StudioQueryingAssistantHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioQueryingAssistantHandler.cs
@@ -7,7 +7,7 @@ namespace Raven.Server.Web.Studio;
 
 public class StudioQueryingAssistantHandler : DatabaseRequestHandler
 {
-    [RavenAction("/databases/*/studio/tasks/embeddinggenerationtasks", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+    [RavenAction("/databases/*/studio/tasks/embeddings", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
     public async Task GetEmbeddingGenerationTasks()
     {
         using (var processor = new StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks(this))

--- a/src/Raven.Server/Web/Studio/StudioQueryingAssistantHandler.cs
+++ b/src/Raven.Server/Web/Studio/StudioQueryingAssistantHandler.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.Processors.Studio;
+using Raven.Server.Routing;
+
+namespace Raven.Server.Web.Studio;
+
+public class StudioQueryingAssistantHandler : DatabaseRequestHandler
+{
+    [RavenAction("/databases/*/studio/tasks/embeddinggenerationtasks", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+    public async Task GetEmbeddingGenerationTasks()
+    {
+        using (var processor = new StudioQueryingAssistantProcessorForEmbeddingsGenerationTasks(this))
+            await processor.ExecuteAsync();
+    }
+}

--- a/src/Raven.Studio/languageService/src/autocomplete.ts
+++ b/src/Raven.Studio/languageService/src/autocomplete.ts
@@ -12,6 +12,7 @@ import { AutocompleteGroupBy } from "./providers/group_by";
 import { AutocompleteOrderBy } from "./providers/order_by";
 import { ProgContext } from "./generated/BaseRqlParser";
 import { AutoCompleteFields } from "./providers/fields";
+import { AutocompleteAiTasks } from "./providers/aiTasks";
 
 export const ignoredTokens: number[] = [
     RqlParser.EOF,
@@ -128,7 +129,8 @@ export class autoCompleteEngine {
             RqlParser.RULE_orderBySortingAs,
             RqlParser.RULE_orderByOrder,
             RqlParser.RULE_identifiersWithoutRootKeywords,
-            RqlParser.RULE_identifiersAllNames
+            RqlParser.RULE_identifiersAllNames,
+            RqlParser.RULE_aiTaskMethod
         ]);
 
         core.translateRulesTopDown = true;
@@ -177,7 +179,8 @@ export class autoCompleteEngine {
             new AutocompleteFrom(metadataProvider),
             new AutoCompleteFields(metadataProvider),
             new AutocompleteGroupBy(metadataProvider),
-            new AutocompleteOrderBy(metadataProvider)
+            new AutocompleteOrderBy(metadataProvider),
+            new AutocompleteAiTasks(metadataProvider)
         ];
     }
 }

--- a/src/Raven.Studio/languageService/src/providers/aiTasks.ts
+++ b/src/Raven.Studio/languageService/src/providers/aiTasks.ts
@@ -137,10 +137,10 @@ export class AutocompleteAiTasks extends BaseAutocompleteProvider implements Aut
                 return true;
             }
             
-            const t = scanner.tokenType();
-            const isNonContentToken = t === Token.EOF
-                || t === RqlParser.CL_PAR
-                || t === RqlParser.COMMA;
+            const tokenType = scanner.tokenType();
+            const isNonContentToken = tokenType === Token.EOF
+                || tokenType === RqlParser.CL_PAR
+                || tokenType === RqlParser.COMMA;
 
             if (isNonContentToken && scanner.lookBack() === RqlParser.OP_PAR) {
                 scanner.previous();

--- a/src/Raven.Studio/languageService/src/providers/aiTasks.ts
+++ b/src/Raven.Studio/languageService/src/providers/aiTasks.ts
@@ -1,0 +1,172 @@
+import { BaseAutocompleteProvider } from "./baseProvider";
+import { AUTOCOMPLETE_META, AUTOCOMPLETE_SCORING, AutocompleteContext, AutocompleteProvider } from "./common";
+import { RqlParser } from "../RqlParser";
+import { Scanner } from "../scanner";
+import { QuoteUtils } from "../quoteUtils";
+import { Token } from "antlr4ts/Token";
+
+type EmbeddingTasksMap = Record<string, Record<string, string[]>>;
+
+export class AutocompleteAiTasks extends BaseAutocompleteProvider implements AutocompleteProvider {
+
+    async collectAsync(ctx: AutocompleteContext): Promise<autoCompleteWordList[]> {
+        const { candidates, scanner, writtenText, queryMetaInfo } = ctx;
+
+        if (this.isInsideAiTask(scanner)) {
+            const data = await this.fetchAiTasks();
+            const taskNames = AutocompleteAiTasks.extractTaskNames(data);
+            const quoteType = BaseAutocompleteProvider.detectQuoteType(writtenText) !== "None"
+                ? BaseAutocompleteProvider.detectQuoteType(writtenText)
+                : "Single";
+
+            return taskNames.map(taskName => ({
+                meta: AUTOCOMPLETE_META.function,
+                score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
+                caption: taskName,
+                value: QuoteUtils.quote(taskName, quoteType)
+            }));
+        }
+
+        if (candidates.rules.has(RqlParser.RULE_aiTaskMethod)) {
+            const data = await this.fetchAiTasks();
+            const taskNames = AutocompleteAiTasks.extractTaskNames(data);
+            const completions: autoCompleteWordList[] = taskNames.map(taskName => ({
+                meta: AUTOCOMPLETE_META.aiTask,
+                score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
+                caption: `ai.task('${taskName}')`,
+                value: `ai.task('${taskName}')`
+            }));
+
+            completions.push({
+                value: "ai.task(",
+                caption: "ai.task(name)",
+                meta: AUTOCOMPLETE_META.function,
+                score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
+                snippet: `ai.task('\${1}')`
+            });
+
+            return completions;
+        }
+
+        if (this.isAtEmbeddingTextOpenParen(scanner)) {
+            const collection = queryMetaInfo?.querySourceType === "collection"
+                ? queryMetaInfo.querySourceName
+                : null;
+
+            if (collection) {
+                const data = await this.fetchAiTasks();
+                const taskMap = data[collection.toLowerCase()] ?? {};
+
+                return Object.entries(taskMap).flatMap(([taskName, fields]) =>
+                    fields.map(fieldName => ({
+                        meta: AUTOCOMPLETE_META.function,
+                        score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
+                        caption: `${fieldName}, ai.task('${taskName}')`,
+                        value: `${fieldName}, ai.task('${taskName}')`,
+                        snippet: `${fieldName}, ai.task('${taskName}')\${0}`
+                    }))
+                );
+            }
+
+            return [];
+        }
+
+        if (this.isInsideEmbeddingTextLiteral(scanner)) {
+            const data = await this.fetchAiTasks();
+            const taskNames = AutocompleteAiTasks.extractTaskNames(data);
+            const quoteType = BaseAutocompleteProvider.detectQuoteType(writtenText) !== "None"
+                ? BaseAutocompleteProvider.detectQuoteType(writtenText)
+                : "Single";
+
+            return taskNames.map(taskName => ({
+                meta: AUTOCOMPLETE_META.function,
+                score: AUTOCOMPLETE_SCORING.functionVectorTextualOverload,
+                caption: `ai.task('${taskName}')`,
+                value: `, ai.task(${QuoteUtils.quote(taskName, quoteType)})`,
+                snippet: `\${0}, ai.task(${QuoteUtils.quote(taskName, quoteType)})`
+            }));
+        }
+
+        return [];
+    }
+
+    private static extractTaskNames(data: EmbeddingTasksMap): string[] {
+        const names = new Set<string>();
+        for (const taskMap of Object.values(data)) {
+            for (const name of Object.keys(taskMap)) {
+                names.add(name);
+            }
+        }
+        return [...names];
+    }
+
+    private async fetchAiTasks(): Promise<EmbeddingTasksMap> {
+        return new Promise<EmbeddingTasksMap>(resolve =>
+            this.metadataProvider.aiTasks(data =>
+                resolve(Object.fromEntries(Object.entries(data).map(([k, v]) => [k.toLowerCase(), v])))
+            )
+        );
+    }
+
+    /// ai.task(|
+    private isInsideAiTask(scanner: Scanner): boolean {
+        scanner.push();
+        try {
+            if (scanner.tokenType() === RqlParser.OP_PAR && scanner.lookBack() === RqlParser.AI_TASK) {
+                return true;
+            }
+
+            if (scanner.previous() === false) {
+                return false;
+            }
+
+            if (scanner.tokenType() !== RqlParser.OP_PAR) {
+                return false;
+            }
+            return scanner.lookBack() === RqlParser.AI_TASK;
+        } finally {
+            scanner.pop();
+        }
+    }
+    
+    private isAtEmbeddingTextOpenParen(scanner: Scanner): boolean {
+        scanner.push();
+        try {
+            if (scanner.tokenType() === RqlParser.OP_PAR
+                && scanner.lookBack() === RqlParser.EMBEDDING_TEXT) {
+                return true;
+            }
+            
+            const t = scanner.tokenType();
+            const isNonContentToken = t === Token.EOF
+                || t === RqlParser.CL_PAR
+                || t === RqlParser.COMMA;
+
+            if (isNonContentToken && scanner.lookBack() === RqlParser.OP_PAR) {
+                scanner.previous();
+                return scanner.lookBack() === RqlParser.EMBEDDING_TEXT;
+            }
+            return false;
+        } finally {
+            scanner.pop();
+        }
+    }
+
+    // embedding.text(Name|
+    // embedding.text_i8(Name|
+    // embedding.text_i1(Name|
+    private isInsideEmbeddingTextLiteral(scanner: Scanner): boolean {
+        scanner.push();
+        try {
+            if (scanner.lookBack() !== RqlParser.OP_PAR) {
+                return false;
+            }
+            if (scanner.previous() === false) {
+                return false;
+            }
+            return scanner.lookBack() === RqlParser.EMBEDDING_TEXT;
+        } finally {
+            scanner.pop();
+        }
+    }
+}

--- a/src/Raven.Studio/languageService/src/providers/common.ts
+++ b/src/Raven.Studio/languageService/src/providers/common.ts
@@ -20,6 +20,7 @@ export const AUTOCOMPLETE_META = {
     operator: "operator",
     keyword: "keyword",
     function: "function",
+    aiTask: "aiTask",
     field: "field",
     index: "index",
     collection: "collection"

--- a/src/Raven.Studio/languageService/test/autocomplete/EmptyMetadataProvider.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/EmptyMetadataProvider.ts
@@ -16,4 +16,8 @@ export class EmptyMetadataProvider implements queryCompleterProviders {
     indexFields(indexName: string, callback: (fields: string[]) => void): void {
         callback([]);
     }
+
+    aiTasks(callback: (data: Record<string, Record<string, string[]>>) => void): void {
+        callback({});
+    }
 }

--- a/src/Raven.Studio/languageService/test/autocomplete/FakeMetadataProvider.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/FakeMetadataProvider.ts
@@ -56,8 +56,9 @@ export class FakeMetadataProvider implements queryCompleterProviders {
     
     private collectionStubs = stubCollectionFields();
     private indexStubs = stubIndexFields();
+    private aiTaskStubs: Record<string, Record<string, string[]>> = {};
     
-    public constructor(overrides?: { indexes?: Record<string, string[]>, collections?: Record<string, Record<string, Record<string, string>>> }) {
+    public constructor(overrides?: { indexes?: Record<string, string[]>, collections?: Record<string, Record<string, Record<string, string>>>, aiTasks?: Record<string, Record<string, string[]>> }) {
         if (overrides?.indexes) {
             this.indexStubs = new Map<string, string[]>(Object.entries(overrides.indexes ?? []));
         }
@@ -67,6 +68,9 @@ export class FakeMetadataProvider implements queryCompleterProviders {
                 map.set(key, new Map<string, dictionary<string>>(Object.entries(value ?? [])));
             }
             this.collectionStubs = map;
+        }
+        if (overrides?.aiTasks) {
+            this.aiTaskStubs = overrides.aiTasks;
         }
     }
     
@@ -94,5 +98,9 @@ export class FakeMetadataProvider implements queryCompleterProviders {
         } else {
             callback([]);
         }
+    }
+
+    aiTasks(callback: (data: Record<string, Record<string, string[]>>) => void): void {
+        callback(this.aiTaskStubs);
     }
 }

--- a/src/Raven.Studio/languageService/test/autocomplete/aiTasks.spec.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/aiTasks.spec.ts
@@ -1,0 +1,258 @@
+import { autocomplete } from "../autocompleteUtils";
+import { FakeMetadataProvider } from "./FakeMetadataProvider";
+import { EmptyMetadataProvider } from "./EmptyMetadataProvider";
+
+const tasks = ["FirstTask", "SecondTask"];
+
+const taskFields = {
+    Products: {
+        FirstTask: ["Name", "Category"],
+        SecondTask: ["Description"],
+    },
+};
+
+function withTasks() {
+    return new FakeMetadataProvider({ aiTasks: taskFields });
+}
+
+const embeddingFunctions = ["embedding.text", "embedding.text_i8", "embedding.text_i1"];
+
+describe("ai.task autocomplete", function () {
+
+    describe("combined field+task suggestion", function () {
+        test.each(embeddingFunctions)(
+            "suggests 'field, ai.task(task)' for each configured path [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(|`,
+                    withTasks()
+                );
+
+                for (const [taskName, fields] of Object.entries(taskFields.Products)) {
+                    for (const field of fields) {
+                        const caption = `${field}, ai.task('${taskName}')`;
+                        const match = suggestions.find(x => x.caption === caption);
+                        expect(match).toBeTruthy();
+                    }
+                }
+            }
+        );
+        
+        test.each(embeddingFunctions)(
+            "returns no combined suggestions when no tasks exist [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(|`,
+                    new EmptyMetadataProvider()
+                );
+
+                const anyAiTask = suggestions.find(x => x.value?.includes("ai.task("));
+                expect(anyAiTask).toBeFalsy();
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "returns no combined suggestions when querying by index (not collection) [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from index 'Product/Rating' where vector.search(${fn}(|`,
+                    withTasks()
+                );
+
+                const anyAiTask = suggestions.find(x => x.value?.includes("ai.task("));
+                expect(anyAiTask).toBeFalsy();
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "suggests combined field+task [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(|))`,
+                    withTasks()
+                );
+
+                for (const [taskName, fields] of Object.entries(taskFields.Products)) {
+                    for (const field of fields) {
+                        const caption = `${field}, ai.task('${taskName}')`;
+                        const match = suggestions.find(x => x.caption === caption);
+                        expect(match).toBeTruthy();
+                    }
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "returns no suggestions for index query [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from index 'Product/Rating' where vector.search(${fn}(|))`,
+                    withTasks()
+                );
+
+                const anyAiTask = suggestions.find(x => x.value?.includes("ai.task("));
+                expect(anyAiTask).toBeFalsy();
+            }
+        );
+    });
+
+    describe("end of first arg", function () {
+
+        test.each(embeddingFunctions)(
+            "suggests ai.task('TaskName') for [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name|`,
+                    withTasks()
+                );
+
+                for (const task of tasks) {
+                    const match = suggestions.find(x => x.caption === `ai.task('${task}')`);
+                    expect(match).toBeTruthy();
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "snippet positions cursor before the comma so the field name can still be edited [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name|`,
+                    withTasks()
+                );
+
+                for (const task of tasks) {
+                    const match = suggestions.find(x => x.caption === `ai.task('${task}')`);
+                    expect(match).toBeTruthy();
+                    expect(match.snippet).toMatch(/^\$\{0}, ai\.task\(/);
+                    expect(match.value).toMatch(/^, ai\.task\(/);
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "returns no task suggestions when no ai tasks exist [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name|`,
+                    new EmptyMetadataProvider()
+                );
+
+                const anyAiTask = suggestions.find(x => x.value.includes("ai.task("));
+                expect(anyAiTask).toBeFalsy();
+            }
+        );
+    });
+
+    describe("cursor after the comma", function () {
+
+        test.each(embeddingFunctions)(
+            "suggests ai.task('TaskName') for each task [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, |`,
+                    withTasks()
+                );
+
+                for (const task of tasks) {
+                    const match = suggestions.find(x => x.value === `ai.task('${task}')`);
+                    expect(match).toBeTruthy();
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "suggests the generic ai.task() [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, |`,
+                    new EmptyMetadataProvider()
+                );
+
+                const genericSnippet = suggestions.find(x => x.value.startsWith("ai.task("));
+                expect(genericSnippet).toBeTruthy();
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "returns no per-task suggestions when no ai tasks exist [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, |`,
+                    new EmptyMetadataProvider()
+                );
+
+                const taskSpecific = suggestions.filter(x =>
+                    tasks.some(t => x.value === `ai.task('${t}')`)
+                );
+                expect(taskSpecific).toHaveLength(0);
+            }
+        );
+    });
+
+    describe("cursor inside ai.task('...')", function () {
+
+        test.each(embeddingFunctions)(
+            "suggests quoted task names right after the opening [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, ai.task(|`,
+                    withTasks()
+                );
+
+                for (const task of tasks) {
+                    const match = suggestions.find(x => x.caption === task);
+                    expect(match).toBeTruthy();
+                    expect(match.value).toBe(`'${task}'`);
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "suggests quoted task names [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, ai.task('Open|`,
+                    withTasks()
+                );
+
+                for (const task of tasks) {
+                    const match = suggestions.find(x => x.caption === task);
+                    expect(match).toBeTruthy();
+                    expect(match.value).toBe(`'${task}'`);
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "uses double quotes when the user started with a double quote [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, ai.task("|`,
+                    withTasks()
+                );
+
+                for (const task of tasks) {
+                    const match = suggestions.find(x => x.caption === task);
+                    expect(match).toBeTruthy();
+                    expect(match.value).toBe(`"${task}"`);
+                }
+            }
+        );
+
+        test.each(embeddingFunctions)(
+            "returns no task suggestions when no ai tasks exist [%s]",
+            async (fn) => {
+                const suggestions = await autocomplete(
+                    `from Products where vector.search(${fn}(Name, ai.task(|`,
+                    new EmptyMetadataProvider()
+                );
+
+                const anyTask = suggestions.find(x =>
+                    tasks.some(t => x.caption === t)
+                );
+                expect(anyTask).toBeFalsy();
+            }
+        );
+    });
+});

--- a/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
+++ b/src/Raven.Studio/languageService/test/autocomplete/where.spec.ts
@@ -37,9 +37,9 @@ describe("can complete where", function () {
         }
     });
 
-    it("vector.search(embedding.text(Name,  <- suggest method ai_task", async () => {
+    it("vector.search(embedding.text(Name,  <- suggest method ai.task", async () => {
         const suggestions = await autocomplete("from CollectionWithoutDefinedFields where vector.search(embedding.text(Name, |", new EmptyMetadataProvider());
-        for (let specialFunction of ['ai_task']) {
+        for (let specialFunction of ['ai.task(']) {
             const matchingItem = suggestions.find(x => x.value.startsWith(specialFunction));
             expect(matchingItem)
                 .toBeTruthy();

--- a/src/Raven.Studio/typescript/commands/database/tasks/getEmbeddingGenerationTasksCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getEmbeddingGenerationTasksCommand.ts
@@ -3,16 +3,8 @@ import database =  require("models/resources/database");
 import endpoints = require("endpoints");
 
 class getEmbeddingGenerationTasksCommand  extends commandBase {
-
-    private readonly db: database | string;
-    private readonly location: databaseLocationSpecifier;
-    private readonly reportFailure: boolean;
-
-    constructor(db: database | string, location: databaseLocationSpecifier, reportFailure = true) {
+    constructor(private db: database | string, private location: databaseLocationSpecifier, private reportFailure = true) {
         super();
-        this.db = db;
-        this.location = location;
-        this.reportFailure = reportFailure;
     }
 
     execute(): JQueryPromise<Record<string, Record<string, string[]>>> {
@@ -28,11 +20,9 @@ class getEmbeddingGenerationTasksCommand  extends commandBase {
     }
 
     private getEmbeddingsGenerationTaskNames(): JQueryPromise<Record<string, Record<string, string[]>>> {
-        const args = {
-            ...this.location
-        };
+        const args = this.location;
 
-        const url = endpoints.databases.studioQueryingAssistant.studioTasksEmbeddinggenerationtasks;
+        const url = endpoints.databases.studioQueryingAssistant.studioTasksEmbeddings;
 
         return this.query(url, args, this.db);
     }

--- a/src/Raven.Studio/typescript/commands/database/tasks/getEmbeddingGenerationTasksCommand.ts
+++ b/src/Raven.Studio/typescript/commands/database/tasks/getEmbeddingGenerationTasksCommand.ts
@@ -1,0 +1,41 @@
+import commandBase = require("commands/commandBase");
+import database =  require("models/resources/database");
+import endpoints = require("endpoints");
+
+class getEmbeddingGenerationTasksCommand  extends commandBase {
+
+    private readonly db: database | string;
+    private readonly location: databaseLocationSpecifier;
+    private readonly reportFailure: boolean;
+
+    constructor(db: database | string, location: databaseLocationSpecifier, reportFailure = true) {
+        super();
+        this.db = db;
+        this.location = location;
+        this.reportFailure = reportFailure;
+    }
+
+    execute(): JQueryPromise<Record<string, Record<string, string[]>>> {
+        const task = this.getEmbeddingsGenerationTaskNames();
+
+        if (this.reportFailure) {
+            task.fail((response: JQueryXHR) => {
+                this.reportError("Failed to get embedding generation tasks", response.responseText, response.statusText);
+            });
+        }
+
+        return task;
+    }
+
+    private getEmbeddingsGenerationTaskNames(): JQueryPromise<Record<string, Record<string, string[]>>> {
+        const args = {
+            ...this.location
+        };
+
+        const url = endpoints.databases.studioQueryingAssistant.studioTasksEmbeddinggenerationtasks;
+
+        return this.query(url, args, this.db);
+    }
+}
+
+export = getEmbeddingGenerationTasksCommand;

--- a/src/Raven.Studio/typescript/common/autoComplete/cachedMetadataProvider.ts
+++ b/src/Raven.Studio/typescript/common/autoComplete/cachedMetadataProvider.ts
@@ -7,7 +7,8 @@ class cachedMetadataProvider implements queryCompleterProviders {
     private cachedCollections: Promise<string[]> = undefined;
     private cachedIndexFields: Map<string, Promise<string[]>> = new Map<string, Promise<string[]>>();
     private cachedCollectionFields: Map<string, Map<string, Promise<dictionary<string>>>> = new Map<string, Map<string, Promise<dictionary<string>>>>();
-    
+    private cachedAiTasks: Promise<Record<string, Record<string, string[]>>> = undefined;
+
     constructor(parent: queryCompleterProviders) {
         this.parent = parent;
     }
@@ -71,6 +72,18 @@ class cachedMetadataProvider implements queryCompleterProviders {
             });
             
             await this.indexNames(callback);
+        }
+    }
+
+    async aiTasks(callback: (data: Record<string, Record<string, string[]>>) => void) {
+        if (this.cachedAiTasks) {
+            const data = await this.cachedAiTasks;
+            callback(data);
+        } else {
+            this.cachedAiTasks = new Promise<Record<string, Record<string, string[]>>>(resolve => {
+                this.parent.aiTasks(resolve);
+            });
+            await this.aiTasks(callback);
         }
     }
 }

--- a/src/Raven.Studio/typescript/common/autoComplete/proxyMetadataProvider.ts
+++ b/src/Raven.Studio/typescript/common/autoComplete/proxyMetadataProvider.ts
@@ -45,6 +45,14 @@ export class proxyMetadataProvider implements queryCompleterProviders {
         this.pendingMessages.set(id, (payload: MetadataResponseIndexes) => callback(payload.names));
     }
 
+    aiTasks(callback: (data: Record<string, Record<string, string[]>>) => void): void {
+        const id = this.sender({
+            type: "aiTasks"
+        });
+
+        this.pendingMessages.set(id, (payload: MetadataResponseAiTasks) => callback(payload.data));
+    }
+
     onResponse(id: number, response: MetadataResponsePayload) {
         const callback = this.pendingMessages.get(id);
         try {

--- a/src/Raven.Studio/typescript/common/autoComplete/remoteMetadataProvider.ts
+++ b/src/Raven.Studio/typescript/common/autoComplete/remoteMetadataProvider.ts
@@ -2,6 +2,7 @@ import database = require("models/resources/database");
 import collectionsTracker = require("common/helpers/database/collectionsTracker");
 import getIndexEntriesFieldsCommand = require("commands/database/index/getIndexEntriesFieldsCommand");
 import getCollectionFieldsCommand = require("commands/database/documents/getCollectionFieldsCommand");
+import getEmbeddingGenerationTasksCommand = require("commands/database/tasks/getEmbeddingGenerationTasksCommand");
 import IndexUtils = require("components/utils/IndexUtils");
 import databases = require("components/models/databases");
 import DatabaseUtils = require("components/utils/DatabaseUtils");
@@ -27,6 +28,16 @@ class remoteMetadataProvider implements queryCompleterProviders {
             .execute()
             .done(result => {
                 callback(result.filter(x => x.FieldType === "Static").map(x => x.Name).filter(x => !IndexUtils.default.FieldsToHideOnUi.includes(x)));
+            });
+    }
+
+    aiTasks(callback: (data: Record<string, Record<string, string[]>>) => void): void {
+        const locations = this.db instanceof database ? this.db.getLocations() : DatabaseUtils.default.getLocations(this.db);
+
+        new getEmbeddingGenerationTasksCommand(this.db.name, locations[0])
+            .execute()
+            .done(result => {
+                callback(result);
             });
     }
 

--- a/src/Raven.Studio/typescript/common/rqlLanguageService.ts
+++ b/src/Raven.Studio/typescript/common/rqlLanguageService.ts
@@ -111,6 +111,13 @@ class rqlLanguageService implements aceEditor.LanguageService {
                     })
                 }
                 break;
+            case "aiTasks":
+                this.metadataProvider.aiTasks(data => {
+                    this.sendMetadataResponse(request, {
+                        data
+                    });
+                });
+                break;
             
             default:
                 throw new Error("Unhandled metadata request" + request.payload);

--- a/src/Raven.Studio/typings/_studio/dto.d.ts
+++ b/src/Raven.Studio/typings/_studio/dto.d.ts
@@ -573,6 +573,7 @@ interface queryCompleterProviders {
     collectionFields: (collectionName: string, prefix: string, callback: (fields: dictionary<string>) => void) => void;
     collections: (callback: (collectionNames: string[]) => void) => void;
     indexNames: (callback: (indexNames: string[]) => void) => void;
+    aiTasks: (callback: (data: Record<string, Record<string, string[]>>) => void) => void;
 }
 
 type rqlQueryType = "Select" | "Update";

--- a/src/Raven.Studio/typings/_studio/languageService.d.ts
+++ b/src/Raven.Studio/typings/_studio/languageService.d.ts
@@ -42,10 +42,15 @@ type MetadataRequestListIndexes = {
     type: "indexes";
 }
 
+type MetadataRequestListAiTasks = {
+    type: "aiTasks";
+}
+
 type MetadataRequestPayload = MetadataRequestListCollections 
     | MetadataRequestListIndexes 
     | MetadataRequestListCollectionFields
-    | MetadataRequestListIndexFields;
+    | MetadataRequestListIndexFields
+    | MetadataRequestListAiTasks;
 
 type LanguageServiceRequest = LanguageServiceSyntaxRequest | LanguageServiceAutoCompleteRequest | LanguageServiceMetadataRequest;
 
@@ -82,9 +87,14 @@ type MetadataResponseIndexFields = {
     fields: string[];
 }
 
+type MetadataResponseAiTasks = {
+    data: Record<string, Record<string, string[]>>;
+}
+
 type MetadataResponsePayload = MetadataResponseCollections 
     | MetadataResponseIndexes 
     | MetadataResponseIndexFields 
-    | MetadataResponseCollectionFields;
+    | MetadataResponseCollectionFields
+    | MetadataResponseAiTasks;
 
 type LanguageServiceResponse = LanguageServiceSyntaxResponse | LanguageServiceAutoCompleteResponse | LanguageServiceMetadataResponse;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26141

### Additional description

Suggest:
Pair: `(Path, ai.task(TaskName))`
<img width="1357" height="410" alt="image" src="https://github.com/user-attachments/assets/4b8c5ed3-e509-4865-adfa-196d38d243f6" />

Just only Task Name:

<img width="1984" height="469" alt="image" src="https://github.com/user-attachments/assets/d7a4b835-3a24-4bbb-9a90-5dbf090181e0" />


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
