### PR TITLE
RavenDB-26252 add offset and rounding parameters to now() and today() RQL functions

### DIFF
--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -420,10 +420,7 @@ namespace Raven.Client.Documents.Linq
                                         value = RavenDocumentQuery.Now();
                                     return true;
                                 case nameof(RavenQuery.Today):
-                                    if (mce.Arguments.Count > 0 && TryGetMethodArguments(mce, out var todayArgs))
-                                        value = RavenDocumentQuery.Today((string)todayArgs[0]);
-                                    else
-                                        value = RavenDocumentQuery.Today();
+                                    value = RavenDocumentQuery.Today();
                                     return true;
                             }
                         }

--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -414,10 +414,16 @@ namespace Raven.Client.Documents.Linq
                                     value = RavenDocumentQuery.CmpXchg((string)args[0]);
                                     return true;
                                 case nameof(RavenQuery.Now):
-                                    value = RavenDocumentQuery.Now();
+                                    if (mce.Arguments.Count > 0 && TryGetMethodArguments(mce, out var nowArgs))
+                                        value = RavenDocumentQuery.Now((string)nowArgs[0]);
+                                    else
+                                        value = RavenDocumentQuery.Now();
                                     return true;
                                 case nameof(RavenQuery.Today):
-                                    value = RavenDocumentQuery.Today();
+                                    if (mce.Arguments.Count > 0 && TryGetMethodArguments(mce, out var todayArgs))
+                                        value = RavenDocumentQuery.Today((string)todayArgs[0]);
+                                    else
+                                        value = RavenDocumentQuery.Today();
                                     return true;
                             }
                         }

--- a/src/Raven.Client/Documents/Queries/RavenDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenDocumentQuery.cs
@@ -25,7 +25,17 @@ namespace Raven.Client.Documents.Queries
         /// Returns the current UTC date and time on the server, adjusted by the specified offset and floor-rounded
         /// to the smallest precision unit. Translates to the <c>now(offset)</c> RQL function.
         /// </summary>
-        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1d", "-2h30m", "1y6mo").</param>
+        /// <param name="offset">
+        /// A duration string representing the time offset.
+        /// <para>
+        /// Format: <c>[+|-][n]y[n]mo[n]d[n]h[n]m[n]s</c>
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description><c>y, mo, d</c>: Years, Months, Days</description></item>
+        /// <item><description><c>h, m, s</c>: Hours, Minutes, Seconds</description></item>
+        /// </list>
+        /// Examples: <c>"+1y6mo"</c>, <c>"-2h30m"</c>, <c>"15d"</c> (defaults to positive).
+        /// </param>
         /// <example>
         /// <code>
         /// session.Advanced.DocumentQuery&lt;Order&gt;()
@@ -46,18 +56,6 @@ namespace Raven.Client.Documents.Queries
         /// </example>
         public static MethodCall Today() => Time.TodayInstance;
 
-        /// <summary>
-        /// Returns the start of the current UTC day (midnight) on the server, adjusted by the specified offset
-        /// and floor-rounded to the smallest precision unit. Translates to the <c>today(offset)</c> RQL function.
-        /// </summary>
-        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1mo", "-7d", "1y").</param>
-        /// <example>
-        /// <code>
-        /// session.Advanced.DocumentQuery&lt;Order&gt;()
-        ///     .WhereGreaterThanOrEqual(x => x.CreatedAt, RavenDocumentQuery.Today("-1mo"));
-        /// </code>
-        /// </example>
-        public static MethodCall Today(string offset) => new Time(WhereToken.MethodsType.Today, offset);
 
         /// <summary>
         /// Retrieves a compare exchange value by key for use in a query filter. Translates to the <c>cmpxchg()</c> RQL function.

--- a/src/Raven.Client/Documents/Queries/RavenDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenDocumentQuery.cs
@@ -26,15 +26,16 @@ namespace Raven.Client.Documents.Queries
         /// to the smallest precision unit. Translates to the <c>now(offset)</c> RQL function.
         /// </summary>
         /// <param name="offset">
-        /// A duration string representing the time offset.
+        /// A duration string representing the time offset. The result is floor-rounded to the smallest unit specified.
         /// <para>
-        /// Format: <c>[+|-][n]y[n]mo[n]d[n]h[n]m[n]s</c>
+        /// Format: <c>[+|-]Ny[Nmo][Nd][Nh][Nm][Ns]</c> — units must appear in descending order (year to second).
+        /// Not all units are required; only the ones you need. Spaces between components are allowed.
         /// </para>
-        /// <list type="bullet">
-        /// <item><description><c>y, mo, d</c>: Years, Months, Days</description></item>
-        /// <item><description><c>h, m, s</c>: Hours, Minutes, Seconds</description></item>
-        /// </list>
-        /// Examples: <c>"+1y6mo"</c>, <c>"-2h30m"</c>, <c>"15d"</c> (defaults to positive).
+        /// <para>
+        /// Each unit supports aliases:
+        /// <c>[+|-]N(y|year|years)[N(mo|month|months)][N(d|day|days)][N(h|hour|hours)][N(m|min|minute|minutes)][N(s|sec|second|seconds)]</c>
+        /// </para>
+        /// Examples: <c>"+1y6mo"</c>, <c>"-2hours30minutes"</c>, <c>"1 year 6 months"</c>, <c>"15d"</c> (defaults to positive).
         /// </param>
         /// <example>
         /// <code>

--- a/src/Raven.Client/Documents/Queries/RavenDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenDocumentQuery.cs
@@ -22,6 +22,19 @@ namespace Raven.Client.Documents.Queries
         public static MethodCall Now() => Time.NowInstance;
 
         /// <summary>
+        /// Returns the current UTC date and time on the server, adjusted by the specified offset and floor-rounded
+        /// to the smallest precision unit. Translates to the <c>now(offset)</c> RQL function.
+        /// </summary>
+        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1d", "-2h30m", "1y6mo").</param>
+        /// <example>
+        /// <code>
+        /// session.Advanced.DocumentQuery&lt;Order&gt;()
+        ///     .WhereGreaterThan(x => x.CreatedAt, RavenDocumentQuery.Now("-30d"));
+        /// </code>
+        /// </example>
+        public static MethodCall Now(string offset) => new Time(WhereToken.MethodsType.Now, offset);
+
+        /// <summary>
         /// Returns the start of the current UTC day (midnight) on the server. Translates to the <c>today()</c> RQL function.
         /// For use with <c>WhereEquals</c>, <c>WhereGreaterThan</c>, and other DocumentQuery/AsyncDocumentQuery filter methods.
         /// </summary>
@@ -32,6 +45,19 @@ namespace Raven.Client.Documents.Queries
         /// </code>
         /// </example>
         public static MethodCall Today() => Time.TodayInstance;
+
+        /// <summary>
+        /// Returns the start of the current UTC day (midnight) on the server, adjusted by the specified offset
+        /// and floor-rounded to the smallest precision unit. Translates to the <c>today(offset)</c> RQL function.
+        /// </summary>
+        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1mo", "-7d", "1y").</param>
+        /// <example>
+        /// <code>
+        /// session.Advanced.DocumentQuery&lt;Order&gt;()
+        ///     .WhereGreaterThanOrEqual(x => x.CreatedAt, RavenDocumentQuery.Today("-1mo"));
+        /// </code>
+        /// </example>
+        public static MethodCall Today(string offset) => new Time(WhereToken.MethodsType.Today, offset);
 
         /// <summary>
         /// Retrieves a compare exchange value by key for use in a query filter. Translates to the <c>cmpxchg()</c> RQL function.
@@ -58,10 +84,16 @@ namespace Raven.Client.Documents.Queries
 
             public WhereToken.MethodsType MethodType { get; }
 
-            private Time(WhereToken.MethodsType methodType)
+            internal Time(WhereToken.MethodsType methodType)
             {
                 MethodType = methodType;
                 Args = Array.Empty<object>();
+            }
+
+            internal Time(WhereToken.MethodsType methodType, string offset)
+            {
+                MethodType = methodType;
+                Args = new object[] { offset };
             }
         }
     }

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -237,15 +237,16 @@ namespace Raven.Client.Documents.Queries
         /// For use in LINQ queries only. For DocumentQuery and AsyncDocumentQuery, use <see cref="RavenDocumentQuery.Now(string)"/> instead.
         /// </summary>
         /// <param name="offset">
-        /// A duration string representing the time offset.
+        /// A duration string representing the time offset. The result is floor-rounded to the smallest unit specified.
         /// <para>
-        /// Format: <c>[+|-][n]y[n]mo[n]d[n]h[n]m[n]s</c>
+        /// Format: <c>[+|-]Ny[Nmo][Nd][Nh][Nm][Ns]</c> — units must appear in descending order (year to second).
+        /// Not all units are required; only the ones you need. Spaces between components are allowed.
         /// </para>
-        /// <list type="bullet">
-        /// <item><description><c>y, mo, d</c>: Years, Months, Days</description></item>
-        /// <item><description><c>h, m, s</c>: Hours, Minutes, Seconds</description></item>
-        /// </list>
-        /// Examples: <c>"+1y6mo"</c>, <c>"-2h30m"</c>, <c>"15d"</c> (defaults to positive).
+        /// <para>
+        /// Each unit supports aliases:
+        /// <c>[+|-]N(y|year|years)[N(mo|month|months)][N(d|day|days)][N(h|hour|hours)][N(m|min|minute|minutes)][N(s|sec|second|seconds)]</c>
+        /// </para>
+        /// Examples: <c>"+1y6mo"</c>, <c>"-2hours30minutes"</c>, <c>"1 year 6 months"</c>, <c>"15d"</c> (defaults to positive).
         /// </param>
         /// <returns>The adjusted and rounded UTC date and time.</returns>
         /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -232,12 +232,38 @@ namespace Raven.Client.Documents.Queries
         }
 
         /// <summary>
+        /// Returns the current UTC date and time on the server, adjusted by the specified offset and floor-rounded
+        /// to the smallest precision unit. Translates to the <c>now(offset)</c> RQL function.
+        /// For use in LINQ queries only. For DocumentQuery and AsyncDocumentQuery, use <see cref="RavenDocumentQuery.Now(string)"/> instead.
+        /// </summary>
+        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1d", "-2h30m", "1y6mo").</param>
+        /// <returns>The adjusted and rounded UTC date and time.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
+        public static DateTime Now(string offset)
+        {
+            throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
+        }
+
+        /// <summary>
         /// Returns the start of the current UTC day (midnight) on the server. Translates to the <c>today()</c> RQL function.
         /// For use in LINQ queries only. For DocumentQuery and AsyncDocumentQuery, use <see cref="RavenDocumentQuery.Today"/> instead.
         /// </summary>
         /// <returns>The start of the current UTC day.</returns>
         /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static DateTime Today()
+        {
+            throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
+        }
+
+        /// <summary>
+        /// Returns the start of the current UTC day (midnight) on the server, adjusted by the specified offset
+        /// and floor-rounded to the smallest precision unit. Translates to the <c>today(offset)</c> RQL function.
+        /// For use in LINQ queries only. For DocumentQuery and AsyncDocumentQuery, use <see cref="RavenDocumentQuery.Today(string)"/> instead.
+        /// </summary>
+        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1mo", "-7d", "1y").</param>
+        /// <returns>The adjusted and rounded start of the UTC day.</returns>
+        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
+        public static DateTime Today(string offset)
         {
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }

--- a/src/Raven.Client/Documents/Queries/RavenQuery.cs
+++ b/src/Raven.Client/Documents/Queries/RavenQuery.cs
@@ -236,7 +236,17 @@ namespace Raven.Client.Documents.Queries
         /// to the smallest precision unit. Translates to the <c>now(offset)</c> RQL function.
         /// For use in LINQ queries only. For DocumentQuery and AsyncDocumentQuery, use <see cref="RavenDocumentQuery.Now(string)"/> instead.
         /// </summary>
-        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1d", "-2h30m", "1y6mo").</param>
+        /// <param name="offset">
+        /// A duration string representing the time offset.
+        /// <para>
+        /// Format: <c>[+|-][n]y[n]mo[n]d[n]h[n]m[n]s</c>
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description><c>y, mo, d</c>: Years, Months, Days</description></item>
+        /// <item><description><c>h, m, s</c>: Hours, Minutes, Seconds</description></item>
+        /// </list>
+        /// Examples: <c>"+1y6mo"</c>, <c>"-2h30m"</c>, <c>"15d"</c> (defaults to positive).
+        /// </param>
         /// <returns>The adjusted and rounded UTC date and time.</returns>
         /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
         public static DateTime Now(string offset)
@@ -255,18 +265,6 @@ namespace Raven.Client.Documents.Queries
             throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
         }
 
-        /// <summary>
-        /// Returns the start of the current UTC day (midnight) on the server, adjusted by the specified offset
-        /// and floor-rounded to the smallest precision unit. Translates to the <c>today(offset)</c> RQL function.
-        /// For use in LINQ queries only. For DocumentQuery and AsyncDocumentQuery, use <see cref="RavenDocumentQuery.Today(string)"/> instead.
-        /// </summary>
-        /// <param name="offset">Offset string in the format [+|-]NyNmoNdNhNmNs (e.g., "+1mo", "-7d", "1y").</param>
-        /// <returns>The adjusted and rounded start of the UTC day.</returns>
-        /// <exception cref="NotSupportedException">Thrown when called directly in client code.</exception>
-        public static DateTime Today(string offset)
-        {
-            throw new NotSupportedException("This method is here for strongly type support of server side call during Linq queries and should never be directly called");
-        }
 
         /// <summary>
         /// Includes a related document path in the query for loading. This method is for server-side LINQ query translation only.

--- a/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
@@ -119,10 +119,22 @@ namespace Raven.Client.Documents.Session.Tokens
                         writer.Append("cmpxchg(");
                         break;
                     case MethodsType.Now:
-                        writer.Append("now()");
+                        writer.Append("now(");
+                        if (Options.Method.Parameters is { Length: > 0 })
+                        {
+                            writer.Append("$");
+                            writer.Append(Options.Method.Parameters[0]);
+                        }
+                        writer.Append(")");
                         return true;
                     case MethodsType.Today:
-                        writer.Append("today()");
+                        writer.Append("today(");
+                        if (Options.Method.Parameters is { Length: > 0 })
+                        {
+                            writer.Append("$");
+                            writer.Append(Options.Method.Parameters[0]);
+                        }
+                        writer.Append(")");
                         return true;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
+++ b/src/Raven.Client/Documents/Session/Tokens/WhereToken.cs
@@ -128,13 +128,7 @@ namespace Raven.Client.Documents.Session.Tokens
                         writer.Append(")");
                         return true;
                     case MethodsType.Today:
-                        writer.Append("today(");
-                        if (Options.Method.Parameters is { Length: > 0 })
-                        {
-                            writer.Append("$");
-                            writer.Append(Options.Method.Parameters[0]);
-                        }
-                        writer.Append(")");
+                        writer.Append("today()");
                         return true;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4214,7 +4214,7 @@ namespace Raven.Server.Documents.Indexes
 
             CalculateIndexEtagInternal(indexEtagBytes, isStale, State, queryContext, indexContext);
 
-            UseAllDocumentsCounterCmpXchgAndTimeSeriesEtags(queryContext, q, length, indexEtagBytes, queryTime);
+            UseAllDocumentsCounterCmpXchgTimeSeriesAndTimeBasedEtags(queryContext, q, length, indexEtagBytes, queryTime);
 
             unchecked
             {
@@ -4254,14 +4254,14 @@ namespace Raven.Server.Documents.Indexes
             var indexEtagBytes = stackalloc byte[length];
 
             CalculateIndexEtagInternal(indexEtagBytes, isStale, State, queryContext, indexContext);
-            UseAllDocumentsCounterCmpXchgAndTimeSeriesEtags(queryContext, query, length, indexEtagBytes, queryTime);
+            UseAllDocumentsCounterCmpXchgTimeSeriesAndTimeBasedEtags(queryContext, query, length, indexEtagBytes, queryTime);
 
             var writePos = indexEtagBytes + minLength;
 
             return StaticIndexHelper.CalculateIndexEtag(this, length, indexEtagBytes, writePos, queryContext, indexContext, referencedCollectionsDict, collectionsWithCompareExchangeReferences);
         }
 
-        private static unsafe void UseAllDocumentsCounterCmpXchgAndTimeSeriesEtags(QueryOperationContext queryContext, QueryMetadata q, int length, byte* indexEtagBytes, QueryTimeScope queryTime = null)
+        private static unsafe void UseAllDocumentsCounterCmpXchgTimeSeriesAndTimeBasedEtags(QueryOperationContext queryContext, QueryMetadata q, int length, byte* indexEtagBytes, QueryTimeScope queryTime = null)
         {
             if (q == null)
                 return;

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4290,9 +4290,9 @@ namespace Raven.Server.Documents.Indexes
                 *(long*)(indexEtagBytes + pos) = queryTime.Today.Ticks;
             }
 
-            if (q.TimeBasedOffsets is { Count: > 0 })
+            if (q.NowOffsets is { Count: > 0 })
             {
-                foreach (var offset in q.TimeBasedOffsets)
+                foreach (var offset in q.NowOffsets)
                 {
                     pos -= sizeof(long);
                     *(long*)(indexEtagBytes + pos) = offset.Apply(queryTime.Now).Ticks;
@@ -4347,8 +4347,8 @@ namespace Raven.Server.Documents.Indexes
             if (q.HasToday)
                 length += sizeof(long);
 
-            if (q.TimeBasedOffsets is { Count: > 0 })
-                length += sizeof(long) * q.TimeBasedOffsets.Count;
+            if (q.NowOffsets is { Count: > 0 })
+                length += sizeof(long) * q.NowOffsets.Count;
 
             return length;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4290,6 +4290,16 @@ namespace Raven.Server.Documents.Indexes
                 *(long*)(indexEtagBytes + pos) = queryTime.Today.Ticks;
             }
 
+            if (q.TimeBasedOffsets is { Count: > 0 })
+            {
+                foreach (var (offset, isNow) in q.TimeBasedOffsets)
+                {
+                    var baseTime = isNow ? queryTime.Now : queryTime.Today;
+                    pos -= sizeof(long);
+                    *(long*)(indexEtagBytes + pos) = offset.Apply(baseTime).Ticks;
+                }
+            }
+
             if (hasCmpXchg)
             {
                 Debug.Assert(length > sizeof(long) * 5, "The index-etag buffer does not have enough space for last compare exchange index");
@@ -4337,6 +4347,9 @@ namespace Raven.Server.Documents.Indexes
 
             if (q.HasToday)
                 length += sizeof(long);
+
+            if (q.TimeBasedOffsets is { Count: > 0 })
+                length += sizeof(long) * q.TimeBasedOffsets.Count;
 
             return length;
         }

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -4292,11 +4292,10 @@ namespace Raven.Server.Documents.Indexes
 
             if (q.TimeBasedOffsets is { Count: > 0 })
             {
-                foreach (var (offset, isNow) in q.TimeBasedOffsets)
+                foreach (var offset in q.TimeBasedOffsets)
                 {
-                    var baseTime = isNow ? queryTime.Now : queryTime.Today;
                     pos -= sizeof(long);
-                    *(long*)(indexEtagBytes + pos) = offset.Apply(baseTime).Ticks;
+                    *(long*)(indexEtagBytes + pos) = offset.Apply(queryTime.Now).Ticks;
                 }
             }
 

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -622,7 +622,9 @@ namespace Raven.Server.Documents.Queries
             if (TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
                 throw new InvalidQueryException(
                     $"Invalid offset format '{offsetString}' for {method.Name.Value}(). " +
-                    "Expected format: [+|-]NyNmoNdNhNmNs (e.g., '+1d', '-2h30m', '1y6mo').",
+                    "Expected format: [+|-]N(y|year|years)[N(mo|month|months)][N(d|day|days)][N(h|hour|hours)][N(m|min|minute|minutes)][N(s|sec|second|seconds)]. " +
+                    "Units must appear in descending order. Spaces between components are allowed. " +
+                    "Examples: '+1y6mo', '-2hours30minutes', '1 year 6 months', '15d'.",
                     query.QueryText, parameters);
 
             return offset.Apply(baseTime);

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -591,17 +591,41 @@ namespace Raven.Server.Documents.Queries
                     return new ValueExpression(value.ToString(), ValueTokenType.String);
 
                 case MethodType.Now:
-                    if (method.Arguments is { Count: > 0 })
-                        throw new InvalidQueryException("Method now() expects zero arguments.", query.QueryText, parameters);
-                    return new ValueExpression(queryTime.Now.GetDefaultRavenFormat(isUtc: true), ValueTokenType.String);
+                    if (method.Arguments is { Count: > 1 })
+                        throw new InvalidQueryException("Method now() expects zero or one argument.", query.QueryText, parameters);
+                    return new ValueExpression(
+                        ResolveTimeFunction(query, metadata, parameters, method, queryTime.Now).GetDefaultRavenFormat(isUtc: true),
+                        ValueTokenType.String);
 
                 case MethodType.Today:
-                    if (method.Arguments is { Count: > 0 })
-                        throw new InvalidQueryException("Method today() expects zero arguments.", query.QueryText, parameters);
-                    return new ValueExpression(queryTime.Today.GetDefaultRavenFormat(isUtc: true), ValueTokenType.String);
+                    if (method.Arguments is { Count: > 1 })
+                        throw new InvalidQueryException("Method today() expects zero or one argument.", query.QueryText, parameters);
+                    return new ValueExpression(
+                        ResolveTimeFunction(query, metadata, parameters, method, queryTime.Today).GetDefaultRavenFormat(isUtc: true),
+                        ValueTokenType.String);
             }
 
             throw new ArgumentException($"Unknown method {method.Name}");
+        }
+
+        private static DateTime ResolveTimeFunction(Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters, MethodExpression method, DateTime baseTime)
+        {
+            if (method.Arguments is not { Count: 1 })
+                return baseTime;
+
+            var (value, _) = QueryBuilderHelper.GetValue(query, metadata, parameters, method.Arguments[0]);
+            var offsetString = value?.ToString();
+
+            if (string.IsNullOrEmpty(offsetString))
+                throw new InvalidQueryException($"Method {method.Name.Value}() offset argument must be a non-empty string.", query.QueryText, parameters);
+
+            if (TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
+                throw new InvalidQueryException(
+                    $"Invalid offset format '{offsetString}' for {method.Name.Value}(). " +
+                    "Expected format: [+|-]NyNmoNdNhNmNs (e.g., '+1d', '-2h30m', '1y6mo').",
+                    query.QueryText, parameters);
+
+            return offset.Apply(baseTime);
         }
 
         private static IEnumerable<(string Value, ValueTokenType Type)> GetValuesForIn(

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -598,10 +598,10 @@ namespace Raven.Server.Documents.Queries
                         ValueTokenType.String);
 
                 case MethodType.Today:
-                    if (method.Arguments is { Count: > 1 })
-                        throw new InvalidQueryException("Method today() expects zero or one argument.", query.QueryText, parameters);
+                    if (method.Arguments is { Count: > 0 })
+                        throw new InvalidQueryException("Method today() does not accept arguments. Use now() with an offset instead (e.g., now('+1d')).", query.QueryText, parameters);
                     return new ValueExpression(
-                        ResolveTimeFunction(query, metadata, parameters, method, queryTime.Today).GetDefaultRavenFormat(isUtc: true),
+                        queryTime.Today.GetDefaultRavenFormat(isUtc: true),
                         ValueTokenType.String);
             }
 

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -594,7 +594,7 @@ namespace Raven.Server.Documents.Queries
                     if (method.Arguments is { Count: > 1 })
                         throw new InvalidQueryException("Method now() expects zero or one argument.", query.QueryText, parameters);
                     return new ValueExpression(
-                        ResolveTimeFunction(query, metadata, parameters, method, queryTime.Now).GetDefaultRavenFormat(isUtc: true),
+                        QueryBuilderHelper.ResolveTimeFunction(query, metadata, parameters, method, queryTime.Now).GetDefaultRavenFormat(isUtc: true),
                         ValueTokenType.String);
 
                 case MethodType.Today:
@@ -608,27 +608,6 @@ namespace Raven.Server.Documents.Queries
             throw new ArgumentException($"Unknown method {method.Name}");
         }
 
-        private static DateTime ResolveTimeFunction(Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters, MethodExpression method, DateTime baseTime)
-        {
-            if (method.Arguments is not { Count: 1 })
-                return baseTime;
-
-            var (value, _) = QueryBuilderHelper.GetValue(query, metadata, parameters, method.Arguments[0]);
-            var offsetString = value?.ToString();
-
-            if (string.IsNullOrEmpty(offsetString))
-                throw new InvalidQueryException($"Method {method.Name.Value}() offset argument must be a non-empty string.", query.QueryText, parameters);
-
-            if (TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
-                throw new InvalidQueryException(
-                    $"Invalid offset format '{offsetString}' for {method.Name.Value}(). " +
-                    "Expected format: [+|-]N(y|year|years)[N(mo|month|months)][N(d|day|days)][N(h|hour|hours)][N(m|min|minute|minutes)][N(s|sec|second|seconds)]. " +
-                    "Units must appear in descending order. Spaces between components are allowed. " +
-                    "Examples: '+1y6mo', '-2hours30minutes', '1 year 6 months', '15d'.",
-                    query.QueryText, parameters);
-
-            return offset.Apply(baseTime);
-        }
 
         private static IEnumerable<(string Value, ValueTokenType Type)> GetValuesForIn(
             Query query,

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -640,7 +640,7 @@ public static class QueryBuilderHelper
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static DateTime ResolveTimeFunction(Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters, MethodExpression method, DateTime baseTime)
+    internal static DateTime ResolveTimeFunction(Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters, MethodExpression method, DateTime baseTime)
     {
         if (method.Arguments is not { Count: 1 })
             return baseTime;

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -654,7 +654,9 @@ public static class QueryBuilderHelper
         if (TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
             throw new InvalidQueryException(
                 $"Invalid offset format '{offsetString}' for {method.Name.Value}(). " +
-                "Expected format: [+|-]NyNmoNdNhNmNs (e.g., '+1d', '-2h30m', '1y6mo').",
+                "Expected format: [+|-]N(y|year|years)[N(mo|month|months)][N(d|day|days)][N(h|hour|hours)][N(m|min|minute|minutes)][N(s|sec|second|seconds)]. " +
+                    "Units must appear in descending order. Spaces between components are allowed. " +
+                    "Examples: '+1y6mo', '-2hours30minutes', '1 year 6 months', '15d'.",
                 query.QueryText, parameters);
 
         return offset.Apply(baseTime);

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -622,17 +622,42 @@ public static class QueryBuilderHelper
                 return new ValueExpression(value.ToString(), ValueTokenType.String);
 
             case MethodType.Now:
-                if (method.Arguments is { Count: > 0 })
-                    throw new InvalidQueryException("Method now() expects zero arguments.", query.QueryText, parameters);
-                return new ValueExpression(queryTime.Now.GetDefaultRavenFormat(isUtc: true), ValueTokenType.String);
+                if (method.Arguments is { Count: > 1 })
+                    throw new InvalidQueryException("Method now() expects zero or one argument.", query.QueryText, parameters);
+                return new ValueExpression(
+                    ResolveTimeFunction(query, metadata, parameters, method, queryTime.Now).GetDefaultRavenFormat(isUtc: true),
+                    ValueTokenType.String);
 
             case MethodType.Today:
-                if (method.Arguments is { Count: > 0 })
-                    throw new InvalidQueryException("Method today() expects zero arguments.", query.QueryText, parameters);
-                return new ValueExpression(queryTime.Today.GetDefaultRavenFormat(isUtc: true), ValueTokenType.String);
+                if (method.Arguments is { Count: > 1 })
+                    throw new InvalidQueryException("Method today() expects zero or one argument.", query.QueryText, parameters);
+                return new ValueExpression(
+                    ResolveTimeFunction(query, metadata, parameters, method, queryTime.Today).GetDefaultRavenFormat(isUtc: true),
+                    ValueTokenType.String);
         }
 
         throw new ArgumentException($"Unknown method {method.Name}");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static DateTime ResolveTimeFunction(Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters, MethodExpression method, DateTime baseTime)
+    {
+        if (method.Arguments is not { Count: 1 })
+            return baseTime;
+
+        var (value, _) = GetValue(query, metadata, parameters, method.Arguments[0]);
+        var offsetString = value?.ToString();
+
+        if (string.IsNullOrEmpty(offsetString))
+            throw new InvalidQueryException($"Method {method.Name.Value}() offset argument must be a non-empty string.", query.QueryText, parameters);
+
+        if (TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
+            throw new InvalidQueryException(
+                $"Invalid offset format '{offsetString}' for {method.Name.Value}(). " +
+                "Expected format: [+|-]NyNmoNdNhNmNs (e.g., '+1d', '-2h30m', '1y6mo').",
+                query.QueryText, parameters);
+
+        return offset.Apply(baseTime);
     }
 
     internal static string CoraxGetValueAsString(object value) => value switch

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -629,10 +629,10 @@ public static class QueryBuilderHelper
                     ValueTokenType.String);
 
             case MethodType.Today:
-                if (method.Arguments is { Count: > 1 })
-                    throw new InvalidQueryException("Method today() expects zero or one argument.", query.QueryText, parameters);
+                if (method.Arguments is { Count: > 0 })
+                    throw new InvalidQueryException("Method today() does not accept arguments. Use now() with an offset instead (e.g., now('+1d')).", query.QueryText, parameters);
                 return new ValueExpression(
-                    ResolveTimeFunction(query, metadata, parameters, method, queryTime.Today).GetDefaultRavenFormat(isUtc: true),
+                    queryTime.Today.GetDefaultRavenFormat(isUtc: true),
                     ValueTokenType.String);
         }
 

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -235,10 +235,9 @@ function execute(doc, args){
         public bool HasToday;
 
         /// <summary>
-        /// Parsed offsets from now('+1h') / today('+1d') calls. Used for ETag computation.
-        /// Each entry records the offset spec and whether the base is Now or Today.
+        /// Parsed offsets from now('+1h') calls. Used for ETag computation.
         /// </summary>
-        internal List<(TimeFunctionOffset Offset, bool IsNow)> TimeBasedOffsets;
+        internal List<TimeFunctionOffset> TimeBasedOffsets;
 
         public bool HasTimeBasedFunction => HasNow || HasToday || TimeBasedOffsets is { Count: > 0 };
 
@@ -305,23 +304,20 @@ function execute(doc, args){
             }
         }
 
-        internal void TrackTimeBasedOffset(MethodExpression me, bool isNow)
+        internal void TrackTimeBasedOffset(MethodExpression me)
         {
             if (me.Arguments[0] is ValueExpression ve && ve.Value == ValueTokenType.String)
             {
                 if (TimeFunctionOffset.TryParse(ve.Token.Value.AsSpan(), out var offset))
                 {
-                    TimeBasedOffsets ??= new List<(TimeFunctionOffset, bool)>();
-                    TimeBasedOffsets.Add((offset, isNow));
+                    TimeBasedOffsets ??= new List<TimeFunctionOffset>();
+                    TimeBasedOffsets.Add(offset);
                     return;
                 }
             }
 
-            // parameter-based offset or unparseable literal — treat as non-deterministic for now()
-            if (isNow)
-                HasNow = true;
-            else
-                HasToday = true;
+            // parameter-based offset or unparseable literal — treat as non-deterministic
+            HasNow = true;
         }
 
         private void AddExistField(QueryFieldName fieldName, BlittableJsonReaderObject parameters)
@@ -2238,15 +2234,12 @@ function execute(doc, args){
                             break;
                         case MethodType.Now:
                             if (rme.Arguments is { Count: > 0 })
-                                _metadata.TrackTimeBasedOffset(rme, isNow: true);
+                                _metadata.TrackTimeBasedOffset(rme);
                             else
                                 _metadata.HasNow = true;
                             break;
                         case MethodType.Today:
-                            if (rme.Arguments is { Count: > 0 })
-                                _metadata.TrackTimeBasedOffset(rme, isNow: false);
-                            else
-                                _metadata.HasToday = true;
+                            _metadata.HasToday = true;
                             break;
                     }
                 }

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -237,9 +237,9 @@ function execute(doc, args){
         /// <summary>
         /// Parsed offsets from now('+1h') calls. Used for ETag computation.
         /// </summary>
-        internal List<TimeFunctionOffset> TimeBasedOffsets;
+        internal List<TimeFunctionOffset> NowOffsets;
 
-        public bool HasTimeBasedFunction => HasNow || HasToday || TimeBasedOffsets is { Count: > 0 };
+        public bool HasTimeBasedFunction => HasNow || HasToday || NowOffsets is { Count: > 0 };
 
         public bool HasNonDeterministicFunction => HasOrderByRandom || HasNow;
 
@@ -310,8 +310,8 @@ function execute(doc, args){
             {
                 if (TimeFunctionOffset.TryParse(ve.Token.Value.AsSpan(), out var offset))
                 {
-                    TimeBasedOffsets ??= new List<TimeFunctionOffset>();
-                    TimeBasedOffsets.Add(offset);
+                    NowOffsets ??= new List<TimeFunctionOffset>();
+                    NowOffsets.Add(offset);
                     return;
                 }
             }

--- a/src/Raven.Server/Documents/Queries/QueryMetadata.cs
+++ b/src/Raven.Server/Documents/Queries/QueryMetadata.cs
@@ -234,7 +234,13 @@ function execute(doc, args){
 
         public bool HasToday;
 
-        public bool HasTimeBasedFunction => HasNow || HasToday;
+        /// <summary>
+        /// Parsed offsets from now('+1h') / today('+1d') calls. Used for ETag computation.
+        /// Each entry records the offset spec and whether the base is Now or Today.
+        /// </summary>
+        internal List<(TimeFunctionOffset Offset, bool IsNow)> TimeBasedOffsets;
+
+        public bool HasTimeBasedFunction => HasNow || HasToday || TimeBasedOffsets is { Count: > 0 };
 
         public bool HasNonDeterministicFunction => HasOrderByRandom || HasNow;
 
@@ -297,6 +303,25 @@ function execute(doc, args){
                 }
                 return _queryData;
             }
+        }
+
+        internal void TrackTimeBasedOffset(MethodExpression me, bool isNow)
+        {
+            if (me.Arguments[0] is ValueExpression ve && ve.Value == ValueTokenType.String)
+            {
+                if (TimeFunctionOffset.TryParse(ve.Token.Value.AsSpan(), out var offset))
+                {
+                    TimeBasedOffsets ??= new List<(TimeFunctionOffset, bool)>();
+                    TimeBasedOffsets.Add((offset, isNow));
+                    return;
+                }
+            }
+
+            // parameter-based offset or unparseable literal — treat as non-deterministic for now()
+            if (isNow)
+                HasNow = true;
+            else
+                HasToday = true;
         }
 
         private void AddExistField(QueryFieldName fieldName, BlittableJsonReaderObject parameters)
@@ -2212,10 +2237,16 @@ function execute(doc, args){
                             _metadata.HasCmpXchg = true;
                             break;
                         case MethodType.Now:
-                            _metadata.HasNow = true;
+                            if (rme.Arguments is { Count: > 0 })
+                                _metadata.TrackTimeBasedOffset(rme, isNow: true);
+                            else
+                                _metadata.HasNow = true;
                             break;
                         case MethodType.Today:
-                            _metadata.HasToday = true;
+                            if (rme.Arguments is { Count: > 0 })
+                                _metadata.TrackTimeBasedOffset(rme, isNow: false);
+                            else
+                                _metadata.HasToday = true;
                             break;
                     }
                 }

--- a/src/Raven.Server/Documents/Queries/TimeFunctionOffset.cs
+++ b/src/Raven.Server/Documents/Queries/TimeFunctionOffset.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Raven.Server.Documents.Queries;
 
-internal enum DateTimePrecision : byte
+internal enum DateTimePrecision
 {
     None = 0,
     Year = 1,
@@ -14,11 +14,6 @@ internal enum DateTimePrecision : byte
     Second = 6
 }
 
-/// <summary>
-/// Parses and applies time offsets for now()/today() RQL functions.
-/// Format: [+|-]NyNmoNdNhNmNs (e.g., "+1y7mo5d4h5m7s", "-1d", "1h30m")
-/// The result is floor-rounded to the smallest precision unit specified.
-/// </summary>
 internal readonly struct TimeFunctionOffset
 {
     public readonly int Years;
@@ -45,136 +40,125 @@ internal readonly struct TimeFunctionOffset
     public static bool TryParse(ReadOnlySpan<char> input, out TimeFunctionOffset result)
     {
         result = default;
-
-        if (input.IsEmpty)
-            return false;
+        input = input.Trim();
+        if (input.IsEmpty) return false;
 
         int pos = 0;
         bool isNegative = false;
 
-        // consume optional sign
-        if (input[pos] == '+')
-        {
-            pos++;
-        }
-        else if (input[pos] == '-')
+        // 1. Consume optional sign
+        if (input[pos] == '-')
         {
             isNegative = true;
             pos++;
         }
-
-        if (pos >= input.Length)
-            return false;
+        else if (input[pos] == '+')
+        {
+            pos++;
+        }
 
         int years = 0, months = 0, days = 0, hours = 0, minutes = 0, seconds = 0;
-        var smallestUnit = DateTimePrecision.None;
-        bool hasAnyUnit = false;
+        DateTimePrecision lastUnit = DateTimePrecision.None;
 
         while (pos < input.Length)
         {
-            // parse numeric value
-            int numStart = pos;
-            int value = 0;
+            // Skip whitespace before numbers
+            while (pos < input.Length && char.IsWhiteSpace(input[pos])) pos++;
+            if (pos >= input.Length) break;
 
-            while (pos < input.Length && IsDigit(input[pos]))
+            // 2. Parse numeric value (stepping)
+            if (TryParseStep(input.Slice(pos), out long value, out int numConsumed) == false)
+                return false;
+
+            pos += numConsumed;
+
+            // Skip whitespace between number and unit
+            while (pos < input.Length && char.IsWhiteSpace(input[pos])) pos++;
+            if (pos >= input.Length) return false; // Digits without a unit suffix
+
+            // 3. Parse unit suffix
+            if (TryMatchUnit(input.Slice(pos), out DateTimePrecision currentUnit, out int unitConsumed) == false)
+                return false;
+
+            // 4. Enforce strict ordering (e.g., cannot have 'days' before 'years')
+            if (currentUnit <= lastUnit) return false;
+
+            switch (currentUnit)
             {
-                value = value * 10 + (input[pos] - '0');
-                pos++;
+                case DateTimePrecision.Year: years = (int)value; break;
+                case DateTimePrecision.Month: months = (int)value; break;
+                case DateTimePrecision.Day: days = (int)value; break;
+                case DateTimePrecision.Hour: hours = (int)value; break;
+                case DateTimePrecision.Minute: minutes = (int)value; break;
+                case DateTimePrecision.Second: seconds = (int)value; break;
             }
 
-            if (pos == numStart || pos >= input.Length)
-                return false; // no digits found or no unit suffix
-
-            // parse unit suffix
-            char unit = input[pos];
-            switch (unit)
-            {
-                case 'y':
-                case 'Y':
-                    years = value;
-                    pos++;
-                    if (smallestUnit < DateTimePrecision.Year)
-                        smallestUnit = DateTimePrecision.Year;
-                    break;
-
-                case 'm':
-                case 'M':
-                    // lookahead: 'mo' = months, bare 'm' = minutes
-                    if (pos + 1 < input.Length && (input[pos + 1] == 'o' || input[pos + 1] == 'O'))
-                    {
-                        months = value;
-                        pos += 2;
-                        if (smallestUnit < DateTimePrecision.Month)
-                            smallestUnit = DateTimePrecision.Month;
-                    }
-                    else
-                    {
-                        minutes = value;
-                        pos++;
-                        if (smallestUnit < DateTimePrecision.Minute)
-                            smallestUnit = DateTimePrecision.Minute;
-                    }
-                    break;
-
-                case 'd':
-                case 'D':
-                    days = value;
-                    pos++;
-                    if (smallestUnit < DateTimePrecision.Day)
-                        smallestUnit = DateTimePrecision.Day;
-                    break;
-
-                case 'h':
-                case 'H':
-                    hours = value;
-                    pos++;
-                    if (smallestUnit < DateTimePrecision.Hour)
-                        smallestUnit = DateTimePrecision.Hour;
-                    break;
-
-                case 's':
-                case 'S':
-                    seconds = value;
-                    pos++;
-                    if (smallestUnit < DateTimePrecision.Second)
-                        smallestUnit = DateTimePrecision.Second;
-                    break;
-
-                default:
-                    return false; // unknown unit
-            }
-
-            hasAnyUnit = true;
+            lastUnit = currentUnit;
+            pos += unitConsumed;
         }
 
-        if (hasAnyUnit == false)
-            return false;
+        if (lastUnit == DateTimePrecision.None) return false;
 
-        result = new TimeFunctionOffset(years, months, days, hours, minutes, seconds, isNegative, smallestUnit);
+        result = new TimeFunctionOffset(years, months, days, hours, minutes, seconds, isNegative, lastUnit);
         return true;
     }
 
-    /// <summary>
-    /// Applies the offset to the base time and floor-rounds to the smallest precision unit.
-    /// </summary>
+    private static bool TryParseStep(ReadOnlySpan<char> source, out long value, out int charsConsumed)
+    {
+        charsConsumed = 0;
+        while (charsConsumed < source.Length && char.IsDigit(source[charsConsumed]))
+            charsConsumed++;
+
+        if (charsConsumed == 0)
+        {
+            value = 0;
+            return false;
+        }
+
+        return long.TryParse(source.Slice(0, charsConsumed), out value);
+    }
+
+    private static bool TryMatchUnit(ReadOnlySpan<char> input, out DateTimePrecision unit, out int consumed)
+    {
+        unit = DateTimePrecision.None;
+        consumed = 0;
+
+        // Longest strings first to avoid greedy matching errors (e.g., 'm' matching 'month')
+        if (StartsWith(input, out consumed, "years", "year", "y")) unit = DateTimePrecision.Year;
+        else if (StartsWith(input, out consumed, "months", "month", "mo")) unit = DateTimePrecision.Month;
+        else if (StartsWith(input, out consumed, "days", "day", "d")) unit = DateTimePrecision.Day;
+        else if (StartsWith(input, out consumed, "hours", "hour", "h")) unit = DateTimePrecision.Hour;
+        else if (StartsWith(input, out consumed, "minutes", "minute", "min", "m")) unit = DateTimePrecision.Minute;
+        else if (StartsWith(input, out consumed, "seconds", "second", "sec", "s")) unit = DateTimePrecision.Second;
+
+        return unit != DateTimePrecision.None;
+    }
+
+    private static bool StartsWith(ReadOnlySpan<char> input, out int length, params string[] options)
+    {
+        foreach (var opt in options)
+        {
+            if (input.StartsWith(opt, StringComparison.OrdinalIgnoreCase))
+            {
+                length = opt.Length;
+                return true;
+            }
+        }
+        length = 0;
+        return false;
+    }
+
     public DateTime Apply(DateTime baseTime)
     {
         int sign = IsNegative ? -1 : 1;
-
         var result = baseTime;
 
-        if (Years != 0)
-            result = result.AddYears(Years * sign);
-        if (Months != 0)
-            result = result.AddMonths(Months * sign);
-        if (Days != 0)
-            result = result.AddDays(Days * sign);
-        if (Hours != 0)
-            result = result.AddHours(Hours * sign);
-        if (Minutes != 0)
-            result = result.AddMinutes(Minutes * sign);
-        if (Seconds != 0)
-            result = result.AddSeconds(Seconds * sign);
+        if (Years != 0) result = result.AddYears(Years * sign);
+        if (Months != 0) result = result.AddMonths(Months * sign);
+        if (Days != 0) result = result.AddDays(Days * sign);
+        if (Hours != 0) result = result.AddHours(Hours * sign);
+        if (Minutes != 0) result = result.AddMinutes(Minutes * sign);
+        if (Seconds != 0) result = result.AddSeconds(Seconds * sign);
 
         return FloorTo(result, SmallestUnit);
     }
@@ -193,7 +177,4 @@ internal readonly struct TimeFunctionOffset
             _ => dt
         };
     }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsDigit(char c) => (uint)(c - '0') <= 9;
 }

--- a/src/Raven.Server/Documents/Queries/TimeFunctionOffset.cs
+++ b/src/Raven.Server/Documents/Queries/TimeFunctionOffset.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Raven.Server.Documents.Queries;
+
+internal enum DateTimePrecision : byte
+{
+    None = 0,
+    Year = 1,
+    Month = 2,
+    Day = 3,
+    Hour = 4,
+    Minute = 5,
+    Second = 6
+}
+
+/// <summary>
+/// Parses and applies time offsets for now()/today() RQL functions.
+/// Format: [+|-]NyNmoNdNhNmNs (e.g., "+1y7mo5d4h5m7s", "-1d", "1h30m")
+/// The result is floor-rounded to the smallest precision unit specified.
+/// </summary>
+internal readonly struct TimeFunctionOffset
+{
+    public readonly int Years;
+    public readonly int Months;
+    public readonly int Days;
+    public readonly int Hours;
+    public readonly int Minutes;
+    public readonly int Seconds;
+    public readonly bool IsNegative;
+    public readonly DateTimePrecision SmallestUnit;
+
+    private TimeFunctionOffset(int years, int months, int days, int hours, int minutes, int seconds, bool isNegative, DateTimePrecision smallestUnit)
+    {
+        Years = years;
+        Months = months;
+        Days = days;
+        Hours = hours;
+        Minutes = minutes;
+        Seconds = seconds;
+        IsNegative = isNegative;
+        SmallestUnit = smallestUnit;
+    }
+
+    public static bool TryParse(ReadOnlySpan<char> input, out TimeFunctionOffset result)
+    {
+        result = default;
+
+        if (input.IsEmpty)
+            return false;
+
+        int pos = 0;
+        bool isNegative = false;
+
+        // consume optional sign
+        if (input[pos] == '+')
+        {
+            pos++;
+        }
+        else if (input[pos] == '-')
+        {
+            isNegative = true;
+            pos++;
+        }
+
+        if (pos >= input.Length)
+            return false;
+
+        int years = 0, months = 0, days = 0, hours = 0, minutes = 0, seconds = 0;
+        var smallestUnit = DateTimePrecision.None;
+        bool hasAnyUnit = false;
+
+        while (pos < input.Length)
+        {
+            // parse numeric value
+            int numStart = pos;
+            int value = 0;
+
+            while (pos < input.Length && IsDigit(input[pos]))
+            {
+                value = value * 10 + (input[pos] - '0');
+                pos++;
+            }
+
+            if (pos == numStart || pos >= input.Length)
+                return false; // no digits found or no unit suffix
+
+            // parse unit suffix
+            char unit = input[pos];
+            switch (unit)
+            {
+                case 'y':
+                case 'Y':
+                    years = value;
+                    pos++;
+                    if (smallestUnit < DateTimePrecision.Year)
+                        smallestUnit = DateTimePrecision.Year;
+                    break;
+
+                case 'm':
+                case 'M':
+                    // lookahead: 'mo' = months, bare 'm' = minutes
+                    if (pos + 1 < input.Length && (input[pos + 1] == 'o' || input[pos + 1] == 'O'))
+                    {
+                        months = value;
+                        pos += 2;
+                        if (smallestUnit < DateTimePrecision.Month)
+                            smallestUnit = DateTimePrecision.Month;
+                    }
+                    else
+                    {
+                        minutes = value;
+                        pos++;
+                        if (smallestUnit < DateTimePrecision.Minute)
+                            smallestUnit = DateTimePrecision.Minute;
+                    }
+                    break;
+
+                case 'd':
+                case 'D':
+                    days = value;
+                    pos++;
+                    if (smallestUnit < DateTimePrecision.Day)
+                        smallestUnit = DateTimePrecision.Day;
+                    break;
+
+                case 'h':
+                case 'H':
+                    hours = value;
+                    pos++;
+                    if (smallestUnit < DateTimePrecision.Hour)
+                        smallestUnit = DateTimePrecision.Hour;
+                    break;
+
+                case 's':
+                case 'S':
+                    seconds = value;
+                    pos++;
+                    if (smallestUnit < DateTimePrecision.Second)
+                        smallestUnit = DateTimePrecision.Second;
+                    break;
+
+                default:
+                    return false; // unknown unit
+            }
+
+            hasAnyUnit = true;
+        }
+
+        if (hasAnyUnit == false)
+            return false;
+
+        result = new TimeFunctionOffset(years, months, days, hours, minutes, seconds, isNegative, smallestUnit);
+        return true;
+    }
+
+    /// <summary>
+    /// Applies the offset to the base time and floor-rounds to the smallest precision unit.
+    /// </summary>
+    public DateTime Apply(DateTime baseTime)
+    {
+        int sign = IsNegative ? -1 : 1;
+
+        var result = baseTime;
+
+        if (Years != 0)
+            result = result.AddYears(Years * sign);
+        if (Months != 0)
+            result = result.AddMonths(Months * sign);
+        if (Days != 0)
+            result = result.AddDays(Days * sign);
+        if (Hours != 0)
+            result = result.AddHours(Hours * sign);
+        if (Minutes != 0)
+            result = result.AddMinutes(Minutes * sign);
+        if (Seconds != 0)
+            result = result.AddSeconds(Seconds * sign);
+
+        return FloorTo(result, SmallestUnit);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static DateTime FloorTo(DateTime dt, DateTimePrecision precision)
+    {
+        return precision switch
+        {
+            DateTimePrecision.Year => new DateTime(dt.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            DateTimePrecision.Month => new DateTime(dt.Year, dt.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+            DateTimePrecision.Day => new DateTime(dt.Year, dt.Month, dt.Day, 0, 0, 0, DateTimeKind.Utc),
+            DateTimePrecision.Hour => new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, 0, 0, DateTimeKind.Utc),
+            DateTimePrecision.Minute => new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, 0, DateTimeKind.Utc),
+            DateTimePrecision.Second => new DateTime(dt.Year, dt.Month, dt.Day, dt.Hour, dt.Minute, dt.Second, DateTimeKind.Utc),
+            _ => dt
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDigit(char c) => (uint)(c - '0') <= 9;
+}

--- a/src/Raven.Server/Documents/Queries/TimeFunctionOffset.cs
+++ b/src/Raven.Server/Documents/Queries/TimeFunctionOffset.cs
@@ -124,17 +124,17 @@ internal readonly struct TimeFunctionOffset
         consumed = 0;
 
         // Longest strings first to avoid greedy matching errors (e.g., 'm' matching 'month')
-        if (StartsWith(input, out consumed, "years", "year", "y")) unit = DateTimePrecision.Year;
-        else if (StartsWith(input, out consumed, "months", "month", "mo")) unit = DateTimePrecision.Month;
-        else if (StartsWith(input, out consumed, "days", "day", "d")) unit = DateTimePrecision.Day;
-        else if (StartsWith(input, out consumed, "hours", "hour", "h")) unit = DateTimePrecision.Hour;
-        else if (StartsWith(input, out consumed, "minutes", "minute", "min", "m")) unit = DateTimePrecision.Minute;
-        else if (StartsWith(input, out consumed, "seconds", "second", "sec", "s")) unit = DateTimePrecision.Second;
+        if (StartsWith(input, out consumed, ["years", "year", "y"])) unit = DateTimePrecision.Year;
+        else if (StartsWith(input, out consumed, ["months", "month", "mo"])) unit = DateTimePrecision.Month;
+        else if (StartsWith(input, out consumed, ["days", "day", "d"])) unit = DateTimePrecision.Day;
+        else if (StartsWith(input, out consumed, ["hours", "hour", "h"])) unit = DateTimePrecision.Hour;
+        else if (StartsWith(input, out consumed, ["minutes", "minute", "min", "m"])) unit = DateTimePrecision.Minute;
+        else if (StartsWith(input, out consumed, ["seconds", "second", "sec", "s"])) unit = DateTimePrecision.Second;
 
         return unit != DateTimePrecision.None;
     }
 
-    private static bool StartsWith(ReadOnlySpan<char> input, out int length, params string[] options)
+    private static bool StartsWith(ReadOnlySpan<char> input, out int length, ReadOnlySpan<string> options)
     {
         foreach (var opt in options)
         {

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -519,8 +519,15 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             {
                 var offsetString = GetOffsetString(me.Arguments[0]);
 
-                if (string.IsNullOrEmpty(offsetString) || TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
-                    throw new InvalidQueryException($"Invalid offset format for {me.Name.Value}().");
+                if (string.IsNullOrEmpty(offsetString))
+                    throw new InvalidQueryException($"Method {me.Name.Value}() offset argument must be a non-empty string.");
+
+                if (TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
+                    throw new InvalidQueryException(
+                        $"Invalid offset format '{offsetString}' for {me.Name.Value}(). " +
+                        "Expected format: [+|-]N(y|year|years)[N(mo|month|months)][N(d|day|days)][N(h|hour|hours)][N(m|min|minute|minutes)][N(s|sec|second|seconds)]. " +
+                        "Units must appear in descending order. Spaces between components are allowed. " +
+                        "Examples: '+1y6mo', '-2hours30minutes', '1 year 6 months', '15d'.");
 
                 resolved = offset.Apply(_now);
             }
@@ -567,6 +574,8 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
                 return context.ResolveNow(me);
 
             case MethodExpression me when me.Name.Value.Equals("today", StringComparison.OrdinalIgnoreCase):
+                if (me.Arguments is { Count: > 0 })
+                    throw new InvalidQueryException("Method today() does not accept arguments. Use now() with an offset instead (e.g., now('+1d')).");
                 return context.ResolveToday();
 
             case BinaryExpression be:

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -511,9 +511,8 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             _queryParameters = queryParameters;
         }
 
-        public ValueExpression ResolveTimeFunction(MethodExpression me, bool isNow)
+        public ValueExpression ResolveNow(MethodExpression me)
         {
-            var baseTime = isNow ? _now : _today;
             DateTime resolved;
 
             if (me.Arguments is { Count: 1 })
@@ -523,15 +522,22 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
                 if (string.IsNullOrEmpty(offsetString) || TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
                     throw new InvalidQueryException($"Invalid offset format for {me.Name.Value}().");
 
-                resolved = offset.Apply(baseTime);
+                resolved = offset.Apply(_now);
             }
             else
             {
-                resolved = baseTime;
+                resolved = _now;
             }
 
-            var token = $"__raven_{(isNow ? "now" : "today")}_{_counter++}";
+            var token = $"__raven_now_{_counter++}";
             ResolvedParameters.Add((token, resolved.GetDefaultRavenFormat(isUtc: true)));
+            return new ValueExpression(token, ValueTokenType.Parameter);
+        }
+
+        public ValueExpression ResolveToday()
+        {
+            var token = $"__raven_today_{_counter++}";
+            ResolvedParameters.Add((token, _today.GetDefaultRavenFormat(isUtc: true)));
             return new ValueExpression(token, ValueTokenType.Parameter);
         }
 
@@ -558,10 +564,10 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         switch (expr)
         {
             case MethodExpression me when me.Name.Value.Equals("now", StringComparison.OrdinalIgnoreCase):
-                return context.ResolveTimeFunction(me, isNow: true);
+                return context.ResolveNow(me);
 
             case MethodExpression me when me.Name.Value.Equals("today", StringComparison.OrdinalIgnoreCase):
-                return context.ResolveTimeFunction(me, isNow: false);
+                return context.ResolveToday();
 
             case BinaryExpression be:
                 var newLeft = ReplaceTimeBasedFunctions(be.Left, context);

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Session.Loaders;
 using Raven.Client.Documents.Session.Tokens;
+using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Documents.Indexes;
 using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Extensions;
@@ -40,8 +41,6 @@ namespace Raven.Server.Documents.Sharding.Queries;
 public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombinedResult> where TCommand : RavenCommand<TResult>
 {
     private const string LimitToken = "__raven_limit";
-    private const string NowToken = "__raven_now";
-    private const string TodayToken = "__raven_today";
 
     private Dictionary<int, BlittableJsonReaderObject> _queryTemplates;
     private Dictionary<int, TCommand> _commands;
@@ -448,35 +447,33 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             // In sharded queries, each shard resolves now()/today() independently, which can lead to
             // slightly different values across shards. We resolve them once on the orchestrator and
             // replace the function calls with query parameters to ensure consistency.
-            var usedFunctions = TimeBasedFunction.None;
+            var now = DateTime.UtcNow;
+            queryTemplate.TryGet(nameof(IndexQuery.QueryParameters), out BlittableJsonReaderObject existingArgs);
+            var rewriteContext = new TimeBasedRewriteContext(now, existingArgs);
 
             if (clone.Where != null)
-                clone.Where = ReplaceTimeBasedFunctions(clone.Where, ref usedFunctions);
+                clone.Where = ReplaceTimeBasedFunctions(clone.Where, rewriteContext);
 
             if (clone.Filter != null)
-                clone.Filter = ReplaceTimeBasedFunctions(clone.Filter, ref usedFunctions);
+                clone.Filter = ReplaceTimeBasedFunctions(clone.Filter, rewriteContext);
 
-            if (usedFunctions != TimeBasedFunction.None)
+            if (rewriteContext.ResolvedParameters.Count > 0)
             {
-                var now = DateTime.UtcNow;
                 QueryTime = now;
 
                 DynamicJsonValue modifiedArgs;
-                if (queryTemplate.TryGet(nameof(IndexQuery.QueryParameters), out BlittableJsonReaderObject args) && args != null)
+                if (existingArgs != null)
                 {
-                    modifiedArgs = new DynamicJsonValue(args);
-                    args.Modifications = modifiedArgs;
+                    modifiedArgs = new DynamicJsonValue(existingArgs);
+                    existingArgs.Modifications = modifiedArgs;
                 }
                 else
                 {
                     modifications[nameof(IndexQuery.QueryParameters)] = modifiedArgs = new DynamicJsonValue();
                 }
 
-                if (usedFunctions.HasFlag(TimeBasedFunction.Now))
-                    modifiedArgs[NowToken] = now.GetDefaultRavenFormat(isUtc: true);
-
-                if (usedFunctions.HasFlag(TimeBasedFunction.Today))
-                    modifiedArgs[TodayToken] = now.Date.GetDefaultRavenFormat(isUtc: true);
+                foreach (var (token, resolvedValue) in rewriteContext.ResolvedParameters)
+                    modifiedArgs[token] = resolvedValue;
             }
         }
 
@@ -498,21 +495,77 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         }
     }
 
-    private static QueryExpression ReplaceTimeBasedFunctions(QueryExpression expr, ref TimeBasedFunction usedFunctions)
+    private sealed class TimeBasedRewriteContext
+    {
+        private readonly DateTime _now;
+        private readonly DateTime _today;
+        private readonly BlittableJsonReaderObject _queryParameters;
+        private int _counter;
+
+        public readonly List<(string Token, string Value)> ResolvedParameters = new();
+
+        public TimeBasedRewriteContext(DateTime now, BlittableJsonReaderObject queryParameters)
+        {
+            _now = now;
+            _today = now.Date;
+            _queryParameters = queryParameters;
+        }
+
+        public ValueExpression ResolveTimeFunction(MethodExpression me, bool isNow)
+        {
+            var baseTime = isNow ? _now : _today;
+            DateTime resolved;
+
+            if (me.Arguments is { Count: 1 })
+            {
+                var offsetString = GetOffsetString(me.Arguments[0]);
+
+                if (string.IsNullOrEmpty(offsetString) || TimeFunctionOffset.TryParse(offsetString.AsSpan(), out var offset) == false)
+                    throw new InvalidQueryException($"Invalid offset format for {me.Name.Value}().");
+
+                resolved = offset.Apply(baseTime);
+            }
+            else
+            {
+                resolved = baseTime;
+            }
+
+            var token = $"__raven_{(isNow ? "now" : "today")}_{_counter++}";
+            ResolvedParameters.Add((token, resolved.GetDefaultRavenFormat(isUtc: true)));
+            return new ValueExpression(token, ValueTokenType.Parameter);
+        }
+
+        private string GetOffsetString(QueryExpression arg)
+        {
+            if (arg is ValueExpression ve)
+            {
+                if (ve.Value == ValueTokenType.String)
+                    return ve.Token.Value;
+
+                if (ve.Value == ValueTokenType.Parameter && _queryParameters != null)
+                {
+                    if (_queryParameters.TryGetMember(ve.Token.Value, out var paramValue))
+                        return paramValue?.ToString();
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private static QueryExpression ReplaceTimeBasedFunctions(QueryExpression expr, TimeBasedRewriteContext context)
     {
         switch (expr)
         {
             case MethodExpression me when me.Name.Value.Equals("now", StringComparison.OrdinalIgnoreCase):
-                usedFunctions |= TimeBasedFunction.Now;
-                return new ValueExpression(NowToken, ValueTokenType.Parameter);
+                return context.ResolveTimeFunction(me, isNow: true);
 
             case MethodExpression me when me.Name.Value.Equals("today", StringComparison.OrdinalIgnoreCase):
-                usedFunctions |= TimeBasedFunction.Today;
-                return new ValueExpression(TodayToken, ValueTokenType.Parameter);
+                return context.ResolveTimeFunction(me, isNow: false);
 
             case BinaryExpression be:
-                var newLeft = ReplaceTimeBasedFunctions(be.Left, ref usedFunctions);
-                var newRight = ReplaceTimeBasedFunctions(be.Right, ref usedFunctions);
+                var newLeft = ReplaceTimeBasedFunctions(be.Left, context);
+                var newRight = ReplaceTimeBasedFunctions(be.Right, context);
 
                 if (ReferenceEquals(newLeft, be.Left) && ReferenceEquals(newRight, be.Right))
                     return be;
@@ -520,7 +573,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
                 return new BinaryExpression(newLeft, newRight, be.Operator) { Parenthesis = be.Parenthesis };
 
             case NegatedExpression ne:
-                var newInner = ReplaceTimeBasedFunctions(ne.Expression, ref usedFunctions);
+                var newInner = ReplaceTimeBasedFunctions(ne.Expression, context);
 
                 if (ReferenceEquals(newInner, ne.Expression))
                     return ne;
@@ -533,7 +586,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
 
                 foreach (var arg in me.Arguments)
                 {
-                    var newArg = ReplaceTimeBasedFunctions(arg, ref usedFunctions);
+                    var newArg = ReplaceTimeBasedFunctions(arg, context);
                     if (ReferenceEquals(newArg, arg) == false)
                         changed = true;
                     newArgs.Add(newArg);
@@ -550,7 +603,7 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
 
                 foreach (var val in ie.Values)
                 {
-                    var newVal = ReplaceTimeBasedFunctions(val, ref usedFunctions);
+                    var newVal = ReplaceTimeBasedFunctions(val, context);
                     if (ReferenceEquals(newVal, val) == false)
                         valuesChanged = true;
                     newValues.Add(newVal);
@@ -995,13 +1048,6 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         RewriteTimeBasedFunctions = 1 << 7
     }
 
-    [Flags]
-    private enum TimeBasedFunction
-    {
-        None = 0,
-        Now = 1 << 0,
-        Today = 1 << 1
-    }
 
     protected enum QueryType
     {

--- a/test/FastTests/Utils/TimeFunctionOffsetParsing.cs
+++ b/test/FastTests/Utils/TimeFunctionOffsetParsing.cs
@@ -1,0 +1,218 @@
+using System;
+using Raven.Server.Documents.Queries;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Utils
+{
+    public class TimeFunctionOffsetParsing(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingleUnit_Years()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("7y", out var result));
+            Assert.Equal(7, result.Years);
+            Assert.Equal(DateTimePrecision.Year, result.SmallestUnit);
+            Assert.False(result.IsNegative);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingleUnit_Months()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("3mo", out var result));
+            Assert.Equal(3, result.Months);
+            Assert.Equal(DateTimePrecision.Month, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingleUnit_Days()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("5d", out var result));
+            Assert.Equal(5, result.Days);
+            Assert.Equal(DateTimePrecision.Day, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingleUnit_Hours()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("4h", out var result));
+            Assert.Equal(4, result.Hours);
+            Assert.Equal(DateTimePrecision.Hour, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingleUnit_Minutes()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("30m", out var result));
+            Assert.Equal(30, result.Minutes);
+            Assert.Equal(DateTimePrecision.Minute, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingleUnit_Seconds()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("15s", out var result));
+            Assert.Equal(15, result.Seconds);
+            Assert.Equal(DateTimePrecision.Second, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseAllUnits()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1y7mo5d4h5m7s", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(7, result.Months);
+            Assert.Equal(5, result.Days);
+            Assert.Equal(4, result.Hours);
+            Assert.Equal(5, result.Minutes);
+            Assert.Equal(7, result.Seconds);
+            Assert.Equal(DateTimePrecision.Second, result.SmallestUnit);
+            Assert.False(result.IsNegative);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParsePositiveSign()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("+1d5h", out var result));
+            Assert.Equal(1, result.Days);
+            Assert.Equal(5, result.Hours);
+            Assert.False(result.IsNegative);
+            Assert.Equal(DateTimePrecision.Hour, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseNegativeSign()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("-1d5h", out var result));
+            Assert.Equal(1, result.Days);
+            Assert.Equal(5, result.Hours);
+            Assert.True(result.IsNegative);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void SmallestUnit_TracksFinestPrecision()
+        {
+            // 7y has year precision, 0s has second precision -> smallest is second
+            Assert.True(TimeFunctionOffset.TryParse("7y0s", out var result));
+            Assert.Equal(7, result.Years);
+            Assert.Equal(0, result.Seconds);
+            Assert.Equal(DateTimePrecision.Second, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void SmallestUnit_CoarserUnitAfterFinerUnit()
+        {
+            // days after hours -> smallest is still hour (finer)
+            Assert.True(TimeFunctionOffset.TryParse("5h1d", out var result));
+            Assert.Equal(5, result.Hours);
+            Assert.Equal(1, result.Days);
+            Assert.Equal(DateTimePrecision.Hour, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanDistinguish_Minutes_From_Months()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("5mo10m", out var result));
+            Assert.Equal(5, result.Months);
+            Assert.Equal(10, result.Minutes);
+            Assert.Equal(DateTimePrecision.Minute, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CaseInsensitiveUnits()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1Y2MO3D4H5M6S", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(2, result.Months);
+            Assert.Equal(3, result.Days);
+            Assert.Equal(4, result.Hours);
+            Assert.Equal(5, result.Minutes);
+            Assert.Equal(6, result.Seconds);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void FailsOnEmptyString()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("", out _));
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void FailsOnSignOnly()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("+", out _));
+            Assert.False(TimeFunctionOffset.TryParse("-", out _));
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void FailsOnUnknownUnit()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("5x", out _));
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void FailsOnMissingUnit()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("5", out _));
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void FailsOnMissingNumber()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("d", out _));
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_AddsYearsAndFloorsToYear()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("+7y", out var offset));
+            var baseTime = new DateTime(2026, 6, 15, 14, 30, 45, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2033, 1, 1, 0, 0, 0, DateTimeKind.Utc), result);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_AddsMonthsAndFloorsToMonth()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("+1mo", out var offset));
+            var baseTime = new DateTime(2026, 6, 15, 14, 30, 45, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc), result);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_AddsDaysAndHoursAndFloorsToHour()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("+1d5h", out var offset));
+            var baseTime = new DateTime(2026, 3, 22, 14, 30, 45, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2026, 3, 23, 19, 0, 0, DateTimeKind.Utc), result);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_YearsWithSecondPrecision_FloorsToSecond()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("7y0s", out var offset));
+            var baseTime = new DateTime(2026, 6, 15, 14, 30, 45, 123, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2033, 6, 15, 14, 30, 45, 0, DateTimeKind.Utc), result);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_NegativeOffset_SubtractsDays()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("-1d", out var offset));
+            var baseTime = new DateTime(2026, 3, 22, 14, 30, 45, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2026, 3, 21, 0, 0, 0, DateTimeKind.Utc), result);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_ZeroOffset_FloorsToUnit()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("0h", out var offset));
+            var baseTime = new DateTime(2026, 3, 22, 14, 30, 45, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2026, 3, 22, 14, 0, 0, DateTimeKind.Utc), result);
+        }
+    }
+}

--- a/test/FastTests/Utils/TimeFunctionOffsetParsing.cs
+++ b/test/FastTests/Utils/TimeFunctionOffsetParsing.cs
@@ -100,13 +100,16 @@ namespace FastTests.Utils
         }
 
         [RavenFact(RavenTestCategory.Querying)]
-        public void SmallestUnit_CoarserUnitAfterFinerUnit()
+        public void StrictOrdering_RejectsOutOfOrder()
         {
-            // days after hours -> smallest is still hour (finer)
-            Assert.True(TimeFunctionOffset.TryParse("5h1d", out var result));
-            Assert.Equal(5, result.Hours);
-            Assert.Equal(1, result.Days);
-            Assert.Equal(DateTimePrecision.Hour, result.SmallestUnit);
+            // hours before days violates strict descending order
+            Assert.False(TimeFunctionOffset.TryParse("5h1d", out _));
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void StrictOrdering_RejectsDuplicateUnits()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("1d2d", out _));
         }
 
         [RavenFact(RavenTestCategory.Querying)]
@@ -119,6 +122,55 @@ namespace FastTests.Utils
         }
 
         [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseReadableUnitNames()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1year6months5days", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(6, result.Months);
+            Assert.Equal(5, result.Days);
+            Assert.Equal(DateTimePrecision.Day, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseSingularUnitNames()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1year1month1day1hour1minute1second", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(1, result.Months);
+            Assert.Equal(1, result.Days);
+            Assert.Equal(1, result.Hours);
+            Assert.Equal(1, result.Minutes);
+            Assert.Equal(1, result.Seconds);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseShortAliases_MinSec()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("5min30sec", out var result));
+            Assert.Equal(5, result.Minutes);
+            Assert.Equal(30, result.Seconds);
+            Assert.Equal(DateTimePrecision.Second, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseWithWhitespace()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1y 6mo 5d", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(6, result.Months);
+            Assert.Equal(5, result.Days);
+            Assert.Equal(DateTimePrecision.Day, result.SmallestUnit);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseWithLeadingTrailingWhitespace()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("  +1d  ", out var result));
+            Assert.Equal(1, result.Days);
+            Assert.False(result.IsNegative);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
         public void CaseInsensitiveUnits()
         {
             Assert.True(TimeFunctionOffset.TryParse("1Y2MO3D4H5M6S", out var result));
@@ -128,6 +180,14 @@ namespace FastTests.Utils
             Assert.Equal(4, result.Hours);
             Assert.Equal(5, result.Minutes);
             Assert.Equal(6, result.Seconds);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CaseInsensitiveReadableNames()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1Year 2Months", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(2, result.Months);
         }
 
         [RavenFact(RavenTestCategory.Querying)]
@@ -213,6 +273,15 @@ namespace FastTests.Utils
             var baseTime = new DateTime(2026, 3, 22, 14, 30, 45, DateTimeKind.Utc);
             var result = offset.Apply(baseTime);
             Assert.Equal(new DateTime(2026, 3, 22, 14, 0, 0, DateTimeKind.Utc), result);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void Apply_ReadableUnitsWithSpaces()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("+1 year 6 months", out var offset));
+            var baseTime = new DateTime(2026, 1, 15, 14, 30, 45, DateTimeKind.Utc);
+            var result = offset.Apply(baseTime);
+            Assert.Equal(new DateTime(2027, 7, 1, 0, 0, 0, DateTimeKind.Utc), result);
         }
     }
 }

--- a/test/FastTests/Utils/TimeFunctionOffsetParsing.cs
+++ b/test/FastTests/Utils/TimeFunctionOffsetParsing.cs
@@ -283,5 +283,27 @@ namespace FastTests.Utils
             var result = offset.Apply(baseTime);
             Assert.Equal(new DateTime(2027, 7, 1, 0, 0, 0, DateTimeKind.Utc), result);
         }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseWithWhitespaceAfterSign()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("+ 1d", out var result));
+            Assert.Equal(1, result.Days);
+            Assert.False(result.IsNegative);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void CanParseWithMultipleSpaces()
+        {
+            Assert.True(TimeFunctionOffset.TryParse("1y  6mo", out var result));
+            Assert.Equal(1, result.Years);
+            Assert.Equal(6, result.Months);
+        }
+
+        [RavenFact(RavenTestCategory.Querying)]
+        public void FailsOnWhitespaceOnly()
+        {
+            Assert.False(TimeFunctionOffset.TryParse("   ", out _));
+        }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB-26183.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26183.cs
@@ -897,4 +897,296 @@ public class RavenDB_26183 : RavenTestBase
             }
         }
     }
+
+    // --- Offset tests ---
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithPositiveOffset_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(20) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                // now('+7d') adds 7 days, floors to day boundary
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= now('+7d')")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithNegativeOffset_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-10) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(1) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                // now('-3d') subtracts 3 days, floors to day boundary
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= now('-3d')")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(1, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Today_WithOffset_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(-2) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(2) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                // today('+1mo') adds 1 month, floors to month boundary
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt < today('+1mo')")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithParameterOffset_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(20) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= now($offset)")
+                    .AddParameter("offset", "+7d")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithOffset_DocumentQuery_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(20) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Advanced.DocumentQuery<Employee>()
+                    .WhereLessThanOrEqual("HiredAt", RavenDocumentQuery.Now("+7d"))
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Today_WithOffset_DocumentQuery_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(-2) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(2) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Advanced.DocumentQuery<Employee>()
+                    .WhereLessThan("HiredAt", RavenDocumentQuery.Today("+1mo"))
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithOffset_Linq_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(20) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Query<Employee>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .Where(x => x.HiredAt <= RavenQuery.Now("+7d"))
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithMultiUnitOffset_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(1).AddHours(3) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(2) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                // now('+1d5h') adds 1 day and 5 hours, floors to hour boundary
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= now('+1d5h')")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithoutOffset_StillWorks(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddYears(1) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= now()")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(1, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithInvalidOffset_Throws(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var ex = Assert.ThrowsAny<RavenException>(() =>
+                {
+                    session.Advanced
+                        .RawQuery<Employee>("from Employees where HiredAt <= now('invalid')")
+                        .WaitForNonStaleResults()
+                        .ToList();
+                });
+                Assert.Contains("Invalid offset format", ex.Message);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithOffset_IsCaseInsensitive(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(20) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= NOW('+7d')")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB-26183.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26183.cs
@@ -956,33 +956,6 @@ public class RavenDB_26183 : RavenTestBase
 
     [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
-    public void Today_WithOffset_ReturnsCorrectDocuments(Options options)
-    {
-        using (var store = GetDocumentStore(options))
-        {
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(-2) });
-                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-5) });
-                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(2) });
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                // today('+1mo') adds 1 month, floors to month boundary
-                var employees = session.Advanced
-                    .RawQuery<Employee>("from Employees where HiredAt < today('+1mo')")
-                    .WaitForNonStaleResults()
-                    .ToList();
-
-                Assert.Equal(2, employees.Count);
-            }
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
     public void Now_WithParameterOffset_ReturnsCorrectDocuments(Options options)
     {
         using (var store = GetDocumentStore(options))
@@ -1026,32 +999,6 @@ public class RavenDB_26183 : RavenTestBase
             {
                 var employees = session.Advanced.DocumentQuery<Employee>()
                     .WhereLessThanOrEqual("HiredAt", RavenDocumentQuery.Now("+7d"))
-                    .WaitForNonStaleResults()
-                    .ToList();
-
-                Assert.Equal(2, employees.Count);
-            }
-        }
-    }
-
-    [RavenTheory(RavenTestCategory.Querying)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
-    public void Today_WithOffset_DocumentQuery_ReturnsCorrectDocuments(Options options)
-    {
-        using (var store = GetDocumentStore(options))
-        {
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(-2) });
-                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-5) });
-                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddMonths(2) });
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var employees = session.Advanced.DocumentQuery<Employee>()
-                    .WhereLessThan("HiredAt", RavenDocumentQuery.Today("+1mo"))
                     .WaitForNonStaleResults()
                     .ToList();
 

--- a/test/SlowTests.Issues/Issues/RavenDB-26183.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26183.cs
@@ -1136,4 +1136,82 @@ public class RavenDB_26183 : RavenTestBase
             }
         }
     }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Today_WithOffset_IsRejected(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var ex = Assert.ThrowsAny<RavenException>(() =>
+                {
+                    session.Advanced
+                        .RawQuery<Employee>("from Employees where HiredAt < today('+1d')")
+                        .WaitForNonStaleResults()
+                        .ToList();
+                });
+                Assert.Contains("today() does not accept arguments", ex.Message);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithReadableUnitNames_ReturnsCorrectDocuments(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(-1) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(5) });
+                session.Store(new Employee { HiredAt = DateTime.UtcNow.AddDays(20) });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var employees = session.Advanced
+                    .RawQuery<Employee>("from Employees where HiredAt <= now('+7 days')")
+                    .WaitForNonStaleResults()
+                    .ToList();
+
+                Assert.Equal(2, employees.Count);
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All)]
+    public void Now_WithEmptyOffset_Throws(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Employee { HiredAt = DateTime.UtcNow });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var ex = Assert.ThrowsAny<RavenException>(() =>
+                {
+                    session.Advanced
+                        .RawQuery<Employee>("from Employees where HiredAt <= now('')")
+                        .WaitForNonStaleResults()
+                        .ToList();
+                });
+                Assert.Contains("offset argument must be a non-empty string", ex.Message);
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26252

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
