### PR TITLE
RavenDB-25154: Replace TrackingMode with OptimisticConcurrencyMode enum

### DIFF
--- a/src/Raven.Client/DocumentationUrls.cs
+++ b/src/Raven.Client/DocumentationUrls.cs
@@ -143,7 +143,7 @@ internal static class DocumentationUrls
         internal static class Options
         {
             ///<remarks><seealso href="https://ravendb.net/docs/article-page/7.2/csharp/client-api/session/configuration/how-to-disable-tracking#disable-entity-tracking"/></remarks>
-            public const string TrackingMode = nameof(TrackingMode);
+            public const string NoTracking = nameof(NoTracking);
 
             ///<remarks><seealso href="https://ravendb.net/docs/article-page/7.2/csharp/client-api/session/configuration/how-to-disable-caching"/></remarks>
             public const string NoCaching = nameof(NoCaching);

--- a/src/Raven.Client/Documents/Commands/Batches/BatchTrackChangesCommandData.cs
+++ b/src/Raven.Client/Documents/Commands/Batches/BatchTrackChangesCommandData.cs
@@ -1,8 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
-using Raven.Client.Extensions;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
@@ -11,23 +10,35 @@ namespace Raven.Client.Documents.Commands.Batches
     internal sealed class BatchTrackChangesCommandData : ICommandData
     {
         internal readonly Dictionary<string, string> TrackedEntities;
+        private readonly HashSet<string> _idsToSkip;
         public string Id => throw new NotSupportedException();
         public string Name { get; } = null;
         public string ChangeVector => throw new NotSupportedException();
 
         public CommandType Type { get; } = CommandType.BatchTrackChanges;
 
-        public BatchTrackChangesCommandData(Dictionary<string, string> trackedEntities)
+        public BatchTrackChangesCommandData(Dictionary<string, string> trackedEntities, HashSet<string> idsToSkip)
         {
             TrackedEntities = trackedEntities;
+            _idsToSkip = idsToSkip;
         }
 
         public DynamicJsonValue ToJson(DocumentConventions conventions, JsonOperationContext context)
         {
+            var trackedEntitiesJson = new DynamicJsonValue();
+
+            foreach (var kvp in TrackedEntities)
+            {
+                if (_idsToSkip.Contains(kvp.Key))
+                    continue;
+
+                trackedEntitiesJson[kvp.Key] = kvp.Value;
+            }
+
             var json = new DynamicJsonValue
             {
                 [nameof(Type)] = Type.ToString(),
-                [nameof(TrackedEntities)] = TrackedEntities.ToJson(),
+                [nameof(TrackedEntities)] = trackedEntitiesJson,
             };
             return json;
         }

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -400,6 +400,8 @@ namespace Raven.Client.Documents.Conventions
         private Func<string, BlittableJsonReaderObject, string> _findClrType;
         private Func<string, Type> _resolveTypeFromClrTypeName;
         private OptimisticConcurrencyMode _optimisticConcurrencyMode;
+        private bool _useOptimisticConcurrencyWasSet;
+        private bool _optimisticConcurrencyModeWasSet;
         private bool _addIdFieldToDynamicObjects;
         private int _maxNumberOfRequestsPerSession;
 
@@ -845,6 +847,12 @@ namespace Raven.Client.Documents.Conventions
             set
             {
                 AssertNotFrozen();
+#pragma warning disable CS0618
+                if (_useOptimisticConcurrencyWasSet)
+                    throw new InvalidOperationException($"{nameof(OptimisticConcurrencyMode)} cannot be set when {nameof(UseOptimisticConcurrency)} was set. Please use {nameof(OptimisticConcurrencyMode)} instead of {nameof(UseOptimisticConcurrency)}.");
+#pragma warning restore CS0618
+
+                _optimisticConcurrencyModeWasSet = true;
                 _optimisticConcurrencyMode = value;
             }
         }
@@ -860,6 +868,11 @@ namespace Raven.Client.Documents.Conventions
             set
             {
                 AssertNotFrozen();
+
+                if (_optimisticConcurrencyModeWasSet)
+                    throw new InvalidOperationException($"{nameof(UseOptimisticConcurrency)} cannot be set when {nameof(OptimisticConcurrencyMode)} was set. Please use {nameof(OptimisticConcurrencyMode)} instead of {nameof(UseOptimisticConcurrency)}.");
+
+                _useOptimisticConcurrencyWasSet = true;
                 _optimisticConcurrencyMode = value ? OptimisticConcurrencyMode.Writes : OptimisticConcurrencyMode.None;
             }
         }

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -839,7 +839,9 @@ namespace Raven.Client.Documents.Conventions
         }
 
         /// <summary>
-        ///     Configure optimistic concurrency mode for all opened sessions by default
+        ///     Configure the default optimistic concurrency mode for all sessions opened from this store.<br/>
+        ///     Sessions inherit this value unless overridden via <see cref="SessionOptions.OptimisticConcurrencyMode"/>.<br/>
+        ///     Cannot be mixed with the obsolete <see cref="UseOptimisticConcurrency"/> property.
         /// </summary>
         public OptimisticConcurrencyMode OptimisticConcurrencyMode
         {
@@ -858,7 +860,10 @@ namespace Raven.Client.Documents.Conventions
         }
 
         /// <summary>
-        ///     Whether UseOptimisticConcurrency is set to true by default for all opened sessions
+        ///     Gets or sets whether optimistic concurrency is enabled for all sessions by default.<br/>
+        ///     Setting to <c>true</c> maps to <see cref="OptimisticConcurrencyMode.Writes"/>;
+        ///     setting to <c>false</c> maps to <see cref="OptimisticConcurrencyMode.None"/>.<br/>
+        ///     Note: <see cref="OptimisticConcurrencyMode.WritesAndReads"/> cannot be represented by this property.
         /// </summary>
         [Obsolete("UseOptimisticConcurrency is obsolete and will be removed in the next major version. Please use " +
                   nameof(OptimisticConcurrencyMode) + " instead.")]

--- a/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
+++ b/src/Raven.Client/Documents/Conventions/DocumentConventions.cs
@@ -399,7 +399,7 @@ namespace Raven.Client.Documents.Conventions
         private Func<Type, string> _findClrTypeName;
         private Func<string, BlittableJsonReaderObject, string> _findClrType;
         private Func<string, Type> _resolveTypeFromClrTypeName;
-        private bool _useOptimisticConcurrency;
+        private OptimisticConcurrencyMode _optimisticConcurrencyMode;
         private bool _addIdFieldToDynamicObjects;
         private int _maxNumberOfRequestsPerSession;
 
@@ -837,15 +837,30 @@ namespace Raven.Client.Documents.Conventions
         }
 
         /// <summary>
-        ///     Whether UseOptimisticConcurrency is set to true by default for all opened sessions
+        ///     Configure optimistic concurrency mode for all opened sessions by default
         /// </summary>
-        public bool UseOptimisticConcurrency
+        public OptimisticConcurrencyMode OptimisticConcurrencyMode
         {
-            get => _useOptimisticConcurrency;
+            get => _optimisticConcurrencyMode;
             set
             {
                 AssertNotFrozen();
-                _useOptimisticConcurrency = value;
+                _optimisticConcurrencyMode = value;
+            }
+        }
+
+        /// <summary>
+        ///     Whether UseOptimisticConcurrency is set to true by default for all opened sessions
+        /// </summary>
+        [Obsolete("UseOptimisticConcurrency is obsolete and will be removed in the next major version. Please use " +
+                  nameof(OptimisticConcurrencyMode) + " instead.")]
+        public bool UseOptimisticConcurrency
+        {
+            get => _optimisticConcurrencyMode != OptimisticConcurrencyMode.None;
+            set
+            {
+                AssertNotFrozen();
+                _optimisticConcurrencyMode = value ? OptimisticConcurrencyMode.Writes : OptimisticConcurrencyMode.None;
             }
         }
 

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -193,7 +193,7 @@ namespace Raven.Client.Documents.Session
                     if (command == null)
                         return;
 
-                    if (TrackingMode == TrackingMode.NoTracking)
+                    if (NoTracking)
                         throw new InvalidOperationException($"Cannot execute '{nameof(SaveChangesAsync)}' when entity tracking is disabled in session.");
 
                     await RequestExecutor.ExecuteAsync(command, Context, _sessionInfo, token).ConfigureAwait(false);

--- a/src/Raven.Client/Documents/Session/AsyncSessionDocumentCounters.cs
+++ b/src/Raven.Client/Documents/Session/AsyncSessionDocumentCounters.cs
@@ -58,7 +58,7 @@ namespace Raven.Client.Documents.Session
 
                 cache.Values[counter] = value;
 
-                if (Session.TrackingMode != TrackingMode.NoTracking)
+                if (Session.NoTracking == false)
                     Session.CountersByDocId[DocId] = cache;
 
                 return value;
@@ -114,7 +114,7 @@ namespace Raven.Client.Documents.Session
                     break;
                 }
 
-                if (Session.TrackingMode != TrackingMode.NoTracking)
+                if (Session.NoTracking == false)
                     Session.CountersByDocId[DocId] = cache;
 
                 return result;
@@ -174,7 +174,7 @@ namespace Raven.Client.Documents.Session
 
                 cache.GotAll = true;
 
-                if (Session.TrackingMode != TrackingMode.NoTracking)
+                if (Session.NoTracking == false)
                     Session.CountersByDocId[DocId] = cache;
 
                 return cache.Values;

--- a/src/Raven.Client/Documents/Session/AsyncSessionDocumentTimeSeries.cs
+++ b/src/Raven.Client/Documents/Session/AsyncSessionDocumentTimeSeries.cs
@@ -115,7 +115,7 @@ namespace Raven.Client.Documents.Session
             if (rangeResult == null)
                 return null;
 
-            if (Session.TrackingMode != TrackingMode.NoTracking)
+            if (Session.NoTracking == false)
             {
                 HandleIncludes(rangeResult);
 
@@ -286,7 +286,7 @@ namespace Raven.Client.Documents.Session
             var mergedValues = MergeRangesWithResults(from, to, ranges, fromRangeIndex, toRangeIndex,
                 resultFromServer: details.Values[Name], out var resultToUser);
 
-            if (Session.TrackingMode != TrackingMode.NoTracking)
+            if (Session.NoTracking == false)
             {
                 from = details.Values[Name].Min(ts => ts.From);
                 to = details.Values[Name].Max(ts => ts.To);

--- a/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
+++ b/src/Raven.Client/Documents/Session/ClusterTransactionSession.cs
@@ -225,7 +225,7 @@ namespace Raven.Client.Documents.Session
         internal CompareExchangeSessionValue RegisterMissingCompareExchangeValue(string key)
         {
             var value = new CompareExchangeSessionValue(key, -1, CompareExchangeSessionValue.CompareExchangeValueState.Missing);
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
                 return value;
 
             _state.Add(key, value);
@@ -234,7 +234,7 @@ namespace Raven.Client.Documents.Session
 
         internal void RegisterCompareExchangeIncludes(BlittableJsonReaderObject values, bool includingMissingAtomicGuards)
         {
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
                 return;
 
             if (values != null)
@@ -272,7 +272,7 @@ namespace Raven.Client.Documents.Session
 
             AssertNotAtomicGuard(value);
 
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
                 return new CompareExchangeSessionValue(value);
 
             _compareExchangeIncludes.Remove(value.Key);
@@ -291,7 +291,7 @@ namespace Raven.Client.Documents.Session
 
             AssertNotAtomicGuard(value);
 
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
                 return;
 
             _compareExchangeIncludes[value.Key] = value;
@@ -301,7 +301,7 @@ namespace Raven.Client.Documents.Session
         {
             AssertNotAtomicGuard(key);
 
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
                 return;
             
             _compareExchangeIncludes[key] = new CompareExchangeValue<BlittableJsonReaderObject>(key, -1, null);

--- a/src/Raven.Client/Documents/Session/ConcurrencyCheckMode.cs
+++ b/src/Raven.Client/Documents/Session/ConcurrencyCheckMode.cs
@@ -14,8 +14,8 @@ namespace Raven.Client.Documents.Session
 
         /// <summary>
         /// Disable optimistic concurrency check for this entity's PUT/DELETE command even if <see cref="OptimisticConcurrencyMode"/> is set.<br/>
-        /// Note: when <see cref="OptimisticConcurrencyMode.WritesAndReads"/> is active, the entity is still tracked
-        /// and verified by the <c>BatchTrackChangesCommand</c>.
+        /// Note: when <see cref="OptimisticConcurrencyMode.WritesAndReads"/> is active, the entity is still verified
+        /// during <see cref="DocumentSession.SaveChanges"/> to ensure it was not modified by another session.
         /// </summary>
         Disabled
     }

--- a/src/Raven.Client/Documents/Session/ConcurrencyCheckMode.cs
+++ b/src/Raven.Client/Documents/Session/ConcurrencyCheckMode.cs
@@ -3,17 +3,19 @@ namespace Raven.Client.Documents.Session
     public enum ConcurrencyCheckMode
     {
         /// <summary>
-        /// Automatic optimistic concurrency check depending on UseOptimisticConcurrency setting or provided Change Vector
+        /// Automatic optimistic concurrency check depending on <see cref="OptimisticConcurrencyMode"/> setting or provided Change Vector
         /// </summary>
         Auto,
 
         /// <summary>
-        /// Force optimistic concurrency check even if UseOptimisticConcurrency is not set
+        /// Force optimistic concurrency check even if <see cref="OptimisticConcurrencyMode"/> is <see cref="OptimisticConcurrencyMode.None"/>
         /// </summary>
         Forced,
 
         /// <summary>
-        /// Disable optimistic concurrency check even if UseOptimisticConcurrency is set
+        /// Disable optimistic concurrency check for this entity's PUT/DELETE command even if <see cref="OptimisticConcurrencyMode"/> is set.<br/>
+        /// Note: when <see cref="OptimisticConcurrencyMode.WritesAndReads"/> is active, the entity is still tracked
+        /// and verified by the <c>BatchTrackChangesCommand</c>.
         /// </summary>
         Disabled
     }

--- a/src/Raven.Client/Documents/Session/DocumentInfo.cs
+++ b/src/Raven.Client/Documents/Session/DocumentInfo.cs
@@ -21,8 +21,8 @@ namespace Raven.Client.Documents.Session
         public string ChangeVector { get; set; }
 
         /// <summary>
-        /// A concurrency check will be forced on this entity 
-        /// even if UseOptimisticConcurrency is set to false
+        /// Controls whether a concurrency check is forced or disabled for this entity,
+        /// regardless of the session's <see cref="OptimisticConcurrencyMode"/> setting.
         /// </summary>
         public ConcurrencyCheckMode ConcurrencyCheckMode { get; set; }
 

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -93,7 +93,7 @@ namespace Raven.Client.Documents.Session
                 if (command == null)
                     return;
 
-                if (TrackingMode == TrackingMode.NoTracking)
+                if (NoTracking)
                     throw new InvalidOperationException($"Cannot execute '{nameof(SaveChanges)}' when entity tracking is disabled in session.");
 
                 RequestExecutor.Execute(command, Context, sessionInfo: _sessionInfo);

--- a/src/Raven.Client/Documents/Session/IAdvancedDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedDocumentSessionOperations.cs
@@ -114,8 +114,10 @@ namespace Raven.Client.Documents.Session
         string StoreIdentifier { get; }
 
         /// <summary>
-        ///     Gets or sets the optimistic concurrency mode for the session.
+        ///     Gets or sets the optimistic concurrency mode for the session.<br/>
+        ///     Cannot be mixed with the obsolete <c>UseOptimisticConcurrency</c> property in the same session.
         /// </summary>
+        /// <seealso cref="OptimisticConcurrencyMode"/>
         OptimisticConcurrencyMode OptimisticConcurrencyMode { get; set; }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/IAdvancedDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/IAdvancedDocumentSessionOperations.cs
@@ -114,10 +114,17 @@ namespace Raven.Client.Documents.Session
         string StoreIdentifier { get; }
 
         /// <summary>
+        ///     Gets or sets the optimistic concurrency mode for the session.
+        /// </summary>
+        OptimisticConcurrencyMode OptimisticConcurrencyMode { get; set; }
+
+        /// <summary>
         ///     Gets or sets a value indicating whether the session should use optimistic concurrency.
         ///     When set to <c>true</c>, a check is made so that a change made behind the session back would fail
         ///     and raise <see cref="ConcurrencyException" />.
         /// </summary>
+        [Obsolete("UseOptimisticConcurrency is obsolete and will be removed in the next major version. Please use " +
+                  nameof(OptimisticConcurrencyMode) + " instead.")]
         bool UseOptimisticConcurrency { get; set; }
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -278,6 +278,12 @@ namespace Raven.Client.Documents.Session
             _optimisticConcurrencyMode = options.OptimisticConcurrencyMode
                                          ?? _requestExecutor.Conventions.OptimisticConcurrencyMode;
 
+            if (NoTracking && _optimisticConcurrencyMode != OptimisticConcurrencyMode.None)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(OptimisticConcurrencyMode)} cannot be set to {_optimisticConcurrencyMode} when {nameof(NoTracking)} is true.");
+            }
+
             TrackedEntities = new TrackedEntitiesHolder(_optimisticConcurrencyMode == OptimisticConcurrencyMode.WritesAndReads);
             _knownMissingIds = new KnownMissingIdsHolder(TrackedEntities);
             MaxNumberOfRequestsPerSession = _requestExecutor.Conventions.MaxNumberOfRequestsPerSession;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -280,6 +280,9 @@ namespace Raven.Client.Documents.Session
             _optimisticConcurrencyMode = options.OptimisticConcurrencyMode
                                          ?? _requestExecutor.Conventions.OptimisticConcurrencyMode;
 
+            if (options.OptimisticConcurrencyMode.HasValue)
+                _optimisticConcurrencyModeWasSet = true;
+
             if (NoTracking && _optimisticConcurrencyMode != OptimisticConcurrencyMode.None)
             {
                 throw new InvalidOperationException(

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1081,6 +1081,9 @@ more responsive application.
                             OnBeforeDeleteInvoke(new BeforeDeleteEventArgs(this, documentInfo.Id, documentInfo.Entity));
                         }
 
+                        if (changeVector != null)
+                            result.IdsAlreadyCheckedForConcurrency.Add(documentInfo.Id);
+
                         var deleteCommandData = new DeleteCommandData(documentInfo.Id, changeVector, documentInfo.ChangeVector);
                         result.SessionCommands.Add(deleteCommandData);
                     }
@@ -1184,6 +1187,9 @@ more responsive application.
                             forceRevisionCreationStrategy = creationStrategy;
                         }
                     }
+
+                    if (changeVector != null)
+                        result.IdsAlreadyCheckedForConcurrency.Add(entity.Value.Id);
 
                     result.SessionCommands.Add(new PutCommandDataWithBlittableJson(entity.Value.Id, changeVector, entity.Value.ChangeVector, document, forceRevisionCreationStrategy));
                 }
@@ -2452,6 +2458,7 @@ more responsive application.
             public readonly Dictionary<(string, CommandType, string), ICommandData> DeferredCommandsDictionary;
             public readonly List<ICommandData> SessionCommands = new List<ICommandData>();
             public BatchTrackChangesCommandData TrackChangesCommandData;
+            public readonly HashSet<string> IdsAlreadyCheckedForConcurrency = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             public readonly List<object> Entities = new List<object>();
             public readonly BatchOptions Options;
             internal readonly ActionsToRunOnSuccess OnSuccess;
@@ -3013,10 +3020,10 @@ more responsive application.
 
         public void PrepareForEntitiesTrack(InMemoryDocumentSessionOperations.SaveChangesData result)
         {
-            if (Any() == false) 
+            if (Any() == false)
                 return;
 
-            result.TrackChangesCommandData = new BatchTrackChangesCommandData(_trackedEntities);
+            result.TrackChangesCommandData = new BatchTrackChangesCommandData(_trackedEntities, result.IdsAlreadyCheckedForConcurrency);
             result.SessionCommands.Insert(0, result.TrackChangesCommandData);
         }
     }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -202,8 +202,10 @@ namespace Raven.Client.Documents.Session
         private bool _optimisticConcurrencyModeWasSet;
 
         /// <summary>
-        /// Gets or sets the optimistic concurrency mode for the session.
+        /// Gets or sets the optimistic concurrency mode for the session.<br/>
+        /// Cannot be set if the obsolete <see cref="UseOptimisticConcurrency"/> was already set on this session.
         /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when <see cref="UseOptimisticConcurrency"/> was already set on this session.</exception>
         public OptimisticConcurrencyMode OptimisticConcurrencyMode
         {
             get => _optimisticConcurrencyMode;

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -197,20 +197,55 @@ namespace Raven.Client.Documents.Session
         /// <value>The max number of requests per session.</value>
         public int MaxNumberOfRequestsPerSession { get; set; }
 
+        private OptimisticConcurrencyMode _optimisticConcurrencyMode;
+        private bool _useOptimisticConcurrencyWasSet;
+        private bool _optimisticConcurrencyModeWasSet;
+
+        /// <summary>
+        /// Gets or sets the optimistic concurrency mode for the session.
+        /// </summary>
+        public OptimisticConcurrencyMode OptimisticConcurrencyMode
+        {
+            get => _optimisticConcurrencyMode;
+            set
+            {
+                if (_useOptimisticConcurrencyWasSet)
+#pragma warning disable CS0618
+                    throw new InvalidOperationException($"{nameof(OptimisticConcurrencyMode)} cannot be set when {nameof(UseOptimisticConcurrency)} was set. Please use {nameof(OptimisticConcurrencyMode)} instead of {nameof(UseOptimisticConcurrency)}.");
+#pragma warning restore CS0618
+
+                _optimisticConcurrencyModeWasSet = true;
+                _optimisticConcurrencyMode = value;
+            }
+        }
+
         /// <summary>
         /// Gets or sets a value indicating whether the session should use optimistic concurrency.
         /// When set to <c>true</c>, a check is made so that a change made behind the session back would fail
         /// and raise <see cref="ConcurrencyException"/>.
         /// </summary>
         /// <value></value>
-        public bool UseOptimisticConcurrency { get; set; }
+        [Obsolete("UseOptimisticConcurrency is obsolete and will be removed in the next major version. Please use " +
+                  nameof(OptimisticConcurrencyMode) + " instead.")]
+        public bool UseOptimisticConcurrency
+        {
+            get => _optimisticConcurrencyMode != OptimisticConcurrencyMode.None;
+            set
+            {
+                if (_optimisticConcurrencyModeWasSet)
+                    throw new InvalidOperationException($"{nameof(UseOptimisticConcurrency)} cannot be set when {nameof(OptimisticConcurrencyMode)} was set. Please use {nameof(OptimisticConcurrencyMode)} instead of {nameof(UseOptimisticConcurrency)}.");
+
+                _useOptimisticConcurrencyWasSet = true;
+                _optimisticConcurrencyMode = value ? OptimisticConcurrencyMode.Writes : OptimisticConcurrencyMode.None;
+            }
+        }
 
         protected readonly List<ICommandData> DeferredCommands = new List<ICommandData>();
 
         protected internal readonly Dictionary<(string, CommandType, string), ICommandData> DeferredCommandsDictionary =
             new Dictionary<(string, CommandType, string), ICommandData>();
 
-        public readonly TrackingMode TrackingMode;
+        public readonly bool NoTracking;
 
         internal Dictionary<string, ForceRevisionStrategy> IdsForCreatingForcedRevisions = new Dictionary<string, ForceRevisionStrategy>(StringComparer.OrdinalIgnoreCase);
 
@@ -238,12 +273,13 @@ namespace Raven.Client.Documents.Session
             _requestExecutor = options.RequestExecutor ?? documentStore.GetRequestExecutor(DatabaseName);
             _releaseOperationContext = _requestExecutor.ContextPool.AllocateOperationContext(out _context);
 
-            TrackingMode = options.TrackingMode;
+            NoTracking = options.NoTracking;
 
-            TrackedEntities = new TrackedEntitiesHolder(options.TrackingMode);
+            _optimisticConcurrencyMode = options.OptimisticConcurrencyMode
+                                         ?? _requestExecutor.Conventions.OptimisticConcurrencyMode;
+
+            TrackedEntities = new TrackedEntitiesHolder(_optimisticConcurrencyMode == OptimisticConcurrencyMode.WritesAndReads);
             _knownMissingIds = new KnownMissingIdsHolder(TrackedEntities);
-
-            UseOptimisticConcurrency = _requestExecutor.Conventions.UseOptimisticConcurrency;
             MaxNumberOfRequestsPerSession = _requestExecutor.Conventions.MaxNumberOfRequestsPerSession;
             GenerateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(_requestExecutor.Conventions, entity => _requestExecutor.Conventions.GenerateDocumentIdAsync(DatabaseName, entity));
             JsonConverter = _requestExecutor.Conventions.Serialization.CreateConverter(this);
@@ -486,12 +522,12 @@ more responsive application.
         /// <returns></returns>
         private object TrackEntity(Type entityType, DocumentInfo documentFound)
         {
-            return TrackEntity(entityType, documentFound.Id, documentFound.Document, documentFound.Metadata, noTracking: TrackingMode == TrackingMode.NoTracking);
+            return TrackEntity(entityType, documentFound.Id, documentFound.Document, documentFound.Metadata, noTracking: NoTracking);
         }
 
         internal void RegisterExternalLoadedIntoTheSession(DocumentInfo info)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             if (DocumentsById.TryGetValue(info.Id, out var existing))
@@ -523,7 +559,7 @@ more responsive application.
         /// <returns></returns>
         private object TrackEntity(Type entityType, string id, BlittableJsonReaderObject document, BlittableJsonReaderObject metadata, bool noTracking)
         {
-            noTracking = TrackingMode == TrackingMode.NoTracking || noTracking; // if noTracking is session-wide then we want to override the passed argument
+            noTracking = NoTracking || noTracking; // if noTracking is session-wide then we want to override the passed argument
 
             if (string.IsNullOrEmpty(id))
             {
@@ -667,7 +703,7 @@ more responsive application.
                 _knownMissingIds.AddWithoutTracking(id);
             }
 
-            changeVector = UseOptimisticConcurrency ? changeVector : null;
+            changeVector = _optimisticConcurrencyMode != OptimisticConcurrencyMode.None ? changeVector : null;
 
             _countersByDocId?.Remove(id);
             Defer(new DeleteCommandData(id, expectedChangeVector ?? changeVector, expectedChangeVector ?? documentInfo?.ChangeVector));
@@ -700,7 +736,7 @@ more responsive application.
 
         private void StoreInternal(object entity, string changeVector, string id, ConcurrencyCheckMode forceConcurrencyCheck)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 throw new InvalidOperationException("Cannot store entity. Entity tracking is disabled in this session.");
 
             if (entity == null)
@@ -888,9 +924,9 @@ more responsive application.
             if (TransactionMode != TransactionMode.ClusterWide)
                 return;
 
-            if (UseOptimisticConcurrency)
+            if (_optimisticConcurrencyMode != OptimisticConcurrencyMode.None)
                 throw new NotSupportedException(
-                    $"{nameof(UseOptimisticConcurrency)} is not supported with {nameof(TransactionMode)} set to {nameof(TransactionMode.ClusterWide)}");
+                    $"{nameof(OptimisticConcurrencyMode)} is not supported with {nameof(TransactionMode)} set to {nameof(TransactionMode.ClusterWide)}");
 
             foreach (var command in result.SessionCommands)
             {
@@ -1031,7 +1067,7 @@ more responsive application.
                             result.OnSuccess.RemoveDocumentById(documentInfo.Id);
                         }
 
-                        if (UseOptimisticConcurrency == false)
+                        if (_optimisticConcurrencyMode == OptimisticConcurrencyMode.None)
                             changeVector = null;
 
                         if (deletedEntity.ExecuteOnBeforeDelete)
@@ -1118,7 +1154,7 @@ more responsive application.
                     }
 
                     string changeVector;
-                    if (UseOptimisticConcurrency)
+                    if (_optimisticConcurrencyMode != OptimisticConcurrencyMode.None)
                     {
                         if (entity.Value.ConcurrencyCheckMode != ConcurrencyCheckMode.Disabled)
                             // if the user didn't provide a change vector, we'll test for an empty one
@@ -1495,7 +1531,7 @@ more responsive application.
 
         public void RegisterMissing(string id)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             _knownMissingIds.Add(id);
@@ -1503,7 +1539,7 @@ more responsive application.
 
         public void RegisterMissing(IEnumerable<string> ids)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             _knownMissingIds.UnionWith(ids);
@@ -1511,7 +1547,7 @@ more responsive application.
 
         internal void RegisterIncludes(BlittableJsonReaderObject includes, bool registerMissingIds = false)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             if (includes == null)
@@ -1541,7 +1577,7 @@ more responsive application.
 
         internal void RegisterRevisionIncludes(BlittableJsonReaderArray revisionIncludes)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             if (revisionIncludes == null)
@@ -1573,7 +1609,7 @@ more responsive application.
 
         public void RegisterMissingIncludes(BlittableJsonReaderArray results, BlittableJsonReaderObject includes, ICollection<string> includePaths)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             if (includePaths == null || includePaths.Count == 0)
@@ -1609,7 +1645,7 @@ more responsive application.
 
         internal void RegisterCounters(BlittableJsonReaderObject resultCounters, string[] ids, string[] countersToInclude, bool gotAll)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             if (resultCounters == null || resultCounters.Count == 0)
@@ -1634,7 +1670,7 @@ more responsive application.
 
         internal void RegisterCounters(BlittableJsonReaderObject resultCounters, Dictionary<string, string[]> countersToInclude)
         {
-            if (TrackingMode == TrackingMode.NoTracking)
+            if (NoTracking)
                 return;
 
             if (resultCounters == null || resultCounters.Count == 0)
@@ -1794,7 +1830,7 @@ more responsive application.
 
         internal void RegisterTimeSeries(BlittableJsonReaderObject resultTimeSeries)
         {
-            if (TrackingMode == TrackingMode.NoTracking || resultTimeSeries == null)
+            if (NoTracking || resultTimeSeries == null)
                 return;
 
             var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
@@ -2350,10 +2386,10 @@ more responsive application.
                 documentInfo.ChangeVector = (LazyStringValue)changeVector;
             }
 
-            if (documentInfo.Entity != null && TrackingMode != TrackingMode.NoTracking)
+            if (documentInfo.Entity != null && NoTracking == false)
                 JsonConverter.RemoveFromMissing(documentInfo.Entity);
 
-            documentInfo.Entity = JsonConverter.FromBlittable<T>(ref document, documentInfo.Id, TrackingMode != TrackingMode.NoTracking);
+            documentInfo.Entity = JsonConverter.FromBlittable<T>(ref document, documentInfo.Id, NoTracking == false);
             documentInfo.Document = document;
 
             var type = entity.GetType();
@@ -2655,7 +2691,7 @@ more responsive application.
 
         internal void AssertNoIncludesInNonTrackingSession()
         {
-            if (TrackingMode != TrackingMode.NoTracking)
+            if (NoTracking == false)
                 return;
 
             throw new InvalidOperationException(
@@ -2902,9 +2938,9 @@ more responsive application.
 
         private readonly bool _shouldTrack;
 
-        public TrackedEntitiesHolder(TrackingMode trackingMode)
+        public TrackedEntitiesHolder(bool shouldTrack)
         {
-            _shouldTrack = trackingMode == TrackingMode.TrackAllEntities;
+            _shouldTrack = shouldTrack;
         }
 
         public bool Any()

--- a/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/GetRevisionOperation.cs
@@ -71,7 +71,7 @@ namespace Raven.Client.Documents.Session.Operations
 
             var metadata = document.GetMetadata();
             var id = metadata.GetId();
-            var entity = _session.JsonConverter.FromBlittable<T>(ref document, id, _session.TrackingMode != TrackingMode.NoTracking);
+            var entity = _session.JsonConverter.FromBlittable<T>(ref document, id, _session.NoTracking == false);
 
             _session.DocumentsByEntity[entity] = new DocumentInfo
             {

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValueOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValueOperation.cs
@@ -61,7 +61,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
             {
                 var value = CompareExchangeValueResultParser<BlittableJsonReaderObject>.GetValue((BlittableJsonReaderObject)response.Result, materializeMetadata: false, _conventions);
 
-                if (_clusterSession._session.TrackingMode == TrackingMode.NoTracking)
+                if (_clusterSession._session.NoTracking)
                 {
                     if (value == null)
                     {
@@ -81,7 +81,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
                 _clusterSession.RegisterMissingCompareExchangeValue(_key);
 
             Result = _clusterSession.GetCompareExchangeValueFromSessionInternal<T>(_key, out var notTracked);
-            Debug.Assert(_clusterSession._session.TrackingMode == TrackingMode.NoTracking || notTracked == false, "notTracked == false");
+            Debug.Assert(_clusterSession._session.NoTracking || notTracked == false, "notTracked == false");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValuesOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/Lazy/LazyGetCompareExchangeValuesOperation.cs
@@ -98,7 +98,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
 
             if (response.Result != null)
             {
-                if (_clusterSession._session.TrackingMode == TrackingMode.NoTracking)
+                if (_clusterSession._session.NoTracking)
                 {
                     var result = new Dictionary<string, CompareExchangeValue<T>>(StringComparer.OrdinalIgnoreCase);
                     foreach (var kvp in CompareExchangeValueResultParser<BlittableJsonReaderObject>.GetValues((BlittableJsonReaderObject)response.Result, materializeMetadata: false, _conventions))
@@ -137,7 +137,7 @@ namespace Raven.Client.Documents.Session.Operations.Lazy
             }
 
             Result = _clusterSession.GetCompareExchangeValuesFromSessionInternal<T>(_keys, out var notTrackedKeys);
-            Debug.Assert(_clusterSession._session.TrackingMode == TrackingMode.NoTracking || notTrackedKeys == null, "notTrackedKeys == null");
+            Debug.Assert(_clusterSession._session.NoTracking || notTrackedKeys == null, "notTrackedKeys == null");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadOperation.cs
@@ -144,7 +144,7 @@ namespace Raven.Client.Documents.Session.Operations
 
         public T GetDocument<T>()
         {
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
             {
                 if (_resultsSet == false && _ids.Length > 0)
                     throw new InvalidOperationException($"Cannot execute '{nameof(GetDocument)}' before operation execution.");
@@ -184,7 +184,7 @@ namespace Raven.Client.Documents.Session.Operations
         public Dictionary<string, T> GetDocuments<T>()
         {
             var finalResults = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
             {
                 if (_resultsSet == false && _ids.Length > 0)
                     throw new InvalidOperationException($"Cannot execute '{nameof(GetDocuments)}' before operation execution.");
@@ -220,7 +220,7 @@ namespace Raven.Client.Documents.Session.Operations
         {
             _resultsSet = true;
 
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
             {
                 _results = result;
                 return;

--- a/src/Raven.Client/Documents/Session/Operations/LoadStartingWithOperation.cs
+++ b/src/Raven.Client/Documents/Session/Operations/LoadStartingWithOperation.cs
@@ -53,7 +53,7 @@ namespace Raven.Client.Documents.Session.Operations
         {
             _resultsSet = true;
 
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
             {
                 _results = result;
                 return;
@@ -71,7 +71,7 @@ namespace Raven.Client.Documents.Session.Operations
             var i = 0;
             T[] finalResults;
 
-            if (_session.TrackingMode == TrackingMode.NoTracking)
+            if (_session.NoTracking)
             {
                 if (_resultsSet == false)
                     throw new InvalidOperationException($"Cannot execute '{nameof(GetDocuments)}' before operation execution.");

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -75,7 +75,20 @@ namespace Raven.Client.Documents.Session
         /// Disable tracking for all entities in the session<br/>
         /// </summary>
         /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.NoTracking"/></remarks>
-        public bool NoTracking { get; set; }
+        public bool NoTracking
+        {
+            get;
+            set
+            {
+                if (value && _optimisticConcurrencyMode != null && _optimisticConcurrencyMode != Session.OptimisticConcurrencyMode.None)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(NoTracking)} cannot be set to true when {nameof(OptimisticConcurrencyMode)} is {_optimisticConcurrencyMode}.");
+                }
+
+                field = value;
+            }
+        }
 
         /// <summary>
         /// Configure optimistic concurrency mode for the session.<br/>
@@ -91,6 +104,12 @@ namespace Raven.Client.Documents.Session
                 {
                     throw new InvalidOperationException(
                         $"{nameof(OptimisticConcurrencyMode)} cannot be set to {value} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
+                }
+
+                if (value != null && value != Session.OptimisticConcurrencyMode.None && NoTracking)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(OptimisticConcurrencyMode)} cannot be set to {value} when {nameof(NoTracking)} is true.");
                 }
 
                 _optimisticConcurrencyMode = value;

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -104,8 +104,8 @@ namespace Raven.Client.Documents.Session
         /// When <c>null</c> (default), the session inherits the value from conventions.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// Thrown when set to <see cref="Session.OptimisticConcurrencyMode.Writes"/> or
-        /// <see cref="Session.OptimisticConcurrencyMode.WritesAndReads"/> while
+        /// Thrown when set to <see cref="OptimisticConcurrencyMode.Writes"/> or
+        /// <see cref="OptimisticConcurrencyMode.WritesAndReads"/> while
         /// <see cref="NoTracking"/> is <c>true</c> or <see cref="TransactionMode"/> is <see cref="TransactionMode.ClusterWide"/>.
         /// </exception>
         public OptimisticConcurrencyMode? OptimisticConcurrencyMode

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -1,6 +1,5 @@
 using System;
 using Raven.Client.Http;
-#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Raven.Client.Documents.Session
 {
@@ -42,22 +41,24 @@ namespace Raven.Client.Documents.Session
         NonTransactionalMultiBucket
     }
 
-    public enum TrackingMode
+    public enum OptimisticConcurrencyMode
     {
         /// <summary>
-        /// Do not force any behavior from the Client API and rely on Server's default
+        /// No optimistic concurrency checks are performed
         /// </summary>
-        Default,
+        None,
 
         /// <summary>
-        /// Disable tracking for all entities in the session<br/>
+        /// Optimistic concurrency checks are performed for written entities only
         /// </summary>
-        NoTracking,
+        Writes,
 
         /// <summary>
-        /// Enable tracking for all entities in the session<br/>
+        /// Optimistic concurrency checks are performed for all entities loaded or written in the session.
+        /// On <see cref="DocumentSession.SaveChanges"/>, the server will verify that no tracked entity
+        /// was modified by another session since it was loaded.
         /// </summary>
-        TrackAllEntities
+        WritesAndReads
     }
 
     /// <summary>
@@ -73,50 +74,30 @@ namespace Raven.Client.Documents.Session
         /// <summary>
         /// Disable tracking for all entities in the session<br/>
         /// </summary>
-        /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.TrackingMode"/></remarks>
-        [Obsolete("SessionOptions.NoTracking is obsolete and will be removed in the next major version. Please use " +
-                  nameof(SessionOptions) + "." + nameof(TrackingMode) + " instead. " +
-                  "See: https://ravendb.net/docs/article-page/latest/csharp/client-api/session/options#notracking")]
-        public bool NoTracking
-        {
-            get => TrackingMode == TrackingMode.NoTracking;
-            set
-            {
-                if (TrackingModeWasSet)
-                    throw new InvalidOperationException($"{nameof(NoTracking)} cannot be set when {nameof(TrackingMode)} was set. Please use {nameof(TrackingMode)} instead of {nameof(NoTracking)}.");
-
-                _trackingMode = value ? TrackingMode.NoTracking : TrackingMode.Default;
-                NoTrackingWasSet = true;
-            }
-        }
-
-        internal bool NoTrackingWasSet { get; set; }
-        internal bool TrackingModeWasSet { get; set; }
-        private TrackingMode _trackingMode;
+        /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.NoTracking"/></remarks>
+        public bool NoTracking { get; set; }
 
         /// <summary>
-        /// Enable tracking mode in the session<br/>
+        /// Configure optimistic concurrency mode for the session.<br/>
+        /// When set, overrides the default from <see cref="Conventions.DocumentConventions.OptimisticConcurrencyMode"/>.
         /// </summary>
-        /// <remarks>For more details visit: <inheritdoc cref="DocumentationUrls.Session.Options.TrackingMode"/></remarks>
-        public TrackingMode TrackingMode
+        public OptimisticConcurrencyMode? OptimisticConcurrencyMode
         {
-            get => _trackingMode;
+            get => _optimisticConcurrencyMode;
             set
             {
-                if (NoTrackingWasSet)
-                    throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set when {nameof(NoTracking)} was set. Please use {nameof(TrackingMode)} instead of {nameof(NoTracking)}.");
-
-                TrackingModeWasSet = true;
-
-                if (value == TrackingMode.TrackAllEntities)
+                if (value != null && value != Session.OptimisticConcurrencyMode.None
+                    && TransactionMode == TransactionMode.ClusterWide)
                 {
-                    if (TransactionMode == TransactionMode.ClusterWide)
-                        throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set to {nameof(TrackingMode.TrackAllEntities)} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
+                    throw new InvalidOperationException(
+                        $"{nameof(OptimisticConcurrencyMode)} cannot be set to {value} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
                 }
 
-                _trackingMode = value;
+                _optimisticConcurrencyMode = value;
             }
         }
+
+        private OptimisticConcurrencyMode? _optimisticConcurrencyMode;
 
         /// <summary>
         /// Disable caching of HTTP responses for the session<br/>
@@ -136,8 +117,12 @@ namespace Raven.Client.Documents.Session
             get;
             set
             {
-                if (value == TransactionMode.ClusterWide && TrackingMode == TrackingMode.TrackAllEntities)
-                    throw new InvalidOperationException($"{nameof(TrackingMode)} cannot be set to {nameof(TrackingMode.TrackAllEntities)} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
+                if (value == TransactionMode.ClusterWide &&
+                    _optimisticConcurrencyMode != null && _optimisticConcurrencyMode != Session.OptimisticConcurrencyMode.None)
+                {
+                    throw new InvalidOperationException(
+                        $"{nameof(OptimisticConcurrencyMode)} cannot be set to {_optimisticConcurrencyMode} when {nameof(TransactionMode)} is {TransactionMode.ClusterWide}.");
+                }
 
                 field = value;
             }

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -44,19 +44,27 @@ namespace Raven.Client.Documents.Session
     public enum OptimisticConcurrencyMode
     {
         /// <summary>
-        /// No optimistic concurrency checks are performed
+        /// No optimistic concurrency checks are performed.<br/>
+        /// PUT and DELETE commands are sent without a change vector, so the server does not check for concurrent modifications.
         /// </summary>
         None,
 
         /// <summary>
-        /// Optimistic concurrency checks are performed for written entities only
+        /// Optimistic concurrency checks are performed for written (PUT) and deleted (DELETE) entities only.<br/>
+        /// Each PUT/DELETE command includes the entity's change vector so the server rejects the operation
+        /// if the document was modified by another session since it was loaded.<br/>
+        /// Read-only entities (loaded but not modified) are <b>not</b> checked.
         /// </summary>
         Writes,
 
         /// <summary>
-        /// Optimistic concurrency checks are performed for all entities loaded or written in the session.
-        /// On <see cref="DocumentSession.SaveChanges"/>, the server will verify that no tracked entity
-        /// was modified by another session since it was loaded.
+        /// Optimistic concurrency checks are performed for <b>all</b> entities in the session — both written and read-only.<br/>
+        /// In addition to the per-command change vector checks from <see cref="Writes"/>, a <c>BatchTrackChangesCommand</c>
+        /// is sent as part of <see cref="DocumentSession.SaveChanges"/> that verifies no tracked entity
+        /// was modified by another session since it was loaded.<br/>
+        /// <br/>
+        /// This mode is incompatible with <see cref="SessionOptions.NoTracking"/>,
+        /// <see cref="TransactionMode.ClusterWide"/>, and sharded databases.
         /// </summary>
         WritesAndReads
     }
@@ -92,8 +100,14 @@ namespace Raven.Client.Documents.Session
 
         /// <summary>
         /// Configure optimistic concurrency mode for the session.<br/>
-        /// When set, overrides the default from <see cref="Conventions.DocumentConventions.OptimisticConcurrencyMode"/>.
+        /// When set, overrides the default from <see cref="Conventions.DocumentConventions.OptimisticConcurrencyMode"/>.<br/>
+        /// When <c>null</c> (default), the session inherits the value from conventions.
         /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when set to <see cref="Session.OptimisticConcurrencyMode.Writes"/> or
+        /// <see cref="Session.OptimisticConcurrencyMode.WritesAndReads"/> while
+        /// <see cref="NoTracking"/> is <c>true</c> or <see cref="TransactionMode"/> is <see cref="TransactionMode.ClusterWide"/>.
+        /// </exception>
         public OptimisticConcurrencyMode? OptimisticConcurrencyMode
         {
             get => _optimisticConcurrencyMode;

--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -53,18 +53,18 @@ namespace Raven.Client.Documents.Session
         /// Optimistic concurrency checks are performed for written (PUT) and deleted (DELETE) entities only.<br/>
         /// Each PUT/DELETE command includes the entity's change vector so the server rejects the operation
         /// if the document was modified by another session since it was loaded.<br/>
-        /// Read-only entities (loaded but not modified) are <b>not</b> checked.
+        /// Entities that were loaded but not modified are <b>not</b> checked.
         /// </summary>
         Writes,
 
         /// <summary>
-        /// Optimistic concurrency checks are performed for <b>all</b> entities in the session — both written and read-only.<br/>
-        /// In addition to the per-command change vector checks from <see cref="Writes"/>, a <c>BatchTrackChangesCommand</c>
-        /// is sent as part of <see cref="DocumentSession.SaveChanges"/> that verifies no tracked entity
+        /// Optimistic concurrency checks are performed for <b>all</b> entities in the session — both modified and not modified.<br/>
+        /// In addition to the per-command change vector checks from <see cref="Writes"/>,
+        /// <see cref="DocumentSession.SaveChanges"/> verifies that no tracked entity
         /// was modified by another session since it was loaded.<br/>
         /// <br/>
-        /// This mode is incompatible with <see cref="SessionOptions.NoTracking"/>,
-        /// <see cref="TransactionMode.ClusterWide"/>, and sharded databases.
+        /// This mode is incompatible with <see cref="SessionOptions.NoTracking"/>
+        /// and <see cref="TransactionMode.ClusterWide"/>.
         /// </summary>
         WritesAndReads
     }

--- a/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
+++ b/src/Raven.Client/Documents/Subscriptions/SubscriptionBatch.cs
@@ -136,7 +136,7 @@ namespace Raven.Client.Documents.Subscriptions
 
         private void LoadDataToSession(InMemoryDocumentSessionOperations s)
         {
-            if (s.TrackingMode == TrackingMode.NoTracking)
+            if (s.NoTracking)
                 return;
 
             if (_includes?.Count > 0)

--- a/test/FastTests/Client/OptimisticConcurrencyModeTests.cs
+++ b/test/FastTests/Client/OptimisticConcurrencyModeTests.cs
@@ -299,6 +299,44 @@ namespace FastTests.Client
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
+        public void UseOptimisticConcurrency_AfterSessionOptionsOptimisticConcurrencyMode_ShouldThrow()
+        {
+            // Copilot review: constructor should set _optimisticConcurrencyModeWasSet when
+            // options.OptimisticConcurrencyMode is provided, so that UseOptimisticConcurrency
+            // cannot be set afterwards without going through advanced.OptimisticConcurrencyMode first
+            using (var store = GetDocumentStore())
+            {
+                using var session = store.OpenSession(new SessionOptions
+                {
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                });
+
+                // should throw because the session was created with the new API via SessionOptions
+                var ex = Assert.Throws<InvalidOperationException>(() => session.Advanced.UseOptimisticConcurrency = true);
+                Assert.Contains(nameof(InMemoryDocumentSessionOperations.UseOptimisticConcurrency), ex.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void UseOptimisticConcurrency_WhenInheritedFromConventions_ShouldNotThrow()
+        {
+            // When conventions set OptimisticConcurrencyMode but SessionOptions doesn't explicitly set it,
+            // the session inherits from conventions. In this case, UseOptimisticConcurrency should still
+            // be settable (no flag was set on the session itself).
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDocumentStore = s => s.Conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes
+                   }))
+            {
+                using var session = store.OpenSession(); // no explicit SessionOptions.OptimisticConcurrencyMode
+
+                // should NOT throw because the mode was inherited from conventions, not explicitly set on session
+                session.Advanced.UseOptimisticConcurrency = false;
+                Assert.Equal(OptimisticConcurrencyMode.None, session.Advanced.OptimisticConcurrencyMode);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
         public void Conventions_UseOptimisticConcurrency_LossyRoundTrip()
         {
             var conventions = new DocumentConventions();

--- a/test/FastTests/Client/OptimisticConcurrencyModeTests.cs
+++ b/test/FastTests/Client/OptimisticConcurrencyModeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
@@ -6,9 +7,9 @@ using Xunit;
 
 namespace FastTests.Client
 {
-    public class TrackingModeTests : RavenTestBase
+    public class OptimisticConcurrencyModeTests : RavenTestBase
     {
-        public TrackingModeTests(ITestOutputHelper output) : base(output)
+        public OptimisticConcurrencyModeTests(ITestOutputHelper output) : base(output)
         {
         }
 
@@ -280,6 +281,53 @@ namespace FastTests.Client
                     Assert.Equal(OptimisticConcurrencyMode.None, inMemSes.OptimisticConcurrencyMode);
                 }
             }
+        }
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void NoTracking_WithOptimisticConcurrencyMode_Writes_FromConventions_ShouldThrow()
+        {
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDocumentStore = s => s.Conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes
+                   }))
+            {
+                var exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    store.OpenSession(new SessionOptions { NoTracking = true });
+                });
+                Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void Conventions_UseOptimisticConcurrency_LossyRoundTrip()
+        {
+            var conventions = new DocumentConventions();
+
+            // set WritesAndReads via new API
+            conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads;
+            Assert.Equal(OptimisticConcurrencyMode.WritesAndReads, conventions.OptimisticConcurrencyMode);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void Conventions_MutualExclusion_OptimisticConcurrencyMode_Then_UseOptimisticConcurrency_ShouldThrow()
+        {
+            var conventions = new DocumentConventions();
+
+            conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads;
+
+            var ex = Assert.Throws<InvalidOperationException>(() => conventions.UseOptimisticConcurrency = true);
+            Assert.Contains(nameof(DocumentConventions.UseOptimisticConcurrency), ex.Message);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void Conventions_MutualExclusion_UseOptimisticConcurrency_Then_OptimisticConcurrencyMode_ShouldThrow()
+        {
+            var conventions = new DocumentConventions();
+
+            conventions.UseOptimisticConcurrency = true;
+
+            var ex = Assert.Throws<InvalidOperationException>(() => conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes);
+            Assert.Contains(nameof(DocumentConventions.OptimisticConcurrencyMode), ex.Message);
         }
     }
 }

--- a/test/FastTests/Client/TrackingModeTests.cs
+++ b/test/FastTests/Client/TrackingModeTests.cs
@@ -155,6 +155,86 @@ namespace FastTests.Client
             }
         }
 
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OptimisticConcurrencyMode_Writes_WithNoTracking_ShouldThrow()
+        {
+            var exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    NoTracking = true,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes,
+                    NoTracking = true,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OptimisticConcurrencyMode_WritesAndReads_WithNoTracking_ShouldThrow()
+        {
+            var exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    NoTracking = true,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
+                    NoTracking = true,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OptimisticConcurrencyMode_None_WithNoTracking_ShouldNotThrow()
+        {
+            _ = new SessionOptions
+            {
+                NoTracking = true,
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.None,
+            };
+
+            _ = new SessionOptions
+            {
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.None,
+                NoTracking = true,
+            };
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void NoTracking_WithOptimisticConcurrencyMode_FromConventions_ShouldThrow()
+        {
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDocumentStore = s => s.Conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                   }))
+            {
+                var exp = Assert.Throws<InvalidOperationException>(() =>
+                {
+                    store.OpenSession(new SessionOptions { NoTracking = true });
+                });
+                Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+            }
+        }
+
         [RavenTheory(RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
         public void CanConfigureOptimisticConcurrencyModeForSessions(Options options)

--- a/test/FastTests/Client/TrackingModeTests.cs
+++ b/test/FastTests/Client/TrackingModeTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Raven.Client.Documents.Session;
 using Tests.Infrastructure;
 using Xunit;
@@ -13,289 +13,191 @@ namespace FastTests.Client
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public void NoTracking_CanBeSetMultipleTimes_WithoutThrowingMisleadingError()
+        public void NoTracking_CanBeSetMultipleTimes()
         {
             var options = new SessionOptions();
 
-            // First assignment - should not throw
             options.NoTracking = true;
             Assert.True(options.NoTracking);
-            Assert.Equal(TrackingMode.NoTracking, options.TrackingMode);
 
-            // Second assignment (toggling off) - must not throw with a misleading
-            // "TrackingMode was set" message, because TrackingMode was never set explicitly
-            var ex = Record.Exception(() => options.NoTracking = false);
-            Assert.Null(ex);
+            options.NoTracking = false;
             Assert.False(options.NoTracking);
-            Assert.Equal(TrackingMode.Default, options.TrackingMode);
 
-            // Third assignment (toggling back on) - must still not throw
-            ex = Record.Exception(() => options.NoTracking = true);
-            Assert.Null(ex);
+            options.NoTracking = true;
             Assert.True(options.NoTracking);
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public void NoTracking_DoesNotSetTrackingModeWasSet_Flag()
+        public void UseOptimisticConcurrency_AfterOptimisticConcurrencyMode_ShouldThrow()
         {
-            var options = new SessionOptions();
+            var options = new SessionOptions { OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads };
 
-            options.NoTracking = true;
+            using (var store = GetDocumentStore())
+            {
+                using var session = store.OpenSession(options);
+                var advanced = session.Advanced;
+                advanced.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes;
 
-            // TrackingModeWasSet must remain false so that the cross-flag guard between
-            // NoTracking and TrackingMode still works correctly in both directions
-            Assert.False(options.TrackingModeWasSet);
-            Assert.True(options.NoTrackingWasSet);
+                var ex = Assert.Throws<InvalidOperationException>(() => advanced.UseOptimisticConcurrency = true);
+                Assert.Contains(nameof(InMemoryDocumentSessionOperations.UseOptimisticConcurrency), ex.Message);
+            }
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public void TrackingMode_AfterNoTracking_ShouldThrow()
+        public void OptimisticConcurrencyMode_AfterUseOptimisticConcurrency_ShouldThrow()
         {
-            var options = new SessionOptions();
-            options.NoTracking = true;
+            using (var store = GetDocumentStore())
+            {
+                using var session = store.OpenSession();
+                var advanced = session.Advanced;
+                advanced.UseOptimisticConcurrency = true;
 
-            // Setting TrackingMode explicitly after NoTracking was used must still throw
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                options.TrackingMode = TrackingMode.TrackAllEntities);
-
-            Assert.Contains(nameof(SessionOptions.TrackingMode), ex.Message);
+                var ex = Assert.Throws<InvalidOperationException>(() => advanced.OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads);
+                Assert.Contains(nameof(InMemoryDocumentSessionOperations.OptimisticConcurrencyMode), ex.Message);
+            }
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public void NoTracking_AfterTrackingMode_ShouldThrow()
+        public void OptimisticConcurrencyMode_Writes_WithClusterWide_ShouldThrow()
         {
-            var options = new SessionOptions();
-            options.TrackingMode = TrackingMode.NoTracking;
+            var exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
 
-            // Setting NoTracking explicitly after TrackingMode was used must still throw
-            var ex = Assert.Throws<InvalidOperationException>(() => options.NoTracking = false);
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes,
+                    TransactionMode = TransactionMode.ClusterWide,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+        }
 
-            Assert.Contains(nameof(SessionOptions.NoTracking), ex.Message);
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OptimisticConcurrencyMode_WritesAndReads_WithClusterWide_ShouldThrow()
+        {
+            var exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    TransactionMode = TransactionMode.ClusterWide,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+
+            exp = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _ = new SessionOptions
+                {
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
+                    TransactionMode = TransactionMode.ClusterWide,
+                };
+            });
+            Assert.Contains(nameof(OptimisticConcurrencyMode), exp.Message);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OptimisticConcurrencyMode_None_WithClusterWide_ShouldNotThrow()
+        {
+            _ = new SessionOptions
+            {
+                TransactionMode = TransactionMode.ClusterWide,
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.None,
+            };
+
+            _ = new SessionOptions
+            {
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.None,
+                TransactionMode = TransactionMode.ClusterWide,
+            };
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void OptimisticConcurrencyMode_WithSingleNode_ShouldNotThrow()
+        {
+            _ = new SessionOptions
+            {
+                TransactionMode = TransactionMode.SingleNode,
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
+            };
+
+            _ = new SessionOptions
+            {
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
+                TransactionMode = TransactionMode.SingleNode,
+            };
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void UseOptimisticConcurrency_MapsCorrectly()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using var session = store.OpenSession();
+                var advanced = session.Advanced;
+
+                Assert.Equal(OptimisticConcurrencyMode.None, advanced.OptimisticConcurrencyMode);
+
+                advanced.UseOptimisticConcurrency = true;
+                Assert.Equal(OptimisticConcurrencyMode.Writes, advanced.OptimisticConcurrencyMode);
+
+                advanced.UseOptimisticConcurrency = false;
+                Assert.Equal(OptimisticConcurrencyMode.None, advanced.OptimisticConcurrencyMode);
+            }
         }
 
         [RavenTheory(RavenTestCategory.ClientApi)]
         [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
-        public void CanConfigureTrackingModeForClusterwideSessions(Options options)
+        public void CanConfigureOptimisticConcurrencyModeForSessions(Options options)
         {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var ses = new SessionOptions()
-                {
-                    TransactionMode = TransactionMode.ClusterWide,
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
-
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                    TransactionMode = TransactionMode.ClusterWide,
-
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set to TrackAllEntities when TransactionMode is ClusterWide.", exp.Message);
-
-            var session = new SessionOptions()
-            {
-                NoTracking = true,
-                TransactionMode = TransactionMode.ClusterWide,
-            };
-
-            session = new SessionOptions()
-            {
-                TransactionMode = TransactionMode.ClusterWide,
-                NoTracking = true,
-            };
-
-            session = new SessionOptions()
-            {
-                NoTracking = false,
-                TransactionMode = TransactionMode.ClusterWide,
-
-            };
-            session = new SessionOptions()
-            {
-                TransactionMode = TransactionMode.ClusterWide,
-                NoTracking = false,
-
-
-            };
-
-            session = new SessionOptions()
-            {
-                TransactionMode = TransactionMode.SingleNode,
-                TrackingMode = TrackingMode.TrackAllEntities,
-            };
-            session = new SessionOptions()
-            {
-                TrackingMode = TrackingMode.TrackAllEntities,
-                TransactionMode = TransactionMode.SingleNode,
-
-            };
-        }
-
-        [RavenTheory(RavenTestCategory.ClientApi)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
-        public void CanConfigureTrackingModeForSessions(Options options)
-        {
-            var exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                    NoTracking = true
-                };
-            });
-            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.Default,
-                    NoTracking = true
-                };
-            });
-            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.NoTracking,
-                    NoTracking = true
-                };
-
-            });
-            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                    NoTracking = false
-                };
-            });
-            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.Default,
-                    NoTracking = false
-                };
-            });
-            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.NoTracking,
-                    NoTracking = false
-                };
-            });
-            Assert.Equal("NoTracking cannot be set when TrackingMode was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    NoTracking = true,
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    NoTracking = true,
-                    TrackingMode = TrackingMode.Default,
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    NoTracking = true,
-                    TrackingMode = TrackingMode.NoTracking,
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    NoTracking = false,
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-
-                var session = new SessionOptions()
-                {
-                    NoTracking = false,
-                    TrackingMode = TrackingMode.Default,
-                };
-            });
-            Assert.Equal("TrackingMode cannot be set when NoTracking was set. Please use TrackingMode instead of NoTracking.", exp.Message);
-            exp = Assert.Throws<InvalidOperationException>(() =>
-            {
-                var session = new SessionOptions()
-                {
-                    NoTracking = false,
-                    TrackingMode = TrackingMode.NoTracking,
-                };
-            });
             using (var store = GetDocumentStore(options))
             {
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = false }))
                 {
-                    NoTracking = false
-                }))
-                {
-                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
-                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.Default);
+                    var inMemSes = (InMemoryDocumentSessionOperations)session;
+                    Assert.False(inMemSes.NoTracking);
                 }
 
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                using (var session = store.OpenSession(new SessionOptions { NoTracking = true }))
                 {
-                    NoTracking = true
-                }))
-                {
-                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
-                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.NoTracking);
+                    var inMemSes = (InMemoryDocumentSessionOperations)session;
+                    Assert.True(inMemSes.NoTracking);
                 }
 
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
                 {
-                    TrackingMode = TrackingMode.NoTracking,
-                }))
-                {
-                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
-                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.NoTracking);
+                    var inMemSes = (InMemoryDocumentSessionOperations)session;
+                    Assert.Equal(OptimisticConcurrencyMode.WritesAndReads, inMemSes.OptimisticConcurrencyMode);
                 }
 
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes
+                       }))
                 {
-                    TrackingMode = TrackingMode.Default,
-                }))
-                {
-                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
-                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.Default);
+                    var inMemSes = (InMemoryDocumentSessionOperations)session;
+                    Assert.Equal(OptimisticConcurrencyMode.Writes, inMemSes.OptimisticConcurrencyMode);
                 }
 
-                using (IDocumentSession session = store.OpenSession(new SessionOptions()
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.None
+                       }))
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
-                }))
-                {
-                    var inMemSes = ((InMemoryDocumentSessionOperations)session);
-                    Assert.Equal(inMemSes.TrackingMode, TrackingMode.TrackAllEntities);
+                    var inMemSes = (InMemoryDocumentSessionOperations)session;
+                    Assert.Equal(OptimisticConcurrencyMode.None, inMemSes.OptimisticConcurrencyMode);
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB-17128.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17128.cs
@@ -121,8 +121,10 @@ namespace SlowTests.Issues
                 using (var session = store.OpenSession())
                 using (var session2 = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
                     session2.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     var o1 = session.Load<Document>("objects/1");
                     var o2 = session.Load<Document>("objects/2");

--- a/test/SlowTests.Issues/Issues/RavenDB-24640.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-24640.cs
@@ -36,7 +36,9 @@ namespace SlowTests.Issues
                     s.Conventions.PreserveDocumentPropertiesNotFoundOnModel = true;
                     s.Conventions.IdentityPartsSeparator = '-';
                     s.Conventions.MaxNumberOfRequestsPerSession = int.MaxValue;
+#pragma warning disable CS0618 // Type or member is obsolete
                     s.Conventions.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }))
             {

--- a/test/SlowTests.Issues/Issues/RavenDB_13034.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13034.cs
@@ -30,7 +30,9 @@ namespace SlowTests.Issues
 
                 using (var s2 = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     s2.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     var u2 = s2.Load<User>("users/1-A");
 

--- a/test/SlowTests.Issues/Issues/RavenDB_13488.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_13488.cs
@@ -38,7 +38,9 @@ namespace SlowTests.Issues
                 }
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     User concurrentUser = new User
                     {
                         Name = "UserWithAttachment"

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
+using Raven.Client.Exceptions;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
@@ -204,7 +205,7 @@ namespace SlowTests.Issues
 
             using (IDocumentSession session = store.OpenSession(new SessionOptions()
                    {
-                       TrackingMode = TrackingMode.TrackAllEntities,
+                       OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                    }))
             {
                 var jerry = session.Load<Employee>("employees/1-A");
@@ -242,7 +243,7 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenSession(new SessionOptions()
                    {
-                       TrackingMode = TrackingMode.TrackAllEntities
+                       OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                    }))
             {
                 var egor = session.Load<Employee>("employees/2-A");
@@ -281,7 +282,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -321,7 +322,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -357,7 +358,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -396,7 +397,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -436,7 +437,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -474,7 +475,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -514,7 +515,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -526,7 +527,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -566,7 +567,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -586,7 +587,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -625,7 +626,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -660,7 +661,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -717,7 +718,7 @@ namespace SlowTests.Issues
 
             using (IDocumentSession session = store.OpenSession(new SessionOptions()
                    {
-                       TrackingMode = TrackingMode.TrackAllEntities,
+                       OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                    }))
             {
                 var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
@@ -759,7 +760,7 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenSession(new SessionOptions()
                    {
-                       TrackingMode = TrackingMode.TrackAllEntities
+                       OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                    }))
             {
                 var egor = session.Load<Employee>("employees/2-A");
@@ -773,11 +774,13 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityEvictedFromTheSessionAndThenAddedBack()
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityEvictedFromTheSessionAndThenAddedBack()
         {
+            // WritesAndReads mode includes write concurrency checks.
+            // After evicting and re-storing with the same ID, the entity is treated as new (empty CV),
+            // so the server rejects the put because the document already exists.
             using (var store = GetDocumentStore(Options.ForMode(RavenDatabaseMode.Single)))
             {
-                string addressId;
                 using (var session = store.OpenSession())
                 {
                     var address = new Address()
@@ -786,9 +789,6 @@ namespace SlowTests.Issues
                         Street = "Erets Rd"
                     };
                     session.Store(address);
-                    addressId = session.Advanced.GetDocumentId(address);
-                    Assert.NotNull(addressId);
-                    address.Id = addressId;
                     session.Store(new Employee
                     {
                         FirstName = "Jerry",
@@ -803,52 +803,31 @@ namespace SlowTests.Issues
                         }
                     }, "employees/2-A");
                     session.SaveChanges();
-
                 }
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                        {
-                           TrackingMode = TrackingMode.TrackAllEntities,
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                        }))
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
-
-                    var numOfRequests = session.Advanced.NumberOfRequests;
-
                     var address = session.Load<Address>(jerry.Address.Id);
-
                     Assert.NotNull(address);
-                    Assert.Equal(numOfRequests, session.Advanced.NumberOfRequests);
 
                     ModifyEgorWithStoreOverwriteAfterLoadAndEvict(session);
 
-                    var expected = session.Advanced.GetChangeVectorFor(address);
-                    Assert.NotEmpty(expected);
-                    Assert.NotNull(expected);
-
-                    // this should not throw concurrency exception
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession(new SessionOptions()
-                       {
-                           TrackingMode = TrackingMode.TrackAllEntities
-                       }))
-                {
-                    var egor = session.Load<Employee>("employees/2-A");
-
-                    Assert.Equal("Egor", egor.FirstName);
-                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
-
-                    var j = session.Load<Address>(addressId);
-                    Assert.Equal("Harish", j.City);
+                    // WritesAndReads enables write concurrency, evict+store treats entity as new → ConcurrencyException
+                    Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
                 }
             }
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
-        public void ShouldNotThrowConcurrencyException_WhenTrackedEntityReStored()
+        public void ShouldThrowConcurrencyException_WhenTrackedEntityReStored()
         {
+            // WritesAndReads mode includes write concurrency checks.
+            // Storing a new entity with an existing document ID (without loading first)
+            // sends an empty change vector, which the server rejects because the document already exists.
             using (var store = GetDocumentStore(Options.ForMode(RavenDatabaseMode.Single)))
             {
                 using (var session = store.OpenSession())
@@ -866,7 +845,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     session.Store(new Employee
@@ -878,19 +857,8 @@ namespace SlowTests.Issues
                         }
                     }, "employees/2-A");
 
-                    // this should not throw concurrency exception
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession(new SessionOptions()
-                {
-                    TrackingMode = TrackingMode.TrackAllEntities
-                }))
-                {
-                    var egor = session.Load<Employee>("employees/2-A");
-
-                    Assert.Equal("Egor", egor.FirstName);
-                    Assert.Equal("Mul HaHof Village", egor.Address.Street);
+                    // WritesAndReads enables write concurrency, blind store (without load) → ConcurrencyException
+                    Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
                 }
             }
         }
@@ -930,7 +898,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // this should put the include into missing ids
@@ -966,7 +934,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1018,7 +986,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // this should put the include into missing ids
@@ -1059,7 +1027,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1110,7 +1078,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
@@ -1147,7 +1115,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1196,7 +1164,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // this should put the include into missing ids
@@ -1214,7 +1182,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1253,7 +1221,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1287,7 +1255,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1309,7 +1277,7 @@ namespace SlowTests.Issues
                 string addressId;
                 using (var session = store.OpenAsyncSession(new SessionOptions()
                        {
-                           TrackingMode = TrackingMode.TrackAllEntities,
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                        }))
                 {
                     var address = new Address()
@@ -1339,7 +1307,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
@@ -1376,7 +1344,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1397,7 +1365,7 @@ namespace SlowTests.Issues
                 string addressId;
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                        {
-                           TrackingMode = TrackingMode.TrackAllEntities,
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                        }))
                 {
                     var address = new Address()
@@ -1427,7 +1395,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Include<Employee>(x => x.Address.Id).Load("employees/1-A");
@@ -1464,7 +1432,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1506,7 +1474,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1537,7 +1505,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1580,7 +1548,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1633,7 +1601,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1663,7 +1631,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1722,7 +1690,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1757,7 +1725,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1826,7 +1794,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1849,7 +1817,7 @@ namespace SlowTests.Issues
                 }
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1889,7 +1857,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -1912,7 +1880,7 @@ namespace SlowTests.Issues
                 }
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -1943,7 +1911,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -2002,7 +1970,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -2059,7 +2027,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // Load Jerry to get his change vector
@@ -2142,7 +2110,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // Load Jerry normally
@@ -2220,7 +2188,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // Load Jerry normally
@@ -2268,7 +2236,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // Load Jerry normally
@@ -2316,7 +2284,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // Load Jerry normally
@@ -2412,7 +2380,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.NoTracking,
+                    NoTracking = true,
                 }))
                 {
                     // Try to register an external entity in NoTracking session
@@ -2482,7 +2450,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     // Load with include
@@ -2581,7 +2549,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                        {
-                           TrackingMode = TrackingMode.TrackAllEntities,
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                        }))
                 {
                     var jerry = session.Load<Employee>("employees/1-A");
@@ -2615,7 +2583,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                        {
-                           TrackingMode = TrackingMode.TrackAllEntities
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                        }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -2657,7 +2625,7 @@ namespace SlowTests.Issues
 
                 using (IDocumentSession session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities,
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
                 }))
                 {
                     string expected = null;
@@ -2706,7 +2674,7 @@ namespace SlowTests.Issues
 
                 using (var session = store.OpenSession(new SessionOptions()
                 {
-                    TrackingMode = TrackingMode.TrackAllEntities
+                    OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                 }))
                 {
                     var egor = session.Load<Employee>("employees/2-A");
@@ -2894,7 +2862,7 @@ namespace SlowTests.Issues
 
             using (IAsyncDocumentSession session = store.OpenAsyncSession(new SessionOptions()
             {
-                TrackingMode = TrackingMode.TrackAllEntities,
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads,
             }))
             {
                 var jerry = await session.LoadAsync<Employee>("employees/1-A");
@@ -2932,7 +2900,7 @@ namespace SlowTests.Issues
 
             using (var session = store.OpenSession(new SessionOptions()
             {
-                TrackingMode = TrackingMode.TrackAllEntities
+                OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
             }))
             {
                 var egor = session.Load<Employee>("employees/2-A");

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -466,10 +466,10 @@ namespace SlowTests.Issues
                     Assert.NotEmpty(actual);
                     Assert.NotNull(actual);
 
-                    // this should throw concurrency exception for jerry
+                    // this should throw concurrency exception for jerry via the DELETE command's own CV check
                     var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
+                    Assert.Contains($"Document employees/1-A has change vector {actual}, but Delete was called with change vector '{expected}'", e.Message);
                     Assert.Equal("employees/1-A", e.Id);
                     Assert.Equal(actual, e.ActualChangeVector);
                     Assert.Equal(expected, e.ExpectedChangeVector);
@@ -2077,9 +2077,11 @@ namespace SlowTests.Issues
                     }
 
                     // This should throw concurrency exception for Egor (the externally tracked entity)
+                    // Note: external entities have Document=null, so EntityChanged returns true and a PUT is generated.
+                    // The concurrency error comes from the PUT command, not the BatchTrackChangesCommand.
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document 'employees/2-A' has been modified", ex.Message);
+                    Assert.Contains($"Document employees/2-A has change vector {actualEgorCv}, but Put was called with change vector {externalChangeVector}", ex.Message);
                     Assert.Equal("employees/2-A", ex.Id);
                     Assert.Equal(actualEgorCv, ex.ActualChangeVector);
                     Assert.Equal(externalChangeVector, ex.ExpectedChangeVector);
@@ -2357,9 +2359,10 @@ namespace SlowTests.Issues
                     }
 
                     // Should throw concurrency exception for Alice
+                    // Note: external entities have Document=null, so a PUT is generated and the error comes from the PUT command.
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document 'employees/3-A' has been modified", ex.Message);
+                    Assert.Contains($"Document employees/3-A has change vector {actualAliceCv}, but Put was called with change vector {aliceCv}", ex.Message);
                     Assert.Equal("employees/3-A", ex.Id);
                     Assert.Equal(actualAliceCv, ex.ActualChangeVector);
                     Assert.Equal(aliceCv, ex.ExpectedChangeVector);
@@ -2504,9 +2507,10 @@ namespace SlowTests.Issues
                     }
 
                     // Should throw concurrency exception for the address
+                    // Note: external entities have Document=null, so a PUT is generated and the error comes from the PUT command.
                     var ex = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
 
-                    Assert.Contains("Document 'addresses/1-A' has been modified", ex.Message);
+                    Assert.Contains($"Document {addressId} has change vector {actualAddressCv}, but Put was called with change vector {addressCv}", ex.Message);
                     Assert.Equal(addressId, ex.Id);
                     Assert.Equal(actualAddressCv, ex.ActualChangeVector);
                     Assert.Equal(addressCv, ex.ExpectedChangeVector);
@@ -2661,10 +2665,11 @@ namespace SlowTests.Issues
                     if (deleteByIdInBackgroundSession == false)
                     {
                         // this should throw concurrency exception for jerry since it was tracked in session when deleted
+                        // The DELETE command detects the doc was already deleted (tombstone) and throws with the expected CV
                         var e = Assert.Throws<Raven.Client.Exceptions.ConcurrencyException>(() => session.SaveChanges());
-                        Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
-                        Assert.Equal("employees/1-A", e.Id);
-                        Assert.Empty(e.ActualChangeVector);
+                        Assert.Contains("does not exist, but delete was called with change vector", e.Message);
+                        Assert.Equal("employees/1-a", e.Id); // tombstone stores lowercase ID
+                        Assert.Null(e.ActualChangeVector); // doc no longer exists, so no actual CV
                         Assert.Equal(expected, e.ExpectedChangeVector);
                     }
                     else

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
-using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Tests.Core.Utils.Entities;

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -2912,5 +2912,110 @@ namespace SlowTests.Issues
                 Assert.Equal("Hadera", j.Address.City);
             }
         }
+
+        [RavenTheory(RavenTestCategory.ClientApi)]
+        [MemberData(nameof(SessionActions))]
+        public void ShouldThrowConcurrencyException_WhenOptimisticConcurrencyModeIsSetViaConventions(Action<IDocumentSession> sessionAction)
+        {
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDocumentStore = s => s.Conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                   }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.Store(new Employee
+                    {
+                        FirstName = "Egor",
+                        Address = new Address()
+                        {
+                            Street = "Ahad Ha'am"
+                        }
+                    }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                // open session without explicit SessionOptions - should inherit from conventions
+                using (IDocumentSession session = store.OpenSession())
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    sessionAction.Invoke(session);
+
+                    var expected = session.Advanced.GetChangeVectorFor(jerry);
+                    Assert.NotEmpty(expected);
+                    Assert.NotNull(expected);
+
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address()
+                        {
+                            City = "Hadera"
+                        };
+                        s.SaveChanges();
+                    }
+
+                    // this should throw concurrency exception for jerry because conventions set WritesAndReads
+                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+
+                    Assert.Contains("Document 'employees/1-A' has been modified", e.Message);
+                    Assert.Equal("employees/1-A", e.Id);
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var egor = session.Load<Employee>("employees/2-A");
+
+                    Assert.Equal("Egor", egor.FirstName);
+                    Assert.Equal("Ahad Ha'am", egor.Address.Street);
+
+                    var j = session.Load<Employee>("employees/1-A");
+                    Assert.Equal("Hadera", j.Address.City);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void SessionOptions_ShouldOverride_Conventions()
+        {
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDocumentStore = s => s.Conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                   }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee
+                    {
+                        FirstName = "Jerry"
+                    }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                // session explicitly sets None - should override the convention
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.None
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address { City = "Hadera" };
+                        s.SaveChanges();
+                    }
+
+                    // should NOT throw because session overrides convention with None
+                    session.SaveChanges();
+                }
+            }
+        }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
 using Raven.Client.Exceptions;
 using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
@@ -3014,6 +3015,160 @@ namespace SlowTests.Issues
 
                     // should NOT throw because session overrides convention with None
                     session.SaveChanges();
+                }
+            }
+        }
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void WritesAndReads_ShouldStillDetectConcurrencyOnReadOnlyEntity_WhenModifiedEntityIsExcludedFromTrackCommand()
+        {
+            // This test verifies that when a document is modified (PUT), it is excluded from the
+            // BatchTrackChangesCommand (since the PUT already checks concurrency), but read-only
+            // tracked documents are still verified by the BatchTrackChangesCommand.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor", Address = new Address { Street = "Ahad Ha'am" } }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    // load both - both are tracked
+                    var jerry = session.Load<Employee>("employees/1-A");  // read-only (not modified)
+                    var egor = session.Load<Employee>("employees/2-A");   // will be modified
+
+                    // modify only egor - this will generate a PUT command with change vector
+                    egor.Address = new Address { Street = "New Street" };
+
+                    // background-modify jerry (the read-only entity)
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address { City = "Hadera" };
+                        s.SaveChanges();
+                    }
+
+                    // SaveChanges should throw for jerry via BatchTrackChangesCommand
+                    // (egor's PUT has its own concurrency check, jerry is only checked via the track command)
+                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                    Assert.Contains("employees/1-A", e.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void WritesAndReads_ShouldStillDetectConcurrencyOnModifiedEntity_ViaPutCommand()
+        {
+            // This test verifies that even though the modified document is excluded from the
+            // BatchTrackChangesCommand, the PUT command itself still checks concurrency.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor", Address = new Address { Street = "Ahad Ha'am" } }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    // load both - both are tracked
+                    var jerry = session.Load<Employee>("employees/1-A");  // read-only
+                    var egor = session.Load<Employee>("employees/2-A");   // will be modified
+
+                    // modify egor
+                    egor.Address = new Address { Street = "New Street" };
+
+                    // background-modify egor (the entity we're also modifying)
+                    using (var s = store.OpenSession())
+                    {
+                        var e2 = s.Load<Employee>("employees/2-A");
+                        e2.Address = new Address { Street = "Background Street" };
+                        s.SaveChanges();
+                    }
+
+                    // SaveChanges should throw for egor via the PUT command's own concurrency check
+                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                    Assert.Contains("employees/2-A", e.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void WritesAndReads_ModifiedEntityShouldBeExcludedFromBatchTrackChangesCommand()
+        {
+            // This test directly verifies that when PrepareForSaveChanges builds the batch,
+            // the modified entity's ID is in IdsAlreadyCheckedForConcurrency (used as idsToSkip),
+            // ensuring the server's BatchTrackChangesCommand does not redundantly check it.
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.Store(new Employee { FirstName = "Dana" }, "employees/3-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    var internalSession = (InMemoryDocumentSessionOperations)session;
+
+                    // load 3 docs - all tracked
+                    var jerry = session.Load<Employee>("employees/1-A");   // read-only
+                    var egor = session.Load<Employee>("employees/2-A");    // will be modified
+                    var dana = session.Load<Employee>("employees/3-A");    // read-only
+
+                    // modify only egor
+                    egor.FirstName = "Egor Modified";
+
+                    var saveChangesData = internalSession.PrepareForSaveChanges();
+
+                    // egor's ID should be in the skip set (because the PUT command already checks concurrency for it)
+                    Assert.Contains("employees/2-A", saveChangesData.IdsAlreadyCheckedForConcurrency);
+
+                    // jerry and dana should NOT be in the skip set (they are read-only, only checked by BatchTrackChanges)
+                    Assert.DoesNotContain("employees/1-A", saveChangesData.IdsAlreadyCheckedForConcurrency);
+                    Assert.DoesNotContain("employees/3-A", saveChangesData.IdsAlreadyCheckedForConcurrency);
+
+                    // the BatchTrackChangesCommandData should exist
+                    Assert.NotNull(saveChangesData.TrackChangesCommandData);
+
+                    // verify TrackedEntities contains all 3 docs
+                    Assert.True(saveChangesData.TrackChangesCommandData.TrackedEntities.ContainsKey("employees/1-A"));
+                    Assert.True(saveChangesData.TrackChangesCommandData.TrackedEntities.ContainsKey("employees/2-A"));
+                    Assert.True(saveChangesData.TrackChangesCommandData.TrackedEntities.ContainsKey("employees/3-A"));
+
+                    // now verify the JSON output - the serialized command should NOT include the modified entity
+                    using (var context = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        var json = saveChangesData.TrackChangesCommandData.ToJson(store.Conventions, context);
+                        using (var blittable = context.ReadObject(json, "test"))
+                        {
+                            var trackedEntities = blittable["TrackedEntities"] as BlittableJsonReaderObject;
+                            Assert.NotNull(trackedEntities);
+
+                            var propertyNames = trackedEntities.GetPropertyNames();
+
+                            // jerry and dana (read-only) should be in the JSON sent to server
+                            Assert.Contains("employees/1-A", propertyNames);
+                            Assert.Contains("employees/3-A", propertyNames);
+
+                            // egor (modified) should NOT be in the JSON sent to server - no duplicate check
+                            Assert.DoesNotContain("employees/2-A", propertyNames);
+                        }
+                    }
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154.cs
@@ -5,7 +5,9 @@ using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Commands.Batches;
 using Raven.Client.Exceptions;
+using Raven.Client.Exceptions.Sharding;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -3169,6 +3171,199 @@ namespace SlowTests.Issues
                             Assert.DoesNotContain("employees/2-A", propertyNames);
                         }
                     }
+                }
+            }
+        }
+        [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.Sharding)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.Sharded)]
+        public void WritesAndReads_ShouldThrowOnShardedDatabase(Options options)
+        {
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    Assert.Throws<NotSupportedInShardingException>(() => session.SaveChanges());
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void WritesAndReads_DeferredDeleteById_IsStillCheckedByBatchTrackChangesCommand()
+        {
+            // Verifies that Delete(string id) via Defer path keeps the entity in BatchTrackChangesCommand
+            // (the deferred delete also checks concurrency, so the check is redundant but correct)
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.Store(new Employee { FirstName = "Egor" }, "employees/2-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    var internalSession = (InMemoryDocumentSessionOperations)session;
+
+                    var jerry = session.Load<Employee>("employees/1-A");   // read-only
+                    var egor = session.Load<Employee>("employees/2-A");    // will be deleted by ID
+
+                    // delete by string ID — goes through Defer path (not PrepareForEntitiesDeletion)
+                    session.Delete("employees/2-A");
+
+                    var saveChangesData = internalSession.PrepareForSaveChanges();
+
+                    // egor's deferred delete is NOT in the skip set (only session commands from
+                    // PrepareForEntitiesPuts/PrepareForEntitiesDeletion add to IdsAlreadyCheckedForConcurrency)
+                    Assert.DoesNotContain("employees/2-A", saveChangesData.IdsAlreadyCheckedForConcurrency);
+
+                    // verify BatchTrackChangesCommand still includes both entities
+                    Assert.NotNull(saveChangesData.TrackChangesCommandData);
+                    using (var context = JsonOperationContext.ShortTermSingleUse())
+                    {
+                        var json = saveChangesData.TrackChangesCommandData.ToJson(store.Conventions, context);
+                        using (var blittable = context.ReadObject(json, "test"))
+                        {
+                            var trackedEntities = blittable["TrackedEntities"] as BlittableJsonReaderObject;
+                            Assert.NotNull(trackedEntities);
+
+                            var propertyNames = trackedEntities.GetPropertyNames();
+                            Assert.Contains("employees/1-A", propertyNames);
+                            Assert.Contains("employees/2-A", propertyNames); // still checked by BatchTrackChanges
+                        }
+                    }
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void WritesFromConventions_ShouldBeInherited_AndNotTrackEntities()
+        {
+            using (var store = GetDocumentStore(new Options
+                   {
+                       ModifyDocumentStore = s => s.Conventions.OptimisticConcurrencyMode = OptimisticConcurrencyMode.Writes
+                   }))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                // open session without explicit OptimisticConcurrencyMode - should inherit Writes from conventions
+                using (var session = store.OpenSession())
+                {
+                    var internalSession = (InMemoryDocumentSessionOperations)session;
+                    Assert.Equal(OptimisticConcurrencyMode.Writes, internalSession.OptimisticConcurrencyMode);
+
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    // Writes mode should NOT track entities (only WritesAndReads does)
+                    Assert.False(internalSession.TrackedEntities.TryGetValue("employees/1-A", out _));
+
+                    // but writes should still be concurrency-checked
+                    jerry.FirstName = "Modified";
+
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.FirstName = "Background";
+                        s.SaveChanges();
+                    }
+
+                    // should throw because the PUT has a change vector (Writes mode)
+                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                    Assert.Contains("employees/1-A", e.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void WritesAndReads_ConcurrencyCheckModeDisabled_ShouldStillBeTracked()
+        {
+            // When ConcurrencyCheckMode.Disabled is used, the PUT won't check concurrency,
+            // but WritesAndReads tracking should still catch changes via BatchTrackChangesCommand
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    var jerry = session.Load<Employee>("employees/1-A");
+
+                    // Store with null changeVector → ConcurrencyCheckMode.Disabled
+                    session.Store(new Employee { FirstName = "NewEmployee" }, changeVector: null, id: "employees/2-A");
+
+                    // background-modify jerry (read-only entity)
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.FirstName = "Background";
+                        s.SaveChanges();
+                    }
+
+                    // should throw for jerry via BatchTrackChangesCommand
+                    var e = Assert.Throws<ConcurrencyException>(() => session.SaveChanges());
+                    Assert.Contains("employees/1-A", e.Message);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task WritesAndReads_AsyncSession_ShouldThrowConcurrencyException()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (var session = store.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Employee { FirstName = "Jerry" }, "employees/1-A");
+                    await session.StoreAsync(new Employee { FirstName = "Egor", Address = new Address { Street = "Ahad Ha'am" } }, "employees/2-A");
+                    await session.SaveChangesAsync();
+                }
+
+                using (var session = store.OpenAsyncSession(new SessionOptions
+                       {
+                           OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
+                       }))
+                {
+                    var jerry = await session.LoadAsync<Employee>("employees/1-A");
+                    var egor = await session.LoadAsync<Employee>("employees/2-A");
+
+                    // modify egor so we have a write
+                    egor.Address = new Address { Street = "New Street" };
+
+                    // background-modify jerry (read-only)
+                    using (var s = store.OpenSession())
+                    {
+                        var j = s.Load<Employee>("employees/1-A");
+                        j.Address = new Address { City = "Hadera" };
+                        s.SaveChanges();
+                    }
+
+                    // should throw for jerry via BatchTrackChangesCommand
+                    var e = await Assert.ThrowsAsync<ConcurrencyException>(() => session.SaveChangesAsync());
+                    Assert.Contains("employees/1-A", e.Message);
                 }
             }
         }

--- a/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
@@ -45,7 +45,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             foreach (var item in batch.Items)
@@ -114,7 +114,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             foreach (var item in batch.Items)
@@ -173,7 +173,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             foreach (var item in batch.Items)
@@ -244,7 +244,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             var jerry = session.Load<User>("users/1-A");
@@ -300,7 +300,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             var jerry = session.Load<User>("users/1-A");
@@ -364,7 +364,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             foreach (var item in batch.Items)
@@ -417,7 +417,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             var jerry = session.Load<User>("users/1-A");
@@ -486,7 +486,7 @@ namespace SlowTests.Issues
                         // Use NoTracking mode - should not track entities
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.NoTracking
+                            NoTracking = true
                         }))
                         {
                             var jerry = session.Load<User>("users/1-A");
@@ -543,7 +543,7 @@ namespace SlowTests.Issues
                     {
                         using (var session = batch.OpenSession(new SessionOptions
                         {
-                            TrackingMode = TrackingMode.TrackAllEntities
+                            OptimisticConcurrencyMode = OptimisticConcurrencyMode.WritesAndReads
                         }))
                         {
                             // Load a document that doesn't exist - should track as missing

--- a/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_25154_Subscriptions.cs
@@ -452,7 +452,8 @@ namespace SlowTests.Issues
                     Assert.True(await processedBatch.WaitAsync(_reasonableWaitTime));
                     Assert.True(await concurrencyExceptionThrown.WaitAsync(_reasonableWaitTime));
                     Assert.NotNull(caughtException);
-                    Assert.Contains("Document 'users/1-A' has been modified", caughtException.Message);
+                    // The DELETE command detects the CV mismatch (background modified jerry)
+                    Assert.Contains("users/1-A", caughtException.Message);
                     Assert.Equal("users/1-A", ((Raven.Client.Exceptions.ConcurrencyException)caughtException).Id);
                 }
             }

--- a/test/SlowTests/Bugs/Stacey/Aspects.cs
+++ b/test/SlowTests/Bugs/Stacey/Aspects.cs
@@ -42,7 +42,9 @@ namespace SlowTests.Bugs.Stacey
                 using (var session = store.OpenSession())
                 {
                     // ensure optimistic concurrency
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // try to insert the apertures into the database
                     session.Store(currency[0], "currencies/1");
@@ -62,7 +64,9 @@ namespace SlowTests.Bugs.Stacey
                 using (var session = store.OpenSession())
                 {
                     // ensure optimistic concurrency
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // try to insert the aspects into the database
                     session.Store(aspects[0], "aspects/1");
@@ -87,7 +91,9 @@ namespace SlowTests.Bugs.Stacey
                 using (var session = store.OpenSession())
                 {
                     // ensure optimistic concurrency
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // create an array to hold the results.
                     var results = new Aspect[2];
@@ -132,7 +138,9 @@ namespace SlowTests.Bugs.Stacey
                 using (var session = store.OpenSession())
                 {
                     // ensure optimistic concurrency
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // create an array to hold the results.
                     // try to query each of the newly inserted aspects.
@@ -183,7 +191,9 @@ namespace SlowTests.Bugs.Stacey
                 using (var session = store.OpenSession())
                 {
                     // ensure optimistic concurrency
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // try to insert the aspects into the database
                     session.Store(aspects[0]);
@@ -209,7 +219,9 @@ namespace SlowTests.Bugs.Stacey
                 using (var session = store.OpenSession())
                 {
                     // ensure optimistic concurrency
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     // create an array to hold the results.
                     // try to query each of the newly inserted aspects.

--- a/test/SlowTests/Client/OptimisticConcurrency.cs
+++ b/test/SlowTests/Client/OptimisticConcurrency.cs
@@ -40,7 +40,9 @@ namespace SlowTests.Client
                 }
                 using (var newSession = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     newSession.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     var foo = new Foo { Name = "Two" };
                     newSession.Store(foo, fooId);
                     var e = Assert.Throws<ConcurrencyException>(() =>
@@ -69,7 +71,9 @@ namespace SlowTests.Client
                 }
                 using (var newSession = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     newSession.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     var foo = new Foo { Name = "Two" };
                     newSession.Store(foo, changeVector: changeVector, fooId);
                     var e = Assert.Throws<ConcurrencyException>(() =>
@@ -96,7 +100,9 @@ namespace SlowTests.Client
                 }
                 using (var newSession = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     newSession.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     newSession.Delete(fooId, "A:1-dummy");
                     var e = Assert.Throws<ConcurrencyException>(() =>
                     {
@@ -123,7 +129,9 @@ namespace SlowTests.Client
 
                 using (var newSession = store.OpenAsyncSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     newSession.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     newSession.Delete(fooId, "A:1-dummy");
                     var e = await Assert.ThrowsAsync<ConcurrencyException>(async () =>
                     {
@@ -146,7 +154,9 @@ namespace SlowTests.Client
         {
             var store = GetDocumentStore(new Options
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 ModifyDocumentStore = s => s.Conventions.UseOptimisticConcurrency = true,
+#pragma warning restore CS0618 // Type or member is obsolete
                 ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
             });
 
@@ -174,7 +184,9 @@ namespace SlowTests.Client
         {
             var store = GetDocumentStore(new Options
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 ModifyDocumentStore = s => s.Conventions.UseOptimisticConcurrency = true,
+#pragma warning restore CS0618 // Type or member is obsolete
                 ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
             });
 
@@ -202,7 +214,9 @@ namespace SlowTests.Client
         {
             var store = GetDocumentStore(new Options
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 ModifyDocumentStore = s => s.Conventions.UseOptimisticConcurrency = true,
+#pragma warning restore CS0618 // Type or member is obsolete
                 ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
             });
 
@@ -243,7 +257,9 @@ namespace SlowTests.Client
         {
             var store = GetDocumentStore(new Options
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 ModifyDocumentStore = s => s.Conventions.UseOptimisticConcurrency = true,
+#pragma warning restore CS0618 // Type or member is obsolete
                 ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
             });
 
@@ -272,7 +288,9 @@ namespace SlowTests.Client
         {
             var store = GetDocumentStore(new Options
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 ModifyDocumentStore = s => s.Conventions.UseOptimisticConcurrency = true,
+#pragma warning restore CS0618 // Type or member is obsolete
                 ModifyDatabaseRecord = r => r.Settings["Tombstones.CleanupIntervalInMin"] = int.MaxValue.ToString()
             });
 
@@ -319,7 +337,9 @@ namespace SlowTests.Client
                 var storeTask = Task.Run(async () =>
                 {
                     using var session = store.OpenAsyncSession();
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     await session.StoreAsync(new TestObj(), "wrongChangedVector", concurrencyFailedId);
                     barrier.SignalAndWait();

--- a/test/SlowTests/Core/Session/Advanced.cs
+++ b/test/SlowTests/Core/Session/Advanced.cs
@@ -215,8 +215,10 @@ namespace SlowTests.Core.Session
             {
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.False(session.Advanced.UseOptimisticConcurrency);
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     session.Store(new User { Id = entityId, Name = "User1" });
                     session.SaveChanges();

--- a/test/SlowTests/MailingList/ConcurrencyTests.cs
+++ b/test/SlowTests/MailingList/ConcurrencyTests.cs
@@ -29,7 +29,9 @@ namespace SlowTests.MailingList
                 Indexes.WaitForIndexing(store);
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     var foos = session.Query<SectionData>().ToList();
 
                     foreach (var sectionData in foos)

--- a/test/SlowTests/MailingList/EtagIssue.cs
+++ b/test/SlowTests/MailingList/EtagIssue.cs
@@ -329,7 +329,9 @@ namespace SlowTests.MailingList
         {
             using (IDocumentSession session = store.OpenSession())
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 foreach (object obj in objs)
                     session.Store(obj);

--- a/test/SlowTests/MailingList/Kwoodard.cs
+++ b/test/SlowTests/MailingList/Kwoodard.cs
@@ -17,13 +17,17 @@ namespace SlowTests.MailingList
             {
                 ModifyDocumentStore = s =>
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     s.Conventions.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }))
             {
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     Assert.True(session.Advanced.UseOptimisticConcurrency);
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
         }

--- a/test/SlowTests/MailingList/Stacey2.cs
+++ b/test/SlowTests/MailingList/Stacey2.cs
@@ -39,7 +39,9 @@ namespace SlowTests.MailingList
 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     session.Store(aggregate);
                     session.SaveChanges();
                 }
@@ -57,7 +59,9 @@ namespace SlowTests.MailingList
 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     session.Store(root); session.SaveChanges();
                 }
 
@@ -69,7 +73,9 @@ namespace SlowTests.MailingList
 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     var query = session
                         .Include("Bridge.Aggregates")
                         .Load<Root>("roots/1-A");
@@ -79,7 +85,9 @@ namespace SlowTests.MailingList
 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     var query = session
                         .Include("Bridge.Aggregates")
                         .Load<Root>("roots/1-A");
@@ -91,7 +99,9 @@ namespace SlowTests.MailingList
 
                 using (var session = store.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
                     var query = session
                         .Include("Bridge.Aggregates")
                         .Load<Root>("roots/1-A");

--- a/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
+++ b/test/SlowTests/Server/Replication/ReplicationTombstoneTests.cs
@@ -86,7 +86,9 @@ namespace SlowTests.Server.Replication
 
                 using (var session = store1.OpenSession())
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     session.Advanced.UseOptimisticConcurrency = true;
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     var user = new User
                     {


### PR DESCRIPTION
Replace the TrackingMode enum (Default/NoTracking/TrackAllEntities) with OptimisticConcurrencyMode (None/Writes/WritesAndReads). Mark UseOptimisticConcurrency as [Obsolete] with delegation to the new enum, following the same pattern used for NoTracking/TrackingMode.

- Add OptimisticConcurrencyMode property to SessionOptions, DocumentConventions, IAdvancedDocumentSessionOperations, and InMemoryDocumentSessionOperations
- WritesAndReads replaces TrackAllEntities for tracked entity CV verification
- Revert NoTracking back to simple bool (remove TrackingMode enum entirely)
- Block Writes and WritesAndReads with ClusterWide transactions
- Mutual exclusion between UseOptimisticConcurrency and OptimisticConcurrencyMode setters on the session to prevent mixing old and new API

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25154

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
