### PR TITLE
RavenDB-25738: 59a3d568447 RavenDB-25738 Differ between JsonString and SimpleString

### DIFF
--- a/src/Raven.Client/Constants.cs
+++ b/src/Raven.Client/Constants.cs
@@ -588,6 +588,7 @@ namespace Raven.Client
                 }
 
                 public const string ThrowRevisionKeyTooBigFix = "ThrowRevisionKeyTooBigFix";
+                public const string ThrowControlCharactersInIdentifier = "ThrowControlCharactersInIdentifier";
             }
         }
 

--- a/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
+++ b/src/Raven.Client/Documents/Commands/MultiGet/MultiGetCommand.cs
@@ -234,7 +234,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
             }
         }
 
-        private static unsafe GetResponse ReadResponse(JsonOperationContext context, PeepingTomStream peepingTomStream, UnmanagedJsonParser parser, JsonParserState state, JsonOperationContext.MemoryBuffer buffer)
+        private static GetResponse ReadResponse(JsonOperationContext context, PeepingTomStream peepingTomStream, UnmanagedJsonParser parser, JsonParserState state, JsonOperationContext.MemoryBuffer buffer)
         {
             if (state.CurrentTokenType != JsonParserToken.StartObject)
                 ThrowInvalidJsonResponse(peepingTomStream);
@@ -251,7 +251,7 @@ namespace Raven.Client.Documents.Commands.MultiGet
                 if (state.CurrentTokenType != JsonParserToken.String)
                     ThrowInvalidJsonResponse(peepingTomStream);
 
-                var property = context.AllocateStringValue(null, state.StringBuffer, state.StringSize).ToString();
+                var property = context.AllocateStringValue(state).ToString();
                 switch (property)
                 {
                     case nameof(GetResponse.Result):

--- a/src/Raven.Client/Exceptions/ControlCharactersAreNotAllowedException.cs
+++ b/src/Raven.Client/Exceptions/ControlCharactersAreNotAllowedException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Raven.Client.Exceptions;
+
+public sealed class ControlCharactersAreNotAllowedException : RavenException
+{
+    public ControlCharactersAreNotAllowedException(string message)
+        : base(message)
+    {
+    }
+    public ControlCharactersAreNotAllowedException(string message, Exception inner)
+        : base(message, inner)
+    {
+    }
+}

--- a/src/Raven.Client/Json/BlittableOperation.cs
+++ b/src/Raven.Client/Json/BlittableOperation.cs
@@ -198,7 +198,8 @@ namespace Raven.Client.Json
                     fixed (byte* pBuff = bytes.Array)
                     {
                         // need to ignore the quote marks
-                        using var str = context.AllocateStringValue(null, pBuff + bytes.Offset + 1, (int)memoryStream.Length - 2);
+                        //TODO To check
+                        using var str = context.AllocateStringValue(null, pBuff + bytes.Offset + 1, (int)memoryStream.Length - 2, LazyStringType.JsonString, true);
 
                         return newProp.Value.Equals(str);
                     }

--- a/src/Raven.Server/Documents/AttachmentsStorage.cs
+++ b/src/Raven.Server/Documents/AttachmentsStorage.cs
@@ -19,6 +19,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data;
 using Voron.Data.Tables;
@@ -137,6 +138,8 @@ namespace Raven.Server.Documents
         public AttachmentDetailsServer PutAttachment(DocumentsOperationContext context, string documentId, string name, string contentType,
             string hash, string expectedChangeVector = null, Stream stream = null, bool updateDocument = true, bool extractCollectionName = false, bool fromSmuggler = false)
         {
+            ValidateAttachmentName(name);
+            
             if (context.Transaction == null)
             {
                 DocumentPutAction.ThrowRequiresTransaction();
@@ -160,6 +163,7 @@ namespace Raven.Server.Documents
                         throw new InvalidOperationException($"Cannot put attachment {name} on artificial document '{documentId}'.");
                 }
 
+                //TODO To reject attachment with control characters in the name & content type
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, name, out Slice lowerName, out Slice namePtr))
                 using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, contentType, out Slice lowerContentType, out Slice contentTypePtr))
                 using (Slice.From(context.Allocator, hash, out Slice base64Hash)) // Hash is a base64 string, so this is a special case that we do not need to escape
@@ -296,6 +300,13 @@ namespace Raven.Server.Documents
                     };
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ValidateAttachmentName(string name)
+        {
+            if(_documentDatabase.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier)
+                StringUtils.CheckAndThrowContainsControlCharacters(name);
         }
 
         /// <summary>
@@ -768,7 +779,8 @@ namespace Raven.Server.Documents
             var result = new Attachment
             {
                 StorageId = tvr.Id,
-                Key = TableValueToString(context, (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType, ref tvr),
+                //TODO-c0e67da7 The key uses the lower attachment name from DocumentIdWorker.GetLowerIdSliceAndStorageKey which doesn't have the escape positions so I think we better disallow control characters on attachment name as well 
+                Key = TableValueToString(context, (int)AttachmentsTable.LowerDocumentIdAndLowerNameAndTypeAndHashAndContentType, ref tvr, LazyStringType.SimpleString),
                 Etag = TableValueToEtag((int)AttachmentsTable.Etag, ref tvr),
                 ChangeVector = TableValueToChangeVector(context, (int)AttachmentsTable.ChangeVector, ref tvr),
                 Name = TableValueToId(context, (int)AttachmentsTable.Name, ref tvr),
@@ -1251,8 +1263,10 @@ namespace Raven.Server.Documents
                 var spanKey = key.AsReadOnlySpan();
                 ExtractDocIdAndAttachmentName(spanKey, out int sizeOfDocId, out int attachmentNameIndex, out int sizeOfAttachmentName, out _);
 
-                var doc = context.AllocateStringValue(null, key.Buffer, sizeOfDocId);
-                var name = context.AllocateStringValue(null, key.Buffer + attachmentNameIndex, sizeOfAttachmentName);
+                //TODO Doesn't contain escape position so not way to identify the type and we are going to disallow that for new databases
+                var doc = context.AllocateStringValue(null, key.Buffer, sizeOfDocId, LazyStringType.SimpleString);
+                //TODO Doesn't contain escape position so not way to identify the type and we are going to disallow that for new databases
+                var name = context.AllocateStringValue(null, key.Buffer + attachmentNameIndex, sizeOfAttachmentName, LazyStringType.SimpleString);
 
                 return (doc, name);
             }

--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -101,7 +101,7 @@ namespace Raven.Server.Documents
             var mem = _ctx.GetMemory(maxSizeOfEscapePos + state.StringSize);
             _allocations.Add(mem);
             Memory.Copy(mem.Address, state.StringBuffer, state.StringSize);
-            var lazyStringValueFromParserState = _ctx.AllocateStringValue(null, mem.Address, state.StringSize);
+            var lazyStringValueFromParserState = _ctx.AllocateStringValue(null, mem.Address, state.StringSize, state.StringType);
             if (escapePositionsCount > 0)
             {
                 lazyStringValueFromParserState.EscapePositions = state.EscapePositions.ToArray();
@@ -520,6 +520,7 @@ namespace Raven.Server.Documents
                     var collection = _metadataCollections;
                     state.StringBuffer = collection.AllocatedMemoryData.Address;
                     state.StringSize = collection.Size;
+                    state.StringType = collection.Type;
                     aboutToReadPropertyName = true;
                     return true;
 
@@ -573,6 +574,7 @@ namespace Raven.Server.Documents
                     var expires = _metadataExpires;
                     state.StringBuffer = expires.AllocatedMemoryData.Address;
                     state.StringSize = expires.Size;
+                    state.StringType = expires.Type;
                     aboutToReadPropertyName = true;
                     return true;
 

--- a/src/Raven.Server/Documents/ConflictsStorage.cs
+++ b/src/Raven.Server/Documents/ConflictsStorage.cs
@@ -146,7 +146,8 @@ namespace Raven.Server.Documents
             var result = new DocumentConflict
             {
                 StorageId = tvr.Id,
-                LowerId = TableValueToString(context, (int)ConflictsTable.LowerId, ref tvr),
+                //TODO We are going to reject Ids with control character and we don't have the escape position to identify the type so we are going to treat that as SimpleString
+                LowerId = TableValueToString(context, (int)ConflictsTable.LowerId, ref tvr, LazyStringType.SimpleString),
                 Id = TableValueToId(context, (int)ConflictsTable.Id, ref tvr),
                 ChangeVector = TableValueToChangeVector(context, (int)ConflictsTable.ChangeVector, ref tvr),
                 Etag = TableValueToEtag((int)ConflictsTable.Etag, ref tvr),
@@ -175,7 +176,8 @@ namespace Raven.Server.Documents
             var result = new DocumentConflict
             {
                 StorageId = tvr.Id,
-                LowerId = TableValueToString(context, (int)ConflictsTable.LowerId, ref tvr),
+                //TODO We are going to reject Ids with control character and we don't have the escape position to identify the type so we are going to treat that as SimpleString
+                LowerId = TableValueToString(context, (int)ConflictsTable.LowerId, ref tvr, LazyStringType.SimpleString),
                 Id = TableValueToId(context, (int)ConflictsTable.Id, ref tvr),
                 ChangeVector = TableValueToChangeVector(context, (int)ConflictsTable.ChangeVector, ref tvr),
                 Etag = etag = TableValueToEtag((int)ConflictsTable.Etag, ref tvr),

--- a/src/Raven.Server/Documents/CountersRepairTask.cs
+++ b/src/Raven.Server/Documents/CountersRepairTask.cs
@@ -257,7 +257,8 @@ public class CountersRepairTask
 
                     if (collection == null)
                     {
-                        collection = TableValueToId(context, (int)Counters.CountersTable.Collection, ref tvr);
+                        //TODO To decide if we want to reject collection name with control characters.
+                        collection = TableValueSizePrefixToString(context, (int)Counters.CountersTable.Collection, ref tvr, LazyStringType.SimpleString);
                         collectionName = _database.DocumentsStorage.ExtractCollectionName(context, collection);
 
                         writeTable = _database.DocumentsStorage.CountersStorage.GetOrCreateTable(context.Transaction.InnerTransaction, _database.DocumentsStorage.CountersStorage.CountersSchema, collectionName, CollectionTableType.CounterGroups);
@@ -341,15 +342,17 @@ public class CountersRepairTask
 
                     // we're using the same change vector and etag here, in order to avoid replicating
                     // the counter group to other nodes (each node should fix its counters locally)
-                    using var changeVector = TableValueToString(context, (int)Counters.CountersTable.ChangeVector, ref tvr);
+                    using var changeVector = TableValueToString(context, (int)Counters.CountersTable.ChangeVector, ref tvr, LazyStringType.SimpleString);
                     var groupEtag = TableValueToEtag((int)Counters.CountersTable.Etag, ref tvr);
 
-                    using (var counterGroupKey = TableValueToString(context, (int)Counters.CountersTable.CounterKey, ref tvr))
+                    //TODO We are going to reject document IDs with control characters and any way we don't have the escape positions to identify the type
+                    using (var counterGroupKey = TableValueToString(context, (int)Counters.CountersTable.CounterKey, ref tvr, LazyStringType.SimpleString))
                     using (context.Allocator.Allocate(counterGroupKey.Size, out var buffer))
                     {
                         counterGroupKey.CopyTo(buffer.Ptr);
 
-                        using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length))
+                        //TODO We are going to reject document IDs with control characters and any way we don't have the escape positions to identify the type
+                        using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length, LazyStringType.SimpleString))
                         using (Slice.External(context.Allocator, clonedKey, out var countersGroupKey))
                         using (Slice.From(context.Allocator, changeVector, out var cv))
                         using (DocumentIdWorker.GetStringPreserveCase(context, collectionName.Name, out Slice collectionSlice))

--- a/src/Raven.Server/Documents/CountersStorage.cs
+++ b/src/Raven.Server/Documents/CountersStorage.cs
@@ -18,6 +18,7 @@ using Sparrow.Json;
 using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data.Tables;
 using Voron.Impl;
@@ -240,7 +241,7 @@ namespace Raven.Server.Documents
             return new CounterGroupDetail
             {
                 DocumentId = docId,
-                ChangeVector = TableValueToString(context, (int)CountersTable.ChangeVector, ref tvr),
+                ChangeVector = TableValueToString(context, (int)CountersTable.ChangeVector, ref tvr, LazyStringType.SimpleString),
                 Etag = TableValueToEtag((int)CountersTable.Etag, ref tvr),
                 Values = GetCounterValuesData(context, ref tvr)
             };
@@ -254,7 +255,7 @@ namespace Raven.Server.Documents
             {
                 DocumentId = docId,
                 Name = name,
-                ChangeVector = TableValueToString(context, (int)CounterTombstonesTable.ChangeVector, ref tvr),
+                ChangeVector = TableValueToString(context, (int)CounterTombstonesTable.ChangeVector, ref tvr, LazyStringType.SimpleString),
                 Etag = TableValueToEtag((int)CounterTombstonesTable.Etag, ref tvr)
             };
         }
@@ -309,10 +310,7 @@ namespace Raven.Server.Documents
                 Debug.Assert(false); // never hit
             }
 
-            if (name.Length > DocumentIdWorker.MaxIdSize)
-            {
-                ThrowCounterNameTooBig(name);
-            }
+            ValidateCounterName(name);
 
             try
             {
@@ -457,6 +455,15 @@ namespace Raven.Server.Documents
 
                 _counterModificationMemoryScopes.Clear();
             }
+        }
+
+        private void ValidateCounterName(string name)
+        {
+            if (name.Length > DocumentIdWorker.MaxIdSize)
+                ThrowCounterNameTooBig(name);
+
+            if(_documentDatabase.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier)
+                StringUtils.CheckAndThrowContainsControlCharacters(name);
         }
 
         [DoesNotReturn]
@@ -933,7 +940,8 @@ namespace Raven.Server.Documents
                             if (table.SeekOneBackwardByPrimaryKeyPrefix(documentKeyPrefix, counterKeySlice, out var tvr) == false)
                                 continue;
 
-                            using (var counterGroupKey = TableValueToString(context, (int)CountersTable.CounterKey, ref tvr))
+                            //TODO We are going to reject document IDs with control characters and we don't have the escape position to identify the type anyway
+                            using (var counterGroupKey = TableValueToString(context, (int)CountersTable.CounterKey, ref tvr, LazyStringType.SimpleString))
                             {
                                 if (entriesToUpdate.TryGetValue(counterGroupKey, out var putCountersData))
                                 {
@@ -1001,7 +1009,8 @@ namespace Raven.Server.Documents
                                     // clone counter group key
                                     var scope = context.Allocator.Allocate(counterGroupKey.Size, out var output);
                                     counterGroupKey.CopyTo(output.Ptr);
-                                    var clonedKey = context.AllocateStringValue(null, output.Ptr, output.Length);
+                                    //TODO We are going to reject document IDs with control characters and we don't have the escape position to identify the type anyway, so we can use simple string here
+                                    var clonedKey = context.AllocateStringValue(null, output.Ptr, output.Length, LazyStringType.SimpleString);
                                     putCountersData.KeyScope = scope;
                                     entriesToUpdate[clonedKey] = putCountersData;
                                 }
@@ -2165,8 +2174,8 @@ namespace Raven.Server.Documents
                 if (p[sizeOfDocId] == SpecialChars.RecordSeparator)
                     break;
             }
-
-            return context.AllocateStringValue(null, p, sizeOfDocId);
+            //TODO We are going to reject IDs with control characters so we can consider it as SimpleString
+            return context.AllocateStringValue(null, p, sizeOfDocId, LazyStringType.SimpleString);
         }
 
         public static void ExtractDocIdAndCounterNameFromCounterTombstoneKey(JsonOperationContext context, ref TableValueReader tvr, out LazyStringValue docId, out LazyStringValue counterName)
@@ -2180,9 +2189,11 @@ namespace Raven.Server.Documents
                     break;
                 next++;
             }
-            docId = context.AllocateStringValue(null, p, sizeOfDocId);
-            counterName = context.GetLazyString(p + next + 1, size - next - 1);
+            //TODO We are going to reject IDs with control characters so we can consider it as SimpleString
+            docId = context.AllocateStringValue(null, p, sizeOfDocId, LazyStringType.SimpleString);
+            counterName = context.AllocateStringValue(null, p + next + 1, size - next - 1, LazyStringType.SimpleString);
 
+            //TODO I am not sure why we have those asserts and it will be nice to remove it as part of the PR
             Debug.Assert(docId != null);
             Debug.Assert(counterName != null);
         }
@@ -2557,7 +2568,8 @@ namespace Raven.Server.Documents
 
                     unsafe LazyStringValue CounterNameLsv()
                     {
-                        return context.GetLazyString(loweredCounterNameSlice.Content.Ptr, loweredCounterNameSlice.Size);
+                        //TODO I am going to reject future counter names with control characters but I want to keep the previous behavior for old data.
+                        return context.GetLazyString(loweredCounterNameSlice.Content.Ptr, loweredCounterNameSlice.Size, LazyStringType.JsonString, true);
                     }
                 }
             }
@@ -2658,7 +2670,8 @@ namespace Raven.Server.Documents
                 unsafe LazyStringValue CounterGroupKey()
                 {
                     var p = tvr.Read((int)CountersTable.CounterKey, out var size);
-                    return context.GetLazyString(p, size);
+                    //TODO We don't have the escape character and future counter names with control characters are going to be rejected
+                    return context.AllocateStringValue(null, p, size, LazyStringType.SimpleString);
                 }
 
                 unsafe LazyStringValue ExtractDocId()
@@ -2671,7 +2684,8 @@ namespace Raven.Server.Documents
                             break;
                     }
 
-                    return context.GetLazyString(p, sizeOfDocId);
+                    //TODO It is used only to hold the pointer and size so escaping makes no sense anyway
+                    return context.AllocateStringValue(null, p, sizeOfDocId, LazyStringType.SimpleString);
                 }
 
                 unsafe IDisposable ToDocumentIdPrefix(LazyStringValue documentId, out Slice documentIdPrefix)
@@ -2688,7 +2702,8 @@ namespace Raven.Server.Documents
                         var scope = context.Allocator.Allocate(counterNameSlice.Size + documentIdPrefix.Size, out var buffer);
                         CreateCounterKeySlice(context, buffer, documentIdPrefix, counterNameSlice, out var counterKeySlice);
 
-                        key = context.AllocateStringValue(null, counterKeySlice.Content.Ptr, counterKeySlice.Content.Length);
+                        //TODO We are going to reject doc IDs with control characters so we can consider it as SimpleString
+                        key = context.AllocateStringValue(null, counterKeySlice.Content.Ptr, counterKeySlice.Content.Length, LazyStringType.SimpleString);
                         return scope;
                     }
                 }
@@ -2709,7 +2724,8 @@ namespace Raven.Server.Documents
                             bufferSpan[offset++] = SpecialChars.LuceneRecordSeparator;
                             counterNameSlice.AsSpan().CopyTo(bufferSpan.Slice(offset));
 
-                            return context.GetLazyString(buffer.Ptr, size);
+                            //TODO We are going to reject counter names with control characters but better to keep the previous behavior for old data
+                            return context.GetLazyString(buffer.Ptr, size, LazyStringType.JsonString);
                         }
                     }
                 }

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -2263,11 +2263,15 @@ namespace Raven.Server.Documents
 
             if (databaseRecord.SupportedFeatures.Contains(Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix))
                 SupportedFeatureTypes.ThrowRevisionKeyTooBigFix = true;
+                        
+            if (databaseRecord.SupportedFeatures.Contains(Constants.DatabaseRecord.SupportedFeatures.ThrowControlCharactersInIdentifier))
+                SupportedFeatureTypes.ThrowControlCharactersInIdentifier = true;
         }
     }
 
     public class SupportedFeatureTypes
     {
         public bool ThrowRevisionKeyTooBigFix;
+        public bool ThrowControlCharactersInIdentifier;
     }
 }

--- a/src/Raven.Server/Documents/DocumentIdWorker.cs
+++ b/src/Raven.Server/Documents/DocumentIdWorker.cs
@@ -97,7 +97,8 @@ namespace Raven.Server.Documents
                     buffer.Ptr[i] = (byte)ch;
             }
 
-            _jsonParserState.FindEscapedPositionsAndEscapeControls(buffer.Ptr, ref strLength, escapeAndControlSize);
+            //TODO We need to keep the key as before
+            _jsonParserState.FindEscapedPositionsAndEscapeControls(buffer.Ptr, ref strLength, escapeAndControlSize, LazyStringType.JsonString);
             if (separator != null)
             {
                 buffer.Ptr[strLength] = separator.Value;
@@ -302,11 +303,13 @@ namespace Raven.Server.Documents
             }
 
             int lowerIdLength = originalStrLength;
-            _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr, ref lowerIdLength, escapePositionsSize);
+            //TODO We need to keep the key as before
+            _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr, ref lowerIdLength, escapePositionsSize, LazyStringType.JsonString);
             if (lowerIdLength != originalStrLength)
             {
                 var idLength = originalStrLength;
-                _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr + maxIdLenSize + maxIdSize, ref idLength, escapePositionsSize);
+                //TODO We need to keep the key as before
+                _jsonParserState.FindEscapedPositionsAndEscapeControls(ptr + maxIdLenSize + maxIdSize, ref idLength, escapePositionsSize, LazyStringType.JsonString);
 
 #if DEBUG
                 if (lowerIdLength != idLength)
@@ -366,7 +369,8 @@ namespace Raven.Server.Documents
                     ThrowDocumentIdTooBig(str);
                 
                 var originalLowerSize = lowerIdSize;
-                _jsonParserState.FindEscapedPositionsAndEscapeControls(lowerId, ref lowerIdSize, escapePositionsSize);
+                //TODO We need to keep the key as before
+                _jsonParserState.FindEscapedPositionsAndEscapeControls(lowerId, ref lowerIdSize, escapePositionsSize, LazyStringType.JsonString);
                 
                 byte* actualIdPtr = buffer.Ptr + strLength * sizeof(char) + maxStrSize;
                 int actualIdSize = Encoding.GetBytes(pChars, strLength, actualIdPtr + maxIdLenSize, maxStrSize);
@@ -379,7 +383,8 @@ namespace Raven.Server.Documents
                 
                 //We already checked if there are control characters to escape
                 if (originalLowerSize != lowerIdSize)
-                    _jsonParserState.FindEscapedPositionsAndEscapeControls(actualIdPtr + maxIdLenSize, ref actualIdSize, escapePositionsSize);
+                    //TODO We need to keep the key as before
+                    _jsonParserState.FindEscapedPositionsAndEscapeControls(actualIdPtr + maxIdLenSize, ref actualIdSize, escapePositionsSize, LazyStringType.JsonString);
 
                 JsonParserState.WriteVariableSizeInt(ref writePos, actualIdSize);
                 escapePositionsSize = _jsonParserState.WriteEscapePositionsTo(writePos + actualIdSize);

--- a/src/Raven.Server/Documents/DocumentPutAction.cs
+++ b/src/Raven.Server/Documents/DocumentPutAction.cs
@@ -19,6 +19,7 @@ using Sparrow.Server;
 using Voron;
 using Voron.Data.Tables;
 using Raven.Client.Util;
+using Sparrow.Utils;
 using Voron.Exceptions;
 using static Raven.Server.Documents.DocumentsStorage;
 using static Raven.Server.Documents.Schemas.Documents;
@@ -125,6 +126,7 @@ namespace Raven.Server.Documents
                 compareClusterTransaction.ValidateAtomicGuard(id, nonPersistentFlags, oldChangeVectorForClusterTransactionIndexCheck);
             }
 
+            ValidateId(id, newFlags, nonPersistentFlags);
             id = BuildDocumentId(id, newEtag, out bool knownNewId);
             using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, id, out Slice lowerId, out Slice idPtr))
             {
@@ -333,6 +335,23 @@ namespace Raven.Server.Documents
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ValidateId(string id, DocumentFlags newFlags, NonPersistentDocumentFlags nonPersistentFlags)
+        {
+            if( string.IsNullOrWhiteSpace(id)
+               ||newFlags.Contain(DocumentFlags.FromReplication)
+               || newFlags.Contain(DocumentFlags.FromClusterTransaction)
+               //TODO To check if needed
+               || newFlags.Contain(DocumentFlags.FromResharding)
+               || nonPersistentFlags.Contain(NonPersistentDocumentFlags.FromSmuggler))
+                return;
+
+            if (_documentDatabase.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier == false)
+                return;
+
+            StringUtils.CheckAndThrowContainsControlCharacters(id);
+        }
+        
         [Conditional("DEBUG")]
         private static void ValidateDocument(string id, BlittableJsonReaderObject document, ref ulong documentDebugHash)
         {
@@ -374,7 +393,7 @@ namespace Raven.Server.Documents
                 var lastChar = id[^1];
                 if (lastChar == '|')
                 {
-                    ThrowInvalidDocumentId(id);
+                    ThrowIdCannotEndWithIdentitySeparator(id);
                 }
 
                 fixed (char* idPtr = id)
@@ -431,7 +450,7 @@ namespace Raven.Server.Documents
         }
 
         [DoesNotReturn]
-        private static void ThrowInvalidDocumentId(string id)
+        private static void ThrowIdCannotEndWithIdentitySeparator(string id)
         {
             throw new NotSupportedException("Document ids cannot end with '|', but was called with " + id +
                                             ". Identities are only generated for external requests, not calls to PutDocument and such.");

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -34,6 +34,7 @@ using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
+using Sparrow.Utils;
 using Voron;
 using Voron.Data;
 using Voron.Data.Fixed;
@@ -1541,7 +1542,8 @@ namespace Raven.Server.Documents
         private static Document InitializeDocument(JsonOperationContext context, Document document, ref TableValueReader tvr)
         {
             document.StorageId = tvr.Id;
-            document.LowerId = TableValueToString(context, (int)DocumentsTable.LowerId, ref tvr);
+            //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+            document.LowerId = TableValueToString(context, (int)DocumentsTable.LowerId, ref tvr, LazyStringType.SimpleString);
             document.Id = TableValueToId(context, (int)DocumentsTable.Id, ref tvr);
             document.Etag = TableValueToEtag((int)DocumentsTable.Etag, ref tvr);
             document.Data = new BlittableJsonReaderObject(tvr.Read((int)DocumentsTable.Data, out int size), size, context);
@@ -1558,7 +1560,8 @@ namespace Raven.Server.Documents
             var result = new Document(context, tvr.Id);
 
             if (fields.Contain(DocumentFields.LowerId))
-                result.LowerId = TableValueToString(context, (int)DocumentsTable.LowerId, ref tvr);
+                //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+                result.LowerId = TableValueToString(context, (int)DocumentsTable.LowerId, ref tvr, LazyStringType.SimpleString);
 
             if (fields.Contain(DocumentFields.Id))
                 result.Id = TableValueToId(context, (int)DocumentsTable.Id, ref tvr);
@@ -1598,7 +1601,8 @@ namespace Raven.Server.Documents
             var result = new Tombstone
             {
                 StorageId = tvr.Id,
-                LowerId = TableValueToString(context, (int)TombstoneTable.LowerId, ref tvr),
+                //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+                LowerId = TableValueToString(context, (int)TombstoneTable.LowerId, ref tvr, LazyStringType.SimpleString),
                 Etag = TableValueToEtag((int)TombstoneTable.Etag, ref tvr),
                 DeletedEtag = TableValueToEtag((int)TombstoneTable.DeletedEtag, ref tvr),
                 Type = *(Tombstone.TombstoneType*)tvr.Read((int)TombstoneTable.Type, out int _),
@@ -2156,7 +2160,8 @@ namespace Raven.Server.Documents
             var allocated = context.GetMemory(size + 1); // we need this extra byte to mark that there is no escaping
             allocated.Address[size] = 0;
             Memory.Copy(allocated.Address, lowerId.Buffer, size);
-            var lsv = context.AllocateStringValue(null, allocated.Address, size);
+            //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+            var lsv = context.AllocateStringValue(null, allocated.Address, size, LazyStringType.SimpleString);
             lsv.AllocatedMemoryData = allocated;
             return lsv;
         }
@@ -2623,7 +2628,11 @@ namespace Raven.Server.Documents
             if (collections == null)
                 throw new InvalidOperationException("Should never happen!");
 
+            if(DocumentDatabase.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier)
+                StringUtils.CheckAndThrowContainsControlCharacters(collectionName);
+                
             name = new CollectionName(collectionName);
+            //TODO Here we escape control with the escape position
             using (DocumentIdWorker.GetStringPreserveCase(context, collectionName, out Slice collectionSlice))
             {
                 using (collections.Allocate(out TableValueBuilder tvr))
@@ -2651,6 +2660,12 @@ namespace Raven.Server.Documents
                 };
             }
             return name;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private string MyInline()
+        {
+            return "Should be inline";
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2807,7 +2822,9 @@ namespace Raven.Server.Documents
             var collections = tx.OpenTable(CollectionsSchema, CollectionsSlice);
             foreach (var tvr in collections.SeekByPrimaryKey(Slices.BeforeAllKeys, 0))
             {
-                var collection = TableValueToId(context, (int)CollectionsTable.Name, ref tvr.Reader);
+                //TODO I think we should avoid also collection name with control characters. I prefer to be explicit about that but we can differ
+                var collection = TableValueSizePrefixToString(context, (int)CollectionsTable.Name, ref tvr.Reader, LazyStringType.JsonString);
+                
                 yield return collection.ToString();
             }
         }
@@ -2899,10 +2916,10 @@ namespace Raven.Server.Documents
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static LazyStringValue TableValueToString(JsonOperationContext context, int index, ref TableValueReader tvr)
+        public static LazyStringValue TableValueToString(JsonOperationContext context, int index, ref TableValueReader tvr, LazyStringType type)
         {
             var ptr = tvr.Read(index, out int size);
-            return context.AllocateStringValue(null, ptr, size);
+            return context.AllocateStringValue(null, ptr, size, type);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -2922,8 +2939,16 @@ namespace Raven.Server.Documents
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static LazyStringValue TableValueToId(JsonOperationContext context, int index, ref TableValueReader tvr)
         {
+            //TODO We are going to reject IDs with control characters so we can treat that as SImpleString
+            return TableValueSizePrefixToString(context, index, ref tvr, LazyStringType.SimpleString);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //TODO To find a better name
+        public static LazyStringValue TableValueSizePrefixToString(JsonOperationContext context, int index, ref TableValueReader tvr, LazyStringType type)
+        {
             var ptr = tvr.Read(index, out _);
-            var lzs = context.GetLazyStringValue(ptr, out bool success);
+            var lzs = context.GetLazyStringValue(ptr, type, out var success);
             if (success == false)
                 ThrowInvalidTagLength();
             return lzs;

--- a/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
+++ b/src/Raven.Server/Documents/Handlers/Batches/BatchRequestParser.cs
@@ -995,14 +995,14 @@ namespace Raven.Server.Documents.Handlers.Batches
         private static unsafe void ThrowInvalidProperty(JsonParserState state, JsonOperationContext ctx)
         {
             throw new InvalidOperationException("Invalid property name: " +
-                                                ctx.AllocateStringValue(null, state.StringBuffer, state.StringSize));
+                                                ctx.AllocateStringValue(null, state.StringBuffer, state.StringSize, state.StringType));
         }
 
         [DoesNotReturn]
         private static unsafe void ThrowInvalidCommandType(JsonParserState state, JsonOperationContext ctx)
         {
             throw new InvalidCommandTypeException("Invalid command type: "
-                                                  + ctx.AllocateStringValue(null, state.StringBuffer, state.StringSize));
+                                                  + ctx.AllocateStringValue(null, state.StringBuffer, state.StringSize, state.StringType));
         }
 
         [DoesNotReturn]

--- a/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DocumentDebugHandler.cs
@@ -11,6 +11,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Server.Documents.Handlers.Debugging
 {
@@ -110,8 +111,9 @@ namespace Raven.Server.Documents.Handlers.Debugging
                                 {
                                     unsafe
                                     {
-                                        using var cloned = context.GetLazyString(doc.LowerId.Buffer, doc.LowerId.Size, longLived: false);
-                                        if (cloned.Length > doc.LowerId.Length)
+
+                                        JsonParserState.FindMaxEscapePositionAndControlCharSize(doc.LowerId.Buffer, doc.LowerId.Size, out var controlCount);
+                                        if (controlCount > 0)
                                         {
                                             AddToResult(unescapedControlCharacterIds, doc);
                                             resultCount--;

--- a/src/Raven.Server/Documents/Indexes/IndexStorage.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStorage.cs
@@ -351,13 +351,16 @@ namespace Raven.Server.Documents.Indexes
 
                     ptr = tvr.Result.Reader.Read(1, out size);
                     if (size != 0)
-                        error.Document = context.AllocateStringValue(null, ptr, size);
+                        //TODO a4800261 We didn't and we don't use the escape positions so better to keep it simple string 
+                        error.Document = context.AllocateStringValue(null, ptr, size, LazyStringType.SimpleString);
 
                     ptr = tvr.Result.Reader.Read(2, out size);
-                    error.Action = context.AllocateStringValue(null, ptr, size);
+                    //TODO a4800261 We didn't and we don't use the escape positions so better to keep it simple string
+                    error.Action = context.AllocateStringValue(null, ptr, size, LazyStringType.SimpleString);
 
                     ptr = tvr.Result.Reader.Read(3, out size);
-                    error.Error = context.AllocateStringValue(null, ptr, size);
+                    //TODO a4800261 We didn't and we don't use the escape positions so better to keep it simple string
+                    error.Error = context.AllocateStringValue(null, ptr, size, LazyStringType.SimpleString);
 
                     errors.Add(error);
                 }
@@ -1047,9 +1050,10 @@ namespace Raven.Server.Documents.Indexes
                     {
                         var error = stats.Errors[i];
                         var ticksBigEndian = Bits.SwapBytes(error.Timestamp.Ticks);
-                        using (var document = context.GetLazyString(error.Document))
-                        using (var action = context.GetLazyString(error.Action))
-                        using (var e = context.GetLazyString(error.Error))
+                        //TODO a4800261 We didn't and we don't use the escape positions so better to keep it simple string
+                        using (var document = context.GetLazyString(error.Document, LazyStringType.SimpleString))
+                        using (var action = context.GetLazyString(error.Action, LazyStringType.SimpleString))
+                        using (var e = context.GetLazyString(error.Error, LazyStringType.SimpleString))
                         {
                             var tvb = new TableValueBuilder
                             {

--- a/src/Raven.Server/Documents/Indexes/Persistence/ConverterBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/ConverterBase.cs
@@ -277,8 +277,8 @@ namespace Raven.Server.Documents.Indexes.Persistence
                 dblAsString = null;
                 return false;
             }
-
-            dblAsString = context.AllocateStringValue(null, ldv.Inner.Buffer, index + 1);
+            //TODO Used only for number so can be identified as SimpleString 
+            dblAsString = context.AllocateStringValue(null, ldv.Inner.Buffer, index + 1, LazyStringType.SimpleString);
             return true;
         }
 

--- a/src/Raven.Server/Documents/Replication/AllowedPathsValidator.cs
+++ b/src/Raven.Server/Documents/Replication/AllowedPathsValidator.cs
@@ -12,7 +12,7 @@ namespace Raven.Server.Documents.Replication
         private readonly List<LazyStringValue> _allowedPaths;
         private readonly List<LazyStringValue> _allowedPathsPrefixes;
         private DocumentInfoHelper _documentInfoHelper;
-        private LazyStringValue GetDocumentId(Slice key) => _documentInfoHelper.GetDocumentId(key);
+        private LazyStringValue GetDocumentId(Slice key) => _documentInfoHelper.GetShortTimeDocumentId(key);
         public string GetItemInformation(ReplicationBatchItem item) => _documentInfoHelper.GetItemInformation(item);
         
         public bool ShouldAllow(ReplicationBatchItem item)

--- a/src/Raven.Server/Documents/Replication/ConflictManager.cs
+++ b/src/Raven.Server/Documents/Replication/ConflictManager.cs
@@ -61,7 +61,8 @@ namespace Raven.Server.Documents.Replication
                         CollectionName.GetCollectionName(doc)
                     ),
                     LastModified = new DateTime(lastModifiedTicks),
-                    LowerId = documentsContext.AllocateStringValue(null, loweredKey.Content.Ptr, loweredKey.Content.Length),
+                    //TODO The actual value here is a JSON value but we are going to reject control characters in the document id and treat it as SimpleString.
+                    LowerId = documentsContext.AllocateStringValue(null, loweredKey.Content.Ptr, loweredKey.Content.Length, LazyStringType.SimpleString),
                     Id = lazyId,
                     ChangeVector = changeVector,
                     Flags = flags

--- a/src/Raven.Server/Documents/Replication/DocumentInfoHelper.cs
+++ b/src/Raven.Server/Documents/Replication/DocumentInfoHelper.cs
@@ -17,36 +17,46 @@ namespace Raven.Server.Documents.Replication
         private LazyStringValue _tmpLazyStringInstance;
         private readonly JsonOperationContext _context;
         private readonly bool _contextOwner;
-        public unsafe LazyStringValue GetDocumentId(Slice key)
+        public unsafe LazyStringValue GetShortTimeDocumentId(Slice key)
         {
             var sepIdx = key.Content.IndexOf(SpecialChars.RecordSeparator);
-            if (_tmpLazyStringInstance == null)
-                _tmpLazyStringInstance = new LazyStringValue(null, null, 0, _context);
-            _tmpLazyStringInstance.Renew(null, key.Content.Ptr, sepIdx, _context);
-            return _tmpLazyStringInstance;
+            return GetShortTimeDocumentId(key.Content.Ptr, sepIdx);
         }
 
-        public unsafe LazyStringValue GetDocumentId(LazyStringValue key)
+        public unsafe LazyStringValue GetShortTimeDocumentId(LazyStringValue key)
         {
             var index = key.IndexOf((char)SpecialChars.RecordSeparator, StringComparison.OrdinalIgnoreCase);
             if (index == -1)
                 return null;
 
-            return _context.GetLazyString(key.Buffer, index);
+            return GetShortTimeDocumentId(key.Buffer, index);
+        }
+        
+        private unsafe LazyStringValue GetShortTimeDocumentId(byte* ptr, int sepIdx)
+        {
+            if (_tmpLazyStringInstance == null)
+            {
+                _tmpLazyStringInstance = new LazyStringValue(null, ptr, sepIdx, _context, LazyStringType.SimpleString);
+                return _tmpLazyStringInstance;
+            }
+            //TODO No escape positions and used for documentID which we are going to disallow control characters.
+            _tmpLazyStringInstance.Renew(null, ptr, sepIdx, _context, LazyStringType.SimpleString);
+            return _tmpLazyStringInstance;
         }
 
         // TODO unify if possible with AllowedPathsValidator
-        public LazyStringValue GetDocumentId(ReplicationBatchItem item)
+        // TODO We anyway convert it to string right away and the LazyStringValue is reused by the helper so better to convert it here to prevent wrong usage
+        public string GetShortTermDocumentId(ReplicationBatchItem item)
         {
             return item switch
             {
-                AttachmentReplicationItem a => GetDocumentId(a.Key),
-                AttachmentTombstoneReplicationItem at => GetDocumentId(at.Key),
+                AttachmentReplicationItem a => GetShortTimeDocumentId(a.Key),
+                AttachmentTombstoneReplicationItem at => GetShortTimeDocumentId(at.Key),
                 CounterReplicationItem c => c.Id,
                 DocumentReplicationItem d => d.Id,
-                RevisionTombstoneReplicationItem r => GetDocumentId(r.Id),
-                TimeSeriesDeletedRangeItem td => GetDocumentId(td.Key),
-                TimeSeriesReplicationItem t => GetDocumentId(t.Key),
+                RevisionTombstoneReplicationItem r => GetShortTimeDocumentId(r.Id),
+                TimeSeriesDeletedRangeItem td => GetShortTimeDocumentId(td.Key),
+                TimeSeriesReplicationItem t => GetShortTimeDocumentId(t.Key),
                 _ => throw new ArgumentOutOfRangeException($"{nameof(item)} - {item}")
             };
         }
@@ -56,7 +66,7 @@ namespace Raven.Server.Documents.Replication
             switch (item)
             {
                 case AttachmentReplicationItem a:
-                    return $"Attachment '{a.Name}' for {GetDocumentId(a.Key)}";
+                    return $"Attachment '{a.Name}' for {GetShortTimeDocumentId(a.Key)}";
                 case AttachmentTombstoneReplicationItem at:
                     var result = AttachmentsStorage.AttachmentKey.ExtractDocIdAndAttachmentName(at.Key);
                     return $"Attachment tombstone '{result.AttachmentName}' for {result.DocId}";
@@ -70,10 +80,10 @@ namespace Raven.Server.Documents.Replication
                 case RevisionTombstoneReplicationItem r:
                     return "Revision for " + r.Id;
                 case TimeSeriesDeletedRangeItem td:
-                    return "Time Series deletion range for: " + GetDocumentId(td.Key);
+                    return "Time Series deletion range for: " + GetShortTimeDocumentId(td.Key);
                 case TimeSeriesReplicationItem t:
                     var baseline = TimeSeriesStorage.GetBaseline(t.Key.Content.Ptr, t.Key.Content.Length);
-                    return $"Time Series segment of '{t.Name}' [{baseline:s} - {t.Segment.GetLastTimestamp(baseline):s}] for {GetDocumentId(t.Key)}";
+                    return $"Time Series segment of '{t.Name}' [{baseline:s} - {t.Segment.GetLastTimestamp(baseline):s}] for {GetShortTimeDocumentId(t.Key)}";
                 default:
                     throw new ArgumentOutOfRangeException($"{nameof(item)} - {item}");
             }

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/ReplicationBatchItem.cs
@@ -129,7 +129,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             return tempBufferPos;
         }
 
-        protected unsafe void SetLazyStringValue(JsonOperationContext context, ref LazyStringValue prop)
+        protected unsafe void SetLazyStringValue(JsonOperationContext context, ref LazyStringValue prop, LazyStringType type)
         {
             var size = *(int*)Reader.ReadExactly(sizeof(int));
             if (size < 0)
@@ -143,7 +143,7 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
 
             var mem = Reader.AllocateMemory(size);
             Memory.Copy(mem, Reader.ReadExactly(size), size);
-            prop = context.AllocateStringValue(null, mem, size);
+            prop = context.AllocateStringValue(null, mem, size, type);
         }
 
         protected unsafe void SetLazyStringValueFromString(JsonOperationContext context, out LazyStringValue prop)

--- a/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
+++ b/src/Raven.Server/Documents/Replication/ReplicationItems/RevisionTombstoneReplicationItem.cs
@@ -73,7 +73,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             {
                 LastModifiedTicks = *(long*)Reader.ReadExactly(sizeof(long));
 
-                SetLazyStringValue(context, ref Id);
+                //TODO We don't have the escape positions and we are going to reject docIds with control characters
+                SetLazyStringValue(context, ref Id, LazyStringType.SimpleString);
                 SetLazyStringValueFromString(context, out Collection);
                 Debug.Assert(Collection != null);
 
@@ -96,7 +97,8 @@ namespace Raven.Server.Documents.Replication.ReplicationItems
             if (index == -1)
                 return;
 
-            Id = context.AllocateStringValue(null, Id.Buffer + index + 1, Id.Size - index - 1);
+            //TODO We are going to disallow docId with control characters
+            Id = context.AllocateStringValue(null, Id.Buffer + index + 1, Id.Size - index - 1, LazyStringType.SimpleString);
         }
 
         public static ByteStringContext.InternalScope TryExtractChangeVectorSliceFromKey(ByteStringContext allocator, LazyStringValue key, out Slice changeVectorSlice)

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -1717,7 +1717,8 @@ namespace Raven.Server.Documents.Revisions
                         return new Document
                         {
                             Flags = DocumentFlags.DeleteRevision,
-                            LowerId = context.AllocateStringValue(null, copy.Content.Ptr, copy.Size),
+                            //TODO We are going to reject IDs with control characters and anyway we don't have the escape position to identify
+                            LowerId = context.AllocateStringValue(null, copy.Content.Ptr, copy.Size, LazyStringType.SimpleString),
                             Id = context.GetLazyString(id)
                         };
                     }
@@ -2825,7 +2826,8 @@ namespace Raven.Server.Documents.Revisions
                 return new Document(context, tvr.Id)
                 {
                     StorageId = tvr.Id,
-                    LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr),
+                    //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+                    LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr, LazyStringType.SimpleString),
                     Id = TableValueToId(context, (int)RevisionsTable.Id, ref tvr),
                     Etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr),
                     LastModified = TableValueToDateTime((int)RevisionsTable.LastModified, ref tvr),
@@ -2844,7 +2846,8 @@ namespace Raven.Server.Documents.Revisions
             var result = new Document(context, tvr.Id);
 
             if (fields.Contain(DocumentFields.LowerId))
-                result.LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr);
+                //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+                result.LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr, LazyStringType.SimpleString);
 
             if (fields.Contain(DocumentFields.Id))
                 result.Id = TableValueToId(context, (int)RevisionsTable.Id, ref tvr);
@@ -2875,7 +2878,8 @@ namespace Raven.Server.Documents.Revisions
             var result = new Document
             {
                 StorageId = tvr.Id,
-                LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr),
+                //TODO We are going to reject docIds with control characters so we can treat the mas simple string.
+                LowerId = TableValueToString(context, (int)RevisionsTable.LowerId, ref tvr, LazyStringType.SimpleString),
                 Id = TableValueToId(context, (int)RevisionsTable.Id, ref tvr),
                 Etag = etag = TableValueToEtag((int)RevisionsTable.Etag, ref tvr),
                 Data = new BlittableJsonReaderObject(ptr, size, context),

--- a/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
+++ b/src/Raven.Server/Documents/Sharding/Handlers/ShardedIncomingReplicationHandler.cs
@@ -301,7 +301,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 {
                     if (SupportedFeatures.Replication.RevisionTombstonesWithId)
                     {
-                        var docId = _documentInfoHelper.GetDocumentId(revisionTombstoneItem);
+                        var docId = _documentInfoHelper.GetShortTermDocumentId(revisionTombstoneItem);
                         if (docId != null)
                         {
                             batches[_parent.Context.GetShardNumberFor(context, docId)].Items.Add(item);
@@ -405,7 +405,7 @@ namespace Raven.Server.Documents.Sharding.Handlers
                 case TimeSeriesDeletedRangeItem:
                 case TimeSeriesReplicationItem:
                 case RevisionTombstoneReplicationItem:
-                    var id = _documentInfoHelper.GetDocumentId(item);
+                    var id = _documentInfoHelper.GetShortTermDocumentId(item);
                     if (string.IsNullOrEmpty(id))
                         throw new ArgumentException("Document id cannot be null or empty", nameof(id));
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesReader.cs
@@ -132,7 +132,6 @@ namespace Raven.Server.Documents.TimeSeries
             _documentId = documentId;
             _name = name.ToLowerInvariant();
             _table = new Table(context.DocumentDatabase.DocumentsStorage.TimeSeriesStorage.TimeSeriesSchema, context.Transaction.InnerTransaction);
-            _tag = new LazyStringValue(null, null, 0, context);
             _offset = offset;
             _token = token;
 

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesRollups.cs
@@ -13,6 +13,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow;
 using Sparrow.Binary;
+using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server;
 using Sparrow.Server.Utils;
@@ -209,9 +210,11 @@ namespace Raven.Server.Documents.TimeSeries
                         Key = key,
                         DocId = docId,
                         Name = name,
-                        Collection = DocumentsStorage.TableValueToId(context, (int)RollupColumns.Collection, ref item.Result.Reader),
+                        //TODO We keep the escape positions so we can verify the type
+                        Collection = DocumentsStorage.TableValueSizePrefixToString(context, (int)RollupColumns.Collection, ref item.Result.Reader, LazyStringType.JsonString),
                         NextRollup = new DateTime(rollUpTime),
-                        RollupPolicy = DocumentsStorage.TableValueToString(context, (int)RollupColumns.PolicyToApply, ref item.Result.Reader),
+                        //TODO We don't escape the PolicyToApply so we can treat is as SimpleString
+                        RollupPolicy = DocumentsStorage.TableValueToString(context, (int)RollupColumns.PolicyToApply, ref item.Result.Reader, LazyStringType.SimpleString),
                         Etag = DocumentsStorage.TableValueToLong((int)RollupColumns.Etag, ref item.Result.Reader),
                         ChangeVector = DocumentsStorage.TableValueToChangeVector(context, (int)RollupColumns.ChangeVector, ref item.Result.Reader)
                     };

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStats.cs
@@ -344,7 +344,10 @@ namespace Raven.Server.Documents.TimeSeries
             if (table.ReadByKey(key, out var tvr) == false)
                 return null;
 
-            return DocumentsStorage.TableValueToString(context, (int)StatsColumns.Name, ref tvr);
+            //TODO I think we should reject timeseries name with control characters as well we 
+            var value = DocumentsStorage.TableValueToString(context, (int)StatsColumns.Name, ref tvr, LazyStringType.SimpleString);
+            value.EscapePositions = [];
+            return value;
         }
 
         public void UpdateTimeSeriesName(DocumentsOperationContext context, CollectionName collection, TimeSeriesSliceHolder slicer)

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesStorage.cs
@@ -1336,7 +1336,9 @@ namespace Raven.Server.Documents.TimeSeries
             SingleResult ToResult(TimeSeriesOperation.AppendOperation element)
             {
                 holder.Values = element.Values;
-                holder.Tag = context.GetLazyString(element.Tag);
+                //TODO The Tag is stored currectly with its escape position so there is no issue to allow control characters but we may want to dissallow that any way
+                //but I think we can implement that in a different PR
+                holder.Tag = context.GetLazyString(element.Tag, LazyStringType.JsonString);
                 holder.Timestamp = element.Timestamp;
                 holder.Status = TimeSeriesValuesSegment.Live;
                 return holder;
@@ -1457,6 +1459,7 @@ namespace Raven.Server.Documents.TimeSeries
 
             var value = positive ? values[0] : values[1];
 
+            //TODO Here we escape control characters to keep the old behaviour but we may consider to avoid that.
             return context.GetLazyString(value);
         }
 
@@ -1800,14 +1803,20 @@ namespace Raven.Server.Documents.TimeSeries
             return context.LastDatabaseChangeVector;
         }
 
-        private static void VerifyLegalName(string name)
+        private void VerifyLegalName(string name)
         {
+            var checkControlChars = _documentDatabase.SupportedFeatures.SupportedFeatureTypes.ThrowControlCharactersInIdentifier;
             for (int i = 0; i < name.Length; i++)
             {
-                if (name[i] == TimeSeriesConfiguration.TimeSeriesRollupSeparator)
+                var c = name[i];
+                if (c == TimeSeriesConfiguration.TimeSeriesRollupSeparator)
                     throw new InvalidOperationException($"Illegal time series name : '{name}'. " +
                                                         $"Time series names cannot contain '{TimeSeriesConfiguration.TimeSeriesRollupSeparator}' character, " +
                                                         "since this character is reserved for time series rollups.");
+                
+                //TODO To check if should skip check in some path like we have for put documents (replication .etc)
+                if(checkControlChars && StringUtils.IsControlCharacter(c))
+                    StringUtils.ThrowIdentifierWithControlCharacters(name);
             }
         }
 
@@ -2363,7 +2372,8 @@ namespace Raven.Server.Documents.TimeSeries
                 Type = ReplicationBatchItem.ReplicationItemType.TimeSeriesSegment,
                 ChangeVector = Encoding.UTF8.GetString(changeVectorPtr, changeVectorSize),
                 Segment = new TimeSeriesValuesSegment(segmentPtr, segmentSize),
-                Collection = DocumentsStorage.TableValueToId(context, (int)TimeSeriesTable.Collection, ref reader),
+                //TODO We have the escape position so we can identify the type.
+                Collection = DocumentsStorage.TableValueSizePrefixToString(context, (int)TimeSeriesTable.Collection, ref reader, LazyStringType.JsonString),
                 Etag = Bits.SwapBytes(etag),
                 TransactionMarker = DocumentsStorage.TableValueToShort((int)TimeSeriesTable.TransactionMarker, nameof(TimeSeriesTable.TransactionMarker), ref reader)
             };
@@ -2447,7 +2457,8 @@ namespace Raven.Server.Documents.TimeSeries
             {
                 Type = ReplicationBatchItem.ReplicationItemType.DeletedTimeSeriesRange,
                 ChangeVector = Encoding.UTF8.GetString(changeVectorPtr, changeVectorSize),
-                Collection = DocumentsStorage.TableValueToId(context, (int)DeletedRangeTable.Collection, ref reader),
+                //TODO We have the escape position so we can identify the type
+                Collection = DocumentsStorage.TableValueSizePrefixToString(context, (int)DeletedRangeTable.Collection, ref reader, LazyStringType.JsonString),
                 Etag = Bits.SwapBytes(etag),
                 TransactionMarker = DocumentsStorage.TableValueToShort((int)DeletedRangeTable.TransactionMarker, nameof(DeletedRangeTable.TransactionMarker), ref reader),
                 From = DocumentsStorage.TableValueToDateTime((int)DeletedRangeTable.From, ref reader),
@@ -2500,7 +2511,8 @@ namespace Raven.Server.Documents.TimeSeries
 
                 return new TimeSeriesDeletedRangeEntry
                 {
-                    Key = new LazyStringValue(null, keyPtr, keySize, context),
+                    //TODO We don't have the escape positions and we are goid to reject docIds and time-series names with control characters
+                    Key = new LazyStringValue(null, keyPtr, keySize, context, LazyStringType.SimpleString),
                     DocId = docId,
                     Name = name,
                     Etag = Bits.SwapBytes(etag)
@@ -2636,14 +2648,16 @@ namespace Raven.Server.Documents.TimeSeries
 
                 return new TimeSeriesSegmentEntry
                 {
-                    Key = new LazyStringValue(null, keyPtr, keySize, context),
+                    //TODO We don't have the escape positions to identify the type and we are going to reject this situation for new databases
+                    Key = new LazyStringValue(null, keyPtr, keySize, context, LazyStringType.SimpleString),
                     LuceneKey = luceneKey,
                     DocId = docId,
                     Name = lowerName,
                     ChangeVector = Encoding.UTF8.GetString(changeVectorPtr, changeVectorSize),
                     Segment = new TimeSeriesValuesSegment(segmentPtr, segmentSize),
                     SegmentSize = segmentSize,
-                    Collection = DocumentsStorage.TableValueToId(context, (int)TimeSeriesTable.Collection, ref reader),
+                    //TODO We have the escape positions to identify the type
+                    Collection = DocumentsStorage.TableValueSizePrefixToString(context, (int)TimeSeriesTable.Collection, ref reader, LazyStringType.JsonString),
                     Start = baseline,
                     Etag = Bits.SwapBytes(etag),
                 };
@@ -2659,7 +2673,8 @@ namespace Raven.Server.Documents.TimeSeries
                 {
                     var keyPtr = reader.Read((int)TimeSeriesTable.TimeSeriesKey, out int keySize);
 
-                    result.Key = new LazyStringValue(null, keyPtr, keySize, context);
+                    //TODO We don't have the escape positions to identify the type and we are going to reject docIds and time-series name with control characters for new databases
+                    result.Key = new LazyStringValue(null, keyPtr, keySize, context, LazyStringType.SimpleString);
 
                     if (fields.Contain(TimeSeriesSegmentEntryFields.DocIdNameAndStart))
                     {
@@ -2696,7 +2711,8 @@ namespace Raven.Server.Documents.TimeSeries
                 }
 
                 if (fields.Contain(TimeSeriesSegmentEntryFields.Collection))
-                    result.Collection = DocumentsStorage.TableValueToId(context, (int)TimeSeriesTable.Collection, ref reader);
+                    //TODO We have the escape positions to identify the type
+                    result.Collection = DocumentsStorage.TableValueSizePrefixToString(context, (int)TimeSeriesTable.Collection, ref reader, LazyStringType.JsonString);
 
                 result.Etag = Bits.SwapBytes(*(long*)reader.Read((int)TimeSeriesTable.Etag, out _));
 
@@ -2725,7 +2741,8 @@ namespace Raven.Server.Documents.TimeSeries
                     if (Utf8Formatter.TryFormat(baseline.Ticks, bufferSpan.Slice(offset), out var bytesWritten, FormatD18) == false || bytesWritten != FormatD18.Precision)
                         throw new InvalidOperationException($"Could not write '{baseline.Ticks}' ticks. Bytes written {bytesWritten}, but expected {FormatD18.Precision}.");
 
-                    return context.GetLazyString(mem.Address, size);
+                    //TODO RavenDB-25738 I set it here to JsonString to keep the same behavior
+                    return context.GetLazyString(mem.Address, size, LazyStringType.JsonString);
                 }
                 finally
                 {
@@ -2749,7 +2766,8 @@ namespace Raven.Server.Documents.TimeSeries
                 var offset = documentId.Size;
                 bufferSpan[offset++] = SpecialChars.LuceneRecordSeparator;
                 name.AsSpan().CopyTo(bufferSpan.Slice(offset));
-                return context.GetLazyString(mem.Address, size);
+                //TODO Keep the same behaviour and escape control characters
+                return context.GetLazyString(mem.Address, size, LazyStringType.JsonString, true);
             }
             finally
             {

--- a/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
+++ b/src/Raven.Server/Documents/TimeSeries/TimeSeriesValuesSegment.cs
@@ -612,7 +612,8 @@ namespace Raven.Server.Documents.TimeSeries
             if (tagPointer.Pointer == null)
                 return null;
 
-            var lzs = context.GetLazyStringValue(tagPointer.Pointer, out bool success);
+            //TODO Escape control characters to keep the previous behaviour
+            var lzs = context.GetLazyStringValue(tagPointer.Pointer, LazyStringType.JsonString, out var success);
             if (success == false)
                 ThrowInvalidTagLength();
             return lzs;
@@ -681,11 +682,13 @@ namespace Raven.Server.Documents.TimeSeries
                 switch (order)
                 {
                     case ParsingOrder.Id:
-                        docId = context.GetLazyString(ptr, i);
+                        //TODO We don't have the escape positions and we are going to disallow new document ids with escape controls, but we need to support old ones, so we will apply ToLower to the entire id including the escape controls
+                        docId = context.GetLazyString(ptr, i, LazyStringType.SimpleString);
                         break;
 
                     case ParsingOrder.Name:
-                        name = context.GetLazyString(ptr + next, i - next);
+                        //TODO When creating the key we only apply ToLower to the name without escaping it and without writing the escape positions. Also we are going to disallow new names with escape controls 
+                        name = context.GetLazyString(ptr + next, i - next, LazyStringType.SimpleString);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException();

--- a/src/Raven.Server/ServerWide/ClusterStateMachine.cs
+++ b/src/Raven.Server/ServerWide/ClusterStateMachine.cs
@@ -3371,7 +3371,8 @@ namespace Raven.Server.ServerWide
         {
             var ptr = reader.Read((int)CompareExchangeTable.Key, out var size);
 
-            var storageKey = context.AllocateStringValue(null, ptr, size);
+            //TODO We don't escape the key of the compare exchange - GetKeyAndPrefixIndexSlices. 
+            var storageKey = context.AllocateStringValue(null, ptr, size, LazyStringType.SimpleString);
             return new CompareExchangeKey(storageKey, dbPrefix.Length + 1);
         }
 

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -338,6 +338,13 @@ namespace Raven.Server.ServerWide.Commands
         {
             if (key.Length > MaxNumberOfCompareExchangeKeyBytes || Encoding.GetByteCount(key) > MaxNumberOfCompareExchangeKeyBytes)
                 ThrowCompareExchangeKeyTooBig(key);
+
+            //TODO We should consider if we want to reject compare exchange with control characters.
+            //Also The database record is not available here so the check should move to another place.
+            // JsonParserState.FindEscapeAndControlCharactersCount(key, out _, out var controlCount);
+            // if (controlCount > 0)
+            //     ThrowCompareExchangeKeyWithControlCharacters(key);
+
             if (TryGetExpires(value, out long ticks))
                 ExpirationTicks = ticks;
 
@@ -428,6 +435,13 @@ namespace Raven.Server.ServerWide.Commands
             throw new CompareExchangeKeyTooBigException(
                 $"Compare Exchange key cannot exceed {MaxNumberOfCompareExchangeKeyBytes} bytes, " +
                 $"but the key was {Encoding.GetByteCount(str)} bytes. The invalid key is '{str}'. Parameter '{nameof(str)}'");
+        }
+
+        [DoesNotReturn]
+        private static void ThrowCompareExchangeKeyWithControlCharacters(string key)
+        {
+            throw new ControlCharactersAreNotAllowedException(
+                $"Compare Exchange key cannot contain control characters. Parameter '{nameof(key)}'.");
         }
 
         protected override bool Validate(ClusterOperationContext context, Slice keySlice, Table items, out long currentIndex)

--- a/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamDestination.cs
@@ -1481,7 +1481,8 @@ namespace Raven.Server.Smuggler.Documents
                 {
                     unsafe
                     {
-                        using (var escapedId = _context.GetLazyString(tombstone.LowerId.Buffer, tombstone.LowerId.Size))
+                        //TODO We should keep the control characters escaped for backward compatibility.
+                        using (var escapedId = _context.GetLazyString(tombstone.LowerId.Buffer, tombstone.LowerId.Size, LazyStringType.JsonString, true, true))
                         {
                             _context.Write(Writer, new DynamicJsonValue
                             {

--- a/src/Raven.Server/Smuggler/Documents/StreamSource.cs
+++ b/src/Raven.Server/Smuggler/Documents/StreamSource.cs
@@ -1262,10 +1262,7 @@ namespace Raven.Server.Smuggler.Documents
             if (_state.CurrentTokenType != JsonParserToken.String)
                 UnmanagedJsonParserHelper.ThrowInvalidJson("Expected property type to be string, but was " + _state.CurrentTokenType, _peepingTomStream, _parser);
 
-            unsafe
-            {
-                return _context.AllocateStringValue(null, _state.StringBuffer, _state.StringSize).ToString();
-            }
+            return _context.AllocateStringValue(_state).ToString();
         }
 
         private async Task ReadObjectAsync(BlittableJsonDocumentBuilder builder)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/40011/From40010.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/40011/From40010.cs
@@ -1,6 +1,7 @@
 ﻿using Raven.Server.Documents;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
 using Voron;
 using Voron.Data.Tables;
 using static Raven.Server.Documents.DocumentsStorage;
@@ -32,7 +33,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     {
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))
                         {
-                            var collection = TableValueToString(context, (int)CollectionsTable.Name, ref read.Reader);
+                            //TODO The collection name uses the origin case value of GetLowerIdSliceAndStorageKey which contains the escape position 
+                            var collection = TableValueToString(context, (int)CollectionsTable.Name, ref read.Reader, LazyStringType.JsonString);
                             using (DocumentIdWorker.GetStringPreserveCase(context, collection, out Slice collectionSlice))
                             using (writeTable.Allocate(out TableValueBuilder write))
                             {
@@ -81,7 +83,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))
                         {
                             var type = *(Tombstone.TombstoneType*)read.Reader.Read((int)TombstoneTable.Type, out _);
-                            var oldCollection = TableValueToString(context, (int)TombstoneTable.Collection, ref read.Reader);
+                            //TODO The collection name uses the origin case value of GetLowerIdSliceAndStorageKey which contains the escape position 
+                            var oldCollection = TableValueToString(context, (int)TombstoneTable.Collection, ref read.Reader, LazyStringType.JsonString);
                             using (DocumentIdWorker.GetStringPreserveCase(context, oldCollection, out Slice collectionSlice))
                             using (writeTable.Allocate(out TableValueBuilder write))
                             {
@@ -119,7 +122,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     {
                         using (TableValueReaderUtil.CloneTableValueReader(context, read))
                         {
-                            var oldCollection = TableValueToString(context, (int)ConflictsTable.Collection, ref read.Reader);
+                            //TODO The collection name uses the origin case value of GetLowerIdSliceAndStorageKey which contains the escape position 
+                            var oldCollection = TableValueToString(context, (int)ConflictsTable.Collection, ref read.Reader, LazyStringType.JsonString);
                             using (DocumentIdWorker.GetStringPreserveCase(context, oldCollection, out Slice collectionSlice))
                             using (writeTable.Allocate(out TableValueBuilder write))
                             {

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/42017/From41016.cs
@@ -286,7 +286,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     {
                         var t = new Tombstone
                         {
-                            LowerId = TableValueToString(context, (int)TombstoneTable.LowerId, ref result.Value.Reader),
+                            //TODO We didn't (and we don't) store the escape positions so there is no way to differ. Better to refer to it as SimpleString.
+                            LowerId = TableValueToString(context, (int)TombstoneTable.LowerId, ref result.Value.Reader, LazyStringType.SimpleString),
                             Type = *(Tombstone.TombstoneType*)result.Value.Reader.Read((int)TombstoneTable.Type, out _),
                         };
 
@@ -526,7 +527,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             {
                 return new CounterDetail
                 {
-                    CounterKey = TableValueToString(context, (int)LegacyCountersTable.CounterKey, ref tvr),
+                    //TODO Counter key contains the document Id and it doesn't have the escape position of it. Better to refer to it as SimpleString.
+                    CounterKey = TableValueToString(context, (int)LegacyCountersTable.CounterKey, ref tvr, LazyStringType.SimpleString),
                     DocumentId = doc.ToString(),
                     CounterName = name.ToString(),
                     TotalValue = TableValueToLong((int)LegacyCountersTable.Value, ref tvr),
@@ -546,7 +548,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     break;
             }
 
-            var doc = context.AllocateStringValue(null, p, sizeOfDocId);
+            //TODO Lower DocId doesn't contain the escape positions
+            var doc = context.AllocateStringValue(null, p, sizeOfDocId, LazyStringType.SimpleString);
             var name = TableValueToId(context, (int)LegacyCountersTable.Name, ref tvr);
             return (doc, name);
         }
@@ -562,12 +565,14 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                     break;
             }
 
-            var doc = context.AllocateStringValue(null, p, sizeOfDocId);
+            //TODO Doesn't contain the escape positions so we define it as SimpleString
+            var doc = context.AllocateStringValue(null, p, sizeOfDocId, LazyStringType.SimpleString);
 
             sizeOfDocId++;
             p += sizeOfDocId;
             int sizeOfName = size - sizeOfDocId - 1;
-            var name = context.AllocateStringValue(null, p, sizeOfName);
+            //TODO Doesn't contain the escape positions so we define it as SimpleString
+            var name = context.AllocateStringValue(null, p, sizeOfName, LazyStringType.SimpleString);
             return (doc, name);
         }
 
@@ -576,7 +581,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
             var offset = counterKey.Size - CountersStorage.DbIdAsBase64Size;
             var p = counterKey.Buffer + offset;
 
-            return context.AllocateStringValue(null, p, CountersStorage.DbIdAsBase64Size);
+            //TODO No way to get here control characters
+            return context.AllocateStringValue(null, p, CountersStorage.DbIdAsBase64Size, LazyStringType.SimpleString);
         }
 
         private static BlittableJsonReaderObject WriteNewCountersDocument(DocumentsOperationContext context, List<string> dbIds, IEnumerable<KeyValuePair<string, List<CounterDetail>>> batch)

--- a/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Documents/50001/From42017.cs
@@ -345,7 +345,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                             if (table.SeekOneBackwardByPrimaryKeyPrefix(documentKeyPrefix, counterKeySlice, out var tvr) == false)
                                 continue;
 
-                            using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)CountersTable.CounterKey, ref tvr))
+                            //TODO Doesn't contain the escape positions so we define it as SimpleString
+                            using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)CountersTable.CounterKey, ref tvr, LazyStringType.SimpleString))
                             {
                                 if (entriesToUpdate.TryGetValue(counterGroupKey, out var putCountersData))
                                 {
@@ -398,7 +399,8 @@ namespace Raven.Server.Storage.Schema.Updates.Documents
                                     // clone counter group key
                                     var scope = context.Allocator.Allocate(counterGroupKey.Size, out var output);
                                     counterGroupKey.CopyTo(output.Ptr);
-                                    var clonedKey = context.AllocateStringValue(null, output.Ptr, output.Length);
+                                    //TODO Doesn't contain the escape positions so we define it as SimpleString
+                                    var clonedKey = context.AllocateStringValue(null, output.Ptr, output.Length, LazyStringType.SimpleString);
                                     putCountersData.KeyScope = scope;
                                     entriesToUpdate[clonedKey] = putCountersData;
                                 }

--- a/src/Raven.Server/Storage/Schema/Updates/Server/53001/From53000.cs
+++ b/src/Raven.Server/Storage/Schema/Updates/Server/53001/From53000.cs
@@ -56,7 +56,8 @@ namespace Raven.Server.Storage.Schema.Updates.Server
         private static unsafe LazyStringValue ReadCompareExchangeKey(JsonOperationContext context, TableValueReader reader)
         {
             var ptr = reader.Read((int)ClusterStateMachine.CompareExchangeTable.Key, out var size);
-            return context.AllocateStringValue(null, ptr, size);
+            //TODO We get the key for compare exchange from GetKeyAndPrefixIndexSlices which doesn't escape the control characters.
+            return context.AllocateStringValue(null, ptr, size, LazyStringType.SimpleString);
         }
 
         private static unsafe void Put(Transaction tx, Slice keySlice, long ticks)

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -287,7 +287,11 @@ namespace Raven.Server.Web.System
 
                 if (databaseRecord.SupportedFeatures == null || databaseRecord.SupportedFeatures.Count == 0)
                 {
-                    databaseRecord.SupportedFeatures = new List<string> { Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix };
+                    databaseRecord.SupportedFeatures = new List<string>
+                    {
+                        Constants.DatabaseRecord.SupportedFeatures.ThrowRevisionKeyTooBigFix,
+                        Constants.DatabaseRecord.SupportedFeatures.ThrowControlCharactersInIdentifier
+                    };
                 }
 
                 var (newIndex, topology, nodeUrlsAddedTo) = await CreateDatabase(databaseRecord.DatabaseName, databaseRecord, context, replicationFactor, index, raftRequestId);

--- a/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
+++ b/src/Sparrow/Json/AbstractBlittableJsonTextWriter.cs
@@ -231,7 +231,7 @@ namespace Sparrow.Json
 
         public void WriteString(string str, bool skipEscaping = false)
         {
-            using (var lazyStr = _context.GetLazyString(str))
+            using (var lazyStr = _context.GetLazyString(str, LazyStringType.SimpleString))
             {
                 WriteString(lazyStr, skipEscaping);
             }
@@ -245,9 +245,14 @@ namespace Sparrow.Json
                 WriteNull();
                 return;
             }
-
+            
             var size = str.Size;
 
+            //TODO I don't see why we need it.
+            //Maybe it was relevant in the past RavenDB-9479
+            //Also we escape here some characters differently like \n and also we escape come characters that we don't escape for string with more then 1 char.
+            //I think it is safe to delete it.
+            //But that make me think if we need for other cases to also escape b >= 127 && b <= 159
             if (size == 1 && str.IsControlCodeCharacter(out var b))
             {
                 WriteString($@"\u{b:X4}", skipEscaping: true);
@@ -256,6 +261,11 @@ namespace Sparrow.Json
 
             var strBuffer = str.Buffer;
             var escapeSequencePos = size;
+            
+            //TODO The code here relay on the function parameter to understand if the underline buffer has size prefix with escape positions.
+            //I think a clean way is to define that when you create/renew the LazyStringValue.
+            //I can make sure to assign the EscapePosition to empty array and check it here 
+            //but since it will require a lot of changes we may want to handle that later.
             var numberOfEscapeSequences = skipEscaping ? 0 : BlittableJsonReaderBase.ReadVariableSizeInt(str.Buffer, ref escapeSequencePos);
 
             // We ensure our buffer will have enough space to deal with the whole string.
@@ -819,7 +829,7 @@ namespace Sparrow.Json
                 return;
             }
 
-            using (var lazyStr = _context.GetLazyString(val.ToString(CultureInfo.InvariantCulture)))
+            using (var lazyStr = _context.GetLazyString(val.ToString(CultureInfo.InvariantCulture), LazyStringType.SimpleString))
             {
                 EnsureBuffer(lazyStr.Size);
                 WriteRawString(lazyStr.Buffer, lazyStr.Size);

--- a/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
+++ b/src/Sparrow/Json/BlittableJsonDocumentBuilder.cs
@@ -472,14 +472,9 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe LazyStringValue CreateLazyStringValueFromParserState()
+        private LazyStringValue CreateLazyStringValueFromParserState()
         {
-            var lazyStringValueFromParserState = _context.AllocateStringValue(null, _state.StringBuffer, _state.StringSize);
-            if (_state.EscapePositions.Count <= 0)
-                return lazyStringValueFromParserState;
-
-            lazyStringValueFromParserState.EscapePositions = _state.EscapePositions.ToArray();
-            return lazyStringValueFromParserState;
+            return _context.AllocateStringValue(_state);
         }
 
         public void FinalizeDocument()

--- a/src/Sparrow/Json/BlittableJsonReaderBase.Debug.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.Debug.cs
@@ -1,0 +1,7 @@
+namespace Sparrow.Json;
+#if DEBUG
+public sealed unsafe partial class BlittableJsonReaderObject
+{
+    public string DebugMemory => DebugMemoryHelper.GetDebugView(_mem, _size);
+}
+#endif

--- a/src/Sparrow/Json/BlittableJsonReaderBase.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderBase.cs
@@ -5,7 +5,7 @@ using Sparrow.Compression;
 
 namespace Sparrow.Json
 {
-    public abstract unsafe class BlittableJsonReaderBase
+    public abstract unsafe partial class BlittableJsonReaderBase
     {
         protected BlittableJsonReaderObject _parent;
         protected internal byte* _mem;
@@ -147,12 +147,12 @@ namespace Sparrow.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public LazyStringValue ReadStringLazily(int pos)
+        public LazyStringValue ReadStringLazily(int pos, bool shouldCheck = false)
         {
             AssertContextNotDisposed();
             var size = VariableSizeEncoding.Read<int>(_mem + pos, out var offset);
 
-            return _context.AllocateStringValue(null, _mem + pos + offset, size);
+            return _context.AllocateStringValue(null, _mem + pos + offset, size, LazyStringType.JsonString);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -163,7 +163,8 @@ namespace Sparrow.Json
             pos += offset;
             var compressedSize = VariableSizeEncoding.Read<int>(_mem + pos, out offset);
             pos += offset;
-            return new LazyCompressedStringValue(null, _mem + pos, uncompressedSize, compressedSize, _context);
+            //TODO To check
+            return new LazyCompressedStringValue(null, _mem + pos, uncompressedSize, compressedSize, LazyStringType.JsonString, _context);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Json/BlittableJsonReaderObject.cs
+++ b/src/Sparrow/Json/BlittableJsonReaderObject.cs
@@ -13,7 +13,7 @@ using Sparrow.Json.Parsing;
 
 namespace Sparrow.Json
 {
-    public sealed unsafe class BlittableJsonReaderObject : BlittableJsonReaderBase, IDisposable
+    public sealed unsafe partial class BlittableJsonReaderObject : BlittableJsonReaderBase, IDisposable
     {
         private static readonly object BoxedTrue = true;
         private static readonly object BoxedFalse = false;
@@ -263,7 +263,7 @@ namespace Sparrow.Json
             // Get the relative "In Document" position of the property Name
             var propRelativePos = _propNames - propertyNameOffset - _mem;
 
-            var propertyName = ReadStringLazily((int)propRelativePos);
+            var propertyName = ReadStringLazily((int)propRelativePos, true);
             return propertyName;
         }
 
@@ -855,8 +855,10 @@ namespace Sparrow.Json
             // Get the property name size
             var size = VariableSizeEncoding.Read<int>(propertyNameRelativePosition, out var propertyNameLengthDataLength);
 
+            //TODO To check what I should do with that
             // Return result of comparison between property name and received comparer
-            return comparer.Compare(propertyNameRelativePosition + propertyNameLengthDataLength, size);
+            var lazyStringValue = _context.AllocateStringValue(null, propertyNameRelativePosition + propertyNameLengthDataLength, size, LazyStringType.JsonString);
+            return comparer.CompareTo(lazyStringValue);
         }
 
         public struct InsertionOrderProperties : IDisposable
@@ -976,7 +978,7 @@ namespace Sparrow.Json
 
                 case BlittableJsonToken.LazyNumber:
                     isBlittableJsonReader = false;
-                    return new LazyNumberValue(ReadStringLazily(position));
+                    return new LazyNumberValue(ReadStringLazily(position, true));
             }
 
             throw new ArgumentOutOfRangeException(nameof(type), type.ToString(), "Unexpected type: " + type);
@@ -1357,7 +1359,7 @@ namespace Sparrow.Json
 
         private void ThrowInvalidNumber(int numberPosition)
         {
-            throw new InvalidDataException("Number not valid (" + ReadStringLazily(numberPosition).ToString() + ")");
+            throw new InvalidDataException("Number not valid (" + ReadStringLazily(numberPosition, true).ToString() + ")");
         }
 
         private static void ThrowInvalidPropertiesId()
@@ -1480,7 +1482,16 @@ namespace Sparrow.Json
 
             foreach (var propertyName in data.GetPropertyNames())
             {
-                var property = data[propertyName];
+                object property = null;
+                try
+                {
+                    property = data[propertyName];
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    // throw;
+                }
                 if (property is BlittableJsonReaderObject inner)
                 {
                     AssertNoModifications(inner, id, assertChildren: true);

--- a/src/Sparrow/Json/BlittableWriter.cs
+++ b/src/Sparrow/Json/BlittableWriter.cs
@@ -460,7 +460,8 @@ namespace Sparrow.Json
                 buffer = _context.GetMemory(size);
 
                 var stringSize = Encodings.Utf8.GetBytes(str.AsSpan(), buffer.AsSpan());
-                JsonParserState.FindEscapedPositionsAndEscapeControls(_intBuffer, buffer.Address, ref stringSize, escapePositionsMaxSize);
+                //TODO We can get a property name here
+                JsonParserState.FindEscapedPositionsAndEscapeControls(_intBuffer, buffer.Address, ref stringSize, escapePositionsMaxSize, LazyStringType.JsonString);
                 return WriteValue(buffer.Address, stringSize, _intBuffer, out token, mode, null);                
             }
             finally

--- a/src/Sparrow/Json/CachedProperties.cs
+++ b/src/Sparrow/Json/CachedProperties.cs
@@ -104,7 +104,9 @@ namespace Sparrow.Json
 
             public int CompareTo(PropertyName other)
             {
-                return Comparer.CompareTo(other.Comparer);
+                //TODO
+                int compareTo = Comparer.CompareTo(other.Comparer);
+                return compareTo;
             }
 
             public override string ToString()
@@ -170,7 +172,8 @@ namespace Sparrow.Json
 
         private readonly FastList<PropertyName> _docPropNames = new FastList<PropertyName>();
         private readonly SortedDictionary<PropertyName, object> _propertiesSortOrder = new SortedDictionary<PropertyName, object>();
-        private readonly Dictionary<LazyStringValue, PropertyName> _propertyNameToId = new Dictionary<LazyStringValue, PropertyName>(default(LazyStringValueStructComparer));
+        //LazyStringValueComparer.Instance
+        private readonly Dictionary<LazyStringValue, PropertyName> _propertyNameToId = new Dictionary<LazyStringValue, PropertyName>(LazyStringValueComparer.Instance);
         private bool _propertiesNeedSorting;
 
         public int PropertiesDiscovered;
@@ -213,13 +216,31 @@ namespace Sparrow.Json
             var prop = new PropertyName(propName.GetHashCode(), propName, -1, propIndex);
 
             _docPropNames.Add(prop);
-            _propertiesSortOrder.Add(prop, prop);
+            while (true)
+            {
+                try
+                {
+                    if (prop.Comparer.StartsWith("haludi"))
+                    {
+                        var a = 0;
+                    }
+                            
+                    _propertiesSortOrder.Add(prop, prop);
+                    break;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+                    
             _propertyNameToId[propName] = prop;
             _propertiesNeedSorting = true;
             if (_docPropNames.Count > PropertiesDiscovered + 1)
             {
                 prop = SwapPropertyIds(prop);
             }
+
             PropertiesDiscovered++;
             return prop;
         }

--- a/src/Sparrow/Json/DebugMemory.cs
+++ b/src/Sparrow/Json/DebugMemory.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Globalization;
+using System.Text;
+
+namespace Sparrow.Json;
+
+#if DEBUG
+public static class DebugMemoryHelper
+{
+    private const int BytesPerLine = 16;
+
+    public static unsafe string GetDebugView(byte* ptr, int size)
+    {
+        if (ptr == null)
+            throw new ArgumentNullException(nameof(ptr));
+        if (size < 0)
+            throw new ArgumentOutOfRangeException(nameof(size));
+
+        var sb = new StringBuilder();
+        AppendHeader(sb);
+
+        byte* start;
+        byte* end;
+
+        if (size == 0)
+        {
+            start = ptr;
+            end = ptr;
+        }
+        else
+        {
+            start = ptr;
+            end = ptr + size - 1;
+        }
+
+        byte* alignedStart = AlignPointer(ptr, size, out var totalLength);
+
+        for (int offset = 0; offset < totalLength; offset += BytesPerLine)
+        {
+            byte* linePtr = alignedStart + offset;
+            AppendLine(sb, linePtr, start, end);
+        }
+
+        return sb.ToString();
+    }
+
+    public static unsafe string GetDebugView(string hexPtr, int size)
+    {
+        if (string.IsNullOrWhiteSpace(hexPtr))
+            throw new ArgumentNullException(nameof(hexPtr));
+
+        ulong address = ulong.Parse(hexPtr, NumberStyles.HexNumber);
+        byte* ptr = (byte*)address;
+
+        return GetDebugView(ptr, size);
+    }
+
+    private static void AppendHeader(StringBuilder sb)
+    {
+        sb.Append(' ', 37);
+        sb.AppendLine("0123456789abcdef");
+    }
+
+    private static unsafe byte* AlignPointer(byte* ptr, int size, out int totalLength)
+    {
+        // Compute extra bytes so that we start on a BytesPerLine boundary.
+        int extra = (int)((long)ptr % BytesPerLine) + BytesPerLine;
+        byte* aligned = ptr - extra;
+
+        // Cover the requested size plus padding before and one extra line after.
+        totalLength = size + extra + BytesPerLine;
+        return aligned;
+    }
+
+    private static unsafe void AppendLine(StringBuilder sb, byte* linePtr, byte* start, byte* end)
+    {
+        AppendOffset(sb, linePtr);
+        AppendHexRange(sb, linePtr, start, end, 0, 8);   // left hex (0–7)
+        AppendAscii(sb, linePtr, start, end);
+        sb.Append(' ');
+        AppendHexRange(sb, linePtr, start, end, 8, BytesPerLine); // right hex (8–15)
+        sb.AppendLine();
+    }
+
+    private static unsafe void AppendOffset(StringBuilder sb, byte* linePtr)
+    {
+        sb.Append($"{(long)linePtr:X8}: ");
+    }
+
+    private static unsafe void AppendHexRange(StringBuilder sb, byte* linePtr, byte* start, byte* end, int from, int to)
+    {
+        for (int i = from; i < to; i++)
+        {
+            byte* current = linePtr + i;
+            AppendHexByteWithMarkers(sb, current, start, end);
+        }
+    }
+
+    private static unsafe void AppendHexByteWithMarkers(StringBuilder sb, byte* current, byte* start, byte* end)
+    {
+        if(current == start)
+            sb[sb.Length - 1] = '*';
+        
+        sb.Append($"{current[0]:X2}");
+        sb.Append(current == end?'*':' ');
+    }
+
+    private static unsafe void AppendAscii(StringBuilder sb, byte* linePtr, byte* start, byte* end)
+    {
+        for (int j = 0; j < BytesPerLine; j++)
+        {
+            byte* current = linePtr + j;
+            byte b = current[0];
+            sb.Append(IsPrintableAscii(b) ? (char)b : '.');
+        }
+    }
+
+    private static bool IsPrintableAscii(byte b) => b is >= 32 and <= 126;
+}
+#endif

--- a/src/Sparrow/Json/JsonOperationContext.cs
+++ b/src/Sparrow/Json/JsonOperationContext.cs
@@ -38,6 +38,7 @@ namespace Sparrow.Json
         private AllocatedMemoryData _tempBuffer;
 
         private readonly Dictionary<StringSegment, LazyStringValue> _fieldNames = new Dictionary<StringSegment, LazyStringValue>(StringSegmentEqualityStructComparer.BoxedInstance);
+        private readonly Dictionary<LazyStringValue, LazyStringValue> _fieldNamesLazyStrings = new Dictionary<LazyStringValue, LazyStringValue>(LazyStringValueComparer.Instance);
 
         private static readonly PerCoreContainer<PathCache> _perCorePathCache = new PerCoreContainer<PathCache>();
         private PathCache _activeAllocatePathCaches;
@@ -53,26 +54,35 @@ namespace Sparrow.Json
         /// </summary>
         public bool DoNotReuse;
 
-        public LazyStringValue Empty => _empty ??= GetLazyString(string.Empty);
+        public LazyStringValue Empty => _empty ??= GetLazyString(string.Empty, LazyStringType.SimpleString);
         private LazyStringValue _empty;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe LazyStringValue AllocateStringValue(string str, byte* ptr, int size)
+        public unsafe LazyStringValue AllocateStringValue(string str, byte* ptr, int size, LazyStringType type, bool shouldCheck = false)
         {
             if (_numberOfAllocatedStringsValues < _allocateStringValues.Count)
             {
                 var lazyStringValue = _allocateStringValues[_numberOfAllocatedStringsValues++];
-                lazyStringValue.Renew(str, ptr, size, this);
+                lazyStringValue.Renew(str, ptr, size, this, type, shouldCheck);
                 return lazyStringValue;
             }
 
-            var allocateStringValue = new LazyStringValue(str, ptr, size, this);
+            var allocateStringValue = new LazyStringValue(str, ptr, size, this, type, shouldCheck);
             if (_numberOfAllocatedStringsValues < _maxNumberOfAllocatedStringValues)
             {
                 _allocateStringValues.Add(allocateStringValue);
                 _numberOfAllocatedStringsValues++;
             }
 
+            return allocateStringValue;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe LazyStringValue AllocateStringValue(JsonParserState state, bool shouldCheck = false)
+        {
+            var allocateStringValue = AllocateStringValue(null, state.StringBuffer, state.StringSize, state.StringType, shouldCheck);
+            //TODO To verify that we want the allocation here
+            allocateStringValue.EscapePositions = state.EscapePositions.Count > 0 ? state.EscapePositions.ToArray() : [];
             return allocateStringValue;
         }
 
@@ -426,7 +436,7 @@ namespace Sparrow.Json
         public LazyStringValue GetLazyStringForFieldWithCaching(StringSegment key)
         {
             EnsureNotDisposed();
-
+            
             if (_fieldNames.TryGetValue(key, out LazyStringValue value))
             {
                 //sanity check, in case the 'value' is manually disposed outside of this function
@@ -437,6 +447,20 @@ namespace Sparrow.Json
             return GetLazyStringForFieldWithCachingUnlikely(key);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LazyStringValue GetLazyStringForFieldWithCaching(LazyStringValue field)
+        {
+            EnsureNotDisposed();
+            if (_fieldNamesLazyStrings.TryGetValue(field, out LazyStringValue value))
+            {
+                // PERF: This is usually the most common scenario, so actually being contiguous improves the behavior.
+                Debug.Assert(value.IsDisposed == false);
+                return value;
+            }
+
+            return GetLazyStringForFieldWithCachingUnlikely(field.ToString());
+        }
+        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue GetLazyStringForFieldWithCaching(string field)
         {
@@ -457,34 +481,36 @@ namespace Sparrow.Json
             using (new SingleThreadAccessAssertion(_threadId, "GetLazyStringForFieldWithCachingUnlikely"))
             {
 #endif
-            EnsureNotDisposed();
-            LazyStringValue value = GetLazyString(key, longLived: true);
-            _fieldNames[key.Value] = value;
+                EnsureNotDisposed();
+                //TODO To verify if it better to use JsonString here 
+                var value = GetLazyString(key, longLived: true, LazyStringType.JsonString);
+                _fieldNames[key.Value] = value;
+                _fieldNamesLazyStrings[value] = value;
 
-            //sanity check, in case the 'value' is manually disposed outside of this function
-            Debug.Assert(value.IsDisposed == false);
-            return value;
+                //sanity check, in case the 'value' is manually disposed outside of this function
+                Debug.Assert(value.IsDisposed == false);
+                return value;
 #if DEBUG || VALIDATE
             }
 #endif
         }
 
-        public LazyStringValue GetLazyString(string field)
+        public LazyStringValue GetLazyString(string field, LazyStringType type = LazyStringType.JsonString)
         {
             EnsureNotDisposed();
 
             if (field == null)
                 return null;
 
-            return GetLazyString(field, longLived: false);
+            return GetLazyString(field, longLived: false, type);
         }
 
-        private unsafe LazyStringValue GetLazyString(StringSegment field, bool longLived)
+        private unsafe LazyStringValue GetLazyString(StringSegment field, bool longLived, LazyStringType type)
         {
             var state = new JsonParserState();
             var maxByteCount = Encodings.Utf8.GetMaxByteCount(field.Length);
 
-            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(field, out _);
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(field, out var controlCount);
 
             int memorySize = maxByteCount + escapePositionsSize;
             var memory = longLived ? GetLongLivedMemory(memorySize) : GetMemory(memorySize);
@@ -494,21 +520,20 @@ namespace Sparrow.Json
                 var address = memory.Address;
                 var actualSize = Encodings.Utf8.GetBytes(pField + field.Offset, field.Length, address, memory.SizeInBytes);
 
-                state.FindEscapedPositionsAndEscapeControls(address, ref actualSize, escapePositionsSize);
+                var originSize = actualSize;
+                state.FindEscapedPositionsAndEscapeControls(address, ref actualSize, escapePositionsSize, type);
 
                 state.WriteEscapePositionsTo(address + actualSize);
-                LazyStringValue result = longLived == false ? AllocateStringValue(field.Value, address, actualSize) : new LazyStringValue(field.Value, address, actualSize, this);
+                var actualType = actualSize > originSize ? LazyStringType.JsonString : LazyStringType.SimpleString;
+                var result = longLived ? new LazyStringValue(field.Value, address, actualSize, this, actualType) : AllocateStringValue(field.Value, address, actualSize, actualType);
                 result.AllocatedMemoryData = memory;
-
-                if (state.EscapePositions.Count > 0)
-                {
-                    result.EscapePositions = state.EscapePositions.ToArray();
-                }
+                result.EscapePositions = state.EscapePositions.Count > 0 ? state.EscapePositions.ToArray() : [];
                 return result;
             }
         }
 
-        public unsafe LazyStringValue GetLazyString(byte* ptr, int size, bool longLived = false)
+        //TODO 
+        public unsafe LazyStringValue GetLazyString(byte* ptr, int size, LazyStringType type, bool shouldCheck = false, bool longLived = false)
         {
             var state = new JsonParserState();
             var maxByteCount = Encodings.Utf8.GetMaxByteCount(size);
@@ -522,25 +547,73 @@ namespace Sparrow.Json
 
             Memory.Copy(address, ptr, size);
 
-            state.FindEscapedPositionsAndEscapeControls(address, ref size, escapePositionsSize);
+            var originSize = size;
+            state.FindEscapedPositionsAndEscapeControls(address, ref size, escapePositionsSize, type);
 
             state.WriteEscapePositionsTo(address + size);
-            LazyStringValue result = longLived == false ? AllocateStringValue(null, address, size) : new LazyStringValue(null, address, size, this);
-            result.AllocatedMemoryData = memory;
+            
+            var actualType = size > originSize ? LazyStringType.JsonString : LazyStringType.SimpleString;
+            var result = longLived ? new LazyStringValue(null, address, size, this, actualType, shouldCheck) : AllocateStringValue(null, address, size, type, shouldCheck);
 
-            if (state.EscapePositions.Count > 0)
-            {
-                result.EscapePositions = state.EscapePositions.ToArray();
-            }
+            result.AllocatedMemoryData = memory;
+            result.EscapePositions = state.EscapePositions.Count > 0 ? state.EscapePositions.ToArray() : []; 
+            
             return result;
         }
 
+        // public unsafe LazyStringValue UnescapeControlCharacters(byte* ptr, int size, int[] escapedPositions, bool longLived = false)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public unsafe LazyStringValue GetLazyStringValue(byte* ptr, out bool success)
+        public unsafe bool CopyAndUnescapeControlCharacters(string stringValue, LazyStringValue str, out LazyStringValue result)
+        {
+            if (str.EscapePositions != null)
+                return CopyAndUnescapeControlCharactersInternal(stringValue, str, str.EscapePositions, out result);
+            
+            var reader = StringUtils.GetEscapePositionsReader(str);
+            //TODO To allocate on heap for very big
+            Span<int> buffer = stackalloc int[reader.Length];
+            var escapePositions = new StringUtils.SpanWriter<int>(buffer);
+            while (reader.Read())
+                escapePositions.Append(reader.Current);
+            
+            return CopyAndUnescapeControlCharactersInternal(stringValue, str, escapePositions.AsSpan(), out result);
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe bool CopyAndUnescapeControlCharactersInternal(string stringValue, LazyStringValue str, Span<int> escapePositions, out LazyStringValue result)
+        {
+            var escapedCount = StringUtils.CountEscapedControlCharacters(str.AsReadOnlySpan(), escapePositions);
+            
+            if (escapedCount == 0)
+            {
+                result = null;
+                return false;
+            }
+            
+            // 1 for the count of the escaped positions
+            var destMemorySize = str.Size + (1 + escapePositions.Length + escapedCount) * JsonParserState.EscapePositionItemSize;
+            var destinationMemory = GetMemory(destMemorySize);
+            var destinationBuffer = new Span<byte>(destinationMemory.Address, str.Length);
+
+            var escapePosLength = escapePositions.Length + escapedCount;
+            //TODO To allocate on heap for very big
+            Span<int> destinationEscapedPositions = stackalloc int[escapePosLength];
+            var unescaped = StringUtils.UnescapeControlCharacters(str.AsReadOnlySpan(), escapePositions, destinationBuffer, destinationEscapedPositions);
+
+            result = AllocateStringValue(stringValue, destinationMemory.Address, unescaped.Length, LazyStringType.SimpleString);
+            JsonParserState.WriteEscapePositionsTo(destinationMemory.Address + unescaped.Length, destinationEscapedPositions);
+            result.Check_TempFunction();
+            
+            result.AllocatedMemoryData = destinationMemory;
+            
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe LazyStringValue GetLazyStringValue(byte* ptr, LazyStringType type, out bool success, bool shouldCheck = false)
         {
             // See format of the lazy string ID in the GetLowerIdSliceAndStorageKey method
             var size = BlittableJsonReaderBase.ReadVariableSizeInt(ptr, 0, out var offset, out success);
-            return AllocateStringValue(null, ptr + offset, size);
+            return AllocateStringValue(null, ptr + offset, size, type, shouldCheck);
         }
 
         public ValueTask<BlittableJsonReaderObject> ReadForDiskAsync(Stream stream, string documentId, CancellationToken? token = null)
@@ -913,6 +986,7 @@ namespace Sparrow.Json
                 allocatorForLongLivedValues.Dispose();
 
                 _fieldNames.Clear();
+                _fieldNamesLazyStrings.Clear(); // no need to dispose the data here, same instances as in _fieldNames 
             }
 
             if (_allocateStringValues != null)
@@ -1046,12 +1120,7 @@ namespace Sparrow.Json
                     writer.WriteComma();
                 first = false;
 
-                LazyStringValue lazyStringValue;
-                unsafe
-                {
-                    lazyStringValue = AllocateStringValue(null, state.StringBuffer, state.StringSize);
-                }
-
+                var lazyStringValue = AllocateStringValue(state);
                 writer.WritePropertyName(lazyStringValue);
 
                 if (parser.Read() == false)
@@ -1086,19 +1155,15 @@ namespace Sparrow.Json
                         LazyCompressedStringValue lazyCompressedStringValue;
                         unsafe
                         {
-                            lazyCompressedStringValue = new LazyCompressedStringValue(null, state.StringBuffer, state.StringSize, state.CompressedSize.Value, this);
+                            //TODO To check
+                            lazyCompressedStringValue = new LazyCompressedStringValue(null, state.StringBuffer, state.StringSize, state.CompressedSize.Value, state.StringType, this);
                         }
 
                         writer.WriteString(lazyCompressedStringValue);
                     }
                     else
                     {
-                        LazyStringValue lazyStringValue;
-                        unsafe
-                        {
-                            lazyStringValue = AllocateStringValue(null, state.StringBuffer, state.StringSize);
-                        }
-
+                        var lazyStringValue = AllocateStringValue(state);
                         writer.WriteString(lazyStringValue);
                     }
                     break;
@@ -1107,7 +1172,7 @@ namespace Sparrow.Json
                     LazyStringValue lazyStringValueForNumber;
                     unsafe
                     {
-                        lazyStringValueForNumber = AllocateStringValue(null, state.StringBuffer, state.StringSize);
+                        lazyStringValueForNumber = AllocateStringValue(null, state.StringBuffer, state.StringSize, LazyStringType.SimpleString);
                     }
 
                     writer.WriteDouble(new LazyNumberValue(lazyStringValueForNumber));

--- a/src/Sparrow/Json/LazyCompressedStringValue.cs
+++ b/src/Sparrow/Json/LazyCompressedStringValue.cs
@@ -4,13 +4,14 @@ using Sparrow.Compression;
 
 namespace Sparrow.Json
 {
-    public sealed unsafe class LazyCompressedStringValue
+    public sealed unsafe class LazyCompressedStringValue //TODO To check
     {
         private readonly JsonOperationContext _context;
         public readonly byte* Buffer;
 
         public readonly int UncompressedSize;
         public readonly int CompressedSize;
+        public readonly LazyStringType Type;
         public string String;
 
         public override bool Equals(object obj)
@@ -43,17 +44,19 @@ namespace Sparrow.Json
         {
             var allocatedUncompressedData = DecompressToAllocatedMemoryData(_context);
 
-            var lazyStringValue = _context.AllocateStringValue(null, allocatedUncompressedData.Address, UncompressedSize);
+            //TODO To check
+            var lazyStringValue = _context.AllocateStringValue(null, allocatedUncompressedData.Address, UncompressedSize, Type, true);
 
             lazyStringValue.AllocatedMemoryData = allocatedUncompressedData;
             return lazyStringValue;
         }
 
-        public LazyCompressedStringValue(string str, byte* buffer, int uncompressedSize, int compressedSize, JsonOperationContext context)
+        public LazyCompressedStringValue(string str, byte* buffer, int uncompressedSize, int compressedSize, LazyStringType type, JsonOperationContext context)
         {
             String = str;
             UncompressedSize = uncompressedSize;
             CompressedSize = compressedSize;
+            Type = type;
             _context = context;
             Buffer = buffer;
         }

--- a/src/Sparrow/Json/LazyStringType.cs
+++ b/src/Sparrow/Json/LazyStringType.cs
@@ -1,0 +1,9 @@
+﻿namespace Sparrow.Json;
+
+public enum LazyStringType
+{
+    Invalid,
+    JsonString,
+    SimpleString,
+    PotentiallyJsonString,
+}

--- a/src/Sparrow/Json/LazyStringValue.Debug.cs
+++ b/src/Sparrow/Json/LazyStringValue.Debug.cs
@@ -1,0 +1,7 @@
+namespace Sparrow.Json;
+#if DEBUG
+public unsafe partial class  LazyStringValue 
+{
+    public string DebugMemory => DebugMemoryHelper.GetDebugView(_buffer, _size);
+}
+#endif

--- a/src/Sparrow/Json/LazyStringValue.cs
+++ b/src/Sparrow/Json/LazyStringValue.cs
@@ -58,7 +58,7 @@ namespace Sparrow.Json
     }
 
     // PERF: Sealed because in CoreCLR 2.0 it will devirtualize virtual calls methods like GetHashCode.
-    public sealed unsafe class LazyStringValue : IComparable<string>, IEquatable<string>,
+    public sealed unsafe partial class LazyStringValue : IComparable<string>, IEquatable<string>,
         IComparable<LazyStringValue>, IEquatable<LazyStringValue>, IDisposable, IComparable, IConvertible, IEnumerable<char>
     {
         internal JsonOperationContext _context;
@@ -87,6 +87,20 @@ namespace Sparrow.Json
             }
         }
 
+        //TODO I implement that so we cache the simple value lazily.
+        //This is only relevant if the value has control characters.
+        //If not we just set the time to SimpleString and this stays null
+        //Since this is only to handle relativly rare cases we can consider of disposing the simple value immidiately rather then caching it
+        private LazyStringValue _simpleStringValue;
+
+        public LazyStringType Type
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private set; 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
+        
         public bool EqualsOrdinalIgnoreCase(LazyStringValue other)
         {
             return CompareToOrdinalIgnoreCase(this.Buffer, Size, other.Buffer, other.Size) == 0;
@@ -151,21 +165,26 @@ namespace Sparrow.Json
             Memory.Copy(dest, _buffer, _size);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public LazyStringValue Clone(JsonOperationContext context)
         {
-            if (_size == 0)
-                return context.Empty;
-
-            return context.GetLazyString(_buffer, _size, longLived: false);
+            //The previous implementation used to also escape control characters so here it is a behaviour change
+            return Clone(context, Type);
         }
-
-        public LazyStringValue CloneOnSameContext()
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LazyStringValue Clone(JsonOperationContext context, LazyStringType type)
         {
-            if (_size == 0)
-                return _context.Empty;
-
-            return _context.GetLazyString(_buffer, _size, longLived: false);
+            return _size == 0
+                ? context.Empty
+                : Type == LazyStringType.SimpleString
+                    ? context.GetLazyString(_buffer, _size, type, longLived: false)
+                    //TODO Implement a more efficient way to clone a json string without the need to convert it to simple string first
+                    : AsSimpleValue().Clone(context, type);
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LazyStringValue CloneOnSameContext() => Clone(_context);
 
         public bool HasStringValue => _string != null;
 
@@ -175,7 +194,7 @@ namespace Sparrow.Json
         [ThreadStatic]
         private static byte[] _lazyStringTempComparisonBuffer;
 
-        private static char[] GetlazyStringTempBuffer(int charCount)
+        private static char[] GetLazyStringTempBuffer(int charCount)
         {
             if (_lazyStringTempBuffer == null || _lazyStringTempBuffer.Length < charCount)
                 _lazyStringTempBuffer = new char[Bits.NextAllocationSize(charCount)];
@@ -198,7 +217,7 @@ namespace Sparrow.Json
         public AllocatedMemoryData AllocatedMemoryData;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public LazyStringValue(string str, byte* buffer, int size, JsonOperationContext context)
+        public LazyStringValue(string str, byte* buffer, int size, JsonOperationContext context, LazyStringType type, bool shouldCheck = false)
         {
             Debug.Assert(context != null);
             _context = context;
@@ -206,6 +225,11 @@ namespace Sparrow.Json
             _buffer = buffer;
             _string = str;
             _length = -1;
+            Type = type;
+
+            //TODO To remove "shouldCheck" (it is just for the time of developing)
+            if (shouldCheck)
+                Check_TempFunction();
         }
 
         static LazyStringValue()
@@ -226,10 +250,11 @@ namespace Sparrow.Json
             if (IsDisposed)
                 ThrowAlreadyDisposed();
 #endif
-
+            if (other == null)
+                return false;
+            
             if (_string != null)
                 return string.Equals(_string, other, StringComparison.Ordinal);
-
 
             var buffer = GetLazyStringTempComparisonBuffer(other.Length);
             fixed (char* pOther = other)
@@ -239,7 +264,8 @@ namespace Sparrow.Json
                 if (Size != tmpSize)
                     return false;
 
-                return Memory.CompareInline(Buffer, pBuffer, tmpSize) == 0;
+                var toCompare = Type == LazyStringType.SimpleString ? this : AsSimpleValue();
+                return Memory.CompareInline(toCompare.Buffer, pBuffer, tmpSize) == 0;
             }
         }
 
@@ -250,9 +276,22 @@ namespace Sparrow.Json
             if (IsDisposed)
                 ThrowAlreadyDisposed();
 #endif
+            if (other == null)
+                return false;
+            
+            if (Type == other.Type)
+                return EqualsSameType(other);
+            
+            return AsSimpleValue().EqualsSameType(other.AsSimpleValue());
+        }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool EqualsSameType(LazyStringValue other)
+        {
+            Debug.Assert(Type == other.Type);
+            
             int size = Size;
-            if (other.Size != size)
+            if (size != other.Size)
                 return false;
 
             return Memory.CompareInline(Buffer, other.Buffer, size) == 0;
@@ -263,6 +302,20 @@ namespace Sparrow.Json
             if (_string != null)
                 return string.Compare(_string, other, StringComparison.Ordinal);
 
+            if(Type == LazyStringType.SimpleString)
+                return CompareSimpleStringTo(other);
+            
+            if(Type == LazyStringType.JsonString)
+                return AsSimpleValue().CompareSimpleStringTo(other);
+            
+            ThrowInvalidType();
+            return 0; // never reached
+        }
+
+        private int CompareSimpleStringTo(string other)
+        {
+            Debug.Assert(Type == LazyStringType.SimpleString);
+            
             var sizeInBytes = Encodings.Utf8.GetMaxByteCount(other.Length);
 
             var buffer = GetLazyStringTempComparisonBuffer(other.Length);
@@ -270,20 +323,30 @@ namespace Sparrow.Json
             fixed (byte* pBuffer = buffer)
             {
                 var tmpSize = Encodings.Utf8.GetBytes(pOther, other.Length, pBuffer, sizeInBytes);
-                return Compare(pBuffer, tmpSize);
+                return CompareSameType(pBuffer, tmpSize);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int CompareTo(LazyStringValue other)
         {
-            if (other.Buffer == Buffer && other.Size == Size)
-                return 0;
-            return Compare(other.Buffer, other.Size);
+            return Type == other.Type 
+                ? CompareSameType(other) 
+                : AsSimpleValue().CompareSameType(AsSimpleValue());
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int Compare(byte* other, int otherSize)
+        private int CompareSameType(LazyStringValue other)
+        {
+            Debug.Assert(Type == other.Type);
+            
+            if (other.Buffer == Buffer && other.Size == Size)
+                return 0;
+            return CompareSameType(other.Buffer, other.Size);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int CompareSameType(byte* other, int otherSize)
         {
 #if DEBUG
             if (IsDisposed)
@@ -329,9 +392,83 @@ namespace Sparrow.Json
             if (self.IsDisposed)
                 self.ThrowAlreadyDisposed();
 #endif
-            return self._string ??
-                   (self._string = Encodings.Utf8.GetString(self._buffer, self._size));
+            if (self._string != null)
+                return self._string;
+
+            if (self.Type == LazyStringType.SimpleString)
+                return self._string = Encodings.Utf8.GetString(self._buffer, self._size);
+
+            if (self.Type == LazyStringType.JsonString)
+            {
+                //TODO
+                LazyStringValue lazyStringValue = self.AsSimpleValue();
+                return self._string = lazyStringValue;
+            }
+
+            ThrowInvalidType();
+            return null; // never reached
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private LazyStringValue AsSimpleValue()
+        {
+            if(Type == LazyStringType.SimpleString)
+                return this;
+            
+            if(_simpleStringValue != null)
+            {
+                //TODO Maybe to handle better if the context was reset
+                if(_simpleStringValue.Type != LazyStringType.Invalid)
+                    return _simpleStringValue;
+                _simpleStringValue = null;
+            }
+
+            if (Type == LazyStringType.JsonString)
+            {
+                if (_context.CopyAndUnescapeControlCharacters(_string, this, out var value))
+                    return _simpleStringValue = value;
+                
+                Type = LazyStringType.SimpleString;
+                return this;
+            }
+
+            ThrowInvalidType();
+            return null; // never reached
+        }
+
+        public void Check_TempFunction()
+        {
+            int controlCharsCount = 0;
+            try
+            {
+                controlCharsCount = CheckControlCharacters_TempFunction();
+            }
+            catch (Exception e)
+            {
+                var breakpoint = 0;
+            }
+            if (controlCharsCount > 0)
+            {
+                var breakpoint = 0;
+            }
+        }
+
+        private int CheckControlCharacters_TempFunction()
+        {
+            if (EscapePositions != null)
+                return StringUtils.CountEscapedControlCharacters(AsSpan(), EscapePositions.AsSpan());
+            
+            var reader = StringUtils.GetEscapePositionsReader(this);
+            //TODO To allocate on heap for very big
+            Span<int> buffer = stackalloc int[reader.Length];
+            var escapePositions = new StringUtils.SpanWriter<int>(buffer);
+            while (reader.Read())
+                escapePositions.Append(reader.Current);
+            
+            return StringUtils.CountEscapedControlCharacters(AsSpan(), escapePositions.AsSpan());
+        }
+        
+        private static void ThrowInvalidType() => throw new InvalidOperationException(); //TODO
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator byte[](LazyStringValue self)
@@ -442,11 +579,31 @@ namespace Sparrow.Json
             if (_hashCode.HasValue)
                 return _hashCode.Value;
 
+            if (Type == LazyStringType.SimpleString)
+            {
+                _hashCode = GetHashCodeForSimpleString();
+                return _hashCode.Value;
+            }
+
+            if (Type == LazyStringType.JsonString)
+            {
+                _hashCode = AsSimpleValue().GetHashCodeForSimpleString();
+                return _hashCode.Value;
+            }
+
+            ThrowInvalidType();
+            return 0; // never reached
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int? GetHashCodeForSimpleString()
+        {
+            Debug.Assert(Type == LazyStringType.SimpleString);
             _hashCode = IntPtr.Size == 4
                 ? (int)Hashing.XXHash32.CalculateInline(Buffer, Size)
                 : (int)Hashing.XXHash64.CalculateInline(Buffer, (ulong)Size);
 
-            return _hashCode.Value;
+            return _hashCode;
         }
 
         public override string ToString()
@@ -488,7 +645,9 @@ namespace Sparrow.Json
                 ThrowAlreadyDisposed();
 
             ReturnAllocatedMemory();
-
+            //TODO The simple string dispose is done by the context
+            _simpleStringValue = null;
+            
             IsDisposed = true;
         }
 
@@ -655,7 +814,7 @@ namespace Sparrow.Json
 
             ValidateIndexes(startIndex, count);
 
-            var buffer = GetlazyStringTempBuffer(Length);
+            var buffer = GetLazyStringTempBuffer(Length);
             fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
 
@@ -718,7 +877,7 @@ namespace Sparrow.Json
 
             ValidateIndexes(startIndex, count);
 
-            var buffer = GetlazyStringTempBuffer(Length);
+            var buffer = GetLazyStringTempBuffer(Length);
             fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
 
@@ -756,7 +915,7 @@ namespace Sparrow.Json
 
             ValidateIndexes(Length - startIndex - 1, count);
 
-            var buffer = GetlazyStringTempBuffer(Length);
+            var buffer = GetLazyStringTempBuffer(Length);
 
             fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
@@ -823,7 +982,7 @@ namespace Sparrow.Json
 
             ValidateIndexes(Length - startIndex - 1, count);
 
-            var buffer = GetlazyStringTempBuffer(Length);
+            var buffer = GetLazyStringTempBuffer(Length);
 
             fixed (char* pChars = buffer)
                 Encodings.Utf8.GetChars(Buffer, Size, pChars, Length);
@@ -1147,7 +1306,7 @@ namespace Sparrow.Json
                 ThrowAlreadyDisposed();
 
             var maxCharCount = Encodings.Utf8.GetMaxCharCount(Length);
-            var charBuf = GetlazyStringTempBuffer(maxCharCount);
+            var charBuf = GetLazyStringTempBuffer(maxCharCount);
 
             var buffer = _buffer;
 
@@ -1177,11 +1336,11 @@ namespace Sparrow.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
-            Renew(null, null, 0, null);
+            Renew(null, null, 0, null, LazyStringType.Invalid);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Renew(string str, byte* buffer, int size, JsonOperationContext context)
+        public void Renew(string str, byte* buffer, int size, JsonOperationContext context, LazyStringType type, bool shouldCheck = false)
         {
             Debug.Assert(size >= 0);
 
@@ -1194,8 +1353,18 @@ namespace Sparrow.Json
             EscapePositions = null;
             IsDisposed = false;
             AllocatedMemoryData = null;
-            _hashCode = default;
+            _hashCode = null;
             _context = context;
+
+            if (_simpleStringValue != null)
+            {
+                _simpleStringValue.Reset();
+                _simpleStringValue = null;
+            }
+            Type = type;
+            
+            if (shouldCheck)
+                Check_TempFunction();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Sparrow/Json/Parsing/JsonParserState.cs
+++ b/src/Sparrow/Json/Parsing/JsonParserState.cs
@@ -10,6 +10,7 @@ namespace Sparrow.Json.Parsing
         public const int ControlCharacterItemSize = 5;
         public byte* StringBuffer;
         public int StringSize;
+        public LazyStringType StringType;
         public int? CompressedSize;
         public long Long;
         public JsonParserToken CurrentTokenType;
@@ -51,9 +52,10 @@ namespace Sparrow.Json.Parsing
             return FindMaxEscapePositionAndControlCharSize(str.AsSpan(), out controlCount);
         }
         
-        public static int FindMaxEscapePositionAndControlCharSize(ReadOnlySpan<char> str, out int controlCount)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void FindEscapeAndControlCharactersCount(ReadOnlySpan<char> str, out int escapedCount, out int controlCount)
         {
-            var count = 0;
+            escapedCount = 0;
             controlCount = 0;
 
             for (int i = 0; i < str.Length; i++)
@@ -72,15 +74,19 @@ namespace Sparrow.Json.Parsing
 
                 if (value == 92 || value == 34 || (value >= 8 && value <= 13 && value != 11))
                 {
-                    count++;
+                    escapedCount++;
                     continue;
                 }
 
                 if (value < 32)
-                {
                     controlCount++;
-                }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int FindMaxEscapePositionAndControlCharSize(ReadOnlySpan<char> str, out int controlCount)
+        {
+            FindEscapeAndControlCharactersCount(str, out int count, out controlCount);
 
             // we take 5 because that is the max number of bytes for variable size int
             // plus 1 for the actual number of positions
@@ -130,12 +136,12 @@ namespace Sparrow.Json.Parsing
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void FindEscapedPositionsAndEscapeControls(byte* str, ref int len, int previousComputedMaxSize)
+        public void FindEscapedPositionsAndEscapeControls(byte* str, ref int len, int previousComputedMaxSize, LazyStringType type)
         {
-            FindEscapedPositionsAndEscapeControls(EscapePositions, str, ref len, previousComputedMaxSize);
+            FindEscapedPositionsAndEscapeControls(EscapePositions, str, ref len, previousComputedMaxSize, type);
         }
 
-        public static void FindEscapedPositionsAndEscapeControls(FastList<int> buffer, byte* str, ref int len, int previousComputedMaxSize)
+        public static void FindEscapedPositionsAndEscapeControls(FastList<int> buffer, byte* str, ref int len, int previousComputedMaxSize, LazyStringType type)
         {
             var originalLen = len;
             buffer.Clear();
@@ -169,6 +175,13 @@ namespace Sparrow.Json.Parsing
                 //Control character ascii values
                 if (value < 32)
                 {
+                    if(type == LazyStringType.SimpleString)
+                    {
+                        buffer.Add(i - lastEscape);
+                        lastEscape = i + 1;
+                        continue;
+                    }
+                    
                     if (len + ControlCharacterItemSize > originalLen + previousComputedMaxSize)
                         ThrowInvalidSizeForEscapeControlChars(previousComputedMaxSize);
 
@@ -197,11 +210,16 @@ namespace Sparrow.Json.Parsing
         public int WriteEscapePositionsTo(byte* buffer)
         {
             var escapePositions = EscapePositions;
-            var originalBuffer = buffer;
-            WriteVariableSizeInt(ref buffer, escapePositions.Count);
+            return WriteEscapePositionsTo(buffer, escapePositions.AsUnsafeSpan());
+        }
 
-            // PERF: Using a for in this way will evict the bounds-check and also avoid the cost of using an struct enumerator. 
-            for (int i = 0; i < escapePositions.Count; i++)
+        public static int WriteEscapePositionsTo(byte* buffer, Span<int> escapePositions)
+        {
+            var originalBuffer = buffer;
+            WriteVariableSizeInt(ref buffer, escapePositions.Length);
+
+            // PERF: Using a for in this way will evict the bounds-check and also avoid the cost of using a struct enumerator. 
+            for (int i = 0; i < escapePositions.Length; i++)
                 WriteVariableSizeInt(ref buffer, escapePositions[i]);
 
             return (int)(buffer - originalBuffer);
@@ -211,6 +229,7 @@ namespace Sparrow.Json.Parsing
         {
             StringBuffer = null;
             StringSize = 0;
+            StringType = LazyStringType.Invalid;
             CompressedSize = null;
             Long = 0;
             CurrentTokenType = JsonParserToken.None;

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -414,6 +414,7 @@ namespace Sparrow.Json.Parsing
                     _state.StringSize = lsv.Size;
                     _state.CompressedSize = null;// don't even try
                     _state.CurrentTokenType = JsonParserToken.String;
+                    _state.StringType = lsv.Type;
                     ReadEscapePositions(lsv.Buffer, lsv.Size);
                     return true;
                 }
@@ -422,6 +423,7 @@ namespace Sparrow.Json.Parsing
                 {
                     _state.StringBuffer = bs.Address;
                     _state.StringSize = bs.Length;
+                    _state.StringType = LazyStringType.Invalid;
                     _state.CompressedSize = null;// don't even try
                     _state.CurrentTokenType = JsonParserToken.Blob;
                     return true;
@@ -433,6 +435,8 @@ namespace Sparrow.Json.Parsing
                     _state.StringSize = lcsv.UncompressedSize;
                     _state.CompressedSize = lcsv.CompressedSize;
                     _state.CurrentTokenType = JsonParserToken.String;
+                    //TODO to check
+                    _state.StringType = lcsv.Type;
                     ReadEscapePositions(lcsv.Buffer, lcsv.CompressedSize);
                     return true;
                 }
@@ -441,6 +445,7 @@ namespace Sparrow.Json.Parsing
                 {
                     _state.StringBuffer = ldv.Inner.Buffer;
                     _state.StringSize = ldv.Inner.Size;
+                    _state.StringType = ldv.Inner.Type;
                     _state.CompressedSize = null;// don't even try
                     _state.CurrentTokenType = JsonParserToken.Float;
                     ReadEscapePositions(ldv.Inner.Buffer, ldv.Inner.Size);
@@ -517,6 +522,7 @@ namespace Sparrow.Json.Parsing
 
                     SetStringBuffer(s);
                     _state.CurrentTokenType = JsonParserToken.String;
+                    _state.StringType = LazyStringType.SimpleString;
                     return true;
                 }
 
@@ -526,6 +532,7 @@ namespace Sparrow.Json.Parsing
 
                     SetStringBuffer(s);
                     _state.CurrentTokenType = JsonParserToken.String;
+                    _state.StringType = LazyStringType.SimpleString;
                     return true;
                 }
 
@@ -535,6 +542,7 @@ namespace Sparrow.Json.Parsing
 
                     SetStringBuffer(s);
                     _state.CurrentTokenType = JsonParserToken.String;
+                    _state.StringType = LazyStringType.SimpleString;
                     return true;
                 }
                 
@@ -545,6 +553,7 @@ namespace Sparrow.Json.Parsing
 
                     SetStringBuffer(s);
                     _state.CurrentTokenType = JsonParserToken.String;
+                    _state.StringType = LazyStringType.SimpleString;
                     return true;
                 }
                 
@@ -554,6 +563,7 @@ namespace Sparrow.Json.Parsing
 
                     SetStringBuffer(s);
                     _state.CurrentTokenType = JsonParserToken.String;
+                    _state.StringType = LazyStringType.SimpleString;
                     return true;
                 }
 #endif
@@ -628,6 +638,7 @@ namespace Sparrow.Json.Parsing
 
         private void ReadEscapePositions(byte* buffer, int escapeSequencePos)
         {
+            //TODO Duplicated code. We can use the new function from LazyStringValue. Just avoid that now to reduce modifications
             _state.EscapePositions.Clear();
             var numberOfEscapeSequences = BlittableJsonReaderBase.ReadVariableSizeInt(buffer, ref escapeSequencePos);
             while (numberOfEscapeSequences > 0)
@@ -648,8 +659,7 @@ namespace Sparrow.Json.Parsing
             // max possible size - we avoid using GetByteCount because profiling showed it to take 2% of runtime
             // the buffer might be a bit longer, but we'll reuse it, and it is better than the computing cost
            
-            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(str, out _);
-
+            int escapePositionsSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(str, out var controlCount);
             int byteCount = str.Length * 5 + escapePositionsSize;
             if (_currentStateBuffer == null || _currentStateBuffer.SizeInBytes < byteCount)
             {
@@ -667,12 +677,13 @@ namespace Sparrow.Json.Parsing
             }
 
             _state.StringBuffer = _currentStateBuffer.Address;
+            _state.StringType = controlCount == 0 ? LazyStringType.SimpleString : LazyStringType.JsonString;
 
             fixed (char* pChars = str)
             {
                 _state.StringSize = Encodings.Utf8.GetBytes(pChars, str.Length, _state.StringBuffer, _currentStateBuffer.SizeInBytes);
                 _state.CompressedSize = null; // don't even try
-                _state.FindEscapedPositionsAndEscapeControls(_state.StringBuffer, ref _state.StringSize, escapePositionsSize);
+                _state.FindEscapedPositionsAndEscapeControls(_state.StringBuffer, ref _state.StringSize, escapePositionsSize, LazyStringType.JsonString);
 
                 var escapePos = _state.StringBuffer + _state.StringSize;
                 _state.WriteEscapePositionsTo(escapePos);

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParser.cs
@@ -228,6 +228,8 @@ namespace Sparrow.Json.Parsing
                 _prevEscapePosition = 0;
                 _currentQuote = b;
                 state.CurrentTokenType = JsonParserToken.String;
+                //TODO We unescape the control characters inside ParseString so we got a SimpleString
+                state.StringType = LazyStringType.SimpleString;
                 if (ParseString(ref pos) == false)
                 {
                     state.Continuation = JsonParserTokenContinuation.PartialString;

--- a/src/Sparrow/Json/Parsing/UnmanagedJsonParserHelper.cs
+++ b/src/Sparrow/Json/Parsing/UnmanagedJsonParserHelper.cs
@@ -19,7 +19,7 @@ namespace Sparrow.Json.Parsing
             if (state.CurrentTokenType != JsonParserToken.String)
                 ThrowInvalidJson(peepingTomStream);
 
-            return context.AllocateStringValue(null, state.StringBuffer, state.StringSize).ToString();
+            return context.AllocateStringValue(state).ToString();
         }
 
         public static bool Read(PeepingTomStream stream, UnmanagedJsonParser parser, JsonParserState state, JsonOperationContext.MemoryBuffer buffer)

--- a/src/Sparrow/Utils/StringUtils.cs
+++ b/src/Sparrow/Utils/StringUtils.cs
@@ -1,0 +1,302 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Sparrow.Json;
+
+namespace Sparrow.Utils;
+
+public static class StringUtils
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe EscapePositionsReader GetEscapePositionsReader(LazyStringValue lazyStringValue)
+    {
+        return new EscapePositionsReader(lazyStringValue.Buffer, lazyStringValue.Size);
+    }    
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CountEscapedControlCharacters(ReadOnlySpan<byte> source, Span<int> escapePositions)
+    {
+        // To identify escaped control characters, we look for the '\uXXXX' sequence.
+        // We only count backslashes that are NOT marked in the escape positions.
+        // A backslash present in the escape positions list indicates it was part of the original 
+        // string (a literal backslash), rather than the start of an escape sequence.
+        
+        if (escapePositions.Length == 0)
+            return CountBackslashes(source);
+
+        var count = 0;
+        for (var i = 0; i < escapePositions.Length; i++)
+        {
+            var next = escapePositions[i];
+            if (next > 0)
+                count += CountBackslashes(source.Slice(0, next));
+
+            source = source.Slice(next + 1);
+        }
+
+        if (source.Length > 0)
+            count += CountBackslashes(source);
+
+        return count;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CountBackslashes(ReadOnlySpan<byte> source)
+    {
+        const byte escapeChar = (byte)'\\';
+        var count = 0;
+        int idx;
+        while ((idx = source.IndexOf(escapeChar)) != -1)
+        {
+            count++;
+            source = source.Slice(idx + 1);
+        }
+        return count;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<byte> UnescapeControlCharacters(ReadOnlySpan<byte> source, Span<int> sourceEscapedPositions, Span<byte> destination, Span<int> destinationEscapedPositions)
+    {
+        const int unicodeHexLength = 4; // \uXXXX
+
+        var newEscapedPositions = new SpanWriter<int>(destinationEscapedPositions);
+
+        var sourceReader = new SpanReader<byte>(source);
+        var destinationWriter = new SpanWriter<byte>(destination);
+
+        var nextEscapedPosition = sourceEscapedPositions.Length > 0 ? sourceEscapedPositions[0] : -1;
+        var escapePositionsIndex = 1;
+        var lastNewEscapedPos = -1;
+
+        while(sourceReader.Read(out var b))
+        {
+            if (sourceReader.Position == nextEscapedPosition)
+            {
+                nextEscapedPosition = escapePositionsIndex < sourceEscapedPositions.Length
+                    ? nextEscapedPosition + sourceEscapedPositions[escapePositionsIndex++] + 1
+                    : -1;
+
+                newEscapedPositions.Append(destinationWriter.Size - lastNewEscapedPos - 1);
+                lastNewEscapedPos = destinationWriter.Size;
+            }
+            else if (b == (byte)'\\')
+            {
+                if (sourceReader.Read(out b) == false || b != (byte)'u')
+                    throw new InvalidOperationException($@"Invalid escape sequence at index {destinationWriter.Size}: expected '\u' but found '\{(char)b}'");
+
+                if(sourceReader.Read(unicodeHexLength, out var span) == false)
+                    throw new InvalidOperationException($@"Invalid escape sequence at index {destinationWriter.Size}: expected {unicodeHexLength} hex characters after '\u'");
+
+                b = ParseUnicodeValue(span);
+                
+                newEscapedPositions.Append(destinationWriter.Size - lastNewEscapedPos - 1);
+                lastNewEscapedPos = destinationWriter.Size;
+            }
+
+            destinationWriter.Append(b);
+        }
+
+        return destinationWriter.AsSpan();
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static byte ParseUnicodeValue(ReadOnlySpan<byte> buffer)
+    {
+        Debug.Assert(buffer.Length >= 4);
+
+        var val = 0;
+        for (var i = 0; i < 4; i++)
+        {
+            var b = buffer[i];
+
+            if (b >= (byte)'0' && b <= (byte)'9')
+            {
+                val = (val << 4) | (b - (byte)'0');
+            }
+            else if (b >= 'a' && b <= (byte)'f')
+            {
+                val = (val << 4) | (10 + (b - (byte)'a'));
+            }
+            else if (b >= 'A' && b <= (byte)'F')
+            {
+                val = (val << 4) | (10 + (b - (byte)'A'));
+            }
+            else
+            {
+                throw new InvalidOperationException($"Invalid hex value '{ (char)b }' (0x{b:X2}) at unicode escape sequence");
+            }
+        }
+
+        if (val > byte.MaxValue)
+            throw new InvalidOperationException($"Unicode value 0x{val:X4} is too large for a byte (max 0xFF)");
+
+        return (byte)val;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void CheckAndThrowContainsControlCharacters(ReadOnlySpan<char> id)
+    {
+        if (HasControlCharacters(id))
+            ThrowIdentifierWithControlCharacters(id);
+    }
+
+    public static void ThrowIdentifierWithControlCharacters(ReadOnlySpan<char> str)
+    {
+        throw new NotSupportedException($"Identifier cannot contain control characters : '{EscapeControlCharacters(str)}' (escaped version)");
+    }
+
+    private static string EscapeControlCharacters(ReadOnlySpan<char> str)
+    {
+        var sb = new StringBuilder();
+        foreach (var c in str)
+        {
+            if (IsControlCharacter(c))
+            {
+                sb.Append("\\u");
+                sb.Append(((int)c).ToString("x4"));
+                continue;
+            }
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasControlCharacters(ReadOnlySpan<char> str)
+    {
+        for (var index = 0; index < str.Length; index++)
+        {
+            if (IsControlCharacter(str[index]))
+                return true;
+        }
+
+        return false;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsControlCharacter(char c)
+    {
+        // 8  => '\b' => 0000 1000
+        // 9  => '\t' => 0000 1001
+        // 10 => '\n' => 0000 1010
+        // 12 => '\f' => 0000 1100
+        // 13 => '\r' => 0000 1101
+        return c < 32 && (c < 8 || c > 13 || c == 11);
+    }
+    
+    public ref struct SpanWriter<T>
+    {
+        private readonly Span<T> _buffer;
+
+        private int _size;
+        
+        public int Size 
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _size;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SpanWriter(Span<T> buffer)
+        {
+            _buffer = buffer;
+            _size = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(T value)
+        {
+            Debug.Assert(_size < _buffer.Length);
+            _buffer[_size++] = value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> AsSpan() => _buffer.Slice(0, _size);
+    }
+
+    private ref struct SpanReader<T>
+    {
+        private readonly ReadOnlySpan<T> _buffer;
+
+        public int Position
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+            private set;
+        } = -1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public SpanReader(ReadOnlySpan<T> buffer)
+        {
+            _buffer = buffer;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Read(out T t)
+        {
+            ++Position;
+            if(Position < _buffer.Length)
+            {
+                t = _buffer[Position];   
+                return true;
+                
+            }
+            t = default;
+            return false;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Read(int i, out ReadOnlySpan<T> span)
+        {
+            if(Position + i < _buffer.Length)
+            {
+                var result =  _buffer.Slice(Position + 1, i); 
+                Position += i;
+                span = result;
+                return true;
+            }
+            span = default;
+            return false;
+        }
+    }
+    
+    public unsafe struct EscapePositionsReader
+    {
+        private readonly byte* _buffer;
+        private int _offset;
+        private int _read;
+
+        public int Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private set; 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
+        
+        public int Current;
+
+        public EscapePositionsReader(byte* buffer, int size)
+        {
+            _read = 0;
+            Current = -1;
+
+            _buffer = buffer;
+            _offset = size;
+            Length = BlittableJsonReaderBase.ReadVariableSizeInt(_buffer, ref _offset);
+        }
+
+        public bool Read()
+        {
+            if (_read >= Length)
+                return false;
+
+            Current = BlittableJsonReaderBase.ReadVariableSizeInt(_buffer, ref _offset);
+
+            _read++;
+            return true;
+        }
+    }
+}

--- a/src/Voron/Slice.Debug.cs
+++ b/src/Voron/Slice.Debug.cs
@@ -1,0 +1,9 @@
+using Sparrow.Json;
+
+namespace Voron;
+#if DEBUG
+public unsafe partial struct Slice
+{
+    public string DebugMemory => DebugMemoryHelper.GetDebugView(Content.Ptr, Content.Length);
+}
+#endif

--- a/src/Voron/Slice.cs
+++ b/src/Voron/Slice.cs
@@ -11,7 +11,7 @@ namespace Voron
 {
     [DebuggerDisplay("{ToString(),nq}")]
     [StructLayout(LayoutKind.Sequential)]
-    public unsafe struct Slice
+    public unsafe partial struct Slice
     {
         public ByteString Content;
 

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/ManualBuilderTests.cs
@@ -779,10 +779,10 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     fixed (byte* b = lsvStringBytes)
                     {
                         var escapePositionsMaxSize = JsonParserState.FindMaxEscapePositionAndControlCharSize(lsvString, out _);
-                        var lsv = context.AllocateStringValue(null, b, lsvStringBytes.Length);
+                        var lsv = context.AllocateStringValue(null, b, lsvStringBytes.Length, LazyStringType.SimpleString);
                         var escapePositions = new FastList<int>();
                         var len = lsvStringBytes.Length;
-                        JsonParserState.FindEscapedPositionsAndEscapeControls(escapePositions, b, ref len, escapePositionsMaxSize);
+                        JsonParserState.FindEscapedPositionsAndEscapeControls(escapePositions, b, ref len, escapePositionsMaxSize, LazyStringType.JsonString);
                         lsv.EscapePositions = escapePositions.ToArray();
 
                         builder.WritePropertyName("LSVString");

--- a/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
+++ b/test/FastTests/Server/Documents/DocumentIdWorkerTests.cs
@@ -206,7 +206,7 @@ namespace FastTests.Server.Documents
 
         private static unsafe LazyStringValue GetLazyStringValue(JsonOperationContext context, Slice idSlice)
         {
-            var ret = context.GetLazyStringValue(idSlice.Content.Ptr, out var success);
+            var ret = context.GetLazyStringValue(idSlice.Content.Ptr, LazyStringType.JsonString,out var success);
             Assert.True(success);
             return ret;
         }

--- a/test/FastTests/Sparrow/LazyStringValueTests.cs
+++ b/test/FastTests/Sparrow/LazyStringValueTests.cs
@@ -1,0 +1,180 @@
+﻿using System.Linq;
+using System.Text;
+using Raven.Client;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Utils;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow;
+
+public unsafe  class LazyStringValueTests : NoDisposalNeeded
+{
+    public LazyStringValueTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    public static TheoryData<string> LazyStringTestCases =>
+    [
+        new string('\u0001', 1),
+        new string('\u0001', 10),
+        string.Concat(Enumerable.Repeat("\u0001a", 1)),
+        string.Concat(Enumerable.Repeat("\u0001a", 10)),
+        '\n' + string.Concat(Enumerable.Repeat("\u0001a", 1)),
+        '\n' + string.Concat(Enumerable.Repeat("\u0001a", 10)),
+        string.Concat(Enumerable.Repeat("\u0001a", 1)) + '\n',
+        string.Concat(Enumerable.Repeat("\u0001a", 10)) + '\n',
+        string.Concat(Enumerable.Repeat("\u0001\n", 10))
+    ];
+    
+    [RavenTheory(RavenTestCategory.Core)]
+    [MemberData(nameof(LazyStringTestCases))]
+    public void LazyStringValue_WhenToStringForJsonType_ShouldResultWithUnescapedValue(string expected)
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        
+        var lazyString = context.GetLazyString(expected);
+        lazyString = context.AllocateStringValue(null, lazyString.Buffer, lazyString.Size, LazyStringType.JsonString);
+        
+        var actual = lazyString.ToString();
+        Assert.Equal(expected, actual);
+    }
+    
+    [RavenTheory(RavenTestCategory.Core)]
+    [MemberData(nameof(LazyStringTestCases))]
+    public void LazyStringValue_WhenToStringForSimpleType_ShouldResultWithUnescapedValue(string expected)
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        var lazyString = context.GetLazyString(expected);
+        lazyString = context.AllocateStringValue(null, lazyString.Buffer, lazyString.Size, LazyStringType.SimpleString);
+        
+        var actual = lazyString.ToString();
+        Assert.Equal(expected, actual);
+    }
+    
+    [RavenTheory(RavenTestCategory.Core)]
+    [MemberData(nameof(LazyStringTestCases))]
+    public void LazyStringValue_WhenEqualsSimpleTypeWithJsonType_ShouldReturnTrue(string value)
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        
+        var expected = context.GetLazyString(value);
+
+        using var blittable = context.ReadObject(new DynamicJsonValue { ["Prop"] = value }, "doc");
+        var actual = (LazyStringValue)blittable["Prop"];
+        // actual.GetHashCode();
+
+        Assert.Equal(expected, actual);
+    }
+    
+    [RavenTheory(RavenTestCategory.Core)]
+    [MemberData(nameof(LazyStringTestCases))]
+    public void LazyStringValue_WhenCompareJsonTypes_ShouldReturnTrue(string value)
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        
+        var jsonValue = context.GetLazyString(value);
+        jsonValue = context.AllocateStringValue(null, jsonValue.Buffer, jsonValue.Size, LazyStringType.JsonString);
+        
+        using var blittable = context.ReadObject(new DynamicJsonValue { ["Prop"] = value }, "doc");
+        var simpleValue = (LazyStringValue)blittable["Prop"];
+        
+        Assert.Equal(0, jsonValue.CompareTo(simpleValue));
+    }
+    
+    
+    public static TheoryData<string, string, int[]> LazyStringPositionsTestData =>
+        new TheoryData<string, string, int[]>
+        {
+            { null, @"C:\work\raven", [2, 4] },
+            { null, @"C:\work\raven\RavenDB-24955\sln\test\FastTests\bin\Debug\net8.0\Databases\CRUD_Operations_1.0-3", [2, 4, 5, 13, 3, 4, 9, 3, 5, 6, 9] },
+            { null, @"01\123\u0001", [2, 4] },
+            { "01\\123\u0001", @"01\123\u0001", [2] }
+        };
+
+    [RavenTheory(RavenTestCategory.Core)]
+    [MemberData(nameof(LazyStringPositionsTestData))]
+    public void LazyStringValue_ShouldCorrectlyHandleEscapePositions(string expected, string value, int[] escapePositions)
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        
+        var lazyString = GetLazyString(context, Encoding.UTF8.GetBytes(value), LazyStringType.SimpleString);
+        lazyString.EscapePositions = escapePositions;
+            
+        Assert.Equal(expected ?? value, lazyString);
+    }
+    
+    public static TheoryData<int, string, int[]> EscapedUnicodeControlCharactersTestData =>
+        new TheoryData<int, string, int[]>
+        {
+            { 0, "1\t\\1\\\\2\\", [1, 0, 1, 0, 1] },
+            { 1, "1\t\\1\\u0001\\\\2\\", [1, 0, 7, 0, 1] },
+            { 0, "1\t\\1\\u0001\\\\2\\", [1, 0, 1, 5, 0, 1] },
+        };
+
+    [RavenTheory(RavenTestCategory.Core)]
+    [MemberData(nameof(EscapedUnicodeControlCharactersTestData))]
+    public void CountEscapedUnicodeControlCharacters_ShouldReturnCorrectCount(int expected, string value, int[] escapePositions)
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        var lazyString = GetLazyString(context, Encoding.UTF8.GetBytes(value), LazyStringType.JsonString);
+
+        var actual = StringUtils.CountEscapedControlCharacters(lazyString.AsSpan(), escapePositions);
+            
+        Assert.Equal(expected , actual);
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void BlittableJsonReaderObject_TryGet_ShouldCorrectlyRetrieveLazyStringValue_WithUnicodeCharacters()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        const string prop = "b\u0001a1";
+        const string value = "b\u0002a2";
+        var obj = new DynamicJsonValue
+        {
+            [prop] = value
+        };
+        using (var json = context.ReadObject(obj, "obj", BlittableJsonDocumentBuilder.UsageMode.ToDisk))
+        {
+            Assert.True(json.TryGet(prop, out LazyStringValue lazyStringValue), "Property not found");
+            Assert.True(lazyStringValue.Equals(value));
+            Assert.Equal(value, lazyStringValue);
+        }
+    }
+    
+    [RavenFact(RavenTestCategory.Core)]
+    public void BlittableJsonReaderObject_WithModifications_ShouldCorrectlyRetrieveLazyStringValue_WithUnicodeCharacters()
+    {
+        using var context = JsonOperationContext.ShortTermSingleUse();
+        const string collection = "b\u0001a1";
+        const string toRemove = "someprop";
+        var obj = new DynamicJsonValue
+        {
+            [Constants.Documents.Metadata.Key] = new DynamicJsonValue
+            {
+                [Constants.Documents.Metadata.Collection] = collection,
+                [toRemove] = "somevalue",
+            }
+        };
+        using var json1 = context.ReadObject(obj, "obj", BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+        Assert.True(json1.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata), "Property not found");
+        metadata.Modifications = new DynamicJsonValue(metadata);
+        metadata.Modifications.Remove(toRemove);
+        
+        using var modifiedMetadata = context.ReadObject(metadata, "metadata", BlittableJsonDocumentBuilder.UsageMode.ToDisk);
+        
+        Assert.True(modifiedMetadata.TryGet(Constants.Documents.Metadata.Collection, out LazyStringValue lazyStringValue), "Property not found");
+        Assert.True(lazyStringValue.Equals(collection));
+        Assert.Equal(collection, lazyStringValue);
+    }
+
+    private static LazyStringValue GetLazyString(JsonOperationContext context, byte[] buffer, LazyStringType type)
+    {
+        fixed (byte* pBytes = buffer)
+        {
+            return context.AllocateStringValue(null, pBytes, buffer.Length, type);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-23167-Voron.cs
+++ b/test/SlowTests/Issues/RavenDB-23167-Voron.cs
@@ -272,7 +272,7 @@ namespace SlowTests.Issues
                         Assert.True(endEtag >= lastLocalEtag, $"endEtag {endEtag}, lastLocalEtag: {lastLocalEtag}");
 
 
-                    var lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr);
+                    var lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr, LazyStringType.SimpleString);
                     Assert.Equal(id, lastLocalId);
 
                 }
@@ -305,7 +305,7 @@ namespace SlowTests.Issues
                         Assert.Equal(expectedEtag.Value, lastLocalEtag);
                     }
 
-                    string lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr).ToString();
+                    string lastLocalId = DocumentsStorage.TableValueToString(ctx, (int)TestTable.LowerId, ref tvr, LazyStringType.SimpleString).ToString();
                     Assert.Equal(id, lastLocalId);
                 }
             }

--- a/test/SlowTests/Issues/RavenDB-24797.cs
+++ b/test/SlowTests/Issues/RavenDB-24797.cs
@@ -650,15 +650,15 @@ namespace SlowTests.Issues
                     data = context.ReadObject(data, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
                 }
 
-                using var changeVector = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.ChangeVector, ref tvr);
+                using var changeVector = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.ChangeVector, ref tvr, LazyStringType.SimpleString);
                 var groupEtag = DocumentsStorage.TableValueToEtag((int)Counters.CountersTable.Etag, ref tvr);
 
-                using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.CounterKey, ref tvr))
+                using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.CounterKey, ref tvr, LazyStringType.SimpleString))
                 using (context.Allocator.Allocate(counterGroupKey.Size, out var buffer))
                 {
                     counterGroupKey.CopyTo(buffer.Ptr);
 
-                    using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length))
+                    using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length, LazyStringType.SimpleString))
                     using (Slice.External(context.Allocator, clonedKey, out var countersGroupKey))
                     using (Slice.From(context.Allocator, changeVector, out var cv))
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, "Users", out _, out Slice collectionSlice))

--- a/test/SlowTests/Issues/RavenDB_12005.cs
+++ b/test/SlowTests/Issues/RavenDB_12005.cs
@@ -27,7 +27,7 @@ namespace SlowTests.Issues
                 idx = lsv.IndexOfAny(new[] { '/' });
                 Assert.Equal(3, idx);
 
-                lsv = context.AllocateStringValue(null, lsv.Buffer, lsv.Size);
+                lsv = context.AllocateStringValue(null, lsv.Buffer, lsv.Size, lsv.Type);
 
                 idx = lsv.LastIndexOf('/');
                 Assert.Equal(3, idx);

--- a/test/SlowTests/Issues/RavenDB_22835.cs
+++ b/test/SlowTests/Issues/RavenDB_22835.cs
@@ -919,15 +919,15 @@ namespace SlowTests.Issues
                     data = context.ReadObject(data, id, BlittableJsonDocumentBuilder.UsageMode.ToDisk);
                 }
 
-                using var changeVector = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.ChangeVector, ref tvr);
+                using var changeVector = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.ChangeVector, ref tvr, LazyStringType.SimpleString);
                 var groupEtag = DocumentsStorage.TableValueToEtag((int)Counters.CountersTable.Etag, ref tvr);
 
-                using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.CounterKey, ref tvr))
+                using (var counterGroupKey = DocumentsStorage.TableValueToString(context, (int)Counters.CountersTable.CounterKey, ref tvr, LazyStringType.SimpleString))
                 using (context.Allocator.Allocate(counterGroupKey.Size, out var buffer))
                 {
                     counterGroupKey.CopyTo(buffer.Ptr);
 
-                    using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length))
+                    using (var clonedKey = context.AllocateStringValue(null, buffer.Ptr, buffer.Length, counterGroupKey.Type))
                     using (Slice.External(context.Allocator, clonedKey, out var countersGroupKey))
                     using (Slice.From(context.Allocator, changeVector, out var cv))
                     using (DocumentIdWorker.GetLowerIdSliceAndStorageKey(context, "Users", out _, out Slice collectionSlice))

--- a/test/SlowTests/SparrowTests/ControlCharactersTests.cs
+++ b/test/SlowTests/SparrowTests/ControlCharactersTests.cs
@@ -1,0 +1,264 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Indexes.TimeSeries;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Session.TimeSeries;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.SparrowTests;
+
+public class ControlCharactersTests : ClusterTestBase
+{
+    public ControlCharactersTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private const string Value = "myravendb\u0001b\tb";
+    private const string DocId = "TestObj/1";
+    
+    [RavenTheory(RavenTestCategory.Core)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task ReplicationWithControlCharactersInCollectionNames(Options options)
+    {
+        const int numberOfNodes = 3;
+        
+        var (nodes, leader) = await CreateRaftCluster(numberOfNodes);
+        options.Server = leader;
+        options.ReplicationFactor = numberOfNodes;
+        options.ModifyDocumentStore = s =>
+        {
+            s.Conventions.FindCollectionName = _ => Value + "s";
+        };
+        using var store = GetDocumentStore(options);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(15), replicas: numberOfNodes - 1);
+            await session.StoreAsync(new TestObj
+            {
+                Prop = new Dictionary<string, object>
+                {
+                    {Value + "prop", Value + "value"}
+                }
+            }, DocId);
+            await session.SaveChangesAsync();
+        }
+
+        foreach (var node in nodes)
+        {
+            using var nodeStore = new DocumentStore { Database = store.Database, Urls = [node.WebUrl], Conventions = new DocumentConventions { DisableTopologyUpdates = true } }.Initialize();
+            using var session = nodeStore.OpenAsyncSession();
+            var obj = await session.LoadAsync<TestObj>(DocId);
+            Assert.Equal(obj.Prop[Value + "prop"], Value + "value");
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Core)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task AttachmentWithControlCharactersInCollectionName(Options options)
+    {
+        const int numberOfNodes = 3;
+        
+        var (_, leader) = await CreateRaftCluster(numberOfNodes);
+        options.Server = leader;
+        options.ReplicationFactor = numberOfNodes;
+        options.ModifyDocumentStore = s =>
+        {
+            s.Conventions.FindCollectionName = _ => Value + "s";
+        };
+        using var store = GetDocumentStore(options);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj
+            {
+                Prop = new Dictionary<string, object>
+                {
+                    {Value + "prop", Value + "value"}
+                }
+            }, DocId);
+            await session.SaveChangesAsync();
+        }
+            
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(15), replicas: numberOfNodes - 1);
+            using var memoryStream = new MemoryStream([1, 2, 3]);
+            session.Advanced.Attachments.Store(DocId, Value + "attachment", memoryStream);
+            await session.SaveChangesAsync();
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Core)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ControlCharacters_Counters(Options options)
+    {
+        const int numberOfNodes = 3;
+        const string counterName = Value + "counter";
+        
+        var (nodes, leader) = await CreateRaftCluster(numberOfNodes);
+        options.Server = leader;
+        options.ReplicationFactor = numberOfNodes;
+        options.ModifyDocumentStore = s =>
+        {
+            s.Conventions.FindCollectionName = _ => Value + "s";
+        };
+        using var store = GetDocumentStore(options);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj
+            {
+                Prop = new Dictionary<string, object>
+                {
+                    {Value + "prop", Value + "value"}
+                }
+            }, DocId);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(15), replicas: numberOfNodes - 1);
+            session.CountersFor(DocId).Increment(counterName);
+            
+            await session.SaveChangesAsync();
+        }
+
+        foreach (var node in nodes)
+        {
+            using var nodeStore = new DocumentStore { Database = store.Database, Urls = [node.WebUrl], Conventions = new DocumentConventions { DisableTopologyUpdates = true } }.Initialize();
+            using var session = nodeStore.OpenAsyncSession();
+            var counterValue = await session.CountersFor(DocId).GetAsync(counterName);
+            Assert.Equal(1, counterValue.Value);
+        }
+    }
+
+    
+    private class TsIndex : AbstractTimeSeriesIndexCreationTask<TestObj>
+    {
+        public TsIndex(string timeSeriesName)
+        {
+            AddMap(timeSeriesName, timeSeries => 
+                from segment in timeSeries
+                from entry in segment.Entries
+                select new TimeSeriesEntry
+                {
+                    Value = entry.Value,
+                    Timestamp = entry.Timestamp,
+                    Tag = entry.Tag,
+                });
+            
+            StoreAllFields(FieldStorage.Yes);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Core)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ControlCharacters_TimeSeries(Options options)
+    {
+        const int numberOfNodes = 3;
+        const string timeSeriesName = Value + "timeseries";
+        const string tag = Value + "tag";
+        
+        var (nodes, leader) = await CreateRaftCluster(numberOfNodes);
+        options.Server = leader;
+        options.ReplicationFactor = numberOfNodes;
+        options.ModifyDocumentStore = s =>
+        {
+            s.Conventions.FindCollectionName = _ => Value + "s";
+        };
+        using var store = GetDocumentStore(options);
+        
+        using (var session = store.OpenAsyncSession())
+        {
+            await session.StoreAsync(new TestObj
+            {
+                Prop = new Dictionary<string, object>
+                {
+                    {Value + "prop", Value + "value"}
+                }
+            }, DocId);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession())
+        {
+            session.Advanced.WaitForReplicationAfterSaveChanges(timeout: TimeSpan.FromSeconds(15), replicas: numberOfNodes - 1);
+            session.TimeSeriesFor(DocId, timeSeriesName).Append(DateTime.Now, 59d, tag);
+            await session.SaveChangesAsync();
+        }
+        
+        foreach (var node in nodes)
+        {
+            using var nodeStore = new DocumentStore { Database = store.Database, Urls = [node.WebUrl], Conventions = new DocumentConventions { DisableTopologyUpdates = true } }.Initialize();
+            using var session = nodeStore.OpenAsyncSession();
+            var result = await session.TimeSeriesFor(DocId, timeSeriesName).GetAsync();
+            Assert.Single(result);
+            Assert.Equal(tag, result.Single().Tag);
+        }
+
+        var indexName = new TsIndex(timeSeriesName);
+        await store.ExecuteIndexAsync(indexName);
+        await Indexes.WaitForIndexingAsync(store);
+        using (var session = store.OpenAsyncSession())
+        {
+            var result = await session.Query<TimeSeriesEntry>(indexName.IndexName).Select(t => t.Tag).ToArrayAsync();
+            Assert.Single(result);
+            Assert.Equal(tag, result.Single());
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Core)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task ControlCharacters_CompareExchange(Options options)
+    {
+        const int numberOfNodes = 3;
+        const string cmpexgValue = Value + "cmpexg";
+        const string id = Value + "someid";
+        
+        var (_, leader) = await CreateRaftCluster(numberOfNodes);
+        options.Server = leader;
+        options.ReplicationFactor = numberOfNodes;
+        options.ModifyDocumentStore = s =>
+        {
+            s.Conventions.FindCollectionName = _ => Value + "s";
+        };
+        using var store = GetDocumentStore(options);
+        
+        using (var session = store.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide}))
+        {
+            session.Advanced.ClusterTransaction.CreateCompareExchangeValue(id, cmpexgValue);
+            await session.SaveChangesAsync();
+        }
+
+        using (var session = store.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide}))
+        {
+            var result = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(id);
+            Assert.Equal(cmpexgValue, result.Value);
+        }
+        
+        await store.Operations.SendAsync(new PutCompareExchangeValueOperation<string>(id + 2, cmpexgValue, 0));
+        
+        using (var session = store.OpenAsyncSession(new SessionOptions{TransactionMode = TransactionMode.ClusterWide}))
+        {
+            var result = await session.Advanced.ClusterTransaction.GetCompareExchangeValueAsync<string>(id + 2);
+            Assert.Equal(cmpexgValue, result.Value);
+        }
+    }
+
+    private class TestObj
+    {
+        public string Id { get; set; }
+        public Dictionary<string, object> Prop { get; set; }
+    }
+}

--- a/tools/Voron.Recovery/Recovery.cs
+++ b/tools/Voron.Recovery/Recovery.cs
@@ -1447,7 +1447,8 @@ namespace Voron.Recovery
                 {
                     if (_logger.IsInfoEnabled)
                     {
-                        using (var key = DocumentsStorage.TableValueToString(context, (int)CountersTable.CounterKey, ref tvr))
+                        //TODO We don't have the escape positions and we are going to reject it for new databases
+                        using (var key = DocumentsStorage.TableValueToString(context, (int)CountersTable.CounterKey, ref tvr, LazyStringType.SimpleString))
                         {
                             _logger.Info(
                                 $"Found counter-group item (key = '{key}') with counter-data document that is missing '{CountersStorage.Values}' property.");


### PR DESCRIPTION
This PR requires extensive changes across the RavenDB codebase.
I will need to perform deep testing to verify that no regressions were introduced.
For now, this is a **Draft PR** because the required testing will take a significant amount of time, and I want to ensure the architectural changes are acceptable first.

### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-25738

### Additional description

#### Background
The `LazyStringValue` structure is typically: `{sizePrefix}{content}{escapeCharactersMetadata}`.

#### The Problem: Ambiguity in String Representation
Currently, we have two different internal representations of `LazyStringValue` that are indistinguishable.
This becomes problematic when dealing with strings containing **control characters** (e.g., `\0`).

**Example 1: The string `"x\0x"`**
1.  **JsonString (Escaped):**
    * **Hex:** `08 78 5C 75 30 30 30 30 78 00` (representing `x\u0000x`).
    * In this case, the escape metadata is set to `0` because the only special character is already escaped.
    * If there were a character like `\n`, it would not be escaped in the content buffer, and the escape position metadata would contain the relevant information.
2.  **SimpleString (Unescaped):**
    * **Hex:** `03 78 00 78 01 01`.
    * The content is `78 00 78` and the metadata indicates one escape-worthy character at index 1.

**Example 2: The string `"x\0x\nx"`**
1.  **JsonString (Escaped):**
    * **Hex:** `0A 78 5C 75 30 30 30 30 78 0A 78` (representing `x\u0000x\nx`).
    * In this case, the escape metadata is set to `1, 8` because we still have one character (`\n`) to escape at position 8.
2.  **SimpleString (Unescaped):**
    * **Hex:** `05 78 00 78 0A 78 02 01 01`.
    * The content is `78 00 78 0A 78`.
    * The metadata indicates two escape characters: the first at index 1, and the second located one character after the next character (index 3).

**Current Limitations:**
* Comparisons are currently performed on raw bytes and ignore escape metadata.
* Consequently, comparing the two versions above returns `false`, even though they represent the same string.
* The `.ToString()` method does not check if the content is already escaped.
* This results in an escaped version even for strings that were not originally escaped.
* This often leads to "double escaping."

*Note: This affects control characters that are invalid in JSON.*
*Standard characters like `\n` are not escaped; they are only flagged in the metadata.*

#### The Solution: Explicit Typing
I have introduced a new property to define the type of `LazyStringValue`.
The two types are **`JsonString`** (the escaped version) and **`SimpleString`** (the original, unescaped version).

**Performance & Optimization:**
* A major goal was to ensure performance for `SimpleString` remains identical to its current state.
* The PR primarily impacts the logic for `JsonString`.
* If a `JsonString` does not contain control characters, it is treated exactly like a `SimpleString`.
* The most critical logic is the check to see if a `JsonString` has control characters.
* If no control characters are found, it is treated as a `SimpleValue` to maintain original performance.
* `JsonString` holds a cached `SimpleValue` for the relevant operations.
* We can also opt to use a temporary `SimpleJson` without caching to simplify the "Dispose"/"Reset"/"Renew" code.
* This is relevant only for `JsonString` with control characters, which is a rare case.

**Handling Buffers Without Metadata:**
* There are some cases where we use `LazyStringValue` on a buffer that lacks both the size prefix and the escape positions metadata.
* Attempting to refer to the metadata position in these cases is incorrect and dangerous.
* I have made changes to ensure this information is explicitly represented in the `LazyStringObject`, though I still need to verify all cases.
* While the size is already available, I ensured that `EscapePositions` is at least set to `Array.Empty`.
* This explicitly marks that the buffer should not be read for escape positions.
* This change will allow us to use this property in the future to avoid relying on the `skipEscape` parameter when dealing with such situations.

#### Identifier Validation & Technical Constraints
This PR also implements a restriction on identifiers containing control characters.
This affects Document IDs, Compare Exchange keys, attachments, counters, and time-series names.

**The "Why":**
The `DocumentIdWorker.GetLowerIdSliceAndStorageKey` method currently contains a bug where it does not utilize `LazyStringValue` escape position metadata.
This makes it impossible to distinguish between `JsonString` and `SimpleString` during ID processing.

**The Decision:**
Fixing this bug properly would require a **schema upgrade**.
Using control characters in identifiers is generally considered bad practice and provides no real benefit.
Therefore, we decided to restrict their use rather than change the storage schema.

**Notes on implementation:**
* This limitation applies **only to new databases** to avoid breaking existing data.
* This is managed via the `SupportedFeatures` database record and can be reverted if necessary.
* We may also want to apply this restriction to `OngoingTasks`.
* I plan to move the identifier validation to a dedicated PR to streamline the review process.
* I have included those changes here to show the full context.

### Type of change
- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [ ] Low 
- [ ] Moderate 
- [x] High
- [ ] Not relevant

### Backward compatibility
- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [x] Yes. Please list the affected features/subsystems and provide appropriate explanation
- Control character handling in Document IDs, Compare Exchange keys, attachments, counters, and time-series names.
- New databases will now reject these identifiers to avoid `DocumentIdWorker` ambiguity.
- [ ] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed