### PR TITLE
RavenDB-26111 fix IOPS monitoring for external disk

### DIFF
--- a/src/Sparrow.Server/Platform/Posix/Syscall.cs
+++ b/src/Sparrow.Server/Platform/Posix/Syscall.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -19,10 +19,12 @@ namespace Sparrow.Server.Platform.Posix
         [DllImport(LIBC_6, SetLastError = true)]
         public static extern int sched_setaffinity(int pid, IntPtr cpusetsize, ref ulong cpuset);
 
+        // realpath(3): resolves all symlinks and relative path components, returning the canonical absolute path.
+        // resolvedPath must point to a buffer of at least PATH_MAX (4096) bytes. Returns IntPtr.Zero on failure.
         [DllImport(LIBC_6, SetLastError = true)]
-        public static extern int readlink(
+        public static extern IntPtr realpath(
             [MarshalAs(UnmanagedType.LPStr)] string path,
-            byte* buffer, int bufferSize);
+            byte* resolvedPath);
 
         [DllImport(LIBC_6, SetLastError = true)]
         public static extern int mkdir(
@@ -127,6 +129,7 @@ namespace Sparrow.Server.Platform.Posix
         [DllImport(LIBC_6, SetLastError = true)]
         private static extern int fsync(int fd);
 
+        // Used by ReadLinkOrThrow / SyncDirectory to resolve symlinks during directory sync
         [DllImport(LIBC_6, SetLastError = true)]
         private static extern int readlink(string path, byte* buf, UIntPtr bufsiz);
 

--- a/src/Sparrow.Server/Utils/DiskUtils.cs
+++ b/src/Sparrow.Server/Utils/DiskUtils.cs
@@ -112,15 +112,18 @@ namespace Sparrow.Server.Utils
             {
                 fixed (byte* buffer = byteArray)
                 {
-                    var result = Syscall.readlink(path, buffer, LinuxMaxPath);
-                    if (result == -1)
+                    // realpath resolves all symlinks (including intermediate path components),
+                    // handles relative paths, and returns the canonical absolute path.
+                    // This is needed to correctly identify the mount point when the path
+                    // contains symlinks in intermediate components (e.g. /var/lib/ravendb -> /mnt/disk2/ravendb).
+                    var result = Syscall.realpath(path, buffer);
+                    if (result == IntPtr.Zero)
                     {
-                        // not a symbolic link
+                        // failed to resolve - fall back to original path
                         return path;
                     }
 
-                    var realPath = Encoding.UTF8.GetString(byteArray, 0, result);
-                    return realPath;
+                    return Marshal.PtrToStringUTF8(result);
                 }
             }
             finally


### PR DESCRIPTION
### Issue link

[RavenDB-26111](https://issues.hibernatingrhinos.com/issue/RavenDB-26111)

### Additional description

Use `realpath()` instead of `readlink()`

<img width="1564" height="693" alt="image" src="https://github.com/user-attachments/assets/42aeeba4-ec4f-468f-b11d-75cf0da559e5" />

<img width="726" height="590" alt="image" src="https://github.com/user-attachments/assets/081e3b8d-3f09-4019-b065-385b068b68ec" />

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. - Linux
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
