### PR TITLE
RavenDB - 24876 : fixed flaky test DocumentsMigratorShouldWork_ClusterCase

### DIFF
--- a/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
+++ b/test/SlowTests/Sharding/BucketMigration/DocumentsMigrationTests.cs
@@ -166,9 +166,14 @@ namespace SlowTests.Sharding.BucketMigration
 
                 var shard = await Sharding.GetShardNumberForAsync(store, "users/1");
                 var wrongShard = ShardingTestBase.GetNextSortedShardNumber((await Sharding.GetShardingConfigurationAsync(store)).Shards, shard);
+                Raven.Client.ServerWide.DatabaseTopology dbTopology = null;
+                Assert.True(await WaitForValueAsync(async () =>
+                {
+                    var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
+                    dbTopology = record.Sharding.Shards[wrongShard];
+                    return dbTopology.Members.Count > 0;
+                }, true, 30_000), string.Join(", ", dbTopology));
 
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(dbName));
-                var dbTopology = record.Sharding.Shards[wrongShard];
                 var serverTag = dbTopology.Members[0];
                 var server = nodes.Single(n => n.ServerStore.NodeTag == serverTag);
 


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24876/SlowTests.Sharding.BucketMigration.DocumentsMigrationTests.DocumentsMigratorShouldWorkClusterCase

### Additional description

Now we wait 30 seconds for the value to change to give the node more time to be a `Member`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
