### PR TITLE
RavenDB-26100 - fix tcpConnectionOptions leak in ShardedIncomingReplicationHandler

### DIFF
--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -50,7 +50,10 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 _sourceShardedDatabaseId = replicatedLastEtag.ShardedDatabaseId;
                 _sourceShardedDatabaseName = ShardHelper.ToDatabaseName(replicatedLastEtag.SourceDatabaseName);
             }
+        }
 
+        internal void Initialize()
+        {
             foreach (var shardNumber in _parent.Context.ShardsTopology.Keys)
             {
                 var node = new ShardReplicationNode { ShardNumber = shardNumber, Database = ShardHelper.ToShardName(_parent.DatabaseName, shardNumber) };
@@ -58,7 +61,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
 
                 _lastSentEtagPerDestination.Add(shardNumber, 0L);
 
-                _handlers[shardNumber] = new ShardedOutgoingReplicationHandler(parent, node, info, replicatedLastEtag.SourceDatabaseId);
+                _handlers[shardNumber] = new ShardedOutgoingReplicationHandler(_parent, node, info, ConnectionInfo.SourceDatabaseId);
                 _handlers[shardNumber].Start();
             }
         }

--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.ReplicationLoader.cs
@@ -87,6 +87,8 @@ namespace Raven.Server.Documents.Sharding
 
                 try
                 {
+                    shardedIncomingHandler.Initialize();
+
                     using (_server.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                     using (var writer = new BlittableJsonTextWriter(context, tcpConnectionOptions.Stream))
                     {


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26100

### Additional description

If there was an exception thrown during the ctor of ShardedIncomingReplicationHandler we would leak a tcpConnectionOptions 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/05594554-1bac-4c6b-bdd3-a25419bb30c4" />
- [ ] Existing tests verify the correct behavior
### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
