### PR TITLE
RavenDB-26282 - Add `RavenDebugExecUtils` to resolve `Raven.Debug` path from the tools directory in dev environments

### DIFF
--- a/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/ThreadsHandler.cs
@@ -14,6 +14,7 @@ using Raven.Server.Routing;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Raven.Server.Utils.Debugging;
 using Raven.Server.Web;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -200,12 +201,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
         [MethodImpl(MethodImplOptions.Synchronized)]
         public static void OutputResultToStream(TextWriter sw, HashSet<string> threadIds = null, bool includeStackObjects = false)
         {
-            var ravenDebugExec = Path.Combine(AppContext.BaseDirectory,
-                PlatformDetails.RunningOnPosix ? "Raven.Debug" : "Raven.Debug.exe"
-            );
-
-            if (File.Exists(ravenDebugExec) == false)
-                throw new FileNotFoundException($"Could not find debugger tool at '{ravenDebugExec}'");
+            var ravenDebugExec = RavenDebugExecUtils.GetRavenDebugExecPath();
 
             using (var currentProcess = Process.GetCurrentProcess())
             {

--- a/src/Raven.Server/Utils/Debugging/RavenDebugExecUtils.cs
+++ b/src/Raven.Server/Utils/Debugging/RavenDebugExecUtils.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using Sparrow.Platform;
+
+namespace Raven.Server.Utils.Debugging;
+
+public static class RavenDebugExecUtils
+{
+    public static string GetRavenDebugExecPath()
+    {
+        var ravenDebugFileName = PlatformDetails.RunningOnPosix ? "Raven.Debug" : "Raven.Debug.exe";
+        var ravenDebugExec = Path.Combine(AppContext.BaseDirectory, ravenDebugFileName);
+
+        if (File.Exists(ravenDebugExec))
+            return ravenDebugExec;
+
+        // In a dev environment, Raven.Debug is not in the same output directory as Raven.Server.
+        // Raven.Server runs from: src/Raven.Server/bin/{config}/net8.0
+        // Raven.Debug is built to: tools/Raven.Debug/bin/{config}/net8.0
+        // In dev, AppContext.BaseDirectory is: <root>/src/Raven.Server/bin/{config}/{tfm}/
+        // We need to go up 5 levels to reach the repo root, then look in: tools/Raven.Debug/bin/{config}/{tfm}/
+        var baseDir = new DirectoryInfo(AppContext.BaseDirectory);
+        var tfm = baseDir.Name;                   // e.g. "net8.0"
+        var config = baseDir.Parent?.Name;        // e.g. "Debug" or "Release"
+        var repoRoot = baseDir.Parent?.Parent?.Parent?.Parent?.Parent; // {config} -> bin -> Raven.Server -> src -> root
+
+        if (repoRoot != null && config != null)
+        {
+            // Try same configuration first, then the opposite one
+            var configs = new[] { config, string.Equals(config, "Debug", StringComparison.OrdinalIgnoreCase) ? "Release" : "Debug" };
+            foreach (var cfg in configs)
+            {
+                var candidate = Path.Combine(repoRoot.FullName, "tools", "Raven.Debug", "bin", cfg, tfm, ravenDebugFileName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+        }
+
+        throw new FileNotFoundException($"Could not find debugger tool at '{ravenDebugExec}'");
+    }
+}

--- a/src/Raven.Server/Utils/Debugging/RavenDebugExecUtils.cs
+++ b/src/Raven.Server/Utils/Debugging/RavenDebugExecUtils.cs
@@ -6,36 +6,24 @@ namespace Raven.Server.Utils.Debugging;
 
 public static class RavenDebugExecUtils
 {
+    internal static string RavenDebugFileName = PlatformDetails.RunningOnPosix ? "Raven.Debug" : "Raven.Debug.exe";
+
+    internal static readonly string[] FileSystemLookupPaths =
+    {
+        ".",
+        "../../../../../tools/Raven.Debug/bin/Debug/net8.0",
+        "../../../../../tools/Raven.Debug/bin/Release/net8.0"
+    };
+
     public static string GetRavenDebugExecPath()
     {
-        var ravenDebugFileName = PlatformDetails.RunningOnPosix ? "Raven.Debug" : "Raven.Debug.exe";
-        var ravenDebugExec = Path.Combine(AppContext.BaseDirectory, ravenDebugFileName);
-
-        if (File.Exists(ravenDebugExec))
-            return ravenDebugExec;
-
-        // In a dev environment, Raven.Debug is not in the same output directory as Raven.Server.
-        // Raven.Server runs from: src/Raven.Server/bin/{config}/net8.0
-        // Raven.Debug is built to: tools/Raven.Debug/bin/{config}/net8.0
-        // In dev, AppContext.BaseDirectory is: <root>/src/Raven.Server/bin/{config}/{tfm}/
-        // We need to go up 5 levels to reach the repo root, then look in: tools/Raven.Debug/bin/{config}/{tfm}/
-        var baseDir = new DirectoryInfo(AppContext.BaseDirectory);
-        var tfm = baseDir.Name;                   // e.g. "net8.0"
-        var config = baseDir.Parent?.Name;        // e.g. "Debug" or "Release"
-        var repoRoot = baseDir.Parent?.Parent?.Parent?.Parent?.Parent; // {config} -> bin -> Raven.Server -> src -> root
-
-        if (repoRoot != null && config != null)
+        foreach (var lookupPath in FileSystemLookupPaths)
         {
-            // Try same configuration first, then the opposite one
-            var configs = new[] { config, string.Equals(config, "Debug", StringComparison.OrdinalIgnoreCase) ? "Release" : "Debug" };
-            foreach (var cfg in configs)
-            {
-                var candidate = Path.Combine(repoRoot.FullName, "tools", "Raven.Debug", "bin", cfg, tfm, ravenDebugFileName);
-                if (File.Exists(candidate))
-                    return candidate;
-            }
+            var candidate = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, lookupPath, RavenDebugFileName));
+            if (File.Exists(candidate))
+                return candidate;
         }
 
-        throw new FileNotFoundException($"Could not find debugger tool at '{ravenDebugExec}'");
+        throw new FileNotFoundException($"Could not find '{RavenDebugFileName}' in any of the lookup paths relative to '{AppContext.BaseDirectory}'");
     }
 }

--- a/src/Raven.Server/Web/System/AdminDumpHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDumpHandler.cs
@@ -10,6 +10,7 @@ using Raven.Client.Properties;
 using Raven.Server.Rachis;
 using Raven.Server.Routing;
 using Raven.Server.Utils;
+using Raven.Server.Utils.Debugging;
 using Sparrow.Logging;
 using Sparrow.Platform;
 using Sparrow.Utils;
@@ -83,12 +84,7 @@ namespace Raven.Server.Web.System
         [MethodImpl(MethodImplOptions.Synchronized)]
         private static void Execute(string args, int processId, string output)
         {
-            var ravenDebugExec = Path.Combine(AppContext.BaseDirectory,
-                PlatformDetails.RunningOnPosix ? "Raven.Debug" : "Raven.Debug.exe"
-            );
-
-            if (File.Exists(ravenDebugExec) == false)
-                throw new FileNotFoundException($"Could not find debugger tool at '{ravenDebugExec}'");
+            var ravenDebugExec = RavenDebugExecUtils.GetRavenDebugExecPath();
 
             var sb = new StringBuilder($"{args} --pid {processId} --output {CommandLineArgumentEscaper.EscapeSingleArg(output)}");
 

--- a/test/FastTests/Issues/RavenDB_26282.cs
+++ b/test/FastTests/Issues/RavenDB_26282.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using System.Linq;
+using Raven.Server.Utils.Debugging;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues;
+
+public class RavenDB_26282 : NoDisposalNeeded
+{
+    public RavenDB_26282(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Core)]
+    public void RavenDebugExec_DevBuildLookupPaths_ShouldResolveToExistingFile()
+    {
+        // Skip the first path (".") - that is the production layout where Raven.Debug
+        // sits next to Raven.Server. In a dev build it won't exist there.
+        // We validate that at least one of the dev lookup paths resolves to a real file.
+        var devPaths = RavenDebugExecUtils.FileSystemLookupPaths.Skip(1).ToList();
+
+        var found = devPaths
+            .Select(p => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, p, RavenDebugExecUtils.RavenDebugFileName)))
+            .FirstOrDefault(File.Exists);
+
+        Assert.True(found != null,
+            $"Raven.Debug executable was not found in any dev lookup path relative to '{AppContext.BaseDirectory}'. " +
+            $"Running on .NET {Environment.Version} (net{Environment.Version.Major}.0). " +
+            $"If the TFM changed, update the hardcoded lookup paths in {nameof(RavenDebugExecUtils)}. " +
+            $"Paths tried: {Environment.NewLine}{string.Join(Environment.NewLine, devPaths)}");
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26282/Cannot-download-stack-traces-dumps-or-GC-dumps-in-dev-environment-Raven.Debug-not-found

### Additional description

In dev environments, Raven.Debug.exe lives under tools/Raven.Debug/bin/{config}/{tfm}/ rather than next to Raven.Server. This caused `FileNotFoundException` on the stack trace, dump, and GC dump endpoints.
Extracted the executable lookup logic into `RavenDebugExecUtils.GetRavenDebugExecPath()` in `Raven.Server.Utils.Debugging`, which first checks `AppContext.BaseDirectory` (production path) and falls back to navigating up to the repo root and into the `tools/Raven.Debug` output directory, trying both `Debug` and `Release` configurations.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
