### PR TITLE
RavenDB-26264 - Added filtering capabilities for request size and response size in the Traffic Watch view

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/trafficWatch.ts
@@ -183,6 +183,14 @@ class trafficWatch extends viewModelBase {
     
     onlyErrors = ko.observable<boolean>(false);
 
+    requestSizeMin = ko.observable<number>();
+    requestSizeMax = ko.observable<number>();
+    responseSizeMin = ko.observable<number>();
+    responseSizeMax = ko.observable<number>();
+
+    requestSizeSummary: KnockoutComputed<string>;
+    responseSizeSummary: KnockoutComputed<string>;
+
     adminLogsUrl = appUrl.forAdminLogs() + "?highlightTrafficWatch=true"
 
     stats = {
@@ -216,6 +224,14 @@ class trafficWatch extends viewModelBase {
         
         this.selectedTypeNamesHttp.subscribe(() => this.refresh());
         this.selectedTypeNamesTcp.subscribe(() => this.refresh());
+        
+        this.requestSizeMin.throttle(500).subscribe(() => this.refresh());
+        this.requestSizeMax.throttle(500).subscribe(() => this.refresh());
+        this.responseSizeMin.throttle(500).subscribe(() => this.refresh());
+        this.responseSizeMax.throttle(500).subscribe(() => this.refresh());
+
+        this.requestSizeSummary = ko.pureComputed(() => trafficWatch.formatSizeRangeSummary(this.requestSizeMin(), this.requestSizeMax()));
+        this.responseSizeSummary = ko.pureComputed(() => trafficWatch.formatSizeRangeSummary(this.responseSizeMin(), this.responseSizeMax()));
     }
     
     activate(args: any) {
@@ -303,7 +319,17 @@ class trafficWatch extends viewModelBase {
             const typeMatch = _.includes(this.selectedTypeNamesHttp(), item.Type);
             const statusMatch = !this.onlyErrors() || item.ResponseStatusCode >= 400;
 
-            return textFilterMatch && typeMatch && statusMatch;
+            const reqMin = trafficWatch.parseNumberFilter(this.requestSizeMin());
+            const reqMax = trafficWatch.parseNumberFilter(this.requestSizeMax());
+            const resMin = trafficWatch.parseNumberFilter(this.responseSizeMin());
+            const resMax = trafficWatch.parseNumberFilter(this.responseSizeMax());
+
+            const requestSizeMatch = (reqMin == null || item.RequestSizeInBytes >= reqMin) &&
+                                     (reqMax == null || item.RequestSizeInBytes <= reqMax);
+            const responseSizeMatch = (resMin == null || item.ResponseSizeInBytes >= resMin) &&
+                                      (resMax == null || item.ResponseSizeInBytes <= resMax);
+
+            return textFilterMatch && typeMatch && statusMatch && requestSizeMatch && responseSizeMatch;
         }
         
         if (trafficWatch.isTcpItem(item)) {
@@ -331,6 +357,22 @@ class trafficWatch extends viewModelBase {
     
     private static isPostgresItem(item: Raven.Client.Documents.Changes.TrafficWatchChangeBase): item is TrafficWatchPostgresChange {
         return item.TrafficWatchType === "Postgres";
+    }
+
+    private static parseNumberFilter(value: any): number | null {
+        if (value == null || value === "") {
+            return null;
+        }
+        const num = Number(value);
+        return isNaN(num) ? null : num;
+    }
+
+    private static formatSizeRangeSummary(minVal: any, maxVal: any): string {
+        const min = trafficWatch.parseNumberFilter(minVal);
+        const max = trafficWatch.parseNumberFilter(maxVal);
+        const minText = min != null ? generalUtils.formatBytesToSize(min) : "0";
+        const maxText = max != null ? generalUtils.formatBytesToSize(max) : "\u221E";
+        return minText + " - " + maxText;
     }
 
     private updateStats(): void {
@@ -640,8 +682,13 @@ class trafficWatch extends viewModelBase {
         const filterUsingTypeTcp = this.selectedTypeNamesTcp().length !== this.filteredTypeDataTcp.length;
         
         const filterUsingStatus = this.onlyErrors();
+
+        const filterUsingSize = trafficWatch.parseNumberFilter(this.requestSizeMin()) != null ||
+                                trafficWatch.parseNumberFilter(this.requestSizeMax()) != null ||
+                                trafficWatch.parseNumberFilter(this.responseSizeMin()) != null ||
+                                trafficWatch.parseNumberFilter(this.responseSizeMax()) != null;
         
-        if (textFilterDefined || filterUsingTypeHttp || filterUsingTypeTcp || filterUsingStatus) {
+        if (textFilterDefined || filterUsingTypeHttp || filterUsingTypeTcp || filterUsingStatus || filterUsingSize) {
             this.filteredData = this.allData.filter(item => this.matchesFilters(item));
             this.isDataFiltered(true);
         } else {

--- a/src/Raven.Studio/wwwroot/App/views/manage/trafficWatch.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/trafficWatch.html
@@ -24,6 +24,42 @@
                             data-bind="options: filteredTypeDataTcp, selectedOptions: selectedTypeNamesTcp, optionsText: 'propertyName', optionsValue: 'propertyName'"></select>
                 </div>
             </div>
+            <div class="btn-group-label" data-label="Request Size">
+                <div class="dropdown" data-placement="top">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span data-bind="text: requestSizeSummary"></span>
+                        <span class="caret"></span>
+                    </button>
+                    <div class="dropdown-menu size-filter-dropdown padding padding-sm" data-bind="dropdownPanel: true">
+                        <div class="size-filter-form-group">
+                            <label>Min (bytes)</label>
+                            <input class="form-control" type="number" min="0" placeholder="Min" data-bind="textInput: requestSizeMin">
+                        </div>
+                        <div class="size-filter-form-group">
+                            <label>Max (bytes)</label>
+                            <input class="form-control" type="number" min="0" placeholder="Max" data-bind="textInput: requestSizeMax">
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="btn-group-label" data-label="Response Size">
+                <div class="dropdown" data-placement="top">
+                    <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span data-bind="text: responseSizeSummary"></span>
+                        <span class="caret"></span>
+                    </button>
+                    <div class="dropdown-menu size-filter-dropdown padding padding-sm" data-bind="dropdownPanel: true">
+                        <div class="size-filter-form-group">
+                            <label>Min (bytes)</label>
+                            <input class="form-control" type="number" min="0" placeholder="Min" data-bind="textInput: responseSizeMin">
+                        </div>
+                        <div class="size-filter-form-group">
+                            <label>Max (bytes)</label>
+                            <input class="form-control" type="number" min="0" placeholder="Max" data-bind="textInput: responseSizeMax">
+                        </div>
+                    </div>
+                </div>
+            </div>
             <div id="trafficFilter">
                 <input class="form-control" placeholder="Filter" data-bind="textInput: filter">
             </div>

--- a/src/Raven.Studio/wwwroot/Content/css/pages/traffic-watch.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/traffic-watch.less
@@ -23,7 +23,33 @@
         width: 220px;
     }
     
+    .btn-group-label:before {
+        white-space: nowrap;
+    }
     
+    .size-filter-dropdown {
+        min-width: 180px;
+        padding: 0;
+        
+        .size-filter-form-group {
+            margin-bottom: 8px;
+            
+            &:last-child {
+                margin-bottom: 0;
+            }
+            
+            label {
+                font-size: 12px;
+                margin-bottom: 4px;
+                display: block;
+            }
+            
+            input.form-control {
+                height: 30px;
+                font-size: 12px;
+            }
+        }
+    }
     
     .dropdown {
         .dropdown-menu.stats-menu {

--- a/src/Raven.Studio/wwwroot/Content/css/pages/traffic-watch.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/traffic-watch.less
@@ -29,7 +29,6 @@
     
     .size-filter-dropdown {
         min-width: 180px;
-        padding: 0;
         
         .size-filter-form-group {
             margin-bottom: 8px;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26264/Add-a-response-size-filter-in-the-traffic-watch

### Additional description

Added min/max range filters for request size and response size to the Traffic Watch toolbar, allowing users to narrow down HTTP traffic entries by byte size.

<img width="964" height="256" alt="image" src="https://github.com/user-attachments/assets/abc5dd9c-eca3-4630-bd6c-5479ce18054a" />

<img width="965" height="251" alt="image" src="https://github.com/user-attachments/assets/902eb01e-e4a9-4134-834e-bb9a08d0f8f3" />

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
