### PR TITLE
RavenDB-26179 : Fix NullReferenceException in OlapEtlConfiguration.ToJson when OlapTables is null

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
@@ -56,7 +56,7 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
             json[nameof(CustomPartitionValue)] = CustomPartitionValue;
             json[nameof(RunFrequency)] = RunFrequency;
-            json[nameof(OlapTables)] = new DynamicJsonArray(OlapTables.Select(x => x.ToJson()));
+            json[nameof(OlapTables)] = OlapTables != null ? new DynamicJsonArray(OlapTables.Select(x => x.ToJson())) : null;
 
             return json;
         }


### PR DESCRIPTION
PR #22467 changed AddEtlCommand.FillJson from TypeConverter.ToBlittableSupportedType to Configuration.ToJson(), which does not handle null OlapTables gracefully.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26179

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
