### PR TITLE
RavenDB-26138 - failing test `AiAgentClientApiHandleActionCalls.CanHandleToolCallWithArgs`

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
@@ -112,7 +112,30 @@ public class AiAgentClientApiHandleActionCalls : RavenTestBase
 
         await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-        var agent = BuildAgent(config.ConnectionStringName);
+        var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName,
+            @"You are an AI agent of an online shop.
+
+You MUST follow these rules strictly:
+
+1. When the user explicitly instructs to use the tool with a specific query (e.g. 'look for X'), you MUST call the tool with EXACTLY that query.
+2. DO NOT expand, rephrase, or generate alternatives to the query.
+3. DO NOT add synonyms, related terms, or multiple queries.
+4. The 'query' parameter MUST contain ONLY the exact text provided by the user.
+5. Only use the tool when explicitly requested or when needed to search products.
+
+If the user says: look for 'salt'
+You MUST call the tool with:
+{ \""query\"": [\""salt\""] }
+
+Deviation from these rules is not allowed.");
+
+        agent.Actions =
+        [
+            new AiAgentToolAction(ProductSearch,"semantic search the store product catalog")
+            {
+                ParametersSampleObject = "{\"query\": [\"term or phrase to search in the catalog\"]}"
+            }
+        ];
 
         var r  = await store.AI.CreateAgentAsync(agent, new
         {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26138/SlowTests.Server.Documents.AI.AiAgent.AiAgentClientApiHandleActionCalls.CanHandleToolCallWithArgsoptions-DatabaseMode-Single

### Additional description

Fix failing test `SlowTests.Server.Documents.AI.AiAgent.AiAgentClientApiHandleActionCalls.CanHandleToolCallWithArgs(options:  DatabaseMode = Single, config: OpenAi_AiIntegrationTask)`

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
