### PR TITLE
RavenDB-26179 : Fix NullReferenceException in OlapEtlConfiguration.ToJson when OlapTables is null

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Elasticsearch/ElasticSearchEtlConfiguration.cs
@@ -44,7 +44,7 @@ namespace Raven.Client.Documents.Operations.ETL.ElasticSearch
         {
             var json = base.ToJson();
 
-            json[nameof(ElasticIndexes)] = new DynamicJsonArray(ElasticIndexes.Select(x => x.ToJson()));
+            json[nameof(ElasticIndexes)] = ElasticIndexes != null ? new DynamicJsonArray(ElasticIndexes.Select(x => x.ToJson())) : null;
 
             return json;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/OLAP/OlapEtlConfiguration.cs
@@ -56,7 +56,7 @@ namespace Raven.Client.Documents.Operations.ETL.OLAP
 
             json[nameof(CustomPartitionValue)] = CustomPartitionValue;
             json[nameof(RunFrequency)] = RunFrequency;
-            json[nameof(OlapTables)] = new DynamicJsonArray(OlapTables.Select(x => x.ToJson()));
+            json[nameof(OlapTables)] = OlapTables != null ? new DynamicJsonArray(OlapTables.Select(x => x.ToJson())) : null;
 
             return json;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -73,7 +73,7 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
 
             json[nameof(BrokerType)] = BrokerType;
             json[nameof(SkipAutomaticQueueDeclaration)] = SkipAutomaticQueueDeclaration;
-            json[nameof(Queues)] = new DynamicJsonArray(Queues.Select(x => x.ToJson()));
+            json[nameof(Queues)] = Queues != null ? new DynamicJsonArray(Queues.Select(x => x.ToJson())) : null;
 
             return json;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/SQL/SqlEtlConfiguration.cs
@@ -146,7 +146,7 @@ namespace Raven.Client.Documents.Operations.ETL.SQL
             result[nameof(ForceQueryRecompile)] = ForceQueryRecompile;
             result[nameof(QuoteTables)] = QuoteTables;
             result[nameof(CommandTimeout)] = CommandTimeout;
-            result[nameof(SqlTables)] = new DynamicJsonArray(SqlTables.Select(x => x.ToJson()));
+            result[nameof(SqlTables)] = SqlTables != null ? new DynamicJsonArray(SqlTables.Select(x => x.ToJson())) : null;
 
             return result;
         }

--- a/src/Raven.Client/Documents/Operations/ETL/Snowflake/SnowflakeEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Snowflake/SnowflakeEtlConfiguration.cs
@@ -49,7 +49,7 @@ public sealed class SnowflakeEtlConfiguration : EtlConfiguration<SnowflakeConnec
         var result = base.ToJson();
 
         result[nameof(CommandTimeout)] = CommandTimeout;
-        result[nameof(SnowflakeTables)] = new DynamicJsonArray(SnowflakeTables.Select(x => x.ToJson()));
+        result[nameof(SnowflakeTables)] = SnowflakeTables != null ? new DynamicJsonArray(SnowflakeTables.Select(x => x.ToJson())) : null;
 
         return result;
     }


### PR DESCRIPTION
PR #22467 changed AddEtlCommand.FillJson from TypeConverter.ToBlittableSupportedType to Configuration.ToJson(), which does not handle null OlapTables gracefully.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26179

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
