### PR TITLE
RavenDB-26256 - Fix StackOverflow: replace async recursion with while loop

### DIFF
--- a/test/SlowTests/Issues/RavenDB_25412.cs
+++ b/test/SlowTests/Issues/RavenDB_25412.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -180,38 +180,40 @@ public class RavenDB_25412 : ReplicationTestBase
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Link the caller's token with our dispose token to handle stream disposal correctly
-            using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token))
+            while (true)
             {
-                try
-                {
-                    // 1. If the gate is closed, wait for it to open.
-                    // This handles new connections created while the network is simulated as "down".
-                    await _gate.WaitToOpenAsync(linkedCts.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                    if (_disposeCts.IsCancellationRequested) throw new IOException("Stream disposed");
-                    throw;
-                }
+                cancellationToken.ThrowIfCancellationRequested();
 
-                // 2. Gate is open. Start reading, but also watch for the gate closing mid-read.
-                // ReSharper disable once PossiblyMistakenUseOfCancellationToken (intentionally using the original token; the recursive call creates a new linked token scope)
-                var readTask = _inner.ReadAsync(buffer, offset, count, cancellationToken);
-                var closeGateTask = _gate.WaitToCloseAsync(linkedCts.Token);
-
-                var completed = await Task.WhenAny(readTask, closeGateTask);
-                if (completed == closeGateTask)
+                // Link the caller's token with our dispose token to handle stream disposal correctly
+                using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token))
                 {
-                    // Gate closed during the read operation.
-                    // Ignore the read result (simulating a hang/packet loss) and recurse to wait for the gate to open again.
-                    // ReSharper disable once PossiblyMistakenUseOfCancellationToken (intentionally using the original token; the recursive call creates a new linked token scope)
-                    return await ReadAsync(buffer, offset, count, cancellationToken);
-                }
+                    try
+                    {
+                        // If the gate is closed, wait for it to open.
+                        // This handles new connections created while the network is simulated as "down".
+                        await _gate.WaitToOpenAsync(linkedCts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        if (_disposeCts.IsCancellationRequested) throw new IOException("Stream disposed");
+                        throw;
+                    }
 
-                return await readTask;
+                    // Gate is open. Start reading, but also watch for the gate closing mid-read.
+                    var readTask = _inner.ReadAsync(buffer, offset, count, cancellationToken);
+                    var closeGateTask = _gate.WaitToCloseAsync(linkedCts.Token);
+
+                    var completedTask = await Task.WhenAny(readTask, closeGateTask);
+                    if (completedTask == closeGateTask)
+                    {
+                        // Gate closed during the read operation — simulating mid-stream hang.
+                        // Discard the current read result (simulating packet loss) and loop back
+                        // to wait for the gate to reopen.
+                        continue;
+                    }
+
+                    return await readTask;
+                }
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26256

### Additional description

`SmartHangingStreamWrapper.ReadAsync` used recursive await, causing `StackOverflow` when `ZstdStream` completed synchronously. Replaced with a while loop.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed