### PR TITLE
RavenDB-26260 Studio should support AiAgentParameter.Type and send typed parameter values instead of strings

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
@@ -78,7 +78,12 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
 
         return {
             prompts: [{ text: "" }],
-            parameters: config.Parameters.map((x) => ({ name: x.Name, value: "" })),
+            parameters: config.Parameters.map((x) => ({
+                name: x.Name,
+                value: "",
+                type: x.Type ?? "Default",
+                sendToModel: x.SendToModel ?? true,
+            })),
             isEnableDocumentExpiration: !isDocumentExpirationEnabled,
             isDocumentExpireInCustomizeEnabled: false,
             persistenceConversationIdPrefix: "",

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/hooks/useChatAiAgent.ts
@@ -78,11 +78,11 @@ export default function useChatAiAgent(queryParams: ChatAiAgentQueryParams) {
 
         return {
             prompts: [{ text: "" }],
-            parameters: config.Parameters.map((x) => ({
+            parameters: config.Parameters.map((x): ChatAiAgentFormData["parameters"][number] => ({
                 name: x.Name,
-                value: "",
+                value: null,
                 type: x.Type ?? "Default",
-                sendToModel: x.SendToModel ?? true,
+                isSendToModel: x.SendToModel ?? true,
             })),
             isEnableDocumentExpiration: !isDocumentExpirationEnabled,
             isDocumentExpireInCustomizeEnabled: false,

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/partials/ChatAiAgentFormBody.tsx
@@ -104,9 +104,8 @@ export default function ChatAiAgentFormBody({
                             <hr />
                             <AiAgentParametersField
                                 control={control}
-                                name="parameters"
                                 value={formValues.parameters}
-                                isTest={false}
+                                panelClassName="panel-bg-1"
                             />
                         </div>
                     )}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -221,11 +221,35 @@ function createParametersDto(
         formParameters.map((x) => [
             x.name,
             {
-                Value: x.value,
-                SendToModel: true,
+                Value: mapParameterToType(x.value, x.type),
+                SendToModel: x.isSendToModel,
             },
         ])
     );
+}
+
+function mapParameterToType(
+    value: string,
+    type: Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType
+) {
+    switch (type) {
+        case "Number":
+            return Number(value);
+        case "Boolean":
+            return value === "true";
+        case "ArrayOfString":
+            return value.split(",").map((x) => x.trim());
+        case "ArrayOfNumber":
+            return value.split(",").map((x) => Number(x.trim()));
+        case "ArrayOfBoolean":
+            return value.split(",").map((x) => x.trim() === "true");
+        case "Null":
+            return null;
+        case "String":
+        case "Default":
+        default:
+            return value;
+    }
 }
 
 const getIsDocumentExpirationEnabled = createAsyncThunk(

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -6,6 +6,7 @@ import { loadableData, loadStatus } from "components/models/common";
 import { createSuccessState, createIdleState, createFailureState } from "components/utils/common";
 import document from "models/database/documents/document";
 import { aiAgentsUtils } from "../../utils/aiAgentsUtils";
+import { aiAgentParametersUtils } from "../../utils/aiAgentParametersUtils";
 import { ChatAiAgentFormData } from "../utils/chatAiAgentValidation";
 import { RunAiAgentRequestDto } from "commands/database/aiAgents/runAiAgentCommand";
 
@@ -221,35 +222,11 @@ function createParametersDto(
         formParameters.map((x) => [
             x.name,
             {
-                Value: mapParameterToType(x.value, x.type),
+                Value: aiAgentParametersUtils.mapParameterValueToType(x.value, x.type),
                 SendToModel: x.isSendToModel,
             },
         ])
     );
-}
-
-function mapParameterToType(
-    value: string,
-    type: Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType
-) {
-    switch (type) {
-        case "Number":
-            return Number(value);
-        case "Boolean":
-            return value === "true";
-        case "ArrayOfString":
-            return value.split(",").map((x) => x.trim());
-        case "ArrayOfNumber":
-            return value.split(",").map((x) => Number(x.trim()));
-        case "ArrayOfBoolean":
-            return value.split(",").map((x) => x.trim() === "true");
-        case "Null":
-            return null;
-        case "String":
-        case "Default":
-        default:
-            return value;
-    }
 }
 
 const getIsDocumentExpirationEnabled = createAsyncThunk(

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/utils/chatAiAgentValidation.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/utils/chatAiAgentValidation.tsx
@@ -17,6 +17,8 @@ const schema = yup.object({
                     is: true,
                     then: (schema) => schema.required(),
                 }),
+            type: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType>().nullable(),
+            isSendToModel: yup.boolean(),
         })
     ),
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/utils/chatAiAgentValidation.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/utils/chatAiAgentValidation.tsx
@@ -1,5 +1,8 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
+import { aiAgentParametersUtils } from "../../utils/aiAgentParametersUtils";
+
+type AiAgentParameterValueType = Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType;
 
 const schema = yup.object({
     prompts: yup.array().of(
@@ -10,14 +13,14 @@ const schema = yup.object({
     parameters: yup.array().of(
         yup.object({
             name: yup.string().nullable(),
-            value: yup
-                .string()
-                .nullable()
-                .when("$areParametersRequired", {
-                    is: true,
+            value: aiAgentParametersUtils
+                .createValueSchema(yup.string().nullable())
+                .when(["$areParametersRequired", "type"], {
+                    is: (areParametersRequired: boolean, type: AiAgentParameterValueType) =>
+                        areParametersRequired && type !== "Null",
                     then: (schema) => schema.required(),
                 }),
-            type: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType>().nullable(),
+            type: yup.string<AiAgentParameterValueType>(),
             isSendToModel: yup.boolean(),
         })
     ),

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/EditAiAgent.scss
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/EditAiAgent.scss
@@ -10,40 +10,13 @@
         }
     }
 
-    .parameters-table-wrapper {
-        border: 1px solid colors.$border-color-light-var;
-        border-radius: sizes.$border-radius-sm;
-        max-height: 220px;
-        overflow-y: auto;
+    .parameters-cards {
+        .parameter-summary {
+            min-width: 0;
 
-        table {
-            margin: 0;
-            background-color: colors.$input-bg-var;
-
-            thead {
-                position: sticky;
-                top: 0;
-                background-color: colors.$panel-bg-2-var;
-                z-index: 5;
-
-                th:not(:first-child) {
-                    border-left: 1px solid colors.$border-color-light-var;
-                }
-            }
-
-            tbody {
-                tr {
-                    border-top: 1px solid colors.$border-color-light-var;
-
-                    td {
-                        padding: 0;
-                        align-content: center;
-                    }
-
-                    td:not(:first-child) {
-                        border-left: 1px solid colors.$border-color-light-var;
-                    }
-                }
+            h4,
+            small {
+                max-width: 100%;
             }
         }
     }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/EditAiAgent.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/EditAiAgent.tsx
@@ -82,7 +82,10 @@ function FormBody({ maxWidth, aiAgentEditor }: FormBodyProps) {
                     )}
                 </div>
                 <div className="p-3 border-top border-secondary">
-                    <EditAiAgentFooter testForm={aiAgentEditor.testForm} editForm={aiAgentEditor.editForm} />
+                    <EditAiAgentFooter
+                        editForm={aiAgentEditor.editForm}
+                        generateTestParameters={aiAgentEditor.generateTestParameters}
+                    />
                 </div>
             </div>
             {isTestOpen && (
@@ -97,7 +100,11 @@ function FormBody({ maxWidth, aiAgentEditor }: FormBodyProps) {
                     className="panel-bg-1 h-100 vstack"
                 >
                     <ColumnResize handleMouseDown={testAreaResizable.handleMouseDown} />
-                    <EditAiAgentTestPanel testForm={aiAgentEditor.testForm} editForm={aiAgentEditor.editForm} />
+                    <EditAiAgentTestPanel
+                        testForm={aiAgentEditor.testForm}
+                        editForm={aiAgentEditor.editForm}
+                        generateTestParameters={aiAgentEditor.generateTestParameters}
+                    />
                 </div>
             )}
         </div>

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
@@ -74,6 +74,24 @@ export default function useEditAiAgent(queryParams: QueryParams) {
         resolver: testAiAgentYupResolver,
     });
 
+    const generateTestParameters = () => {
+        testForm.setValue(
+            "parameters",
+            editForm.getValues().parameters.map((configParam): TestAiAgentFormData["parameters"][number] => {
+                const persistedParameter = testForm
+                    .getValues()
+                    .parameters.find((testParam) => testParam.name === configParam.name);
+
+                return {
+                    name: configParam.name,
+                    type: configParam.type,
+                    isSendToModel: persistedParameter?.isSendToModel ?? configParam.isSendToModel,
+                    value: persistedParameter?.value ?? null,
+                };
+            })
+        );
+    };
+
     const { setIsDirty } = useDirtyFlag(editForm.formState.isDirty);
 
     const reloadEditForm = async () => {
@@ -98,5 +116,6 @@ export default function useEditAiAgent(queryParams: QueryParams) {
         asyncGetEditDefaultValues,
         handleSubmit: editForm.handleSubmit(saveAgent),
         isEditAiAgent,
+        generateTestParameters,
     };
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgentParametersSection.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgentParametersSection.ts
@@ -1,0 +1,59 @@
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { EditAiAgentFormData } from "../utils/editAiAgentValidation";
+
+export default function useEditAiAgentParametersSection() {
+    const { control, trigger } = useFormContext<EditAiAgentFormData>();
+
+    const parameters = useWatch({
+        control,
+        name: "parameters",
+    });
+
+    const fieldArray = useFieldArray({
+        name: "parameters",
+        control,
+    });
+
+    const handleAdd = () => {
+        fieldArray.append({
+            name: "",
+            description: null,
+            isSendToModel: true,
+            policy: "Default",
+            type: "String",
+            isEditing: true,
+        });
+    };
+
+    const handleSave = async (index: number) => {
+        const isValid = await trigger([`parameters.${index}`]);
+        if (!isValid) {
+            return;
+        }
+
+        fieldArray.update(index, {
+            ...parameters[index],
+            isEditing: false,
+        });
+    };
+
+    const handleEdit = (index: number) => {
+        fieldArray.update(index, {
+            ...parameters[index],
+            isEditing: true,
+        });
+    };
+
+    const handleRemove = (index: number) => {
+        fieldArray.remove(index);
+    };
+
+    return {
+        parameters,
+        fieldArray,
+        handleAdd,
+        handleSave,
+        handleEdit,
+        handleRemove,
+    };
+}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentFooter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentFooter.tsx
@@ -3,26 +3,18 @@ import Button from "react-bootstrap/Button";
 import { useAppDispatch } from "components/store";
 import { editAiAgentActions } from "../store/editAiAgentSlice";
 import { useAppUrls } from "components/hooks/useAppUrls";
-import { UseFormReturn, useWatch } from "react-hook-form";
-import { EditAiAgentFormData, TestAiAgentFormData } from "../utils/editAiAgentValidation";
+import { UseFormReturn } from "react-hook-form";
+import { EditAiAgentFormData } from "../utils/editAiAgentValidation";
 import ButtonWithSpinner from "components/common/ButtonWithSpinner";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 
 interface EditAiAgentFooterProps {
-    testForm: UseFormReturn<TestAiAgentFormData>;
     editForm: UseFormReturn<EditAiAgentFormData>;
+    generateTestParameters: () => void;
 }
 
-export default function EditAiAgentFooter({ testForm, editForm }: EditAiAgentFooterProps) {
+export default function EditAiAgentFooter({ editForm, generateTestParameters }: EditAiAgentFooterProps) {
     const dispatch = useAppDispatch();
-
-    const editFormValues = useWatch({
-        control: editForm.control,
-    });
-
-    const testFormValues = useWatch({
-        control: testForm.control,
-    });
 
     const { forCurrentDatabase } = useAppUrls();
 
@@ -32,19 +24,7 @@ export default function EditAiAgentFooter({ testForm, editForm }: EditAiAgentFoo
             return;
         }
 
-        testForm.setValue(
-            "parameters",
-            editFormValues.parameters.map((x) => {
-                const persistedParameter = testFormValues.parameters.find((y) => y.name === x.name);
-
-                return {
-                    name: x.name,
-                    type: x.type,
-                    isSendToModel: persistedParameter?.isSendToModel ?? x.isSendToModel,
-                    value: persistedParameter?.value ?? "",
-                };
-            })
-        );
+        generateTestParameters();
         dispatch(editAiAgentActions.isTestOpenSet(true));
     };
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentFooter.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentFooter.tsx
@@ -34,10 +34,16 @@ export default function EditAiAgentFooter({ testForm, editForm }: EditAiAgentFoo
 
         testForm.setValue(
             "parameters",
-            editFormValues.parameters.map((x) => ({
-                name: x.name,
-                value: testFormValues.parameters.find((y) => y.name === x.name)?.value ?? "",
-            }))
+            editFormValues.parameters.map((x) => {
+                const persistedParameter = testFormValues.parameters.find((y) => y.name === x.name);
+
+                return {
+                    name: x.name,
+                    type: x.type,
+                    isSendToModel: persistedParameter?.isSendToModel ?? x.isSendToModel,
+                    value: persistedParameter?.value ?? "",
+                };
+            })
         );
         dispatch(editAiAgentActions.isTestOpenSet(true));
     };

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentParametersSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentParametersSection.tsx
@@ -252,8 +252,7 @@ const typeOptions: SelectOption<Raven.Client.Documents.Operations.AI.Agents.AiAg
     { value: "Null", label: "Null" },
 ];
 
-const policyOptions: SelectOption<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameter.AiAgentParameterPolicy>[] =
-    [
-        { value: "Default", label: "Default" },
-        { value: "ForbidModelGeneration", label: "Forbid model generation" },
-    ];
+const policyOptions: SelectOption<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterPolicy>[] = [
+    { value: "Default", label: "Default" },
+    { value: "ForbidModelGeneration", label: "Forbid model generation" },
+];

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentParametersSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentParametersSection.tsx
@@ -1,27 +1,33 @@
 import { EmptySet } from "components/common/EmptySet";
-import { FormInput, FormErrorIcon, FormSwitch } from "components/common/Form";
+import {
+    FormErrorIcon,
+    FormGroup,
+    FormInput,
+    FormLabel,
+    FormSelect,
+    FormSwitch,
+    OptionalLabel,
+} from "components/common/Form";
 import { Icon } from "components/common/Icon";
-import { useFormContext, useFieldArray } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import { EditAiAgentFormData } from "../utils/editAiAgentValidation";
 import Button from "react-bootstrap/Button";
+import Badge from "react-bootstrap/Badge";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
-import OptionalLabel from "components/common/OptionalLabel";
 import useBoolean from "components/hooks/useBoolean";
 import Collapse from "react-bootstrap/Collapse";
 import CollapseButton from "components/common/CollapseButton";
+import { SelectOption } from "components/common/select/Select";
+import useEditAiAgentParametersSection from "../hooks/useEditAiAgentParametersSection";
 
 export default function EditAiAgentParametersSection() {
     const { control } = useFormContext<EditAiAgentFormData>();
-
-    const parametersFieldArray = useFieldArray({
-        control,
-        name: "parameters",
-    });
+    const parametersEditor = useEditAiAgentParametersSection();
 
     const { value: isPanelOpen, setValue: setIsPanelOpen, toggle: toggleIsPanelOpen } = useBoolean(true);
 
     return (
-        <div className="edit-ai-agent-parameters-section">
+        <>
             <div className="hstack mt-3">
                 <h3 className="m-0">
                     Set agent parameters
@@ -51,106 +57,203 @@ export default function EditAiAgentParametersSection() {
             <Collapse in={isPanelOpen} mountOnEnter unmountOnExit>
                 <div>
                     <div className="panel-bg-1 p-3 rounded-2 border border-secondary">
-                        <div className="d-flex justify-content-end">
-                            <Button
-                                variant="link"
-                                size="sm"
-                                onClick={() =>
-                                    parametersFieldArray.append({ name: "", description: null, isSendToModel: true })
-                                }
-                                className="mb-1"
-                            >
+                        <div className="hstack justify-content-between">
+                            <div className="hstack gap-2">
+                                <div className="tool-icon bg-faded-secondary border border-secondary small">
+                                    <Icon icon="settings" margin="m-0" className="text-body" />
+                                </div>
+                                <div>Agent parameters</div>
+                            </div>
+                            <Button variant="primary" className="rounded-pill" onClick={parametersEditor.handleAdd}>
                                 <Icon icon="plus" />
                                 Add new parameter
                             </Button>
                         </div>
-                        <div>
-                            {parametersFieldArray.fields.length === 0 ? (
-                                <div className="panel-bg-2 d-flex justify-content-center align-items-center rounded-2 border border-secondary p-2">
+                        <div className="vstack">
+                            {parametersEditor.fieldArray.fields.length === 0 ? (
+                                <div className="well p-2 rounded-2 border border-secondary mt-2 d-flex justify-content-center align-items-center">
                                     <EmptySet compact className="text-muted">
                                         No parameters have been defined yet
                                     </EmptySet>
                                 </div>
                             ) : (
-                                <div className="parameters-table-wrapper">
-                                    <table className="table table-borderless">
-                                        <thead>
-                                            <tr>
-                                                <th>Parameter</th>
-                                                <th>
-                                                    Description <OptionalLabel />
-                                                </th>
-                                                <th style={{ width: "135px" }}>
-                                                    Send to model
-                                                    <PopoverWithHoverWrapper
-                                                        message={
-                                                            <>
-                                                                When enabled, the parameter is exposed to the model. It
-                                                                is included in the prompt sent to the model and in any
-                                                                echo messages.
-                                                                <br />
-                                                                <br />
-                                                                When disabled, the parameter is hidden from the model.
-                                                                It is excluded from both the prompt and echo messages.
-                                                            </>
-                                                        }
-                                                    >
-                                                        <Icon icon="info-new" />
-                                                    </PopoverWithHoverWrapper>
-                                                </th>
-                                                <th style={{ width: "80px" }}>Actions</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {parametersFieldArray.fields.map((field, index) => (
-                                                <tr key={field.id}>
-                                                    <td>
-                                                        <FormInput
-                                                            type="text"
-                                                            control={control}
-                                                            name={`parameters.${index}.name`}
-                                                            placeholder="e.g. company"
-                                                            className="form-control border-0 rounded-0"
-                                                        />
-                                                    </td>
-                                                    <td>
-                                                        <FormInput
-                                                            type="text"
-                                                            control={control}
-                                                            name={`parameters.${index}.description`}
-                                                            placeholder="e.g. The company ID"
-                                                            className="form-control border-0 rounded-0"
-                                                        />
-                                                    </td>
-                                                    <td>
-                                                        <div className="hstack justify-content-center">
-                                                            <FormSwitch
-                                                                control={control}
-                                                                name={`parameters.${index}.isSendToModel`}
-                                                            />
-                                                        </div>
-                                                    </td>
-                                                    <td className="text-center">
-                                                        <Button
-                                                            variant="link"
-                                                            className="text-danger p-0"
-                                                            size="sm"
-                                                            onClick={() => parametersFieldArray.remove(index)}
-                                                            title="Delete this parameter"
-                                                        >
-                                                            <Icon icon="trash" margin="m-0" />
-                                                        </Button>
-                                                    </td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
+                                <div className="parameters-cards vstack">
+                                    {parametersEditor.fieldArray.fields.map((field, index) => (
+                                        <ParameterItem
+                                            key={field.id}
+                                            index={index}
+                                            parameterItem={parametersEditor.parameters[index]}
+                                            remove={() => parametersEditor.handleRemove(index)}
+                                            save={() => parametersEditor.handleSave(index)}
+                                            edit={() => parametersEditor.handleEdit(index)}
+                                        />
+                                    ))}
                                 </div>
                             )}
                         </div>
                     </div>
                 </div>
             </Collapse>
+        </>
+    );
+}
+
+interface ParameterItemProps {
+    index: number;
+    parameterItem: EditAiAgentFormData["parameters"][number];
+    remove: () => void;
+    save: () => Promise<void>;
+    edit: () => void;
+}
+
+function ParameterItem({ index, parameterItem, remove, save, edit }: ParameterItemProps) {
+    const { control } = useFormContext<EditAiAgentFormData>();
+
+    if (!parameterItem) {
+        return null;
+    }
+
+    if (!parameterItem.isEditing) {
+        return (
+            <div className="well p-2 rounded-2 border border-secondary mt-2 d-flex justify-content-between align-items-center gap-2">
+                <div className="parameter-summary min-width-0 flex-grow-1">
+                    <div className="d-flex align-items-center gap-1 min-width-0">
+                        <h4 className="m-0 text-truncate" title={parameterItem.name}>
+                            {parameterItem.name}
+                        </h4>
+                        <Badge pill bg="secondary" className="font-size-12 flex-shrink-0">
+                            {getParameterTypeLabel(parameterItem.type)}
+                        </Badge>
+                    </div>
+                    <small className="d-block text-truncate" title={parameterItem.description}>
+                        {parameterItem.description}
+                    </small>
+                </div>
+                <div className="hstack gap-2 flex-shrink-0">
+                    <Button variant="danger" onClick={remove}>
+                        <Icon icon="trash" margin="m-0" />
+                    </Button>
+                    <Button variant="secondary" onClick={edit}>
+                        <Icon icon="chevron-down" margin="m-0" />
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="well p-2 rounded-2 border border-secondary mt-2">
+            <div className="hstack justify-content-between">
+                <h4 className="m-0">Configure parameter</h4>
+                <div className="hstack gap-2">
+                    <Button variant="danger" onClick={remove}>
+                        <Icon icon="trash" margin="m-0" />
+                    </Button>
+                    <Button variant="secondary" onClick={save}>
+                        <Icon icon="chevron-up" margin="m-0" />
+                    </Button>
+                </div>
+            </div>
+            <hr className="mt-2 mb-3" />
+            <div className="grid gap-2 mb-3">
+                <FormGroup marginClass="m-0" className="g-col-6">
+                    <FormLabel>Parameter name</FormLabel>
+                    <FormInput
+                        type="text"
+                        control={control}
+                        name={`parameters.${index}.name`}
+                        placeholder="e.g. company"
+                    />
+                </FormGroup>
+                <FormGroup marginClass="m-0" className="g-col-6">
+                    <FormLabel>Parameter type</FormLabel>
+                    <FormSelect
+                        control={control}
+                        name={`parameters.${index}.type`}
+                        options={typeOptions}
+                        placeholder="Select a type"
+                        isSearchable={false}
+                        isClearable={false}
+                    />
+                </FormGroup>
+            </div>
+            <FormGroup>
+                <FormLabel>
+                    Description <OptionalLabel />
+                </FormLabel>
+                <FormInput
+                    type="textarea"
+                    as="textarea"
+                    rows={3}
+                    control={control}
+                    name={`parameters.${index}.description`}
+                    placeholder="e.g. The company ID"
+                />
+            </FormGroup>
+            <FormGroup>
+                <FormLabel>
+                    Forbid model generation
+                    <PopoverWithHoverWrapper
+                        message={
+                            <>
+                                When <b>Forbid model generation</b> is set and this agent is used as a sub-agent, the
+                                parent agent is not allowed to generate a parameter value for the sub-agent.
+                                <br />
+                                The parameter&apos;s value may only be inherited from the parent agent parameters. This
+                                ensures that this is a trusted value.
+                            </>
+                        }
+                    >
+                        <Icon icon="info-new" margin="ms-1" />
+                    </PopoverWithHoverWrapper>
+                </FormLabel>
+                <FormSelect
+                    control={control}
+                    name={`parameters.${index}.policy`}
+                    options={policyOptions}
+                    placeholder="Select a value"
+                    isSearchable={false}
+                    isClearable={false}
+                />
+            </FormGroup>
+            <FormSwitch control={control} name={`parameters.${index}.isSendToModel`}>
+                Send to model
+                <PopoverWithHoverWrapper
+                    message={
+                        <>
+                            When enabled, the parameter is exposed to the model. It is included in the prompt sent to
+                            the model and in any echo messages.
+                            <br />
+                            <br />
+                            When disabled, the parameter is hidden from the model. It is excluded from both the prompt
+                            and echo messages.
+                        </>
+                    }
+                >
+                    <Icon icon="info-new" margin="ms-1" />
+                </PopoverWithHoverWrapper>
+            </FormSwitch>
         </div>
     );
 }
+
+function getParameterTypeLabel(type: Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType) {
+    return typeOptions.find((option) => option.value === type)?.label ?? type;
+}
+
+const typeOptions: SelectOption<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType>[] = [
+    { value: "String", label: "String" },
+    { value: "Number", label: "Number" },
+    { value: "Boolean", label: "Boolean" },
+    { value: "ArrayOfString", label: "String[]" },
+    { value: "ArrayOfNumber", label: "Number[]" },
+    { value: "ArrayOfBoolean", label: "Boolean[]" },
+    { value: "Default", label: "Default" },
+    { value: "Null", label: "Null" },
+];
+
+const policyOptions: SelectOption<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameter.AiAgentParameterPolicy>[] =
+    [
+        { value: "Default", label: "Default" },
+        { value: "ForbidModelGeneration", label: "Forbid model generation" },
+    ];

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentParametersSection.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentParametersSection.tsx
@@ -248,7 +248,7 @@ const typeOptions: SelectOption<Raven.Client.Documents.Operations.AI.Agents.AiAg
     { value: "ArrayOfString", label: "String[]" },
     { value: "ArrayOfNumber", label: "Number[]" },
     { value: "ArrayOfBoolean", label: "Boolean[]" },
-    { value: "Default", label: "Default" },
+    { value: "Default", label: "Any" },
     { value: "Null", label: "Null" },
 ];
 

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
@@ -27,9 +27,14 @@ import { AiAgentToolCall } from "components/pages/database/aiHub/aiAgents/utils/
 interface EditAiAgentTestPanelProps {
     testForm: UseFormReturn<TestAiAgentFormData>;
     editForm: UseFormReturn<EditAiAgentFormData>;
+    generateTestParameters: () => void;
 }
 
-export default function EditAiAgentTestPanel({ testForm, editForm }: EditAiAgentTestPanelProps) {
+export default function EditAiAgentTestPanel({
+    testForm,
+    editForm,
+    generateTestParameters,
+}: EditAiAgentTestPanelProps) {
     const dispatch = useAppDispatch();
     const databaseName = useAppSelector(databaseSelectors.activeDatabaseName);
     const rawDataRef = useRef<ReactAce>(null);
@@ -53,7 +58,8 @@ export default function EditAiAgentTestPanel({ testForm, editForm }: EditAiAgent
         testFormValues.parameters?.map((x) => x.name) ?? []
     );
 
-    const hasMissingParameters = messages.length > 0 && testFormValues.parameters.some((x) => !x.value);
+    const hasMissingParameters =
+        messages.length > 0 && testFormValues.parameters.some((x) => x.type !== "Null" && x.value == null);
 
     const isLoading = runTestState === "loading" || isWaitingForActionToolSubmit;
     const isTestDisabled = !hasLatestParameters || hasMissingParameters || isLoading;
@@ -107,19 +113,7 @@ export default function EditAiAgentTestPanel({ testForm, editForm }: EditAiAgent
         dispatch(editAiAgentActions.testMessagesSet([]));
         dispatch(editAiAgentActions.isWaitingForActionToolSubmitSet(false));
         testForm.setValue("prompt", "");
-        testForm.setValue(
-            "parameters",
-            editFormValues.parameters.map((x) => {
-                const persistedParameter = testFormValues.parameters.find((y) => y.name === x.name);
-
-                return {
-                    name: x.name,
-                    type: x.type,
-                    isSendToModel: persistedParameter?.isSendToModel ?? x.isSendToModel,
-                    value: persistedParameter?.value ?? "",
-                };
-            })
-        );
+        generateTestParameters();
     };
 
     return (

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/partials/EditAiAgentTestPanel.tsx
@@ -109,10 +109,16 @@ export default function EditAiAgentTestPanel({ testForm, editForm }: EditAiAgent
         testForm.setValue("prompt", "");
         testForm.setValue(
             "parameters",
-            editFormValues.parameters.map((x) => ({
-                name: x.name,
-                value: testFormValues.parameters.find((y) => y.name === x.name)?.value ?? "",
-            }))
+            editFormValues.parameters.map((x) => {
+                const persistedParameter = testFormValues.parameters.find((y) => y.name === x.name);
+
+                return {
+                    name: x.name,
+                    type: x.type,
+                    isSendToModel: persistedParameter?.isSendToModel ?? x.isSendToModel,
+                    value: persistedParameter?.value ?? "",
+                };
+            })
         );
     };
 
@@ -172,12 +178,13 @@ export default function EditAiAgentTestPanel({ testForm, editForm }: EditAiAgent
             <div className="w-100 flex-grow-1 vstack justify-content-center align-items-center overflow-auto">
                 <div className="flex-grow-1 vstack w-100 overflow-auto p-2 position-relative" ref={messagesPanelRef}>
                     {messages.length === 0 && (
-                        <div className="h-100 vstack justify-content-center">
+                        <div className="h-100 vstack justify-content-center mx-auto" style={{ maxWidth: "600px" }}>
                             <AiAgentParametersField
                                 control={testForm.control}
-                                name="parameters"
                                 value={testFormValues.parameters}
-                                isTest
+                                panelClassName="panel-bg-2"
+                                wrapperClassName="justify-content-center"
+                                headerClassName="text-center"
                             />
                         </div>
                     )}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/store/editAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/store/editAiAgentSlice.ts
@@ -5,6 +5,7 @@ import { services } from "components/hooks/useServices";
 import { loadStatus } from "components/models/common";
 import { TestAiAgentFormData } from "../utils/editAiAgentValidation";
 import { aiAgentsUtils } from "../../utils/aiAgentsUtils";
+import { aiAgentParametersUtils } from "../../utils/aiAgentParametersUtils";
 
 interface EditAiAgentState {
     isTestOpen: boolean;
@@ -121,13 +122,32 @@ const runTest = createAsyncThunk(
             Document: testDocument,
             RequestBody: undefined,
             CreationOptions: {
-                Parameters: Object.fromEntries(testFormValues.parameters.map((item) => [item.name, item.value])),
+                Parameters: createParametersDto(testDocument, testFormValues.parameters),
             },
         });
 
         return { result, configuration };
     }
 );
+
+function createParametersDto(
+    testDocument: documentDto,
+    formParameters: TestAiAgentFormData["parameters"]
+): Record<string, Raven.Client.Documents.AI.AiConversationParameter> {
+    if (testDocument) {
+        return null;
+    }
+
+    return Object.fromEntries(
+        formParameters.map((x) => [
+            x.name,
+            {
+                Value: aiAgentParametersUtils.mapParameterValueToType(x.value, x.type),
+                SendToModel: x.isSendToModel,
+            },
+        ])
+    );
+}
 
 const getAllIdentifiers = createAsyncThunk(
     editAiAgentSlice.name + "/getAllIdentifiers",

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentUtils.ts
@@ -47,6 +47,7 @@ function mapFromDto(
                 isSendToModel: x.SendToModel ?? true,
                 policy: x.Policy ?? "Default",
                 type: x.Type ?? "Default",
+                isEditing: false,
             })) ?? [],
         queries:
             dto.Queries?.map((x) => ({

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
@@ -1,5 +1,8 @@
 import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
+import { aiAgentParametersUtils } from "../../utils/aiAgentParametersUtils";
+
+type AiAgentParameterValueType = Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType;
 
 export type AiAgentTrimmingMethod = "Tokens";
 
@@ -180,8 +183,16 @@ const testSchema = yup.object({
     parameters: yup.array().of(
         yup.object({
             name: yup.string().nullable(),
-            value: yup.string().nullable().required(),
-            type: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType>(),
+            value: aiAgentParametersUtils.createValueSchema(
+                yup
+                    .string()
+                    .nullable()
+                    .when("type", {
+                        is: (type: AiAgentParameterValueType) => type !== "Null",
+                        then: (schema) => schema.required(),
+                    })
+            ),
+            type: yup.string<AiAgentParameterValueType>(),
             isSendToModel: yup.boolean(),
         })
     ),

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/utils/editAiAgentValidation.ts
@@ -56,6 +56,7 @@ const editSchema = yup.object({
             isSendToModel: yup.boolean(),
             policy: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterPolicy>(),
             type: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType>(),
+            isEditing: yup.boolean(),
         })
     ),
 
@@ -180,6 +181,8 @@ const testSchema = yup.object({
         yup.object({
             name: yup.string().nullable(),
             value: yup.string().nullable().required(),
+            type: yup.string<Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType>(),
+            isSendToModel: yup.boolean(),
         })
     ),
 });

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersDropdown.tsx
@@ -3,6 +3,7 @@ import { Icon } from "components/common/Icon";
 import Badge from "react-bootstrap/Badge";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
+import { aiAgentParametersUtils } from "../utils/aiAgentParametersUtils";
 
 interface AiAgentParametersDropdownProps {
     parameters: Record<string, string | Raven.Client.Documents.AI.AiConversationParameter>;
@@ -54,23 +55,24 @@ interface ParameterItemProps {
 function ParameterItem({ name, value, isLast }: ParameterItemProps) {
     const extractedValue = typeof value === "object" && "Value" in value ? value.Value : value;
 
+    // Default to true if not specified for backwards compatibility
+    const isSendToModel = typeof value === "object" && "SendToModel" in value ? (value.SendToModel ?? true) : true;
+    const sendToModelLabel = isSendToModel ? "Sent to model" : "Internal only";
+
+    const displayValue = aiAgentParametersUtils.formatParameterValueForDisplay(extractedValue);
+
     return (
         <div className="w-100">
-            <div className="hstack justify-content-between">
-                <Badge bg="primary" className="text-truncate me-2 fs-5" title={name} style={{ width: "150px" }} pill>
+            <div className="flex-grow-1 min-width-0 hstack gap-2 mb-1">
+                <div className="font-monospace text-truncate flex-grow-1" title={name}>
                     {name}
-                </Badge>
-                <div className="flex-grow-1">
-                    <Form.Control
-                        type="text"
-                        value={extractedValue}
-                        disabled
-                        className="text-truncate"
-                        title={extractedValue}
-                    />
                 </div>
+                <Badge bg={isSendToModel ? "success" : "secondary"} className="font-size-12" pill>
+                    {sendToModelLabel}
+                </Badge>
             </div>
-            {!isLast && <hr className="my-1" />}
+            <Form.Control type="text" value={displayValue} disabled className="text-truncate" title={displayValue} />
+            {!isLast && <hr className="my-2" />}
         </div>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersField.tsx
@@ -1,60 +1,127 @@
 import classNames from "classnames";
-import { FormInput } from "components/common/Form";
+import { FormInput, FormSwitch } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import Badge from "react-bootstrap/Badge";
-import { Control, FieldPath, FieldValues } from "react-hook-form";
+import { Control } from "react-hook-form";
+import { TestAiAgentFormData } from "../edit/utils/editAiAgentValidation";
+import { ChatAiAgentFormData } from "../chat/utils/chatAiAgentValidation";
+import assertUnreachable from "components/utils/assertUnreachable";
 
-interface AiAgentParametersFieldProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>> {
-    control: Control<TFieldValues>;
-    name: TName;
-    value: { name?: string; value?: string }[];
-    isTest: boolean;
+interface Parameter {
+    name?: string;
+    value?: string;
+    type?: Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType;
 }
 
-export default function AiAgentParametersField<
-    TFieldValues extends FieldValues,
-    TName extends FieldPath<TFieldValues>,
->({ control, name, value, isTest }: AiAgentParametersFieldProps<TFieldValues, TName>) {
+type FormData = TestAiAgentFormData | ChatAiAgentFormData;
+
+interface AiAgentParametersFieldProps {
+    control: Control<FormData>;
+    value: Parameter[];
+    wrapperClassName?: string;
+    headerClassName?: string;
+    panelClassName?: string;
+}
+
+export default function AiAgentParametersField({
+    control,
+    value,
+    wrapperClassName,
+    headerClassName,
+    panelClassName,
+}: AiAgentParametersFieldProps) {
     if (value.length === 0) {
         return null;
     }
 
     return (
-        <div className={classNames("w-100 vstack flex-grow-1 overflow-auto", { "justify-content-center": isTest })}>
-            <h3 className={classNames({ "text-center": isTest })}>
+        <div className={classNames("w-100 vstack flex-grow-1 overflow-auto", wrapperClassName)}>
+            <h3 className={classNames(headerClassName)}>
                 <Icon icon="metrics" color="primary" />
                 Provide values for the agent parameters before starting the chat
                 <PopoverWithHoverWrapper message="When a query tool is used, the agent will insert these values into the query definition before executing it against the database, filtering the data and ensuring the query only retrieves data within the allowed scope.">
                     <Icon icon="info-new" margin="ms-1" />
                 </PopoverWithHoverWrapper>
             </h3>
-            <div className="panel-bg-1 p-3 rounded-2 border border-secondary overflow-auto">
-                {value.map((x, idx) => (
-                    <div key={x.name} className="w-100 p-2">
-                        <div className="hstack">
-                            <Badge
-                                bg="primary"
-                                className="text-truncate me-2 fs-5"
-                                title={x.name}
-                                style={{ width: "150px" }}
-                                pill
-                            >
-                                {x.name}
-                            </Badge>
-                            <div className="flex-grow-1">
-                                <FormInput
-                                    type="text"
-                                    control={control}
-                                    name={`${name}.${idx}.value` as TName}
-                                    placeholder={`Enter a value for <${x.name}>`}
-                                />
-                            </div>
-                        </div>
-                        {idx !== value.length - 1 && <hr className="my-1" />}
-                    </div>
+            <div className="overflow-auto d-grid gap-2 mb-2">
+                {value.map((parameter, idx) => (
+                    <ParameterItem
+                        key={idx}
+                        control={control}
+                        parameter={parameter}
+                        idx={idx}
+                        panelClassName={panelClassName}
+                    />
                 ))}
             </div>
         </div>
     );
+}
+
+interface ParameterItemProps {
+    control: Control<FormData>;
+    parameter: Parameter;
+    idx: number;
+    panelClassName?: string;
+}
+
+function ParameterItem({ control, parameter, idx, panelClassName }: ParameterItemProps) {
+    const typeInfo = getParameterTypeInfo(parameter.type);
+
+    if (parameter.type === "Null") {
+        return null;
+    }
+
+    return (
+        <div className={classNames("p-2 rounded-2 d-grid gap-1 border border-secondary", panelClassName)}>
+            <div className="d-flex justify-content-between align-items-end">
+                <Badge
+                    bg="primary"
+                    className="font-size-12 text-truncate"
+                    title={parameter.name}
+                    pill
+                    style={{ maxWidth: "300px" }}
+                >
+                    {parameter.name}
+                </Badge>
+                <FormSwitch control={control} name={`parameters.${idx}.isSendToModel`} color="primary" className="mb-0">
+                    Send to model
+                </FormSwitch>
+            </div>
+            <FormInput
+                type={parameter.type === "Number" ? "number" : "text"}
+                control={control}
+                name={`parameters.${idx}.value`}
+                placeholder={`Enter a value for <${parameter.name}> ${typeInfo.exampleValue ? `(e.g. ${typeInfo.exampleValue})` : ""}`}
+                addon={typeInfo.label}
+            />
+        </div>
+    );
+}
+
+interface ParameterTypeInfo {
+    label: string;
+    exampleValue?: string;
+}
+
+function getParameterTypeInfo(
+    type: Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType
+): ParameterTypeInfo {
+    switch (type) {
+        case "ArrayOfString":
+            return { label: "String[]", exampleValue: `["value1", "value2", "value3"]` };
+        case "ArrayOfNumber":
+            return { label: "Number[]", exampleValue: "[1, 2, 3]" };
+        case "ArrayOfBoolean":
+            return { label: "Boolean[]", exampleValue: "[true, false, true]" };
+        case "String":
+        case "Number":
+        case "Boolean":
+        case "Null":
+        case "Default":
+            return { label: type };
+        default:
+            assertUnreachable(type);
+    }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/partials/AiAgentParametersField.tsx
@@ -1,12 +1,14 @@
 import classNames from "classnames";
-import { FormInput, FormSwitch } from "components/common/Form";
+import { FormInput, FormSelect, FormSwitch } from "components/common/Form";
 import { Icon } from "components/common/Icon";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import Badge from "react-bootstrap/Badge";
 import { Control } from "react-hook-form";
 import { TestAiAgentFormData } from "../edit/utils/editAiAgentValidation";
 import { ChatAiAgentFormData } from "../chat/utils/chatAiAgentValidation";
-import assertUnreachable from "components/utils/assertUnreachable";
+import { SelectOption } from "components/common/select/Select";
+import InputGroup from "react-bootstrap/InputGroup";
+import { aiAgentParametersUtils } from "../utils/aiAgentParametersUtils";
 
 interface Parameter {
     name?: string;
@@ -67,8 +69,6 @@ interface ParameterItemProps {
 }
 
 function ParameterItem({ control, parameter, idx, panelClassName }: ParameterItemProps) {
-    const typeInfo = getParameterTypeInfo(parameter.type);
-
     if (parameter.type === "Null") {
         return null;
     }
@@ -89,39 +89,48 @@ function ParameterItem({ control, parameter, idx, panelClassName }: ParameterIte
                     Send to model
                 </FormSwitch>
             </div>
-            <FormInput
-                type={parameter.type === "Number" ? "number" : "text"}
-                control={control}
-                name={`parameters.${idx}.value`}
-                placeholder={`Enter a value for <${parameter.name}> ${typeInfo.exampleValue ? `(e.g. ${typeInfo.exampleValue})` : ""}`}
-                addon={typeInfo.label}
-            />
+            <ParameterItemInput control={control} parameter={parameter} idx={idx} />
         </div>
     );
 }
 
-interface ParameterTypeInfo {
-    label: string;
-    exampleValue?: string;
+interface ParameterItemInputProps {
+    control: Control<FormData>;
+    parameter: Parameter;
+    idx: number;
 }
 
-function getParameterTypeInfo(
-    type: Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType
-): ParameterTypeInfo {
-    switch (type) {
-        case "ArrayOfString":
-            return { label: "String[]", exampleValue: `["value1", "value2", "value3"]` };
-        case "ArrayOfNumber":
-            return { label: "Number[]", exampleValue: "[1, 2, 3]" };
-        case "ArrayOfBoolean":
-            return { label: "Boolean[]", exampleValue: "[true, false, true]" };
-        case "String":
-        case "Number":
-        case "Boolean":
-        case "Null":
-        case "Default":
-            return { label: type };
-        default:
-            assertUnreachable(type);
+function ParameterItemInput({ control, parameter, idx }: ParameterItemInputProps) {
+    const typeInfo = aiAgentParametersUtils.getParameterTypeInfo(parameter.type);
+
+    if (parameter.type === "Boolean") {
+        return (
+            <InputGroup>
+                <FormSelect
+                    control={control}
+                    name={`parameters.${idx}.value`}
+                    options={
+                        [
+                            { value: true, label: "True" },
+                            { value: false, label: "False" },
+                        ] satisfies SelectOption<boolean>[]
+                    }
+                    isClearable={false}
+                    isSearchable={false}
+                />
+                <InputGroup.Text>{typeInfo.label}</InputGroup.Text>
+            </InputGroup>
+        );
     }
+
+    return (
+        <FormInput
+            type={parameter.type === "Number" ? "number" : "text"}
+            control={control}
+            name={`parameters.${idx}.value`}
+            placeholder={`Enter a value for <${parameter.name}> ${typeInfo.exampleValue ? `(e.g. ${typeInfo.exampleValue})` : ""}`}
+            addon={typeInfo.label}
+        />
+    );
 }
+

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/utils/aiAgentParametersUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/utils/aiAgentParametersUtils.ts
@@ -1,0 +1,190 @@
+import * as yup from "yup";
+import assertUnreachable from "components/utils/assertUnreachable";
+
+type AiAgentParameterValueType = Raven.Client.Documents.Operations.AI.Agents.AiAgentParameterValueType;
+
+export interface AiAgentParameterTypeInfo {
+    label: string;
+    exampleValue?: string;
+}
+
+interface AiAgentParameterValueValidationResult {
+    isValid: boolean;
+    message?: string;
+}
+
+function createValueSchema<T extends yup.StringSchema<string | null | undefined>>(schema: T): T {
+    return schema.test("ai-agent-parameter-value", function (value, { parent }) {
+        const result = validateParameterValue(value, parent?.type);
+
+        if (result.isValid) {
+            return true;
+        }
+
+        return this.createError({ message: result.message });
+    }) as T;
+}
+
+function getParameterTypeInfo(type: AiAgentParameterValueType): AiAgentParameterTypeInfo {
+    switch (type) {
+        case "ArrayOfString":
+            return { label: "String[]", exampleValue: '["value1", "value2", "value3"]' };
+        case "ArrayOfNumber":
+            return { label: "Number[]", exampleValue: "[1, 2, 3]" };
+        case "ArrayOfBoolean":
+            return { label: "Boolean[]", exampleValue: "[true, false, true]" };
+        case "String":
+        case "Number":
+        case "Boolean":
+        case "Null":
+        case "Default":
+            return { label: type };
+        default:
+            assertUnreachable(type);
+    }
+}
+
+function validateParameterValue(
+    value: unknown,
+    type: AiAgentParameterValueType
+): AiAgentParameterValueValidationResult {
+    if (value == null || value === "" || type == null) {
+        return { isValid: true };
+    }
+
+    switch (type) {
+        case "Number":
+            return isFiniteNumberToken(value)
+                ? { isValid: true }
+                : { isValid: false, message: "Value must be a valid Number value" };
+        case "Boolean":
+            return isBooleanToken(value)
+                ? { isValid: true }
+                : { isValid: false, message: "Value must be a valid Boolean value" };
+        case "ArrayOfString":
+            return validateArrayValue(value, (item) => typeof item === "string", type);
+        case "ArrayOfNumber":
+            return validateArrayValue(value, isFiniteNumberToken, type);
+        case "ArrayOfBoolean":
+            return validateArrayValue(value, isBooleanToken, type);
+        case "String":
+        case "Null":
+        case "Default":
+            return { isValid: true };
+        default:
+            assertUnreachable(type);
+    }
+}
+
+function mapParameterValueToType(value: string, type: AiAgentParameterValueType) {
+    switch (type) {
+        case "Number":
+            return Number(value);
+        case "Boolean":
+            return mapBooleanToken(value);
+        case "ArrayOfString":
+            return requireArrayItems(value);
+        case "ArrayOfNumber":
+            return requireArrayItems(value).map((item) => Number(item));
+        case "ArrayOfBoolean":
+            return requireArrayItems(value).map(mapBooleanToken);
+        case "Null":
+            return null;
+        case "String":
+        case "Default":
+        default:
+            return value;
+    }
+}
+
+function validateArrayValue(
+    value: unknown,
+    isValidItem: (item: unknown) => boolean,
+    type: AiAgentParameterValueType
+): AiAgentParameterValueValidationResult {
+    const arrayItems = getArrayItems(value);
+    if (!arrayItems) {
+        return { isValid: false, message: getArrayValidationMessage(type) };
+    }
+
+    return arrayItems.items.every(isValidItem)
+        ? { isValid: true }
+        : { isValid: false, message: getArrayValidationMessage(type) };
+}
+
+function getArrayValidationMessage(type: AiAgentParameterValueType): string {
+    const { label, exampleValue } = getParameterTypeInfo(type);
+    return `Value must be a valid ${label} value, e.g. ${exampleValue}`;
+}
+
+function getArrayItems(value: unknown): { items: unknown[] } | null {
+    if (Array.isArray(value)) {
+        return { items: value };
+    }
+
+    if (typeof value !== "string") {
+        return null;
+    }
+
+    const parsedJson = tryParseJson(value.trim());
+
+    if (Array.isArray(parsedJson)) {
+        return { items: parsedJson };
+    }
+
+    return null;
+}
+
+function requireArrayItems(value: unknown): unknown[] {
+    const arrayItems = getArrayItems(value);
+    if (!arrayItems) {
+        throw new Error("Expected AI agent parameter array value in JSON array format");
+    }
+
+    return arrayItems.items;
+}
+
+function tryParseJson(value: string): unknown {
+    try {
+        return JSON.parse(value);
+    } catch {
+        return null;
+    }
+}
+
+function isFiniteNumberToken(value: unknown): boolean {
+    if (typeof value === "number") {
+        return Number.isFinite(value);
+    }
+
+    if (typeof value !== "string") {
+        return false;
+    }
+
+    const trimmedValue = value.trim();
+    return trimmedValue !== "" && Number.isFinite(Number(trimmedValue));
+}
+
+function isBooleanToken(value: unknown): boolean {
+    if (typeof value === "boolean") {
+        return true;
+    }
+
+    if (typeof value !== "string") {
+        return false;
+    }
+
+    const normalizedValue = value.trim().toLowerCase();
+    return normalizedValue === "true" || normalizedValue === "false";
+}
+
+function mapBooleanToken(value: unknown): boolean {
+    return typeof value === "boolean" ? value : value.toString().trim().toLowerCase() === "true";
+}
+
+export const aiAgentParametersUtils = {
+    createValueSchema,
+    getParameterTypeInfo,
+    mapParameterValueToType,
+    validateParameterValue,
+};

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/utils/aiAgentParametersUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/utils/aiAgentParametersUtils.ts
@@ -183,8 +183,25 @@ function mapBooleanToken(value: unknown): boolean {
     return typeof value === "boolean" ? value : value.toString().trim().toLowerCase() === "true";
 }
 
+function formatParameterValueForDisplay(value: unknown): string {
+    if (value === null) {
+        return "null";
+    }
+
+    if (typeof value === "string") {
+        return value;
+    }
+
+    if (typeof value === "number" || typeof value === "boolean") {
+        return value.toString();
+    }
+
+    return JSON.stringify(value);
+}
+
 export const aiAgentParametersUtils = {
     createValueSchema,
+    formatParameterValueForDisplay,
     getParameterTypeInfo,
     mapParameterValueToType,
     validateParameterValue,

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/utils/aiAgentParametersUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/utils/aiAgentParametersUtils.ts
@@ -33,11 +33,12 @@ function getParameterTypeInfo(type: AiAgentParameterValueType): AiAgentParameter
             return { label: "Number[]", exampleValue: "[1, 2, 3]" };
         case "ArrayOfBoolean":
             return { label: "Boolean[]", exampleValue: "[true, false, true]" };
+        case "Default":
+            return { label: "Any" };
         case "String":
         case "Number":
         case "Boolean":
         case "Null":
-        case "Default":
             return { label: type };
         default:
             assertUnreachable(type);

--- a/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
@@ -65,6 +65,56 @@ export class AiAgentStubs {
                             Policy: "Default",
                             Type: "Default",
                         },
+                        {
+                            Name: "LicenseId",
+                            Description: null,
+                            SendToModel: false,
+                            Policy: "Default",
+                            Type: "String",
+                        },
+                        {
+                            Name: "RavenVersion",
+                            Description: "Currently used server version of RavenDB",
+                            SendToModel: true,
+                            Policy: "Default",
+                            Type: "Number",
+                        },
+                        {
+                            Name: "NumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName",
+                            Description:
+                                "Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion ",
+                            SendToModel: true,
+                            Policy: "ForbidModelGeneration",
+                            Type: "ArrayOfNumber",
+                        },
+                        {
+                            Name: "boolParam",
+                            Description: null,
+                            SendToModel: true,
+                            Policy: "Default",
+                            Type: "Boolean",
+                        },
+                        {
+                            Name: "stringArrayParam",
+                            Description: null,
+                            SendToModel: true,
+                            Policy: "Default",
+                            Type: "ArrayOfString",
+                        },
+                        {
+                            Name: "boolArrayParam",
+                            Description: null,
+                            SendToModel: true,
+                            Policy: "Default",
+                            Type: "ArrayOfBoolean",
+                        },
+                        {
+                            Name: "nullParam",
+                            Description: null,
+                            SendToModel: true,
+                            Policy: "Default",
+                            Type: "Null",
+                        },
                     ],
                     ChatTrimming: null,
                     MaxModelIterationsPerCall: null,
@@ -78,7 +128,35 @@ export class AiAgentStubs {
         return new document({
             Agent: "first-agent",
             Parameters: {
-                company: { Value: "companies/90-A", SendToModel: true },
+                LicenseId: {
+                    Value: "cee0a5b9-9da8-433d-a673-a689da5cdb14",
+                    SendToModel: false,
+                },
+                RavenVersion: {
+                    Value: 7.1,
+                    SendToModel: true,
+                },
+                NumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName:
+                    {
+                        Value: [-0.00001, -553542, -3, 4.132231],
+                        SendToModel: true,
+                    },
+                boolParam: {
+                    Value: true,
+                    SendToModel: true,
+                },
+                stringArrayParam: {
+                    Value: ["aa", "bb"],
+                    SendToModel: true,
+                },
+                boolArrayParam: {
+                    Value: [true, false],
+                    SendToModel: true,
+                },
+                nullParam: {
+                    Value: null,
+                    SendToModel: true,
+                },
             },
             Messages: [
                 {

--- a/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/AiAgentStubs.ts
@@ -36,6 +36,18 @@ export class AiAgentStubs {
                                 AllowModelQueries: null,
                             },
                         },
+                        {
+                            Name: "TEST_parameters",
+                            Description: "Test",
+                            Query: "from @all_docs as doc\r\nselect {\r\n  anyParam: $anyParam,\r\n  stringParam: $stringParam,\r\n  numberParam: $numberParam,\r\n  numberArray: $numberArrayLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName,\r\n  boolParam: $boolParam,\r\n  stringArrayParam: $stringArrayParam,\r\n  boolArrayParam: $boolArrayParam,\r\n  nullParam: $nullParam,\r\n  testLLMParam_number: $testLLMParam_number,\r\n  testLLMParam_numberArray: $testLLMParam_numberArray\r\n}\r\nlimit 1\r\n",
+                            ParametersSampleObject:
+                                '{\n  "testLLMParam_string": "string",\n  "testLLMParam_stringArray": ["string1", "string2"],\n  "testLLMParam_number": 123,\n  "testLLMParam_numberArray": [1,2,3],\n  "testLLMParam_bool": true,\n  "testLLMParam_boolArray": [true, false]\n}',
+                            ParametersSchema: null,
+                            Options: {
+                                AllowModelQueries: null,
+                                AddToInitialContext: null,
+                            },
+                        },
                     ],
                     Actions: [
                         {
@@ -60,27 +72,28 @@ export class AiAgentStubs {
                     ],
                     Parameters: [
                         {
-                            Name: "company",
-                            Description: null,
+                            Name: "anyParam",
+                            Description: "Some long descritpion ",
+                            SendToModel: false,
                             Policy: "Default",
                             Type: "Default",
                         },
                         {
-                            Name: "LicenseId",
+                            Name: "stringParam",
                             Description: null,
                             SendToModel: false,
                             Policy: "Default",
                             Type: "String",
                         },
                         {
-                            Name: "RavenVersion",
+                            Name: "numberParam",
                             Description: "Currently used server version of RavenDB",
                             SendToModel: true,
                             Policy: "Default",
                             Type: "Number",
                         },
                         {
-                            Name: "NumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName",
+                            Name: "numberArrayLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName",
                             Description:
                                 "Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion \nSome long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion Some long descritpion ",
                             SendToModel: true,
@@ -128,17 +141,21 @@ export class AiAgentStubs {
         return new document({
             Agent: "first-agent",
             Parameters: {
-                LicenseId: {
-                    Value: "cee0a5b9-9da8-433d-a673-a689da5cdb14",
+                anyParam: {
+                    Value: "any value",
                     SendToModel: false,
                 },
-                RavenVersion: {
+                stringParam: {
+                    Value: "some string",
+                    SendToModel: false,
+                },
+                numberParam: {
                     Value: 7.1,
                     SendToModel: true,
                 },
-                NumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName:
+                numberArrayLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongNameNumbersVeryLongName:
                     {
-                        Value: [-0.00001, -553542, -3, 4.132231],
+                        Value: [1, 2, 3, 4],
                         SendToModel: true,
                     },
                 boolParam: {
@@ -185,6 +202,15 @@ export class AiAgentStubs {
                             function: {
                                 name: "QueryRecentCategories",
                                 arguments: "{}",
+                            },
+                        },
+                        {
+                            id: "call_whzFC5Mlx17thYJYOvdWf7RW",
+                            type: "function",
+                            function: {
+                                name: "TEST_parameters",
+                                arguments:
+                                    '{"testLLMParam_string":"7.1","testLLMParam_stringArray":["aa","bb"],"testLLMParam_number":7,"testLLMParam_numberArray":[1,2,3,4],"testLLMParam_bool":true,"testLLMParam_boolArray":[true,false]}',
                             },
                         },
                     ],


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26260/Studio-should-support-AiAgentParameter.Type-and-send-typed-parameter-values-instead-of-strings

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
