### PR TITLE
RavenDB-23376 Fix ETL tombstone filtering for artificial documents

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/Enumerators/TombstonesToElasticsearchItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Elasticsearch/Enumerators/TombstonesToElasticsearchItems.cs
@@ -41,7 +41,7 @@ namespace Raven.Server.Documents.ETL.Providers.ElasticSearch.Enumerators
         private bool Filter()
         {
             var tombstone = _tombstones.Current;
-            return tombstone.Type != Tombstone.TombstoneType.Document || tombstone.Flags.Contain(DocumentFlags.Artificial);
+            return tombstone.Type != Tombstone.TombstoneType.Document || (tombstone.Flags.Contain(DocumentFlags.Artificial) && tombstone.Flags.Contain(DocumentFlags.FromResharding));
         }
     }
 }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/AttachmentTombstonesToRavenEtlItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/AttachmentTombstonesToRavenEtlItems.cs
@@ -24,7 +24,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven.Enumerators
             if (tombstone.Type != Tombstone.TombstoneType.Attachment)
                 TombstonesToRavenEtlItems.ThrowInvalidTombstoneType(Tombstone.TombstoneType.Attachment, tombstone.Type);
 
-            if (tombstone.Flags.Contain(DocumentFlags.Artificial))
+            if (tombstone.Flags.Contain(DocumentFlags.Artificial) && tombstone.Flags.Contain(DocumentFlags.FromResharding))
                 return true;
 
             if (FilterAttachment(_context, item))

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/TombstonesToRavenEtlItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/Enumerators/TombstonesToRavenEtlItems.cs
@@ -27,7 +27,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven.Enumerators
         private bool Filter(RavenEtlItem item)
         {
             var tombstone = _tombstones.Current;
-            if (tombstone.Flags.Contain(DocumentFlags.Artificial))
+            if (tombstone.Flags.Contain(DocumentFlags.Artificial) && tombstone.Flags.Contain(DocumentFlags.FromResharding))
                 return true;
 
             if (_allDocs == false)

--- a/src/Raven.Server/Documents/ETL/Providers/SQL/Enumerators/TombstonesToSqlItems.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/SQL/Enumerators/TombstonesToSqlItems.cs
@@ -17,7 +17,7 @@ namespace Raven.Server.Documents.ETL.Providers.SQL.Enumerators
         private bool Filter()
         {
             var tombstone = _tombstones.Current;
-            return tombstone.Type != Tombstone.TombstoneType.Document || tombstone.Flags.Contain(DocumentFlags.Artificial);
+            return tombstone.Type != Tombstone.TombstoneType.Document || (tombstone.Flags.Contain(DocumentFlags.Artificial) && tombstone.Flags.Contain(DocumentFlags.FromResharding));
         }
 
         public bool MoveNext()

--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_23376.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_23376.cs
@@ -1,0 +1,263 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Linq;
+ using System.Text.Json.Serialization;
+ using System.Threading.Tasks;
+ using Elastic.Clients.Elasticsearch;
+ using Orders;
+ using Raven.Client.Documents.Indexes;
+ using Raven.Client.Documents.Operations.ETL.ElasticSearch;
+ using Tests.Infrastructure;
+ using Xunit;
+ using Xunit.Abstractions;
+
+ namespace SlowTests.Server.Documents.ETL.ElasticSearch
+{
+     public class RavenDB_23376 : ElasticSearchEtlTestBase
+     {
+         public RavenDB_23376(ITestOutputHelper output) : base(output)
+         {
+         }
+
+         protected string ProductsByCategoriesIndexName => $"ProductsByCategories{IndexSuffix}".ToLower();
+
+         protected List<ElasticSearchIndex> ProductsByCategoriesIndex => new()
+         {
+             new ElasticSearchIndex
+             {
+                 IndexName = ProductsByCategoriesIndexName,
+                 DocumentIdProperty = "Id"
+             }
+         };
+
+         [RequiresElasticSearchRetryFact]
+         public async Task ShouldPropagateDeletionsOfArtificialDocuments_BasicScenario()
+         {
+             using (var store = GetDocumentStore())
+             using (GetElasticClient(out var client))
+             {
+                 await new ProductsByCategory().ExecuteAsync(store);
+
+                 var etlScript = @"
+ loadToProductsByCategories" + IndexSuffix + @"({
+     Id: id(this),
+     Category: this.Category,
+     TotalPrice: this.TotalPrice,
+     Count: this.Count
+ });
+ ";
+
+                 var config = SetupElasticEtl(store, etlScript, ProductsByCategoriesIndex, new[] { "ProductsByCategories" });
+                 var etlDone = Etl.WaitForEtlToComplete(store);
+
+                 using (var session = store.OpenAsyncSession())
+                 {
+                     await session.StoreAsync(new Product { Name = "Product1", Category = "Electronics", PricePerUnit = 100 });
+                     await session.StoreAsync(new Product { Name = "Product2", Category = "Electronics", PricePerUnit = 200 });
+                     await session.StoreAsync(new Product { Name = "Product3", Category = "Books", PricePerUnit = 50 });
+                     await session.SaveChangesAsync();
+                 }
+
+                 await Indexes.WaitForIndexingAsync(store);
+
+                 using (var session = store.OpenSession())
+                 {
+                     WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, interval: 500);
+                 }
+
+                 await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+                 await client.Indices.RefreshAsync(ProductsByCategoriesIndexName);
+
+                 var count = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(ProductsByCategoriesIndexName)));
+                 Assert.Equal(2, count.Count);
+
+                 var searchResponse = await client.SearchAsync<ProductsByCategories>(s => s
+                     .Index(ProductsByCategoriesIndexName)
+                     .Size(10));
+
+                 Assert.True(searchResponse.IsValidResponse);
+                 Assert.Equal(2, searchResponse.Documents.Count);
+
+                 Assert.Contains(searchResponse.Documents, x => x.Category == "Electronics" && x.TotalPrice == 300);
+                 Assert.Contains(searchResponse.Documents, x => x.Category == "Books" && x.TotalPrice == 50);
+
+                 etlDone.Reset();
+
+                 using (var session = store.OpenAsyncSession())
+                 {
+                     session.Delete("products/1-A");
+                     session.Delete("products/2-A");
+                     session.Delete("products/3-A");
+                     await session.SaveChangesAsync();
+                 }
+
+                 await Indexes.WaitForIndexingAsync(store);
+
+                 using (var session = store.OpenSession())
+                 {
+                     WaitForValue(() => session.Query<ProductsByCategories>().Count(), 0, interval: 500);
+                 }
+
+                 await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+                 await client.Indices.RefreshAsync(ProductsByCategoriesIndexName);
+
+                 var countAfterDelete = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(ProductsByCategoriesIndexName)));
+                 Assert.Equal(0, countAfterDelete.Count);
+             }
+         }
+
+         [RequiresElasticSearchRetryFact]
+         public async Task ShouldPropagateDeletionsOfArtificialDocuments_IndexUpdateScenario()
+         {
+             using (var store = GetDocumentStore())
+             using (GetElasticClient(out var client))
+             {
+                 await new ProductsByCategory().ExecuteAsync(store);
+
+                 using (var session = store.OpenAsyncSession())
+                 {
+                     await session.StoreAsync(new Product { Name = "Product1", Category = "Electronics", PricePerUnit = 100 });
+                     await session.StoreAsync(new Product { Name = "Product2", Category = "Electronics", PricePerUnit = 200 });
+                     await session.StoreAsync(new Product { Name = "Product3", Category = "Books", PricePerUnit = 50 });
+                     await session.SaveChangesAsync();
+                 }
+
+                 await Indexes.WaitForIndexingAsync(store);
+
+                 using (var session = store.OpenSession())
+                 {
+                     WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, interval: 500);
+                 }
+
+                 var etlScript = @"
+ loadToProductsByCategories" + IndexSuffix + @"({
+     Id: id(this),
+     Category: this.Category,
+     TotalPrice: this.TotalPrice,
+     Count: this.Count
+ });
+ ";
+
+                 var config = SetupElasticEtl(store, etlScript, ProductsByCategoriesIndex, new[] { "ProductsByCategories" });
+                 var etlDone = Etl.WaitForEtlToComplete(store);
+
+                 await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
+
+                 await client.Indices.RefreshAsync(ProductsByCategoriesIndexName);
+
+                 var count = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(ProductsByCategoriesIndexName)));
+                 Assert.Equal(2, count.Count);
+
+                 etlDone.Reset();
+
+                 await new ProductsByCategoryUpdated().ExecuteAsync(store);
+
+                 await Indexes.WaitForIndexingAsync(store);
+
+                 using (var session = store.OpenSession())
+                 {
+                     WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, 0, interval: 500);
+                 }
+
+                 etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                 await client.Indices.RefreshAsync(ProductsByCategoriesIndexName);
+                 
+                 var countAfterUpdate = await WaitForValueAsync(async () =>
+                 {
+                     var count = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(ProductsByCategoriesIndexName)));
+                     return (int)count.Count;
+                 }, 2, interval: 500);
+                 
+                 Assert.Equal(2, countAfterUpdate);
+
+                 var searchResponse = await client.SearchAsync<ProductsByCategories>(s => s
+                     .Index(ProductsByCategoriesIndexName)
+                     .Size(10));
+
+                 Assert.True(searchResponse.IsValidResponse);
+                 Assert.Equal(2, searchResponse.Documents.Count);
+                 Assert.Contains(searchResponse.Documents, x => x.Category == "Electronics");
+                 Assert.Contains(searchResponse.Documents, x => x.Category == "Books");
+             }
+         }
+
+         private class ProductsByCategories
+         {
+             [JsonPropertyName("Category")]
+             public string Category { get; set; }
+
+             [JsonPropertyName("TotalPrice")]
+             public decimal TotalPrice { get; set; }
+
+             [JsonPropertyName("Count")]
+             public int Count { get; set; }
+         }
+
+         private class ProductsByCategory : AbstractIndexCreationTask<Product, ProductsByCategories>
+         {
+             public ProductsByCategory()
+             {
+                 Map = products =>
+                     from product in products
+                     select new ProductsByCategories
+                     {
+                         Category = product.Category,
+                         TotalPrice = product.PricePerUnit,
+                         Count = 1
+                     };
+
+                 Reduce = results =>
+                     from result in results
+                     group result by result.Category
+                     into g
+                     select new ProductsByCategories
+                     {
+                         Category = g.Key,
+                         TotalPrice = g.Sum(x => x.TotalPrice),
+                         Count = g.Sum(x => x.Count)
+                     };
+
+                 OutputReduceToCollection = "ProductsByCategories";
+             }
+         }
+
+         private class ProductsByCategoryUpdated : AbstractIndexCreationTask<Product, ProductsByCategories>
+         {
+             public override string IndexName => "ProductsByCategory";
+
+             public ProductsByCategoryUpdated()
+             {
+                 Map = products =>
+                     from product in products
+                     select new ProductsByCategories
+                     {
+                         Category = product.Category,
+                         TotalPrice = product.PricePerUnit,
+                         Count = 1
+                     };
+
+                 Reduce = results =>
+                     from result in results
+                     group result by result.Category
+                     into g
+                     select new ProductsByCategories
+                     {
+                         Category = g.Key,
+                         TotalPrice = g.Sum(x => x.TotalPrice),
+                         Count = g.Sum(x => x.Count)
+                     };
+
+                 OutputReduceToCollection = "ProductsByCategories";
+
+                 // to make the index different
+                 AdditionalSources = new Dictionary<string, string>
+                 {
+                     { "CustomScript", "// Updated version" }
+                 };
+             }
+         }
+     }
+ }

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_23376.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_23376.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.Raven
+{
+    public class RavenDB_23376_Raven : RavenTestBase
+    {
+        public RavenDB_23376_Raven(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task ShouldPropagateDeletionsOfArtificialDocuments_BasicScenario()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                await new ProductsByCategory().ExecuteAsync(src);
+
+                using (var session = src.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Product { Name = "Product1", Category = "Electronics", PricePerUnit = 100 });
+                    await session.StoreAsync(new Product { Name = "Product2", Category = "Electronics", PricePerUnit = 200 });
+                    await session.StoreAsync(new Product { Name = "Product3", Category = "Books", PricePerUnit = 50 });
+                    await session.SaveChangesAsync();
+                }
+
+                await Indexes.WaitForIndexingAsync(src);
+
+                using (var session = src.OpenSession())
+                {
+                    WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, interval: 500);
+                }
+
+                var etlDone = Etl.WaitForEtlToComplete(src);
+
+                Etl.AddEtl(src, dest, "ProductsByCategories", script: @"loadToProductsByCategories(this);");
+
+                Assert.True(etlDone.Wait(TimeSpan.FromMinutes(1)));
+
+                using (var session = dest.OpenAsyncSession())
+                {
+                    var categorySummaries = await session.Query<ProductsByCategories>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .ToListAsync();
+
+                    Assert.Equal(2, categorySummaries.Count);
+                    Assert.Contains(categorySummaries, x => x.Category == "Electronics" && x.TotalPrice == 300);
+                    Assert.Contains(categorySummaries, x => x.Category == "Books" && x.TotalPrice == 50);
+                }
+
+                etlDone.Reset();
+                
+                using (var session = src.OpenAsyncSession())
+                {
+                    session.Delete("products/1-A");
+                    session.Delete("products/2-A");
+                    session.Delete("products/3-A");
+                    await session.SaveChangesAsync();
+                }
+
+                await Indexes.WaitForIndexingAsync(src);
+
+                using (var session = src.OpenSession())
+                {
+                    WaitForValue(() => session.Query<ProductsByCategories>().Count(), 0, interval: 500);
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest.OpenAsyncSession())
+                {
+                    var categorySummaries = await session.Query<ProductsByCategories>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .ToListAsync();
+
+                    Assert.Equal(0, categorySummaries.Count);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task ShouldPropagateDeletionsOfArtificialDocuments_IndexUpdateScenario()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                await new ProductsByCategory().ExecuteAsync(src);
+
+                using (var session = src.OpenAsyncSession())
+                {
+                    await session.StoreAsync(new Product { Name = "Product1", Category = "Electronics", PricePerUnit = 100 });
+                    await session.StoreAsync(new Product { Name = "Product2", Category = "Electronics", PricePerUnit = 200 });
+                    await session.StoreAsync(new Product { Name = "Product3", Category = "Books", PricePerUnit = 50 });
+                    await session.SaveChangesAsync();
+                }
+
+                await Indexes.WaitForIndexingAsync(src);
+
+                var etlDone = Etl.WaitForEtlToComplete(src);
+
+                Etl.AddEtl(src, dest, "ProductsByCategories", script: @"loadToProductsByCategories(this);");
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest.OpenAsyncSession())
+                {
+                    var categorySummaries = await session.Query<ProductsByCategories>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .ToListAsync();
+
+                    Assert.Equal(2, categorySummaries.Count);
+                }
+
+                etlDone.Reset();
+
+                // Update the index definition - this will cause artificial document IDs to be regenerated
+                await new ProductsByCategoryUpdated().ExecuteAsync(src);
+
+                await Indexes.WaitForIndexingAsync(src);
+                
+                using (var session = src.OpenSession())
+                {
+                    WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, 0, interval: 500);
+                }
+
+                etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                using (var session = dest.OpenAsyncSession())
+                {
+                    var categorySummaries = await session.Query<ProductsByCategories>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .ToListAsync();
+
+                    Assert.Equal(2, categorySummaries.Count);
+                    Assert.Contains(categorySummaries, x => x.Category == "Electronics");
+                    Assert.Contains(categorySummaries, x => x.Category == "Books");
+                }
+            }
+        }
+
+        private class ProductsByCategories
+        {
+            public string Category { get; set; }
+            public decimal TotalPrice { get; set; }
+            public int Count { get; set; }
+        }
+
+        private class ProductsByCategory : AbstractIndexCreationTask<Product, ProductsByCategories>
+        {
+            public ProductsByCategory()
+            {
+                Map = products =>
+                    from product in products
+                    select new ProductsByCategories
+                    {
+                        Category = product.Category,
+                        TotalPrice = product.PricePerUnit,
+                        Count = 1
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Category
+                    into g
+                    select new ProductsByCategories
+                    {
+                        Category = g.Key,
+                        TotalPrice = g.Sum(x => x.TotalPrice),
+                        Count = g.Sum(x => x.Count)
+                    };
+
+                OutputReduceToCollection = "ProductsByCategories";
+            }
+        }
+
+        private class ProductsByCategoryUpdated : AbstractIndexCreationTask<Product, ProductsByCategories>
+        {
+            public override string IndexName => "ProductsByCategory";
+
+            public ProductsByCategoryUpdated()
+            {
+                Map = products =>
+                    from product in products
+                    select new ProductsByCategories
+                    {
+                        Category = product.Category,
+                        TotalPrice = product.PricePerUnit,
+                        Count = 1
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Category
+                    into g
+                    select new ProductsByCategories
+                    {
+                        Category = g.Key,
+                        TotalPrice = g.Sum(x => x.TotalPrice),
+                        Count = g.Sum(x => x.Count)
+                    };
+
+                OutputReduceToCollection = "ProductsByCategories";
+                
+                // to make the index different
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    { "CustomScript", "// Updated version" }
+                };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_23376.cs
+++ b/test/SlowTests/Server/Documents/ETL/SQL/RavenDB_23376.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Microsoft.Data.SqlClient;
+using Orders;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Raven.Server.SqlMigration;
+using SlowTests.Server.Documents.Migration;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Server.Documents.ETL.SQL
+{
+    public class RavenDB_23376 : RavenTestBase
+    {
+        public RavenDB_23376(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
+        public async Task ShouldPropagateDeletionsOfArtificialDocuments_BasicScenario()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    CreateCategorySummarySchema(connectionString);
+
+                    await new ProductsByCategory().ExecuteAsync(store);
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new Product { Name = "Product1", Category = "Electronics", PricePerUnit = 100 });
+                        await session.StoreAsync(new Product { Name = "Product2", Category = "Electronics", PricePerUnit = 200 });
+                        await session.StoreAsync(new Product { Name = "Product3", Category = "Books", PricePerUnit = 50 });
+                        await session.SaveChangesAsync();
+                    }
+
+                    await Indexes.WaitForIndexingAsync(store);
+
+                    using (var session = store.OpenSession())
+                    {
+                        WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, interval: 500);
+                    }
+
+                    var etlDone = Etl.WaitForEtlToComplete(store);
+
+                    SetupSqlEtlForCategories(store, connectionString);
+
+                    etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                    using (var con = new SqlConnection())
+                    {
+                        con.ConnectionString = connectionString;
+                        con.Open();
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = "SELECT COUNT(*) FROM ProductsByCategories";
+                            Assert.Equal(2, dbCommand.ExecuteScalar());
+
+                            dbCommand.CommandText = "SELECT Category, TotalPrice FROM ProductsByCategories ORDER BY Category";
+                            using (var reader = dbCommand.ExecuteReader())
+                            {
+                                Assert.True(reader.Read());
+                                Assert.Equal("Books", reader.GetString(0));
+                                Assert.Equal(50m, reader.GetDecimal(1));
+
+                                Assert.True(reader.Read());
+                                Assert.Equal("Electronics", reader.GetString(0));
+                                Assert.Equal(300m, reader.GetDecimal(1));
+
+                                Assert.False(reader.Read());
+                            }
+                        }
+                    }
+
+                    etlDone.Reset();
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        session.Delete("products/1-A");
+                        session.Delete("products/2-A");
+                        session.Delete("products/3-A");
+                        await session.SaveChangesAsync();
+                    }
+
+                    await Indexes.WaitForIndexingAsync(store);
+
+                    using (var session = store.OpenSession())
+                    {
+                        WaitForValue(() => session.Query<ProductsByCategories>().Count(), 0, interval: 500);
+                    }
+
+                    etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                    using (var con = new SqlConnection())
+                    {
+                        con.ConnectionString = connectionString;
+                        con.Open();
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = "SELECT COUNT(*) FROM ProductsByCategories";
+                            Assert.Equal(0, dbCommand.ExecuteScalar());
+                        }
+                    }
+                }
+            }
+        }
+
+        [RequiresMsSqlRetryFact(delayBetweenRetriesMs: 1000)]
+        public async Task ShouldPropagateDeletionsOfArtificialDocuments_IndexUpdateScenario()
+        {
+            using (var store = GetDocumentStore())
+            {
+                using (SqlAwareTestBase.WithSqlDatabase(MigrationProvider.MsSQL, out var connectionString, out string schemaName, dataSet: null, includeData: false))
+                {
+                    CreateCategorySummarySchema(connectionString);
+
+                    await new ProductsByCategory().ExecuteAsync(store);
+
+                    using (var session = store.OpenAsyncSession())
+                    {
+                        await session.StoreAsync(new Product { Name = "Product1", Category = "Electronics", PricePerUnit = 100 });
+                        await session.StoreAsync(new Product { Name = "Product2", Category = "Electronics", PricePerUnit = 200 });
+                        await session.StoreAsync(new Product { Name = "Product3", Category = "Books", PricePerUnit = 50 });
+                        await session.SaveChangesAsync();
+                    }
+
+                    await Indexes.WaitForIndexingAsync(store);
+
+                    using (var session = store.OpenSession())
+                    {
+                        WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, interval: 500);
+                    }
+
+                    var etlDone = Etl.WaitForEtlToComplete(store);
+
+                    SetupSqlEtlForCategories(store, connectionString);
+
+                    etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                    using (var con = new SqlConnection())
+                    {
+                        con.ConnectionString = connectionString;
+                        con.Open();
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = "SELECT COUNT(*) FROM ProductsByCategories";
+                            Assert.Equal(2, dbCommand.ExecuteScalar());
+                        }
+                    }
+
+                    etlDone.Reset();
+
+                    await new ProductsByCategoryUpdated().ExecuteAsync(store);
+
+                    await Indexes.WaitForIndexingAsync(store);
+
+                    using (var session = store.OpenSession())
+                    {
+                        WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, 0, interval: 500);
+                    }
+
+                    etlDone.Wait(TimeSpan.FromMinutes(1));
+
+                    using (var con = new SqlConnection())
+                    {
+                        con.ConnectionString = connectionString;
+                        con.Open();
+
+                        using (var dbCommand = con.CreateCommand())
+                        {
+                            dbCommand.CommandText = "SELECT COUNT(*) FROM ProductsByCategories";
+                            Assert.Equal(2, dbCommand.ExecuteScalar());
+
+                            dbCommand.CommandText = "SELECT Category FROM ProductsByCategories ORDER BY Category";
+                            using (var reader = dbCommand.ExecuteReader())
+                            {
+                                Assert.True(reader.Read());
+                                Assert.Equal("Books", reader.GetString(0));
+
+                                Assert.True(reader.Read());
+                                Assert.Equal("Electronics", reader.GetString(0));
+
+                                Assert.False(reader.Read());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void CreateCategorySummarySchema(string connectionString)
+        {
+            using (var con = new SqlConnection())
+            {
+                con.ConnectionString = connectionString;
+                con.Open();
+
+                using (var dbCommand = con.CreateCommand())
+                {
+                    dbCommand.CommandText = @"
+CREATE TABLE [dbo].[ProductsByCategories]
+(
+    [Id] [nvarchar](50) NOT NULL,
+    [Category] [nvarchar](255) NOT NULL,
+    [TotalPrice] [decimal](18, 2) NOT NULL,
+    [Count] [int] NOT NULL
+)";
+                    dbCommand.ExecuteNonQuery();
+                }
+            }
+        }
+
+        private void SetupSqlEtlForCategories(DocumentStore store, string connectionString)
+        {
+            var connectionStringName = $"{store.Database}@{store.Urls.First()} to SQL DB";
+
+            var script = @"
+loadToProductsByCategories({
+    Id: id(this),
+    Category: this.Category,
+    TotalPrice: this.TotalPrice,
+    Count: this.Count
+});
+";
+
+            Etl.AddEtl(store, new SqlEtlConfiguration()
+            {
+                Name = connectionStringName,
+                ConnectionStringName = connectionStringName,
+                SqlTables = new List<SqlEtlTable>
+                {
+                    new SqlEtlTable { TableName = "ProductsByCategories", DocumentIdColumn = "Id" }
+                },
+                Transforms =
+                {
+                    new Transformation()
+                    {
+                        Name = "ProductsByCategories",
+                        Collections = new List<string> { "ProductsByCategories" },
+                        Script = script
+                    }
+                }
+            }, new SqlConnectionString
+            {
+                Name = connectionStringName,
+                ConnectionString = connectionString,
+                FactoryName = "Microsoft.Data.SqlClient"
+            });
+        }
+
+        private class ProductsByCategories
+        {
+            public string Category { get; set; }
+            public decimal TotalPrice { get; set; }
+            public int Count { get; set; }
+        }
+
+        private class ProductsByCategory : AbstractIndexCreationTask<Product, ProductsByCategories>
+        {
+            public ProductsByCategory()
+            {
+                Map = products =>
+                    from product in products
+                    select new ProductsByCategories
+                    {
+                        Category = product.Category,
+                        TotalPrice = product.PricePerUnit,
+                        Count = 1
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Category
+                    into g
+                    select new ProductsByCategories
+                    {
+                        Category = g.Key,
+                        TotalPrice = g.Sum(x => x.TotalPrice),
+                        Count = g.Sum(x => x.Count)
+                    };
+
+                OutputReduceToCollection = "ProductsByCategories";
+            }
+        }
+
+        private class ProductsByCategoryUpdated : AbstractIndexCreationTask<Product, ProductsByCategories>
+        {
+            public override string IndexName => "ProductsByCategory";
+
+            public ProductsByCategoryUpdated()
+            {
+                Map = products =>
+                    from product in products
+                    select new ProductsByCategories
+                    {
+                        Category = product.Category,
+                        TotalPrice = product.PricePerUnit,
+                        Count = 1
+                    };
+
+                Reduce = results =>
+                    from result in results
+                    group result by result.Category
+                    into g
+                    select new ProductsByCategories
+                    {
+                        Category = g.Key,
+                        TotalPrice = g.Sum(x => x.TotalPrice),
+                        Count = g.Sum(x => x.Count)
+                    };
+
+                OutputReduceToCollection = "ProductsByCategories";
+
+                // to make the index different
+                AdditionalSources = new Dictionary<string, string>
+                {
+                    { "CustomScript", "// Updated version" }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23376

### Additional description

Changed filter to check both `Artificial` AND `FromResharding` flags instead of just Artificial, ensuring artificial documents from OutputReduceToCollection are properly replicated via ETLs.


This is a regression introduced by https://github.com/ravendb/ravendb/commit/1d7a1f46a6f5c4ebf3e7ea937aca4e0806a13903

Once this is merged we'll need to review 7.1 and 7.2 as there is more ETLs supported there

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
