### PR TITLE
RavenDB-11532 : Allow to copy Attachment in patches

### DIFF
--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -1098,7 +1098,7 @@ namespace Raven.Server.Documents
             };
         }
 
-        public AttachmentDetailsServer CopyAttachment(DocumentsOperationContext context, string documentId, string name, string destinationId, string destinationName, LazyStringValue changeVector, AttachmentType attachmentType, bool extractCollectionName = false)
+        public AttachmentDetailsServer CopyAttachment(DocumentsOperationContext context, string documentId, string name, string destinationId, string destinationName, LazyStringValue changeVector, AttachmentType attachmentType, bool updateDocument = true, bool extractCollectionName = false)
         {
             if (string.IsNullOrWhiteSpace(documentId))
                 throw new ArgumentException("Argument cannot be null or whitespace.", nameof(documentId));
@@ -1116,7 +1116,7 @@ namespace Raven.Server.Documents
                 AttachmentDoesNotExistException.ThrowFor(documentId, name);
 
             var hash = attachment.Base64Hash.ToString();
-            return PutAttachment(context, destinationId, destinationName, attachment.ContentType, hash, attachment.Size, attachment.RemoteParameters, string.Empty, attachment.Stream, extractCollectionName: extractCollectionName, fromEtl: attachment.RemoteParameters.IsRemoteStorageAttachment());
+            return PutAttachment(context, destinationId, destinationName, attachment.ContentType, hash, attachment.Size, attachment.RemoteParameters, string.Empty, attachment.Stream, updateDocument: updateDocument, extractCollectionName: extractCollectionName, fromEtl: attachment.RemoteParameters.IsRemoteStorageAttachment());
         }
 
         public MoveAttachmentDetailsServer MoveAttachment(DocumentsOperationContext context, string sourceDocumentId, string sourceName, string destinationDocumentId, string destinationName, LazyStringValue changeVector, string hash = null, string contentType = null, bool usePartialKey = true, bool updateDocument = true, bool extractCollectionName = false)

--- a/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
@@ -18,6 +18,7 @@ namespace Raven.Server.Documents.Patch
         public readonly DynamicJsonArray DeleteTimeSeries = new DynamicJsonArray();
         public readonly DynamicJsonArray RemoteAttachments = new DynamicJsonArray();
         public readonly DynamicJsonArray DeleteAttachment = new DynamicJsonArray();
+        public readonly DynamicJsonArray PutAttachment = new DynamicJsonArray();
 
         public DynamicJsonValue GetDebugActions()
         {
@@ -36,7 +37,8 @@ namespace Raven.Server.Documents.Patch
                 [nameof(IncrementTimeSeries)] = new DynamicJsonArray(IncrementTimeSeries.Items),
                 [nameof(DeleteTimeSeries)] = new DynamicJsonArray(DeleteTimeSeries.Items),
                 [nameof(RemoteAttachments)] = new DynamicJsonArray(RemoteAttachments.Items),
-                [nameof(DeleteAttachment)] = new DynamicJsonArray(DeleteAttachment.Items)
+                [nameof(DeleteAttachment)] = new DynamicJsonArray(DeleteAttachment.Items),
+                [nameof(PutAttachment)] = new DynamicJsonArray(PutAttachment.Items)
             };
         }
 
@@ -56,6 +58,7 @@ namespace Raven.Server.Documents.Patch
             DeleteTimeSeries.Clear();
             RemoteAttachments.Clear();
             DeleteAttachment.Clear();
+            PutAttachment.Clear();
         }
     }
 }

--- a/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
+++ b/src/Raven.Server/Documents/Patch/PatchDebugActions.cs
@@ -18,7 +18,7 @@ namespace Raven.Server.Documents.Patch
         public readonly DynamicJsonArray DeleteTimeSeries = new DynamicJsonArray();
         public readonly DynamicJsonArray RemoteAttachments = new DynamicJsonArray();
         public readonly DynamicJsonArray DeleteAttachment = new DynamicJsonArray();
-        public readonly DynamicJsonArray PutAttachment = new DynamicJsonArray();
+        public readonly DynamicJsonArray CopyAttachment = new DynamicJsonArray();
 
         public DynamicJsonValue GetDebugActions()
         {
@@ -38,7 +38,7 @@ namespace Raven.Server.Documents.Patch
                 [nameof(DeleteTimeSeries)] = new DynamicJsonArray(DeleteTimeSeries.Items),
                 [nameof(RemoteAttachments)] = new DynamicJsonArray(RemoteAttachments.Items),
                 [nameof(DeleteAttachment)] = new DynamicJsonArray(DeleteAttachment.Items),
-                [nameof(PutAttachment)] = new DynamicJsonArray(PutAttachment.Items)
+                [nameof(CopyAttachment)] = new DynamicJsonArray(CopyAttachment.Items)
             };
         }
 
@@ -58,7 +58,7 @@ namespace Raven.Server.Documents.Patch
             DeleteTimeSeries.Clear();
             RemoteAttachments.Clear();
             DeleteAttachment.Clear();
-            PutAttachment.Clear();
+            CopyAttachment.Clear();
         }
     }
 }

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -18,12 +18,15 @@ using Jint.Runtime;
 using Jint.Runtime.Descriptors;
 using Jint.Runtime.Interop;
 using Raven.Client;
+using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Indexes.Spatial;
 using Raven.Client.Documents.Operations.TimeSeries;
 using Raven.Client.Documents.Session.TimeSeries;
 using Raven.Client.Exceptions.Documents;
+using Raven.Client.Exceptions.Documents.Attachments;
 using Raven.Client.Exceptions.Documents.Patching;
 using Raven.Client.Exceptions.Sharding;
+using Raven.Client.Extensions;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static.Spatial;
@@ -847,6 +850,7 @@ namespace Raven.Server.Documents.Patch
                 var obj = new JsObject(ScriptEngine);
                 obj.SetClfFunc("remote", (thisObj, values) => RemoteAttachments(thisObj.Get("doc"), thisObj.Get("name"), values));
                 obj.SetClfFunc("delete", (thisObj, values) => DeleteAttachment(thisObj.Get("doc"), thisObj.Get("name")));
+                obj.SetClfFunc("copyFrom", (thisObj, values) => CopyAttachment(thisObj.Get("doc"), thisObj.Get("name"), values));
                 obj.FastSetDataProperty("doc", args[0]);
                 obj.FastSetDataProperty("name", args[1]);
 
@@ -907,6 +911,55 @@ namespace Raven.Server.Documents.Patch
                 }
 
                 return JsValue.Undefined;
+            }
+
+            private JsValue CopyAttachment(JsValue targetDocument, JsValue targetName, JsValue[] args)
+            {
+                const string signature = "attachments(doc, name).copyFrom(sourceDoc, sourceName)";
+                AssertValidDatabaseContext(signature);
+
+                if (args.Length != 2)
+                    throw new ArgumentException($"{signature}: This method requires 2 arguments but was called with {args.Length}");
+
+                var targetId = GetIdFromArg(targetDocument, signature);
+                var destinationName = GetStringArg(targetName, signature, "name");
+
+                var sourceId = GetIdFromArg(args[0], signature);
+                var sourceName = GetStringArg(args[1], signature, "sourceName");
+
+                try
+                {
+                    _database.DocumentsStorage.AttachmentsStorage.CopyAttachment(
+                        _docsCtx,
+                        sourceId,
+                        sourceName,
+                        targetId,
+                        destinationName,
+                        changeVector: null,
+                        attachmentType: AttachmentType.Document,
+                        updateDocument: false);
+                }
+                catch (AttachmentDoesNotExistException)
+                {
+                    return JsBoolean.False;
+                }
+
+                DocumentAttachmentsToUpdate ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                DocumentAttachmentsToUpdate.Add(targetId);
+
+                if (DebugMode)
+                {
+                    DebugActions.PutAttachment.Add(new DynamicJsonValue
+                    {
+                        ["SourceDocId"] = sourceId,
+                        ["SourceName"] = sourceName,
+                        ["DestinationDocId"] = targetId,
+                        ["DestinationName"] = destinationName,
+                        ["Exists"] = true
+                    });
+                }
+
+                return JsBoolean.True;
             }
 
             private void GenericSortTwoElementArray(JsValue[] args, [CallerMemberName] string caller = null)

--- a/src/Raven.Server/Documents/Patch/ScriptRunner.cs
+++ b/src/Raven.Server/Documents/Patch/ScriptRunner.cs
@@ -26,7 +26,6 @@ using Raven.Client.Exceptions.Documents;
 using Raven.Client.Exceptions.Documents.Attachments;
 using Raven.Client.Exceptions.Documents.Patching;
 using Raven.Client.Exceptions.Sharding;
-using Raven.Client.Extensions;
 using Raven.Server.Config;
 using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Indexes.Static.Spatial;
@@ -949,7 +948,7 @@ namespace Raven.Server.Documents.Patch
 
                 if (DebugMode)
                 {
-                    DebugActions.PutAttachment.Add(new DynamicJsonValue
+                    DebugActions.CopyAttachment.Add(new DynamicJsonValue
                     {
                         ["SourceDocId"] = sourceId,
                         ["SourceName"] = sourceName,

--- a/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
+++ b/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using FastTests;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Operations;
 using Raven.Client.Documents.Operations.Attachments;
@@ -18,7 +19,7 @@ namespace SlowTests.Server.Documents.Attachments.Issues
         {
         }
 
-        [RavenFact(RavenTestCategory.Attachments)]
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
         public async Task Can_Copy_Remote_Attachment_In_Patch()
         {
             using var store = GetDocumentStore();
@@ -46,7 +47,13 @@ namespace SlowTests.Server.Documents.Attachments.Issues
 
                 await session.SaveChangesAsync();
             }
-
+            string beforeCopyCv;
+            using (var commands = store.Commands())
+            {
+                dynamic order2Before = await commands.GetAsync("orders/2", true);
+                dynamic beforeMetadata = order2Before["@metadata"];
+                beforeCopyCv = beforeMetadata["@change-vector"]?.ToString();
+            }
             await using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello remote attachment")))
             {
                 await store.Operations.SendAsync(new PutAttachmentOperation("orders/1", "remote-file", ms, "text/plain"));
@@ -140,13 +147,22 @@ namespace SlowTests.Server.Documents.Attachments.Issues
             Assert.NotNull(copied.Details.RemoteParameters);
             Assert.Equal(RemoteAttachmentFlags.Remote, copied.Details.RemoteParameters.Flags);
             Assert.Equal(identifier, copied.Details.RemoteParameters.Identifier);
+            using (var commands = store.Commands())
+            {
+                dynamic order2After = await commands.GetAsync("orders/2", true);
+                dynamic metadataAfter = order2After["@metadata"];
+                var afterCopyCv = metadataAfter["@change-vector"]?.ToString();
+                Assert.NotEqual(beforeCopyCv, afterCopyCv);
+
+                var flags = metadataAfter["@flags"]?.ToString();
+                Assert.Contains("HasAttachments", flags);
+            }
         }
 
-        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_Copy_Attachment_In_Patch(Options options)
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
+        public void Can_Copy_Attachment_In_Patch()
         {
-            using var store = GetDocumentStore(options);
+            using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
             {
@@ -161,6 +177,17 @@ namespace SlowTests.Server.Documents.Attachments.Issues
                 }, "target/1");
 
                 session.SaveChanges();
+            }
+
+            string beforeCopyCv;
+            using (var commands = store.Commands())
+            {
+                dynamic targetBefore = commands.Get("target/1", true);
+                Assert.NotNull(targetBefore);
+
+                dynamic beforeMetadata = targetBefore["@metadata"];
+                Assert.NotNull(beforeMetadata);
+                beforeCopyCv = beforeMetadata["@change-vector"]?.ToString();
             }
 
             using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello from source attachment")))
@@ -192,13 +219,27 @@ namespace SlowTests.Server.Documents.Attachments.Issues
             {
                 Assert.NotNull(sourceResult);
             }
+
+            using (var commands = store.Commands())
+            {
+                dynamic targetAfter = commands.Get("target/1", true);
+                Assert.NotNull(targetAfter);
+                dynamic afterMetadata = targetAfter["@metadata"];
+                Assert.NotNull(afterMetadata);
+
+                var afterCopyCv = afterMetadata["@change-vector"]?.ToString();
+                Assert.NotEqual(beforeCopyCv, afterCopyCv);
+
+                var flags = afterMetadata["@flags"]?.ToString();
+                Assert.Contains("HasAttachments", flags);
+
+            }
         }
 
-        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
-        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
-        public void Can_Copy_Attachment_In_PatchByQuery(Options options)
+        [RavenFact(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
+        public void Can_Copy_Attachment_In_PatchByQuery()
         {
-            using var store = GetDocumentStore(options);
+            using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
             {
@@ -213,6 +254,16 @@ namespace SlowTests.Server.Documents.Attachments.Issues
                 }, "target/1");
 
                 session.SaveChanges();
+            }
+
+            string beforeCopyCv;
+            using (var commands = store.Commands())
+            {
+                dynamic targetBefore = commands.Get("target/1", true);
+                Assert.NotNull(targetBefore);
+                dynamic beforeMetadata = targetBefore["@metadata"];
+                Assert.NotNull(beforeMetadata);
+                beforeCopyCv = beforeMetadata["@change-vector"]?.ToString();
             }
 
             using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("copied by query")))
@@ -238,6 +289,20 @@ update {
 
                 using var reader = new StreamReader(result.Stream);
                 Assert.Equal("copied by query", reader.ReadToEnd());
+
+                using (var commands = store.Commands())
+                {
+                    dynamic targetAfter = commands.Get("target/1", true);
+                    Assert.NotNull(targetAfter);
+                    dynamic afterMetadata = targetAfter["@metadata"];
+                    Assert.NotNull(afterMetadata);
+
+                    var afterCopyCv = afterMetadata["@change-vector"]?.ToString();
+                    Assert.NotEqual(beforeCopyCv, afterCopyCv);
+
+                    var flags = afterMetadata["@flags"]?.ToString();
+                    Assert.Contains("HasAttachments", flags);
+                }
             }
         }
 

--- a/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
+++ b/test/SlowTests/Server/Documents/Attachments/Issues/RavenDB-11532.cs
@@ -1,0 +1,263 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Operations;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Documents.Queries;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.Attachments.Issues
+{
+    public class AttachmentsPatchSlowTests : RemoteAttachmentsS3Base
+    {
+        public AttachmentsPatchSlowTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Attachments)]
+        public async Task Can_Copy_Remote_Attachment_In_Patch()
+        {
+            using var store = GetDocumentStore();
+            await using var holder = CreateCloudSettings();
+
+            var identifier = await PutRemoteAttachmentsConfiguration(store, Settings);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Id = "orders/1",
+                    OrderedAt = new DateTime(2024, 1, 1),
+                    Company = "companies/1",
+                    ShipVia = "shippers/1"
+                });
+
+                await session.StoreAsync(new Order
+                {
+                    Id = "orders/2",
+                    OrderedAt = new DateTime(2024, 1, 1),
+                    Company = "companies/2",
+                    ShipVia = "shippers/2"
+                });
+
+                await session.SaveChangesAsync();
+            }
+
+            await using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello remote attachment")))
+            {
+                await store.Operations.SendAsync(new PutAttachmentOperation("orders/1", "remote-file", ms, "text/plain"));
+            }
+
+            var dt = DateTime.UtcNow.AddMinutes(3);
+
+            var markRemote = new PatchRequest
+            {
+                Script = "attachments(this, args.name).remote(args.identifier, args.at);",
+                Values =
+         {
+             { "name", "remote-file" },
+             { "identifier", identifier },
+             { "at", dt },
+         }
+            };
+
+            var patchResult = await store.Operations.SendAsync(new PatchOperation("orders/1", null, markRemote));
+            Assert.Equal(PatchStatus.Patched, patchResult);
+
+            using (var att = await store.Operations.SendAsync(
+                       new GetAttachmentOperation("orders/1", "remote-file", AttachmentType.Document, null)))
+            {
+                Assert.Equal("remote-file", att.Details.Name);
+                Assert.NotNull(att.Details.RemoteParameters);
+                Assert.Equal(identifier, att.Details.RemoteParameters.Identifier);
+                Assert.Equal(dt, att.Details.RemoteParameters.At);
+            }
+
+            var database = await GetDocumentDatabaseInstanceForAsync(store.Database);
+
+            var isRemote = await WaitForValueAsync(async () =>
+            {
+                database.Time.UtcDateTime = () => DateTime.UtcNow.AddMinutes(10);
+                await database.RemoteAttachmentsSender.ProcessRemoteAttachments(int.MaxValue, int.MaxValue);
+
+                using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+                using (context.OpenReadTransaction())
+                {
+                    var sourceAttachment = database.DocumentsStorage.AttachmentsStorage.GetAttachment(
+                        context,
+                        "orders/1",
+                        "remote-file",
+                        AttachmentType.Document,
+                        null);
+
+                    return sourceAttachment?.RemoteParameters?.Flags == RemoteAttachmentFlags.Remote;
+                }
+            }, true, timeout: 15_000, interval: 1_000);
+
+            Assert.True(isRemote);
+
+            var cloudObjects = await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+            Assert.Single(cloudObjects);
+
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                var sourceAttachment = database.DocumentsStorage.AttachmentsStorage.GetAttachment(
+                    context,
+                    "orders/1",
+                    "remote-file",
+                    AttachmentType.Document,
+                    null);
+
+                Assert.NotNull(sourceAttachment);
+                Assert.NotNull(sourceAttachment.RemoteParameters);
+                Assert.Equal(RemoteAttachmentFlags.Remote, sourceAttachment.RemoteParameters.Flags);
+                Assert.Equal(identifier, sourceAttachment.RemoteParameters.Identifier);
+            }
+
+            store.Operations.Send(new PatchOperation(
+                "orders/2",
+                null,
+                new PatchRequest
+                {
+                    Script = @"attachments(this, 'copied-remote-file').copyFrom('orders/1', 'remote-file');"
+                }));
+
+            var cloudObjectsAfterCopy = await GetBlobsFromCloudAndAssertForCount(Settings, 1, 15_000);
+            Assert.Single(cloudObjectsAfterCopy);
+
+            using var copied = await store.Operations.SendAsync(
+                new GetAttachmentOperation("orders/2", "copied-remote-file", AttachmentType.Document, null));
+
+            Assert.NotNull(copied);
+            Assert.NotNull(copied.Details);
+            Assert.Equal("copied-remote-file", copied.Details.Name);
+            Assert.Equal("text/plain", copied.Details.ContentType);
+            Assert.NotNull(copied.Details.RemoteParameters);
+            Assert.Equal(RemoteAttachmentFlags.Remote, copied.Details.RemoteParameters.Flags);
+            Assert.Equal(identifier, copied.Details.RemoteParameters.Identifier);
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_Copy_Attachment_In_Patch(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new SourceDoc
+                {
+                    Name = "source"
+                }, "source/1");
+
+                session.Store(new TargetDoc
+                {
+                    Name = "target"
+                }, "target/1");
+
+                session.SaveChanges();
+            }
+
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("hello from source attachment")))
+            {
+                store.Operations.Send(new PutAttachmentOperation("source/1", "thumbnail", ms, "text/plain"));
+            }
+
+            store.Operations.Send(new PatchOperation(
+                "target/1",
+                null,
+                new PatchRequest
+                {
+                    Script = @"attachments(this, 'photo').copyFrom('source/1', 'thumbnail');"
+                }));
+
+            using (var result = store.Operations.Send(
+                       new GetAttachmentOperation("target/1", "photo", AttachmentType.Document, null)))
+            {
+                Assert.NotNull(result);
+                Assert.Equal("photo", result.Details.Name);
+                Assert.Equal("text/plain", result.Details.ContentType);
+
+                using var reader = new StreamReader(result.Stream);
+                Assert.Equal("hello from source attachment", reader.ReadToEnd());
+            }
+
+            using (var sourceResult = store.Operations.Send(
+                       new GetAttachmentOperation("source/1", "thumbnail", AttachmentType.Document, null)))
+            {
+                Assert.NotNull(sourceResult);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching | RavenTestCategory.Attachments)]
+        [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+        public void Can_Copy_Attachment_In_PatchByQuery(Options options)
+        {
+            using var store = GetDocumentStore(options);
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new SourceDoc
+                {
+                    Name = "source"
+                }, "source/1");
+
+                session.Store(new TargetDoc
+                {
+                    Name = "target"
+                }, "target/1");
+
+                session.SaveChanges();
+            }
+
+            using (var ms = new MemoryStream(Encoding.UTF8.GetBytes("copied by query")))
+            {
+                store.Operations.Send(new PutAttachmentOperation("source/1", "thumbnail", ms, "text/plain"));
+            }
+
+            var op = store.Operations.Send(new PatchByQueryOperation(new IndexQuery
+            {
+                Query = @"
+from TargetDocs as t
+update {
+    attachments(t, 'photo').copyFrom('source/1', 'thumbnail');
+}"
+            }));
+            op.WaitForCompletion();
+            using (var result = store.Operations.Send(
+                       new GetAttachmentOperation("target/1", "photo", AttachmentType.Document, null)))
+            {
+                Assert.NotNull(result);
+                Assert.Equal("photo", result.Details.Name);
+                Assert.Equal("text/plain", result.Details.ContentType);
+
+                using var reader = new StreamReader(result.Stream);
+                Assert.Equal("copied by query", reader.ReadToEnd());
+            }
+        }
+
+        public class Order
+        {
+            public string Id { get; set; }
+            public string Company { get; set; }
+            public DateTime OrderedAt { get; set; }
+            public string ShipVia { get; set; }
+        }
+        private sealed class SourceDoc
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private sealed class TargetDoc
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-11532/Allow-to-get-add-attachments-in-patches

### Additional description

Added support to copy an attachment with patches

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
