### PR TITLE
RavenDB-26281 - Add a node tag and a date when downloading the stack traces

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -1,13 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Raven.Client;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Util;
 using Raven.Server.Dashboard;
 using Raven.Server.EventListener;
 using Raven.Server.Routing;
@@ -32,6 +35,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
             var threadIdsAsString = GetStringValuesQueryString("threadId", required: false);
             var includeStackObjects = GetBoolValueQueryString("includeStackObjects", required: false) ?? false;
+            var download = GetBoolValueQueryString("download", required: false) ?? false;
 
             var sp = Stopwatch.StartNew();
             var threadsUsage = new ThreadsUsage();
@@ -51,6 +55,16 @@ namespace Raven.Server.Documents.Handlers.Debugging
 
                 var threadStats = threadsUsage.Calculate(threadIds: threadIdsAsString.Count == 0 ? null : threadIdsAsString.Select(int.Parse).ToHashSet());
                 result["Threads"] = JArray.FromObject(threadStats.List);
+
+                if (download)
+                {
+                    var nodeTag = ServerStore.NodeTag ?? "unknown";
+                    var utcDate = SystemTime.UtcNow.ToString("yyyy-MM-dd HH-mm", CultureInfo.InvariantCulture);
+                    var fileName = $"Node {nodeTag} stack-traces {utcDate}.json";
+
+                    HttpContext.Response.Headers[Constants.Headers.ContentDisposition] = "attachment; filename=" + Uri.EscapeDataString(fileName);
+                    HttpContext.Response.Headers["Content-Type"] = "application/json; charset=utf-8";
+                }
 
                 using (ServerStore.ContextPool.AllocateOperationContext(out TransactionOperationContext context))
                 {

--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -59,7 +59,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
                 if (download)
                 {
                     var nodeTag = ServerStore.NodeTag ?? "unknown";
-                    var utcDate = SystemTime.UtcNow.ToString("yyyy-MM-dd HH-mm", CultureInfo.InvariantCulture);
+                    var utcDate = SystemTime.UtcNow.ToString("yyyy-MM-dd'T'HH-mm-ss'Z'", CultureInfo.InvariantCulture);
                     var fileName = $"Node {nodeTag} stack-traces {utcDate}.json";
 
                     HttpContext.Response.Headers[Constants.Headers.ContentDisposition] = "attachment; filename=" + Uri.EscapeDataString(fileName);

--- a/src/Raven.Studio/typescript/viewmodels/manage/captureStackTraces.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/captureStackTraces.ts
@@ -1,5 +1,6 @@
 import viewModelBase = require("viewmodels/viewModelBase");
 import d3 = require("d3");
+import moment = require("moment");
 import captureLocalStackTracesCommand = require("commands/maintenance/captureLocalStackTracesCommand");
 import captureClusterStackTracesCommand = require("commands/maintenance/captureClusterStackTracesCommand");
 import clusterTopologyManager = require("common/shell/clusterTopologyManager");
@@ -607,8 +608,7 @@ class captureStackTraces extends viewModelBase {
             Threads: this.data.Threads
         };
 
-        // replace characters that are not allowed in file names and remove the milliseconds part from the end of the date to make it more readable
-        const utcDate = new Date().toISOString().replace(/[.:]/g, "-").replace(/-\d{3}Z/, "Z");
+        const utcDate = moment.utc().format('YYYY-MM-DD[T]HH-mm-ss[Z]');
 
         let fileName: string;
         if (this.clusterWide()) {

--- a/src/Raven.Studio/typescript/viewmodels/manage/captureStackTraces.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/captureStackTraces.ts
@@ -606,7 +606,19 @@ class captureStackTraces extends viewModelBase {
             Results: captureStackTraces.reverseStacks(this.data.Results),
             Threads: this.data.Threads
         };
-        fileDownloader.downloadAsJson(dataCopy, "stacks.json");
+
+        // replace characters that are not allowed in file names and remove the milliseconds part from the end of the date to make it more readable
+        const utcDate = new Date().toISOString().replace(/[.:]/g, "-").replace(/-\d{3}Z/, "Z");
+
+        let fileName: string;
+        if (this.clusterWide()) {
+            fileName = "Cluster wide stack-traces " + utcDate + ".json";
+        } else {
+            const nodeTag = clusterTopologyManager.default.localNodeTag();
+            fileName = "Node " + (nodeTag || "unknown") + " stack-traces " + utcDate + ".json";
+        }
+        
+        fileDownloader.downloadAsJson(dataCopy, fileName);
     }
 
     fileSelected(fileInput: HTMLInputElement) {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-20817/High-LuceneUnmanagedAllocations-killing-the-server-every-few-minutes-backup-wont-complete?preview=RavenDB-26281

### Additional description

•	Provide a name for the exported stack traces that includes the node tag and the date.
•	Allow downloading the stack traces from the `/admin/debug/threads/stack-trace` endpoint by providing the query string `?download=true`.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
