### PR TITLE
RavenDB-26284 HSNW.Parallel could benefit from using IThreadPoolWorkItem

### DIFF
--- a/bench/Vector.Benchmark/Program.cs
+++ b/bench/Vector.Benchmark/Program.cs
@@ -148,7 +148,6 @@ static async Task DownloadFile(string fullPath)
         client.Timeout = TimeSpan.FromHours(1); // Set timeout to a reasonable value for large files
         
         string path = url + Path.GetFileName(fullPath);
-        var request = new HttpRequestMessage(HttpMethod.Get, path);
 
         using (var response = await client.GetAsync(path, HttpCompletionOption.ResponseHeadersRead))
         {

--- a/bench/Vector.Benchmark/Program.cs
+++ b/bench/Vector.Benchmark/Program.cs
@@ -4,22 +4,17 @@ using Parquet;
 using Voron;
 using Voron.Data.Graphs;
 
-string[] Files = [
-                 "train-00000-of-00004-1a1932c9ca1c7152.parquet",
-                 "train-00001-of-00004-f4a4f5540ade14b4.parquet",
-                 "train-00002-of-00004-ff770df3ab420d14.parquet",
-                 "train-00003-of-00004-85b3dbbc960e92ec.parquet"
-             ];
+string[] files = ["wikipedia-22-12-simple-embeddings_train.parquet",];
+
 var dbPath = Path.GetFullPath("vectors");
 if (Directory.Exists(dbPath))
 {
     Directory.Delete(dbPath, true);
 }
 
-var sp = Stopwatch.StartNew();
 await ImportData(dbPath);
-Console.WriteLine(sp.Elapsed);
-sp.Restart();
+
+var sp = Stopwatch.StartNew();
 TestRecall(dbPath);
 Console.WriteLine(sp.Elapsed);
 
@@ -36,7 +31,7 @@ void TestRecall(string path)
     var ennMatches = new long[resultsCount];
     var ennDistances = new float[resultsCount];
     long results = 0;
-    foreach (var file in Files)
+    foreach (var file in files)
     {
         using var txr = env.ReadTransaction();
         using var _ = Slice.From(txr.Allocator, "wiki", out var wikiTreeName);
@@ -84,13 +79,15 @@ async Task ImportData(string path)
     Console.WriteLine(options.BasePath.FullPath);
     using var env = new StorageEnvironment(options);
 
+    TimeSpan import = TimeSpan.Zero;
+    
     using (var txw = env.WriteTransaction())
     {
         Hnsw.Create(txw.LowLevelTransaction, "wiki", 768 * 4, 12, 40, VectorEmbeddingType.Single);
         txw.Commit();
     }
 
-    foreach (var file in Files)
+    foreach (var file in files)
     {
         var fullPath = Path.Combine(Path.GetTempPath(), "Vector.Benchmark", file);
         if (File.Exists(fullPath) is false)
@@ -101,6 +98,7 @@ async Task ImportData(string path)
         foreach (var (ids, vectors) in YieldVectors(fullPath))
         {
             var batch = Stopwatch.StartNew();
+            
             using (var txw = env.WriteTransaction())
             {
                 using (var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "wiki"))
@@ -115,11 +113,15 @@ async Task ImportData(string path)
                 }
                 txw.Commit();
             }
-            Console.WriteLine($" * {ids.Length:N0} - {batch.Elapsed}");
+
+            var elapsed = batch.Elapsed;
+            Console.WriteLine($" * {ids.Length:N0} - {elapsed}");
+            import += elapsed;
         }
     }
+    
+    Console.WriteLine($"Import took: {import}");
 }
-
 
 static IEnumerable<(int[], float[])> YieldVectors(string filePath)
 {
@@ -138,14 +140,17 @@ static IEnumerable<(int[], float[])> YieldVectors(string filePath)
 
 static async Task DownloadFile(string fullPath)
 {
-    const string url = "https://huggingface.co/datasets/Cohere/wikipedia-22-12-simple-embeddings/resolve/main/data/";
+    const string url = "https://hub.oxen.ai/api/repos/Cohere/wikipedia-22-12-simple-embeddings/file/main/";
 
     Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
     using (HttpClient client = new())
     {
         client.Timeout = TimeSpan.FromHours(1); // Set timeout to a reasonable value for large files
+        
+        string path = url + Path.GetFileName(fullPath);
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
 
-        using (var response = await client.GetAsync(url + Path.GetFileName(fullPath), HttpCompletionOption.ResponseHeadersRead))
+        using (var response = await client.GetAsync(path, HttpCompletionOption.ResponseHeadersRead))
         {
             response.EnsureSuccessStatusCode();
 

--- a/bench/Vector.Benchmark/Vector.Benchmark.csproj
+++ b/bench/Vector.Benchmark/Vector.Benchmark.csproj
@@ -1,19 +1,77 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Voron\Voron.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Voron\Voron.csproj"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="libsodium" />
-      <PackageReference Include="Parquet.Net" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="libsodium"/>
+    <PackageReference Include="Parquet.Net"/>
+  </ItemGroup>
 
+  <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsWindows64)' == 'true'">
+    <None Include="..\..\libs\librvnpal\librvnpal.win.x64.dll" Link="librvnpal.win.x64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\librvnpal\librvnpal.win7.x64.dll" Link="librvnpal.win7.x64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\libzstd\libzstd.win.x64.dll" Link="libzstd.win.x64.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsWindows32)' == 'true'">
+    <None Include="..\..\libs\librvnpal\librvnpal.win.x86.dll" Link="librvnpal.win.x86.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\librvnpal\librvnpal.win7.x86.dll" Link="librvnpal.win7.x86.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\libzstd\libzstd.win.x86.dll" Link="libzstd.win.x86.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\librvnpal\librvnpal.mac.arm64.dylib" Link="librvnpal.mac.arm64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsLinux64)' == 'true'">
+    <None Include="..\..\libs\librvnpal\librvnpal.linux.x64.so" Link="librvnpal.linux.x64.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\libzstd\libzstd.linux.x64.so" Link="libzstd.linux.x64.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsLinuxArm64)' == 'true'">
+    <None Include="..\..\libs\librvnpal\librvnpal.arm.64.so" Link="librvnpal.arm.64.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\libzstd\libzstd.arm.64.so" Link="libzstd.arm.64.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsLinuxArm32)' == 'true'">
+    <None Include="..\..\libs\librvnpal\librvnpal.arm.32.so" Link="librvnpal.arm.32.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\libzstd\libzstd.arm.32.so" Link="libzstd.arm.32.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsMacOS)' == 'true'">
+    <None Include="..\..\libs\librvnpal\librvnpal.mac.x64.dylib" Link="librvnpal.mac.x64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\libs\libzstd\libzstd.mac.x64.dylib" Link="libzstd.mac.x64.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
 </Project>

--- a/bench/Voron.Benchmark/HnswGraphBuildBenchmark.cs
+++ b/bench/Voron.Benchmark/HnswGraphBuildBenchmark.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using Voron;
+using Voron.Data.Graphs;
+
+namespace Voron.Benchmark;
+
+/// <summary>
+/// Benchmarks HNSW graph construction to measure allocation pressure
+/// from WorkItem scheduling during parallel graph building.
+/// Run: dotnet run -c Release -- --filter "*Hnsw*"
+/// </summary>
+[MemoryDiagnoser]
+[Config(typeof(Config))]
+public class HnswGraphBuildBenchmark
+{
+    private class Config : ManualConfig
+    {
+        public Config()
+        {
+            AddJob(Job.ShortRun
+                .WithWarmupCount(2)
+                .WithIterationCount(5));
+            WithBuildTimeout(TimeSpan.FromMinutes(10));
+        }
+    }
+
+    private const int Dimensions = 16;
+    private const int VectorSizeBytes = Dimensions * sizeof(float);
+    private const int NumberOfNodes = 65536;
+
+    // HNSW parameters
+    private const int NumberOfEdges = 8; // M
+    private const int NumberOfCandidates = 16; // efConstruction
+
+    private float[][] _vectors;
+    private StorageEnvironment _env;
+    private StorageEnvironmentOptions _options;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var rng = new Random(42);
+        _vectors = new float[NumberOfNodes][];
+        for (int i = 0; i < NumberOfNodes; i++)
+        {
+            _vectors[i] = new float[Dimensions];
+            for (int d = 0; d < Dimensions; d++)
+            {
+                _vectors[i][d] = rng.NextSingle() * 2f - 1f;
+            }
+        }
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        _options = StorageEnvironmentOptions.CreateMemoryOnlyForTests("HnswBench");
+        _env = new StorageEnvironment(_options);
+    }
+
+    [IterationCleanup]
+    public void IterationCleanup()
+    {
+        _env?.Dispose();
+        _options?.Dispose();
+    }
+
+    [Benchmark(OperationsPerInvoke = NumberOfNodes)]
+    public void BuildHnswGraph()
+    {
+        var hnswRandom = new Random(42);
+
+        using var txw = _env.WriteTransaction();
+        Hnsw.Create(txw.LowLevelTransaction, "vectors", VectorSizeBytes, NumberOfEdges, NumberOfCandidates, VectorEmbeddingType.Single);
+
+        using var registration = Hnsw.RegistrationFor(txw.LowLevelTransaction, "vectors", hnswRandom);
+        for (int i = 0; i < NumberOfNodes; i++)
+        {
+            registration.Register(i + 1, MemoryMarshal.Cast<float, byte>(_vectors[i]));
+        }
+        registration.Commit(CancellationToken.None);
+        txw.Commit();
+    }
+}

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -8,7 +7,6 @@ using System.Threading;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Server.Utils;
-using Sparrow.Server.Utils.VxSort;
 using Voron.Data.Containers;
 using Voron.Util;
 using Array = System.Array;
@@ -371,11 +369,11 @@ public partial class Hnsw
 
             private sealed class FilterEdgesHeuristicWorker : WorkItem
             {
-                public UnmanagedSpan Src;
+                private UnmanagedSpan _src;
 
                 public void Reset(UnmanagedSpan src, int currentNodeIndex, int level)
                 {
-                    Src = src;
+                    _src = src;
                     CurrentNodeIndex = currentNodeIndex;
                     Level = level;
                 }
@@ -396,7 +394,7 @@ public partial class Hnsw
                     Debug.Assert(queue.Count is 0);
                     for (int i = 0; i < indexes.Count; i++)
                     {
-                        var distance = searchState.Distance(Src, vectors[i]);
+                        var distance = searchState.Distance(_src, vectors[i]);
                         // note that we use local indexes here!
                         queue.Enqueue(i, distance);
                     }
@@ -436,12 +434,12 @@ public partial class Hnsw
             }
             private sealed class ProcessEdgesWorker : WorkItem
             {
-                public UnmanagedSpan Vector;
+                private UnmanagedSpan _vector;
                 public float LowerBound;
 
                 public void Reset(UnmanagedSpan vector, float lowerBound, int currentNodeIndex, int level)
                 {
-                    Vector = vector;
+                    _vector = vector;
                     LowerBound = lowerBound;
                     CurrentNodeIndex = currentNodeIndex;
                     Level = level;
@@ -462,7 +460,7 @@ public partial class Hnsw
                         var nextIndex = indexes[i];
                         Debug.Assert(searchState.Nodes[nextIndex].EdgesPerLevel.Count > Level); 
                    
-                        float nextDist = -searchState.Distance(Vector, vectors[i]);
+                        float nextDist = -searchState.Distance(_vector, vectors[i]);
                         if (nearestEdgesQ.Count < numberOfCandidates)
                         {
                             candidatesQ.Enqueue(nextIndex, -nextDist);
@@ -514,12 +512,12 @@ public partial class Hnsw
 
             private sealed class FindNearestWorker : WorkItem
             {
-                public UnmanagedSpan From;
+                private UnmanagedSpan _from;
                 public float Distance;
 
                 public void Reset(UnmanagedSpan from, int currentNodeIndex, int level)
                 {
-                    From = from;
+                    _from = from;
                     Distance = float.MaxValue;
                     CurrentNodeIndex = currentNodeIndex;
                     Level = level;
@@ -534,7 +532,7 @@ public partial class Hnsw
                     for (var i = 0; i < indexes.Count; i++)
                     {
                         var edgeIdx = indexes[i];
-                        var curDist = searchState.Distance(From, vectors[i]);
+                        var curDist = searchState.Distance(_from, vectors[i]);
                         if (curDist >= Distance || double.IsNaN(curDist))
                             continue;
                         Distance = curDist;

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -98,13 +98,27 @@ public partial class Hnsw
      *   so we won't cause a bottleneck in the thread pool.
      * * We tested using a dedicated thread pool, but those performed significantly worse than the 
      *   default .NET one. 
+     *
+     * # Allocation-free work item dispatch
+     *
+     * The WorkItem base class implements IThreadPoolWorkItem, which allows us to queue it directly to
+     * the .NET thread pool via ThreadPool.UnsafeQueueUserWorkItem without allocating a delegate or a
+     * Task. Each concrete worker (ProcessEdgesWorker, FilterEdgesHeuristicWorker, FindNearestWorker)
+     * is preallocated once per NodePlacement instance and stored in a field. The enumerators in
+     * Process(), FindGraphPlacementForNode(), NearestEdges(), etc. yield the *same* preallocated
+     * worker object repeatedly — mutating its state (CurrentNodeIndex, Level, Owner, etc.) before each
+     * yield return. This means no new work items are heap-allocated during the graph-building loop;
+     * the runner simply resets and re-queues the same objects. The trade-off is that a yielded WorkItem
+     * is only valid until the enumerator advances, but that is fine because the runner always consumes
+     * the item before calling MoveNext again.
      */
     public partial class Registration
     {
         private int _nextNodeIndex;
 
         public int MaxConcurrentBatches = 512;
-        void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer, CancellationToken token)
+
+        private void InsertVectorsToGraph(ref ContextBoundNativeList<byte> byteBuffer, CancellationToken token)
         {
             if (_searchState.TryGetLocationForNode(EntryPointId, out var entryPointNode) is false)
             {

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Sparrow;
 using Sparrow.Binary;
 using Sparrow.Server.Utils;
@@ -145,6 +144,11 @@ public partial class Hnsw
             private int[] _visitedBitmapVersion = [];
             private int _visitedVersion;
             private readonly LinkedListNode<int> _listNode = new(-1);
+
+            // Pooled work items — reused across all yields to avoid per-yield heap allocations
+            private readonly ProcessEdgesWorker _processEdgesWorker = new() { Runner = runner };
+            private readonly FilterEdgesHeuristicWorker _filterEdgesWorker = new() { Runner = runner };
+            private readonly FindNearestWorker _findNearestWorker = new() { Runner = runner };
             
             private void ClearVisited()
             {
@@ -185,6 +189,10 @@ public partial class Hnsw
 
             public IEnumerable<WorkItem> Process()
             {
+                _processEdgesWorker.Owner = this;
+                _filterEdgesWorker.Owner = this;
+                _findNearestWorker.Owner = this;
+
                 try
                 {
                     int createdNodesLength = _searchState.CreatedNodes;
@@ -270,11 +278,8 @@ public partial class Hnsw
                             MarkVisited(edgeIdx);
                         }
 
-                        yield return new FilterEdgesHeuristicWorker(this, vector)
-                        {
-                            CurrentNodeIndex = edgeIdx, 
-                            Level = level
-                        };
+                        _filterEdgesWorker.Reset(vector, edgeIdx, level);
+                        yield return _filterEdgesWorker;
                         
                         PortableExceptions.ThrowIf<InvalidOperationException>(_candidates.Count == 0 , "Cannot add a node to the graph without any edges after heuristic");
                         {
@@ -333,13 +338,9 @@ public partial class Hnsw
                         _nearestEdgesQ.Count == _searchState.Options.NumberOfCandidates)
                         break;
 
-                    var worker = new ProcessEdgesWorker(this, vector, lowerBound)
-                    {
-                        CurrentNodeIndex = cur,
-                        Level = level,
-                    };
-                    yield return worker;
-                    lowerBound = worker.LowerBound;
+                    _processEdgesWorker.Reset(vector, lowerBound, cur, level);
+                    yield return _processEdgesWorker;
+                    lowerBound = _processEdgesWorker.LowerBound;
                 }
 
                 _candidatesQ.Clear();
@@ -362,20 +363,24 @@ public partial class Hnsw
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
 
-                yield return new FilterEdgesHeuristicWorker(this, vector)
-                {
-                    // disable preloading - we already got everything from the 
-                    // previous preloading step and are operating purely in memory 
-                    CurrentNodeIndex = -1,
-                    Level = level
-                };
+                // disable preloading - we already got everything from the 
+                // previous preloading step and are operating purely in memory 
+                _filterEdgesWorker.Reset(vector, -1, level);
+                yield return _filterEdgesWorker;
             }
 
-            private record FilterEdgesHeuristicWorker(
-                NodePlacement Owner,
-                UnmanagedSpan Src) : WorkItem(Owner)
+            private sealed class FilterEdgesHeuristicWorker : WorkItem
             {
-                public override void Execute()
+                public UnmanagedSpan Src;
+
+                public void Reset(UnmanagedSpan src, int currentNodeIndex, int level)
+                {
+                    Src = src;
+                    CurrentNodeIndex = currentNodeIndex;
+                    Level = level;
+                }
+
+                protected override void DoWork()
                 {
                     // See: https://icode.best/i/45208840268843 - Chinese, but auto-translate works, and a good explanation with 
                     // conjunction of: https://img-bc.icode.best/20210425010212938.png
@@ -429,11 +434,20 @@ public partial class Hnsw
                     queue.Clear();
                 }
             }
-            private record ProcessEdgesWorker(NodePlacement Owner, UnmanagedSpan Vector, float LowerBound) : WorkItem(Owner)
+            private sealed class ProcessEdgesWorker : WorkItem
             {
-                public float LowerBound { get; private set; } = LowerBound;
+                public UnmanagedSpan Vector;
+                public float LowerBound;
 
-                public override void Execute()
+                public void Reset(UnmanagedSpan vector, float lowerBound, int currentNodeIndex, int level)
+                {
+                    Vector = vector;
+                    LowerBound = lowerBound;
+                    CurrentNodeIndex = currentNodeIndex;
+                    Level = level;
+                }
+
+                protected override void DoWork()
                 {
                     var searchState = Owner._searchState;
                     var indexes = Owner._indexes;
@@ -483,16 +497,12 @@ public partial class Hnsw
                 {
                     do
                     {
-                        var worker = new FindNearestWorker(this, from)
-                        {
-                            CurrentNodeIndex = currentNodeIndex,
-                            Level = level
-                        };
-                        yield return worker;
-                        if (worker.Distance >= distance)
+                        _findNearestWorker.Reset(from, currentNodeIndex, level);
+                        yield return _findNearestWorker;
+                        if (_findNearestWorker.Distance >= distance)
                             break;
-                        currentNodeIndex = worker.CurrentNodeIndex;
-                        distance = worker.Distance;
+                        currentNodeIndex = _findNearestWorker.CurrentNodeIndex;
+                        distance = _findNearestWorker.Distance;
                     } while (true);
 
                     _nearestIndexes.Add(currentNodeIndex);
@@ -502,11 +512,20 @@ public partial class Hnsw
                 _nearestIndexes.Reverse();
             }
 
-            private record FindNearestWorker(NodePlacement Owner,UnmanagedSpan From) : WorkItem(Owner)
+            private sealed class FindNearestWorker : WorkItem
             {
-                public float Distance = float.MaxValue;
+                public UnmanagedSpan From;
+                public float Distance;
 
-                public override void Execute()
+                public void Reset(UnmanagedSpan from, int currentNodeIndex, int level)
+                {
+                    From = from;
+                    Distance = float.MaxValue;
+                    CurrentNodeIndex = currentNodeIndex;
+                    Level = level;
+                }
+
+                protected override void DoWork()
                 {
                     var indexes = Owner._indexes;
                     var vectors = Owner._vectors;
@@ -628,24 +647,10 @@ public partial class Hnsw
                 }
             }
 
-            private void RunWorkItem(object state)
-            {
-                WorkItem workItem = (WorkItem)state;
-                try
-                {
-                    workItem.Execute();
-                    Enqueue(workItem.Iterator);
-                }
-                catch (Exception e)
-                {
-                    Error(workItem.Iterator, e);
-                }
-            }
             
             public void Run()
             {
                 List<long> batch = [];
-                WaitCallback callback = RunWorkItem;
                 while (true)
                 {
                     _ready.Wait();
@@ -702,7 +707,7 @@ public partial class Hnsw
                             continue; // no work to do, everything was already visited
                         }
 
-                        ThreadPool.UnsafeQueueUserWorkItem(callback, item);
+                        ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
                     }
 
                     var batchSpan = CollectionsMarshal.AsSpan(batch);
@@ -718,7 +723,7 @@ public partial class Hnsw
 
                         if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level))
                         {
-                            ThreadPool.UnsafeQueueUserWorkItem(callback, item);
+                            ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
                         }
                         else
                         {
@@ -748,13 +753,13 @@ public partial class Hnsw
                 }
             }
 
-            private void Enqueue(IEnumerator<WorkItem> it)
+            public void Enqueue(IEnumerator<WorkItem> it)
             { 
                 _placementTasks.Enqueue(it);
                 _ready.Set();
             }
 
-            private void Error(IEnumerator<WorkItem> it, Exception exception)
+            public void Error(IEnumerator<WorkItem> it, Exception exception)
             {
                 _placementErrors.Enqueue((exception, it));
                 _ready.Set();
@@ -779,11 +784,26 @@ public partial class Hnsw
             }
         }
         
-        private abstract record WorkItem(NodePlacement Owner)
+        private abstract class WorkItem : IThreadPoolWorkItem
         {
+            public NodePlacement Owner;
+            public NodePlacementRunner Runner;
             public IEnumerator<WorkItem> Iterator;
 
-            public abstract void Execute();
+            protected abstract void DoWork();
+
+            void IThreadPoolWorkItem.Execute()
+            {
+                try
+                {
+                    DoWork();
+                    Runner.Enqueue(Iterator);
+                }
+                catch (Exception e)
+                {
+                    Runner.Error(Iterator, e);
+                }
+            }
 
             public int CurrentNodeIndex;
             public int Level;

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -144,9 +144,9 @@ public partial class Hnsw
             private readonly LinkedListNode<int> _listNode = new(-1);
 
             // Pooled work items — reused across all yields to avoid per-yield heap allocations
-            private readonly ProcessEdgesWorker _processEdgesWorker = new() { Runner = runner };
-            private readonly FilterEdgesHeuristicWorker _filterEdgesWorker = new() { Runner = runner };
-            private readonly FindNearestWorker _findNearestWorker = new() { Runner = runner };
+            private readonly ProcessEdgesWorker _processEdgesWorker = new(runner);
+            private readonly FilterEdgesHeuristicWorker _filterEdgesWorker = new(runner);
+            private readonly FindNearestWorker _findNearestWorker = new(runner);
             
             private void ClearVisited()
             {
@@ -367,7 +367,7 @@ public partial class Hnsw
                 yield return _filterEdgesWorker;
             }
 
-            private sealed class FilterEdgesHeuristicWorker : WorkItem
+            private sealed class FilterEdgesHeuristicWorker(NodePlacementRunner runner) : WorkItem(runner)
             {
                 private UnmanagedSpan _src;
 
@@ -432,7 +432,7 @@ public partial class Hnsw
                     queue.Clear();
                 }
             }
-            private sealed class ProcessEdgesWorker : WorkItem
+            private sealed class ProcessEdgesWorker(NodePlacementRunner runner) : WorkItem(runner)
             {
                 private UnmanagedSpan _vector;
                 public float LowerBound;
@@ -510,7 +510,7 @@ public partial class Hnsw
                 _nearestIndexes.Reverse();
             }
 
-            private sealed class FindNearestWorker : WorkItem
+            private sealed class FindNearestWorker(NodePlacementRunner runner) : WorkItem(runner)
             {
                 private UnmanagedSpan _from;
                 public float Distance;
@@ -782,10 +782,9 @@ public partial class Hnsw
             }
         }
         
-        private abstract class WorkItem : IThreadPoolWorkItem
+        private abstract class WorkItem(NodePlacementRunner runner) : IThreadPoolWorkItem
         {
             public NodePlacement Owner;
-            public NodePlacementRunner Runner;
             public IEnumerator<WorkItem> Iterator;
 
             protected abstract void DoWork();
@@ -795,11 +794,11 @@ public partial class Hnsw
                 try
                 {
                     DoWork();
-                    Runner.Enqueue(Iterator);
+                    runner.Enqueue(Iterator);
                 }
                 catch (Exception e)
                 {
-                    Runner.Error(Iterator, e);
+                    runner.Error(Iterator, e);
                 }
             }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26284/HSNW.Parallel-could-benefit-from-using-IThreadPoolWorkItem

### Additional description

Currently, `HNSW.Parallel` uses `TheadPool` with a state object and delegate that will be executed on it. This, effectively causes an allocation to capture the state and the delegate, even though the delegate is cached between schedules. There's a low-level API of `IThreadPoolWorkItem` that could be used to schedule the `WorkItem` directly, without the additional allocations. If we use it, we can save a lot of minor allocations.

In addition to this, the enumerator approach is now returning and allocating a lot of items. If we made them resettable we could not allocate while still use the nice `yield return` semantics.

Preliminary benchmarks show that we can save a lot of memory, when performing `HNSW.Parallel`. There's no that much of an impact in regards to the processing time savings. Still, reducing allocs heavily can favor this approach in a constrained environment.

### Benchmarks

#### Microbenchmark

Inserting 0XFFFF elements. Similar timings, much less allocatey after this PR. As far as I understand HNSW, the bigger the graph, the more walking it requires, the more allocatey the previous version would be.

| Method                  | Mean     | Error    | StdDev   | Gen0   | Gen1   | Gen2   | Allocated |
|------------------------ |---------:|---------:|---------:|-------:|-------:|-------:|----------:|
| BuildHnswGraph (before) | 51.40 us | 4.943 us | 0.765 us | 0.4730 | 0.0458 | 0.0305 |   8.94 KB |
| BuildHnswGraph (after)  | 50.74 us | 4.053 us | 1.052 us | 0.0458 | 0.0305 | 0.0305 |   2.12 KB |

#### Vector.Benchmark

The fixed benchmark of `Vector.Benchmark` (previous data sets from HuggingFace are gone), shows no impact on speed. Locally, both versions are inserted at  `~00:05:31` time. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
