### PR TITLE
RavenDB-24945: partial fix of macOS certificates failing tests

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/LetsEncryptSimulationHelper.cs
@@ -122,20 +122,18 @@ public sealed class LetsEncryptSimulationHelper
 
             using (var httpMessageHandler = new HttpClientHandler())
             {
-                // on MacOS this is not supported because Apple...
-                if (PlatformDetails.RunningOnMacOsx == false)
-                {
-                    httpMessageHandler.ServerCertificateCustomValidationCallback += (_, certificate2, _, _) =>
+                httpMessageHandler.ServerCertificateCustomValidationCallback += (_, certificate2, _, _) =>
                     // we want to verify that we get the same thing back
-                    {
-                        if (certificate2.Thumbprint != serverCertificate.Thumbprint)
-                            throw new InvalidOperationException("Expected to get " + serverCertificate.FriendlyName + " with thumbprint " +
-                                                                serverCertificate.Thumbprint + " but got " +
-                                                                certificate2.FriendlyName + " with thumbprint " + certificate2.Thumbprint);
-                        return true;
-                    };
-                }
-
+                {
+                    if (certificate2.Thumbprint != serverCertificate.Thumbprint)
+                        throw new InvalidOperationException("Expected to get " + serverCertificate.FriendlyName + " with thumbprint " +
+                                                            serverCertificate.Thumbprint + " but got " +
+                                                            certificate2.FriendlyName + " with thumbprint " + certificate2.Thumbprint);
+                
+                    // This tells the HttpClient to ignore the UntrustedRoot error
+                    return true;
+                };
+                
                 using (var client = new RavenHttpClient(httpMessageHandler) { BaseAddress = new Uri(serverUrl) })
                 {
                     HttpResponseMessage response = null;

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -81,6 +81,7 @@ using Sparrow.Utils;
 using Voron;
 using DateTime = System.DateTime;
 using Raven.Server.Monitoring.OpenTelemetry;
+using Sparrow.Platform;
 using Constants = Sparrow.Global.Constants;
 using TelemetryConstants = Raven.Server.Monitoring.OpenTelemetry.Constants;
 using ClientConstants = Raven.Client.Constants;
@@ -1344,8 +1345,16 @@ namespace Raven.Server
                     Configuration.Security.CertificateRenewExecArguments,
                     ServerStore.GetLicenseType(),
                     ServerStore.Configuration.Security.CertificateValidationKeyUsages);
-
-                return CertificateLoaderUtil.CreateCertificate(certificate.Export(X509ContentType.Pfx), flags: CertificateLoaderUtil.FlagsForPersist);
+                
+                var flags = CertificateLoaderUtil.FlagsForPersist;
+        
+                // macOS Keychain rigidly blocks silent exports of persisted private keys.
+                // Keeping the key in memory (Ephemeral) bypasses the Keychain restriction.
+                if (PlatformDetails.RunningOnMacOsx)
+                {
+                    flags = CertificateLoaderUtil.FlagsForExport;
+                }
+                return CertificateLoaderUtil.CreateCertificate(certificate.Export(X509ContentType.Pfx), flags: flags);
             }
             catch (Exception e)
             {
@@ -1450,7 +1459,16 @@ namespace Raven.Server
             X509Certificate2 refreshedCertificate;
             try
             {
-                refreshedCertificate = CertificateLoaderUtil.CreateCertificate(newCertBytes, flags: CertificateLoaderUtil.FlagsForPersist);
+                var flags = CertificateLoaderUtil.FlagsForPersist;
+        
+                // macOS Keychain blocks the export of private keys loaded with PersistKeySet.
+                // We must load it as Ephemeral (FlagsForExport) so StartCertificateReplicationAsync can broadcast it.
+                if (PlatformDetails.RunningOnMacOsx)
+                {
+                    flags = CertificateLoaderUtil.FlagsForExport;
+                }
+
+                refreshedCertificate = CertificateLoaderUtil.CreateCertificate(newCertBytes, flags: flags);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -376,9 +376,17 @@ namespace Raven.Server.ServerWide
             SetupProgressAndResult progress = null)
         {
             ValidateExpiration(source, loadedCertificate, licenseType, progress: progress);
-
-            ValidatePrivateKey(source, password, rawBytes, out var privateKey, progress);
-
+            
+            AsymmetricAlgorithm privateKey = null;
+            if (PlatformDetails.RunningOnMacOsx)
+            {
+                ValidatePrivateKeyOnMacOs(source, loadedCertificate, out privateKey);
+            }
+            else
+            {
+                ValidatePrivateKey(source, password, rawBytes, out privateKey, progress);
+            }
+            
             ValidateServerKeyUsages(source, loadedCertificate, validateCertKeyUsages, progress);
             return privateKey;
         }
@@ -820,8 +828,16 @@ namespace Raven.Server.ServerWide
 
                 ValidateExpiration(path, loadedCertificate, licenseType, throwOnExpired: false);
 
-                ValidatePrivateKey(path, password, rawData, out var privateKey);
-
+                AsymmetricAlgorithm privateKey = null;
+                if (PlatformDetails.RunningOnMacOsx)
+                {
+                    ValidatePrivateKeyOnMacOs(path, loadedCertificate, out privateKey);
+                }
+                else
+                {
+                    ValidatePrivateKey(path, password, rawData, out privateKey);
+                }
+                
                 ValidateServerKeyUsages(path, loadedCertificate, certificateValidationKeyUsages);
 
                 return (loadedCertificate, privateKey);
@@ -862,13 +878,7 @@ namespace Raven.Server.ServerWide
             // or if the key extraction failed/returned null, throw the exact expected exception.
             if (certificate.HasPrivateKey == false || pk == null)
             {
-                var msg = "Unable to find the private key in the provided certificate from " + source;
-
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations(msg);
-                progress?.AddInfo(msg);
-        
-                throw new CryptographicException(msg);
+                ThrowCryptographicException(source, progress);
             }
         }
 
@@ -882,13 +892,17 @@ namespace Raven.Server.ServerWide
 
             if (pk == null)
             {
-                var msg = "Unable to find the private key in the provided certificate from " + source;
-
-                if (Logger.IsOperationsEnabled)
-                    Logger.Operations(msg);
-                progress?.AddInfo(msg);
-                throw new CryptographicException(msg);
+                ThrowCryptographicException(source, progress);
             }
+        }
+
+        private static void ThrowCryptographicException(string source, SetupProgressAndResult progress = null)
+        {
+            string msg = "Unable to find the private key in the provided certificate from " + source;
+            if (Logger.IsOperationsEnabled)
+                Logger.Operations(msg);
+            progress?.AddInfo(msg);
+            throw new CryptographicException(msg);
         }
 
 

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -840,12 +840,14 @@ namespace Raven.Server.ServerWide
             {
                 // macOS AppleCrypto blocks exporting ephemeral private keys to PFX, 
                 // We validate the private key's presence directly in memory instead.
-                ValidatePrivateKeyOnMacOs("ValidateCertificateBeforeReplacement", certificate, out _);
+                ValidatePrivateKeyOnMacOs("ValidateCertificateBeforeReplacement", certificate, out var pk);
+                pk?.Dispose();
             }
             else
             {
                 // On Windows and Linux, proceed with the standard export-based validation
-                ValidatePrivateKey("ValidateCertificateBeforeReplacement", password, certificate.Export(X509ContentType.Pkcs12), out _);
+                ValidatePrivateKey("ValidateCertificateBeforeReplacement", password, certificate.Export(X509ContentType.Pkcs12), out var pk);
+                pk?.Dispose();
             }
 
             ValidateServerKeyUsages("ValidateCertificateBeforeReplacement", certificate, certificateValidationKeyUsages);

--- a/src/Raven.Server/ServerWide/SecretProtection.cs
+++ b/src/Raven.Server/ServerWide/SecretProtection.cs
@@ -836,9 +836,38 @@ namespace Raven.Server.ServerWide
         {
             ValidateExpiration("ValidateCertificateBeforeReplacement", certificate, licenseType, throwOnExpired: true);
 
-            ValidatePrivateKey("ValidateCertificateBeforeReplacement", password, certificate.Export(X509ContentType.Pkcs12), out _);
-            
+            if (PlatformDetails.RunningOnMacOsx)
+            {
+                // macOS AppleCrypto blocks exporting ephemeral private keys to PFX, 
+                // We validate the private key's presence directly in memory instead.
+                ValidatePrivateKeyOnMacOs("ValidateCertificateBeforeReplacement", certificate, out _);
+            }
+            else
+            {
+                // On Windows and Linux, proceed with the standard export-based validation
+                ValidatePrivateKey("ValidateCertificateBeforeReplacement", password, certificate.Export(X509ContentType.Pkcs12), out _);
+            }
+
             ValidateServerKeyUsages("ValidateCertificateBeforeReplacement", certificate, certificateValidationKeyUsages);
+        }
+        
+        internal static void ValidatePrivateKeyOnMacOs(string source, X509Certificate2 certificate, out AsymmetricAlgorithm pk, SetupProgressAndResult progress = null)
+        {
+            // Attempt to get the private key directly from memory
+            pk = certificate.GetRSAPrivateKey() ?? (AsymmetricAlgorithm)certificate.GetECDsaPrivateKey();
+
+            // If the certificate is explicitly marked as not having a key, 
+            // or if the key extraction failed/returned null, throw the exact expected exception.
+            if (certificate.HasPrivateKey == false || pk == null)
+            {
+                var msg = "Unable to find the private key in the provided certificate from " + source;
+
+                if (Logger.IsOperationsEnabled)
+                    Logger.Operations(msg);
+                progress?.AddInfo(msg);
+        
+                throw new CryptographicException(msg);
+            }
         }
 
         internal static void ValidatePrivateKey(string source, string certificatePassword, byte[] rawData, out AsymmetricAlgorithm pk, SetupProgressAndResult progress = null)

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -786,7 +786,11 @@ namespace Raven.Server.Utils
                 certificateWithPrivateKey = safeCertificate.CopyWithPrivateKey(ecdsa);
             else
                 throw new NotSupportedException($"Unsupported key type: {privateKey.GetType().Name}");
-
+            
+            if (PlatformDetails.RunningOnMacOsx)
+            {
+                safeCertificate.Dispose();
+            }
             // Build the complete certificate chain.
             using var chain = new X509Chain();
             chain.ChainPolicy.DisableCertificateDownloads = true;

--- a/src/Raven.Server/Utils/CertificateUtils.cs
+++ b/src/Raven.Server/Utils/CertificateUtils.cs
@@ -44,14 +44,22 @@ namespace Raven.Server.Utils
             X509Certificate2 issuerCertificate = null;
 
             var userChain = new X509Chain();
+            var knownCertChain = new X509Chain();
+
+            if (PlatformDetails.RunningOnMacOsx)
+            {
+                using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
+                {
+                    store.Open(OpenFlags.ReadOnly);
+                    userChain.ChainPolicy.ExtraStore.AddRange(store.Certificates);
+                    knownCertChain.ChainPolicy.ExtraStore.AddRange(store.Certificates);
+                }
+            }
+
             // we are not disabling certificate downloads because this method is checking public key pinning hashes
             // in order to do that properly it needs to be able to verify the chain by download the certificates
             // userChain.ChainPolicy.DisableCertificateDownloads = true;
-
-            var knownCertChain = new X509Chain();
-            // we are not disabling certificate downloads because this method is checking public key pinning hashes
-            // in order to do that properly it needs to be able to verify the chain by download the certificates
-            //knownCertChain.ChainPolicy.DisableCertificateDownloads = true;
+            // knownCertChain.ChainPolicy.DisableCertificateDownloads = true;
 
             explanations?.Add($"Try building client certificate chain - {userCertificate.GetDisplayName()}.");
             try
@@ -760,8 +768,24 @@ namespace Raven.Server.Utils
 
         public static X509Certificate2 BuildNewPfx(SetupInfo setupInfo, X509Certificate2 certificate, AsymmetricAlgorithm privateKey)
         {
-            // Combine the main certificate and the private key.
-            var certificateWithPrivateKey = certificate.CopyWithPrivateKey((RSA)privateKey);
+            X509Certificate2 safeCertificate = certificate;
+
+            if (PlatformDetails.RunningOnMacOsx)
+            {
+                // Stripping the keychain context by exporting to raw public bytes (CER) and re-importing
+                // prevents the AppleCrypto crash during CopyWithPrivateKey.
+                byte[] rawPublicBytes = certificate.Export(X509ContentType.Cert);
+                safeCertificate = new X509Certificate2(rawPublicBytes);
+            }
+
+            // Combine the main certificate and the private key safely for both RSA and ECDSA.
+            X509Certificate2 certificateWithPrivateKey;
+            if (privateKey is RSA rsa)
+                certificateWithPrivateKey = safeCertificate.CopyWithPrivateKey(rsa);
+            else if (privateKey is ECDsa ecdsa)
+                certificateWithPrivateKey = safeCertificate.CopyWithPrivateKey(ecdsa);
+            else
+                throw new NotSupportedException($"Unsupported key type: {privateKey.GetType().Name}");
 
             // Build the complete certificate chain.
             using var chain = new X509Chain();

--- a/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
+++ b/src/Raven.Server/Web/Authentication/AdminCertificatesHandler.cs
@@ -27,6 +27,7 @@ using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Logging;
+using Sparrow.Platform;
 using Sparrow.Server.Platform.Posix;
 using Sparrow.Utils;
 
@@ -1172,7 +1173,16 @@ namespace Raven.Server.Web.Authentication
                         X509Certificate2 newCertificate;
                         try
                         {
-                            newCertificate = CertificateLoaderUtil.CreateCertificate(certBytes, flags: CertificateLoaderUtil.FlagsForPersist);
+                            var flags = CertificateLoaderUtil.FlagsForPersist;
+    
+                            // macOS Keychain rigidly blocks exports of persisted private keys.
+                            // Keeping the key in memory (Ephemeral) by dropping PersistKeySet bypasses this.
+                            if (PlatformDetails.RunningOnMacOsx)
+                            {
+                                flags = CertificateLoaderUtil.FlagsForExport; 
+                            }
+
+                            newCertificate = CertificateLoaderUtil.CreateCertificate(certBytes, flags: flags);
                         }
                         catch (Exception e)
                         {

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -616,6 +616,8 @@ namespace SlowTests.Authentication
 
                     if (PlatformDetails.RunningOnMacOsx)
                     {
+                        // currently macOS finds it hard to setup secured cluster and to satisfy heartbeats in rate < 300ms.
+                        // from debugging investigation, it is between 200 < heartbeat < 500
                         settings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "700";
                     }
                     customSettings.Add(settings);

--- a/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
+++ b/test/SlowTests/Authentication/AuthenticationLetsEncryptTests.cs
@@ -35,6 +35,7 @@ using Raven.Client.Json;
 using Raven.Server.ServerWide;
 using Raven.Client.Util;
 using System.Threading;
+using Sparrow.Platform;
 
 namespace SlowTests.Authentication
 {
@@ -532,15 +533,19 @@ namespace SlowTests.Authentication
             char nodeTag = 'A';
             for (int i = 1; i <= clutserSize; i++)
             {
-                var tcpListener = new TcpListener(IPAddress.Loopback, 0);
-                tcpListener.Start();
-                var port = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
-                tcpListener.Stop();
+                var httpReservation = ReservePort();
+                httpReservation.Socket.Dispose();
+                
                 var setupNodeInfo = new NodeInfo
                 {
-                    Port = port,
+                    Port = httpReservation.Port,
                     Addresses = new List<string> { $"127.0.0.{i}" }
                 };
+                
+                if (PlatformDetails.RunningOnMacOsx)
+                {
+                    setupNodeInfo.Addresses = new List<string> { "127.0.0.1" };
+                }
                 nodeSetupInfos.Add(nodeTag.ToString(), setupNodeInfo);
                 nodeTag++;
             }
@@ -608,6 +613,11 @@ namespace SlowTests.Authentication
                         [RavenConfiguration.GetKey(x => x.Core.ExternalIp)] = externalIp,
                         [RavenConfiguration.GetKey(x => x.Core.AcmeUrl)] = acmeStagingUrl
                     };
+
+                    if (PlatformDetails.RunningOnMacOsx)
+                    {
+                        settings[RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "700";
+                    }
                     customSettings.Add(settings);
                 }
             }

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -280,7 +280,7 @@ exit 129";
                 customSettings[RavenConfiguration.GetKey(x => x.Security.MasterKeyExecArguments)] = $"{keyArgs}";
                 customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateLoadExec)] = "bash";
                 customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateLoadExecArguments)] = $"{certArgs}";
-                customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = PlatformDetails.RunningOnMacOsx ? "https://127.0.0.1:0" : "https://" + Environment.MachineName + ":0";
+                customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = PlatformDetails.RunningOnMacOsx ? "https://localhost:0" : "https://" + Environment.MachineName + ":0";
 
                 script = "#!/bin/bash\ncat \"$1\"";
                 File.WriteAllText(scriptPath, script);
@@ -398,7 +398,7 @@ exit 0";
                 await File.WriteAllTextAsync(scriptPath, script);
             }
 
-            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = PlatformDetails.RunningOnMacOsx ? "https://127.0.0.1:0" : "https://" + Environment.MachineName + ":0";
+            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = PlatformDetails.RunningOnMacOsx ? "https://localhost:0" : "https://" + Environment.MachineName + ":0";
             customSettings[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certificates.ServerCertificatePath;
             customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateRenewExec)] = certProcess.exe;
             customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateRenewExecArguments)] = certProcess.certArgs;

--- a/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
+++ b/test/SlowTests/ExtensionPoints/ExtensionPointsTests.cs
@@ -280,7 +280,7 @@ exit 129";
                 customSettings[RavenConfiguration.GetKey(x => x.Security.MasterKeyExecArguments)] = $"{keyArgs}";
                 customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateLoadExec)] = "bash";
                 customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateLoadExecArguments)] = $"{certArgs}";
-                customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = "https://" + Environment.MachineName + ":0";
+                customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = PlatformDetails.RunningOnMacOsx ? "https://127.0.0.1:0" : "https://" + Environment.MachineName + ":0";
 
                 script = "#!/bin/bash\ncat \"$1\"";
                 File.WriteAllText(scriptPath, script);
@@ -398,7 +398,7 @@ exit 0";
                 await File.WriteAllTextAsync(scriptPath, script);
             }
 
-            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = "https://" + Environment.MachineName + ":0";
+            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = PlatformDetails.RunningOnMacOsx ? "https://127.0.0.1:0" : "https://" + Environment.MachineName + ":0";
             customSettings[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certificates.ServerCertificatePath;
             customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateRenewExec)] = certProcess.exe;
             customSettings[RavenConfiguration.GetKey(x => x.Security.CertificateRenewExecArguments)] = certProcess.certArgs;

--- a/test/SlowTests/Issues/RavenDB-22210.cs
+++ b/test/SlowTests/Issues/RavenDB-22210.cs
@@ -306,7 +306,13 @@ public class RavenDB_22210 : RavenTestBase
                 using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
                 {
                     store.Open(OpenFlags.ReadWrite);
-                    store.Add(certificate);
+                
+                    // Strip the private key. macOS Keychain crashes if you try to add 
+                    // an ephemeral private key. Validation only needs the public cert anyway.
+                    using (var publicOnlyCert = new X509Certificate2(certificate.Export(X509ContentType.Cert)))
+                    {
+                        store.Add(publicOnlyCert);
+                    }
                 }
 
                 Thread.Sleep(73);

--- a/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
@@ -83,7 +83,7 @@ public partial class RavenTestBase
 
             customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl ?? (
                 PlatformDetails.RunningOnMacOsx 
-                ? "https://127.0.0.1:0" 
+                ? "https://localhost:0" 
                 : $"https://{Environment.MachineName}:0");
 
             _parent.DoNotReuseServer(customSettings);
@@ -161,6 +161,7 @@ public partial class RavenTestBase
                 }
 
                 X509Certificate2 serverCertificate;
+                AsymmetricAlgorithm pk = null;
                 try
                 {
                     serverCertificate = new X509Certificate2(certBytes, (string)null, X509KeyStorageFlags.MachineKeySet | CertificateLoaderUtil.FlagsForExport);
@@ -169,8 +170,14 @@ public partial class RavenTestBase
                 {
                     throw new CryptographicException($"Unable to load the test certificate for the machine '{Environment.MachineName}'. Log: {log}", e);
                 }
-
-                SecretProtection.ValidatePrivateKey(serverCertificatePath, null, certBytes, out var pk);
+                if (PlatformDetails.RunningOnMacOsx)
+                {
+                    SecretProtection.ValidatePrivateKeyOnMacOs(serverCertificatePath,serverCertificate, out pk);
+                }
+                else
+                {
+                    SecretProtection.ValidatePrivateKey(serverCertificatePath, null, certBytes, out pk);
+                }
                 SecretProtection.ValidateServerKeyUsages(serverCertificatePath, serverCertificate, validateKeyUsages: true);
 
                 string serverCertificateForCommunicationPath;
@@ -213,7 +220,8 @@ public partial class RavenTestBase
                 var clientCertificate1Path = GenerateClientCertificate(1, serverCertificate, pk, ekuSuffix, gen);
                 var clientCertificate2Path = GenerateClientCertificate(2, serverCertificate, pk, ekuSuffix, gen);
                 var clientCertificate3Path = GenerateClientCertificate(3, serverCertificate, pk, ekuSuffix, gen);
-
+                
+                pk?.Dispose();
                 return new TestCertificatesHolder(serverCertificatePath, serverCertificateForCommunicationPath, clientCertificate1Path, clientCertificate2Path, clientCertificate3Path);
             }
 

--- a/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Certificates.cs
@@ -15,6 +15,7 @@ using Raven.Server;
 using Raven.Server.Config;
 using Raven.Server.ServerWide;
 using Raven.Server.Utils;
+using Sparrow.Platform;
 
 namespace FastTests;
 
@@ -80,7 +81,10 @@ public partial class RavenTestBase
             if (customSettings.TryGetValue(RavenConfiguration.GetKey(x => x.Security.CertificateLoadExec), out var _) == false)
                 customSettings[RavenConfiguration.GetKey(x => x.Security.CertificatePath)] = certificates.ServerCertificatePath;
 
-            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl ?? "https://" + Environment.MachineName + ":0";
+            customSettings[RavenConfiguration.GetKey(x => x.Core.ServerUrls)] = serverUrl ?? (
+                PlatformDetails.RunningOnMacOsx 
+                ? "https://127.0.0.1:0" 
+                : $"https://{Environment.MachineName}:0");
 
             _parent.DoNotReuseServer(customSettings);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24945/Unable-to-run-tests-with-secured-setup-on-MacOS

### Additional description

This PR resolves bugs in some of our unit tests running on macOS. Since moving to dotnet API to handle certificates, need to handle certificates differently on macOS.
still need to fix some of the failing tests:
`dotnet test SlowTests.csproj --configuration Release --no-restore --filter Category=Certificates`
and to cycle to Jenkins jobs

### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [X] Yes. macOS.
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
