### PR TITLE
RavenDB-25841: fix MAC verification failed during PKCS12 import bug o…

### DIFF
--- a/src/Raven.Client/Util/CertificateLoaderUtil.cs
+++ b/src/Raven.Client/Util/CertificateLoaderUtil.cs
@@ -38,11 +38,15 @@ internal static class CertificateLoaderUtil
 
     public static X509Certificate2 CreateCertificate(byte[] rawData, string password = null, X509KeyStorageFlags? flags = null)
     {
+        // In order not to tirgger MAC verification during PKCS12 import, we have to use null as password instead of empty string,
+        // since macOS security restrictions doesn't allow empty string as a password
         return CreateCertificate(f => new X509Certificate2(rawData, password == string.Empty ? null : password, f), flags);
     }
 
     internal static X509Certificate2 CreateCertificate(string fileName, string password = null, X509KeyStorageFlags? flags = null)
     {
+        // In order not to tirgger MAC verification during PKCS12 import, we have to use null as password instead of empty string,
+        // since macOS security restrictions doesn't allow empty string as a password
         return CreateCertificate(f => new X509Certificate2(fileName, password == string.Empty ? null : password, f), flags);
     }
 

--- a/src/Raven.Client/Util/CertificateLoaderUtil.cs
+++ b/src/Raven.Client/Util/CertificateLoaderUtil.cs
@@ -38,12 +38,12 @@ internal static class CertificateLoaderUtil
 
     public static X509Certificate2 CreateCertificate(byte[] rawData, string password = null, X509KeyStorageFlags? flags = null)
     {
-        return CreateCertificate(f => new X509Certificate2(rawData, password, f), flags);
+        return CreateCertificate(f => new X509Certificate2(rawData, password == string.Empty ? null : password, f), flags);
     }
 
     internal static X509Certificate2 CreateCertificate(string fileName, string password = null, X509KeyStorageFlags? flags = null)
     {
-        return CreateCertificate(f => new X509Certificate2(fileName, password, f), flags);
+        return CreateCertificate(f => new X509Certificate2(fileName, password == string.Empty ? null : password, f), flags);
     }
 
     private static X509Certificate2 CreateCertificate(Func<X509KeyStorageFlags, X509Certificate2> creator, X509KeyStorageFlags? flag)

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -522,7 +522,7 @@ namespace Raven.Server.Utils
 
             // Return a new X509Certificate2 object from the generated PFX byte array.
             var flags = X509KeyStorageFlags.PersistKeySet;
-            return new X509Certificate2(clientCertBytes, string.Empty, flags);
+            return new X509Certificate2(clientCertBytes, (string)null, flags);
         }
 
         public static X509Certificate2 ExtractServerCertificateFromExtension(X509Certificate2 clientCert)


### PR DESCRIPTION
…n macOS

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25841/Setup-Wizard-MAC-verification-failed-during-PKCS12-import

### Additional description

Since [`BouncyCastle` package](https://github.com/ravendb/ravendb/pull/21520) removal, the macOS secured server setup wasnt working. Additionally, macOS treats `password = null` different than Linux & Windows. Therefore, had to explicitly use `null`, otherwise, macOS will tirgger a MAC verification, and macOS security restrictions wont allow empty string as empty password.

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [x] Yes. macOS.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
