### PR TITLE
RavenDB-26248 Add ability to skip AI tests via RAVEN_SKIP_AI_INTEGRATION_TESTS

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -32,6 +32,8 @@ namespace Raven.Server.Documents.Handlers.AI.Agents;
 
 internal class ConversationHandler(ServerStore server, DocumentDatabase database)
 {
+    internal static Action<string, AiUsage> OnUpdateUsage;
+
     public const int DefaultMaxModelIterationsPerCall = 16;
     private const int DefaultMaxTokensBeforeSummarization = 32 * 1024;
     private const int DefaultMaxTokensAfterSummarization = 1024;
@@ -176,6 +178,7 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
 
             _document.AddMessage(context, r.Message, currentTurnUsage);
             _document.UpdateUsage(talker.AiUsage);
+            OnUpdateUsage?.Invoke(database.Name, currentTurnUsage);
 
             if (currentTurnUsage.PromptTokens > database.Configuration.Ai.ToolsTokenUsageThreshold)
             {
@@ -333,6 +336,8 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
                 "system/msg"), usage);
 
         oldChat.UpdateUsage(usage);
+        OnUpdateUsage?.Invoke($"summary/{database.Name}", usage);
+
         oldChat.CurrentUsage = new AiUsage();
     }
 

--- a/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/AzureOpenAiConnectorForTesting.cs
@@ -15,7 +15,7 @@ public sealed class EmbeddingsAzureOpenAiConnectorForTesting : AbstractEmbedding
         RequiredEnvironmentVariables = [EnvironmentVariableApiKey, EnvironmentVariableDeploymentEndpoint, EnvironmentVariableDeploymentName];
     }
 
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.AzureOpenAi);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.AzureOpenAi;
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
     {
@@ -39,7 +39,7 @@ public class GenAiAzureOpenAiConnectorForTesting : AbstractGenAiConnectorForTest
         RequiredEnvironmentVariables = [EnvironmentVariableApiKey, EnvironmentVariableDeploymentEndpoint, EnvironmentVariableDeploymentName];
     }
 
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.AzureOpenAi);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.AzureOpenAi;
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
     {

--- a/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/BaseAiConnectionStringForTesting.cs
@@ -20,7 +20,7 @@ where TConfig : EtlConfiguration<AiConnectionString>
     TConfig GetAiConfiguration();
     Lazy<bool> CanConnect { get; }
     bool TryConnect(out InMemoryLoggerProvider logger, CancellationToken token);
-    Lazy<AiConnectorType> AiConnectorType { get; }
+    AiConnectorType AiConnectorType { get; }
     bool MissingRequiredEnvVariables(out string environmentVariableName);
 }
 
@@ -32,13 +32,13 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
 
     public static T Instance => _instance ??= new T();
 
-    internal static T CreateNewInstance(string prefixName) => new() { NamePrefix = new Lazy<string>(prefixName) };
+    internal static T CreateNewInstance(string prefixName) => new() { NamePrefix = prefixName };
 
-    protected readonly Lazy<TConfig> _aiIntegrationConfiguration;
+    protected readonly TConfig _aiIntegrationConfiguration;
 
     public Lazy<bool> CanConnect { get; }
 
-    public abstract Lazy<AiConnectorType> AiConnectorType { get; init; }
+    public abstract AiConnectorType AiConnectorType { get; init; }
 
     protected string[] RequiredEnvironmentVariables = [];
 
@@ -57,40 +57,38 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
         return false;
     }
 
-    private Lazy<string> NamePrefix { get; init; }
+    private string NamePrefix { get; init; }
 
     protected BaseAiConnectorForTesting()
     {
-        _aiIntegrationConfiguration = new Lazy<TConfig>(GetAiConfiguration);
+        _aiIntegrationConfiguration = GetAiConfiguration();
         CanConnect = new Lazy<bool>(IsConnectionAllowed);
     }
 
-    protected Lazy<string> AiIntegrationTaskName => new(() =>
+    protected string AiIntegrationTaskName
     {
-        var prefix = string.Empty;
+        get
+        {
+            var prefix = string.IsNullOrWhiteSpace(NamePrefix) ? string.Empty : $"{NamePrefix}_";
+            return $"{prefix}{AiConnectorType}_AiIntegrationTask";
+        }
+    }
 
-        if (string.IsNullOrWhiteSpace(NamePrefix?.Value) == false)
-            prefix = $"{NamePrefix.Value}_";
-
-        return $"{prefix}{AiConnectorType.Value.ToString()}_AiIntegrationTask";
-    });
-
-    protected Lazy<string> ConnectionStringName => new(() =>
+    protected string ConnectionStringName
     {
-        var prefix = string.Empty;
-
-        if (string.IsNullOrWhiteSpace(NamePrefix?.Value) == false)
-            prefix = $"{NamePrefix.Value}_";
-
-        return $"{prefix}{AiConnectorType.Value.ToString()}_ConnectionString";
-    });
+        get
+        {
+            var prefix = string.IsNullOrWhiteSpace(NamePrefix) ? string.Empty : $"{NamePrefix}_";
+            return $"{prefix}{AiConnectorType}_ConnectionString";
+        }
+    }
 
     protected abstract AiConnectionString CreateAiConnectionStringImpl();
 
     public AiConnectionString GetAiConnectionString()
     {
         var connectionString = CreateAiConnectionStringImpl();
-        connectionString.Name = ConnectionStringName.Value;
+        connectionString.Name = ConnectionStringName;
         connectionString.Identifier = Guid.NewGuid().ToString();
 
         return connectionString;
@@ -102,8 +100,8 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
 
         return new TConfig
         {
-            Name = AiIntegrationTaskName.Value,
-            ConnectionStringName = ConnectionStringName.Value,
+            Name = AiIntegrationTaskName,
+            ConnectionStringName = ConnectionStringName,
             Connection = connectionString
         };
     }
@@ -136,7 +134,7 @@ public abstract class BaseAiConnectorForTesting<T, TConfig> : IAiConnectorForTes
             using (var context = JsonOperationContext.ShortTermSingleUse())
             {
                 var errorDetails = context.ReadObject(errorDetailsJson, "error").ToString();
-                Console.WriteLine($"ERROR: Unable to connect to {AiConnectorType.Value} due to the following error:{Environment.NewLine}{errorDetails}");
+                Console.WriteLine($"ERROR: Unable to connect to {AiConnectorType} due to the following error:{Environment.NewLine}{errorDetails}");
             }
 
             return false;
@@ -157,13 +155,13 @@ public abstract class AbstractEmbeddingsConnectorForTesting<T> : BaseAiConnector
     {
         logger = null;
 
-        (IEmbeddingGenerator<string, Embedding<float>> service, logger) = AiHelper.CreateEmbeddingServicesForTest(_aiIntegrationConfiguration.Value);
+        (IEmbeddingGenerator<string, Embedding<float>> service, logger) = AiHelper.CreateEmbeddingServicesForTest(_aiIntegrationConfiguration);
         var embeddings = service.GenerateAsync(EmbeddingsHelper.ValuesListToVerifyConnection, cancellationToken: token).GetAwaiter().GetResult();
 
         var isExpectedResponse = embeddings.Count == EmbeddingsHelper.ValuesListToVerifyConnection.Count;
         if (isExpectedResponse == false)
             Console.WriteLine(
-                $"ERROR: Unexpected response from {AiConnectorType.Value}: '{embeddings.Count}' embeddings were generated for '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' input values.");
+                $"ERROR: Unexpected response from {AiConnectorType}: '{embeddings.Count}' embeddings were generated for '{EmbeddingsHelper.ValuesListToVerifyConnection.Count}' input values.");
 
         return isExpectedResponse;
     }
@@ -174,7 +172,7 @@ public abstract class AbstractGenAiConnectorForTesting<T> : BaseAiConnectorForTe
 {
     public override bool TryConnect(out InMemoryLoggerProvider logger, CancellationToken token)
     {
-        var configuration = _aiIntegrationConfiguration.Value;
+        var configuration = _aiIntegrationConfiguration;
         var schema = ChatCompletionClient.GetSchemaFromSampleObject("{ \"Answer\" : \"answer here\" }");
         using (var contextPool = new JsonContextPool())
         using (var client = ChatCompletionClient.CreateChatCompletionClient(contextPool, configuration.Connection))

--- a/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/EmbeddedConnectorForTesting.cs
@@ -5,7 +5,7 @@ namespace Tests.Infrastructure.ConnectionString.AI;
 
 public class EmbeddedConnectorForTesting : AbstractEmbeddingsConnectorForTesting<EmbeddedConnectorForTesting>
 {
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Embedded);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.Embedded;
 
     protected override AiConnectionString CreateAiConnectionStringImpl() => new() { EmbeddedSettings = new EmbeddedSettings(), ModelType = AiModelType.TextEmbeddings };
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/GoogleConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsGoogleConnectorForTesting : AbstractEmbeddingsConnectorFo
         RequiredEnvironmentVariables = [EnvironmentVariable];
     }
     
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Google);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.Google;
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
     {

--- a/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/HuggingFaceConnectorForTesting.cs
@@ -12,7 +12,7 @@ public class EmbeddingsHuggingFaceConnectorForTesting : AbstractEmbeddingsConnec
     {
         RequiredEnvironmentVariables = [EnvironmentVariable];
     }
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.HuggingFace);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.HuggingFace;
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
     {

--- a/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/MistralAiConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsMistralAiConnectorForTesting : AbstractEmbeddingsConnecto
     {
         RequiredEnvironmentVariables = [EnvironmentVariable];
     }
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.MistralAi);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.MistralAi;
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
     {

--- a/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OllamaConnectorForTesting.cs
@@ -13,7 +13,7 @@ public class EmbeddingsOllamaConnectorForTesting : AbstractEmbeddingsConnectorFo
         RequiredEnvironmentVariables = [EnvironmentVariable];
     }
 
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.Ollama;
 
     protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.TextEmbeddings, EnvironmentVariable);
 }
@@ -28,7 +28,7 @@ public class GenAiOllamaConnectorForTesting : AbstractGenAiConnectorForTesting<G
         RequiredEnvironmentVariables = [EnvironmentVariable];
     }
 
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Ollama);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.Ollama;
 
     protected override AiConnectionString CreateAiConnectionStringImpl() => OllamaConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat, EnvironmentVariable);
 }

--- a/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/OpenAiConnectorForTesting.cs
@@ -11,7 +11,7 @@ public class EmbeddingsOpenAiConnectorForTesting : AbstractEmbeddingsConnectorFo
     {
         RequiredEnvironmentVariables = [OpenAiConnectorHelper.EnvironmentVariable];
     }
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.OpenAi;
 
     protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.TextEmbeddings);
 }
@@ -24,7 +24,7 @@ public class GenAiOpenAiConnectorForTesting : AbstractGenAiConnectorForTesting<G
     {
         RequiredEnvironmentVariables = [OpenAiConnectorHelper.EnvironmentVariable];
     }
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.OpenAi);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.OpenAi;
 
     protected override AiConnectionString CreateAiConnectionStringImpl() => OpenAiConnectorHelper.CreateAiConnectionString(Model, AiModelType.Chat);
     

--- a/test/Tests.Infrastructure/ConnectionString/AI/VertexConnectorForTesting.cs
+++ b/test/Tests.Infrastructure/ConnectionString/AI/VertexConnectorForTesting.cs
@@ -14,7 +14,7 @@ public class EmbeddingsVertexConnectorForTesting : AbstractEmbeddingsConnectorFo
         RequiredEnvironmentVariables = [EnvironmentVariableGoogleCredentialsJson, EnvironmentVariableLocation];
     }
     
-    public override Lazy<AiConnectorType> AiConnectorType { get; init; } = new(Raven.Client.Documents.Operations.AI.AiConnectorType.Vertex);
+    public override AiConnectorType AiConnectorType { get; init; } = AiConnectorType.Vertex;
 
     protected override AiConnectionString CreateAiConnectionStringImpl()
     {

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Org.BouncyCastle.Asn1.Cmp;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Util;
@@ -32,7 +31,7 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 {
     public RavenDatabaseMode DatabaseMode { get; set; } = RavenDatabaseMode.All;
     public RavenAiIntegration IntegrationType { get; set; } = RavenAiIntegration.All;
-    public object[] Data { get; set; } = null;
+    public object[] Data { get; set; }
 
     protected AbstractRavenAiIntegrationDataAttribute()
     {
@@ -45,13 +44,13 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 
     public override IEnumerable<object[]> GetData(MethodInfo testMethod)
     {
-        foreach (var (databaseMode, options) in RavenDataAttribute.GetOptions(DatabaseMode))
+        foreach (var (_, options) in RavenDataAttribute.GetOptions(DatabaseMode))
         {
             foreach (var aiConnectionStringForTesting in GetAiConnectionStringsSingleton(IntegrationType))
             {
                 using (ResetSkipReason(Skip))
                 {
-                    if (HasSkipReason(databaseMode, aiConnectionStringForTesting) == false)
+                    if (HasSkipReason(aiConnectionStringForTesting) == false)
                     {
                         if (aiConnectionStringForTesting.CanConnect.Value == false)
                         {
@@ -75,7 +74,7 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 
     private DisposableAction ResetSkipReason(string skip) => new(() => Skip = skip);
 
-    private bool HasSkipReason(RavenDatabaseMode databaseMode, IAiConnectorForTesting<TConfig> aiConnectorForTesting)
+    private bool HasSkipReason(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
     {
         if (string.IsNullOrEmpty(Skip))
             return true;

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Org.BouncyCastle.Asn1.Cmp;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Util;
@@ -50,17 +51,11 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
             {
                 using (ResetSkipReason(Skip))
                 {
-                    if (string.IsNullOrEmpty(Skip))
+                    if (HasSkipReason(databaseMode, aiConnectionStringForTesting) == false)
                     {
-                        if (RavenTestHelper.SkipAiTests)
+                        if (aiConnectionStringForTesting.CanConnect.Value == false)
                         {
-                            Skip = RavenTestHelper.SkipAiMessage;
-                        }
-                        else
-                        {
-                            SetSkipValueIfShardedDbOnX86(databaseMode);
-                            SetSkipValueIfNoRequiredEnvVariablesDefined(aiConnectionStringForTesting);
-                            SetSkipValueIfUnableConnectToAi(aiConnectionStringForTesting);
+                            Skip = $"Test requires connection to {aiConnectionStringForTesting.AiConnectorType}.";
                         }
                     }
                     
@@ -80,49 +75,32 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
 
     private DisposableAction ResetSkipReason(string skip) => new(() => Skip = skip);
 
-    private void SetSkipValueIfShardedDbOnX86(RavenDatabaseMode databaseMode)
+    private bool HasSkipReason(RavenDatabaseMode databaseMode, IAiConnectorForTesting<TConfig> aiConnectorForTesting)
     {
-        if (Is32Bit == false)
-            return;
+        if (string.IsNullOrEmpty(Skip))
+            return true;
 
-        if (databaseMode.HasFlag(RavenDatabaseMode.Sharded) == false)
-            return;
-
-        Skip = ShardingSkipMessage;
-    }
-    
-    private void SetSkipValueIfNoRequiredEnvVariablesDefined(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
-    {
-        if (RavenTestHelper.IsRunningOnCI)
-            return;
-
-        if (aiConnectorForTesting.MissingRequiredEnvVariables(out var envVar) is false)
-            return;
-        
-        Skip = $"The environment variable {envVar} is required for {aiConnectorForTesting.AiConnectorType}, but was not set.";
-    }
-
-    private void SetSkipValueIfUnableConnectToAi(IAiConnectorForTesting<TConfig> aiConnectorForTesting)
-    {
-        if (RavenTestHelper.IsRunningOnCI)
-            return;
-
-        // we want to skip only if we cannot connect
-        if (CanConnectToAi(aiConnectorForTesting, out string unableToConnectMessage))
-            return;
-
-        Skip = unableToConnectMessage;
-    }
-
-    private bool CanConnectToAi(IAiConnectorForTesting<TConfig> aiConnectorForTesting, out string skipMessage)
-    {
-        if (aiConnectorForTesting.CanConnect.Value)
+        if (RavenTestHelper.SkipAiIntegrationTests)
         {
-            skipMessage = Skip;
+            Skip = RavenTestHelper.SkipAiIntegrationMessage;
             return true;
         }
 
-        skipMessage = $"Test requires connection to {aiConnectorForTesting.AiConnectorType}.";
+        if (Is32Bit)
+        {
+            Skip = "AI tests are skipped on 32-bit process";
+            return true;
+        }
+
+        if (RavenTestHelper.IsRunningOnCI)
+            return false;
+
+        if (aiConnectorForTesting.MissingRequiredEnvVariables(out var envVar))
+        {
+            Skip = $"The environment variable {envVar} is required for {aiConnectorForTesting.AiConnectorType}, but was not set.";
+            return true;
+        }
+
         return false;
     }
 

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -52,9 +52,16 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
                 {
                     if (string.IsNullOrEmpty(Skip))
                     {
-                        SetSkipValueIfShardedDbOnX86(databaseMode);
-                        SetSkipValueIfNoRequiredEnvVariablesDefined(aiConnectionStringForTesting);
-                        SetSkipValueIfUnableConnectToAi(aiConnectionStringForTesting);
+                        if (RavenTestHelper.SkipAiTests)
+                        {
+                            Skip = RavenTestHelper.SkipAiMessage;
+                        }
+                        else
+                        {
+                            SetSkipValueIfShardedDbOnX86(databaseMode);
+                            SetSkipValueIfNoRequiredEnvVariablesDefined(aiConnectionStringForTesting);
+                            SetSkipValueIfUnableConnectToAi(aiConnectionStringForTesting);
+                        }
                     }
                     
                     var aiIntegrationConfiguration = aiConnectionStringForTesting.GetAiConfiguration();

--- a/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
+++ b/test/Tests.Infrastructure/RavenAiIntegrationAttribute.cs
@@ -122,7 +122,7 @@ public abstract class AbstractRavenAiIntegrationDataAttribute<TConfig> : RavenDa
             return true;
         }
 
-        skipMessage = $"Test requires connection to {aiConnectorForTesting.AiConnectorType.Value}.";
+        skipMessage = $"Test requires connection to {aiConnectorForTesting.AiConnectorType}.";
         return false;
     }
 

--- a/test/Tests.Infrastructure/RavenFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenFactAttribute.cs
@@ -126,9 +126,6 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
         {
             if (category.HasFlag(RavenTestCategory.Sharding))
                 return RavenDataAttributeBase.ShardingSkipMessage;
-
-            if (category.HasFlag(RavenTestCategory.Ai))
-                return RavenTestHelper.SkipAiMessage;
         }
 
         if (licenseRequired && ShouldSkipLicense(out skip))

--- a/test/Tests.Infrastructure/RavenFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenFactAttribute.cs
@@ -131,9 +131,6 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
                 return RavenTestHelper.SkipAiMessage;
         }
 
-        if (category.HasFlag(RavenTestCategory.Ai) && RavenTestHelper.SkipAiTests)
-            return RavenTestHelper.SkipAiMessage;
-
         if (licenseRequired && ShouldSkipLicense(out skip))
             return skip;
 

--- a/test/Tests.Infrastructure/RavenFactAttribute.cs
+++ b/test/Tests.Infrastructure/RavenFactAttribute.cs
@@ -117,7 +117,7 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
         return null;
     }
 
-    internal static string ShouldSkip(string skip, RavenTestCategory category, bool licenseRequired, bool nightlyBuildRequired)
+    private static string ShouldSkip(string skip, RavenTestCategory category, bool licenseRequired, bool nightlyBuildRequired)
     {
         if (skip != null)
             return skip;
@@ -126,7 +126,13 @@ public class RavenFactAttribute : FactAttribute, ITraitAttribute
         {
             if (category.HasFlag(RavenTestCategory.Sharding))
                 return RavenDataAttributeBase.ShardingSkipMessage;
+
+            if (category.HasFlag(RavenTestCategory.Ai))
+                return RavenTestHelper.SkipAiMessage;
         }
+
+        if (category.HasFlag(RavenTestCategory.Ai) && RavenTestHelper.SkipAiTests)
+            return RavenTestHelper.SkipAiMessage;
 
         if (licenseRequired && ShouldSkipLicense(out skip))
             return skip;

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -28,9 +28,11 @@ namespace Tests.Infrastructure
     {
         public static readonly bool IsRunningOnCI;
         public static readonly bool SkipIntegrationTests;
+        public static readonly bool SkipAiTests;
         public static bool RunTestsWithDocsCompression;
 
         public const string SkipIntegrationMessage = "Skipping integration tests.";
+        public const string SkipAiMessage = "Skipping AI tests.";
 
         public static readonly ParallelOptions DefaultParallelOptions = new ParallelOptions
         {
@@ -41,6 +43,7 @@ namespace Tests.Infrastructure
         {
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_IS_RUNNING_ON_CI"), out IsRunningOnCI);
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_SKIP_INTEGRATION_TESTS"), out SkipIntegrationTests);
+            bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_SKIP_AI_TESTS"), out SkipAiTests);
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_DOCS_COMPRESSION_TESTS"), out RunTestsWithDocsCompression);
         }
 

--- a/test/Tests.Infrastructure/RavenTestHelper.cs
+++ b/test/Tests.Infrastructure/RavenTestHelper.cs
@@ -28,11 +28,11 @@ namespace Tests.Infrastructure
     {
         public static readonly bool IsRunningOnCI;
         public static readonly bool SkipIntegrationTests;
-        public static readonly bool SkipAiTests;
+        public static readonly bool SkipAiIntegrationTests;
         public static bool RunTestsWithDocsCompression;
 
         public const string SkipIntegrationMessage = "Skipping integration tests.";
-        public const string SkipAiMessage = "Skipping AI tests.";
+        public const string SkipAiIntegrationMessage = "Skipping AI integration tests.";
 
         public static readonly ParallelOptions DefaultParallelOptions = new ParallelOptions
         {
@@ -43,7 +43,7 @@ namespace Tests.Infrastructure
         {
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_IS_RUNNING_ON_CI"), out IsRunningOnCI);
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_SKIP_INTEGRATION_TESTS"), out SkipIntegrationTests);
-            bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_SKIP_AI_TESTS"), out SkipAiTests);
+            bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_SKIP_AI_INTEGRATION_TESTS"), out SkipAiIntegrationTests);
             bool.TryParse(Environment.GetEnvironmentVariable("RAVEN_DOCS_COMPRESSION_TESTS"), out RunTestsWithDocsCompression);
         }
 

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -23,6 +23,7 @@ using Raven.Server.Commercial;
 using Raven.Server.Config;
 using Raven.Server.Config.Settings;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.Documents.Indexes.Static.NuGet;
 using Raven.Server.Documents.PeriodicBackup;
 using Raven.Server.Documents.PeriodicBackup.Restore;
@@ -64,6 +65,8 @@ namespace FastTests
         private readonly ConcurrentSet<string> _localPathsToDelete = new(StringComparer.OrdinalIgnoreCase);
 
         private static RavenServer _globalServer;
+
+        private static long TotalAiTokensUsed;
 
         protected static bool IsGlobalServer(RavenServer server)
         {
@@ -147,8 +150,19 @@ namespace FastTests
                 Console.WriteLine($"Execution of GC due to IO failure on path '{x.Path}' took {x.Duration} (attempt: {x.Attempt})");
             };
 
-            LowMemoryNotification.Instance.SupportsCompactionOfLargeObjectHeap = true;
+#if DEBUG
+            ConversationHandler.OnUpdateUsage += (sender, usage) =>
+            {
+                if (usage == null)
+                    return;
 
+                var value = Interlocked.Add(ref TotalAiTokensUsed, usage.TotalTokens);
+
+                Console.WriteLine($"Total AI tokens used across all tests: {value} (delta: {usage.TotalTokens}, database: {sender})");
+            };
+#endif
+
+            LowMemoryNotification.Instance.SupportsCompactionOfLargeObjectHeap = true;
 #if DEBUG2
             TaskScheduler.UnobservedTaskException += (sender, args) =>
             {

--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -150,7 +150,6 @@ namespace FastTests
                 Console.WriteLine($"Execution of GC due to IO failure on path '{x.Path}' took {x.Duration} (attempt: {x.Attempt})");
             };
 
-#if DEBUG
             ConversationHandler.OnUpdateUsage += (sender, usage) =>
             {
                 if (usage == null)
@@ -160,7 +159,6 @@ namespace FastTests
 
                 Console.WriteLine($"Total AI tokens used across all tests: {value} (delta: {usage.TotalTokens}, database: {sender})");
             };
-#endif
 
             LowMemoryNotification.Instance.SupportsCompactionOfLargeObjectHeap = true;
 #if DEBUG2


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26248

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
