### PR TITLE
RavenDB-26263 Filtered vector search: fixes in small/large posting list processing.

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -213,10 +213,11 @@ public partial class Hnsw
                     }
 
                     //decode in bulk
-                    Registration.InternalEntryIdToEntryId(matches[index..total]);
+                    Registration.InternalEntryIdToEntryId(matches.Slice(index, total));
 
                     var currentDocIdx = index;
-                    for (; currentDocIdx < index + total; currentDocIdx++)
+                    var endDocIdx = index + total;
+                    for (; currentDocIdx < endDocIdx; currentDocIdx++)
                     {
                         if (filter.Contains(matches[currentDocIdx]) == false)
                             continue;
@@ -232,7 +233,7 @@ public partial class Hnsw
 
                 if (_currentMatchesIndex < _postingListResults.Count)
                 {
-                    var currentFillLimit = Math.Min(_postingListResults.Count - _currentMatchesIndex, matches.Length - index);
+                    var currentFillLimit = _currentMatchesIndex + Math.Min(_postingListResults.Count - _currentMatchesIndex, matches.Length - index);
                     for (; _currentMatchesIndex < currentFillLimit; _currentMatchesIndex++)
                     {
                         if (filter.Contains(_postingListResults[_currentMatchesIndex]) == false)

--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using FastTests.Voron;
-using FastTests.Voron.FixedSize;
+using Sparrow.Server.Collections;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Data.Graphs;
@@ -15,6 +15,123 @@ namespace SlowTests.Voron.Graphs;
 
 public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
 {
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void FilteredFillWithLargePostingListDecodesCorrectRange()
+    {
+        using var _ = Slice.From(Allocator, nameof(FilteredFillWithLargePostingListDecodesCorrectRange), out var treeName);
+        const int vectorSize = 4;
+        const int vectorSizeInBytes = vectorSize * sizeof(float);
+        const int singleEntryCount = 10;
+        const int largePostingListCount = 10357;
+        const int totalEntries = singleEntryCount + largePostingListCount;
+        float[] queryVector = [1f, 0f, 0f, 0f];
+        float[] farVector = [0f, 0f, 0f, 1f];
+
+        using (var wTx = Env.WriteTransaction())
+        {
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, vectorSizeInBytes, 3, 16, VectorEmbeddingType.Single);
+
+            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, new Random(42)))
+            {
+                for (int i = 1; i <= singleEntryCount; i++)
+                {
+                    var closeVector = new float[] { 1f, 0.001f * i, 0f, 0f };
+                    registration.Register(i, MemoryMarshal.Cast<float, byte>(closeVector));
+                }
+
+                for (int i = singleEntryCount + 1; i <= totalEntries; i++)
+                    registration.Register(i, MemoryMarshal.Cast<float, byte>(farVector));
+
+                registration.Commit(CancellationToken.None);
+            }
+
+            wTx.Commit();
+        }
+
+        using (var rTx = Env.ReadTransaction())
+        {
+            var qV = MemoryMarshal.Cast<float, byte>(queryVector);
+            using var nearest = Hnsw.ExactNearest(rTx.LowLevelTransaction, treeName,
+                numberOfCandidates: totalEntries, qV.ToArray(), minimumSimilarity: 0f, hasFilterMatch: true);
+
+            var filter = new GrowableBitArray(Allocator, totalEntries + 1);
+            using var __ = filter;
+            for (int i = 1; i <= totalEntries; i++)
+                filter.Add(i);
+            filter.Count = totalEntries;
+
+            var matches = new long[128];
+            var distances = new float[128];
+            List<long> allResults = new();
+
+            int read;
+            do
+            {
+                read = nearest.Fill(matches, distances, filter);
+                allResults.AddRange(matches[..read]);
+            } while (read != 0);
+
+            var expectedIds = Enumerable.Range(1, totalEntries).Select(i => (long)i).ToHashSet();
+            var actualIds = allResults.ToHashSet();
+            var missing = expectedIds.Except(actualIds);
+            Assert.Empty(missing);
+            var unexpected = actualIds.Except(expectedIds);
+            Assert.Empty(unexpected);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void FilteredFillWithSmallPostingListLargerThanMatchesBufferDoesNotInfiniteLoop()
+    {
+        using var _ = Slice.From(Allocator, nameof(FilteredFillWithSmallPostingListLargerThanMatchesBufferDoesNotInfiniteLoop), out var treeName);
+        const int vectorSize = 4;
+        const int vectorSizeInBytes = vectorSize * sizeof(float);
+        const int entriesWithSameVector = 8;
+        const int matchesBufferSize = 4;
+        float[] commonVector = [1.0f, 2.0f, 3.0f, 4.0f];
+
+        using (var wTx = Env.WriteTransaction())
+        {
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, vectorSizeInBytes, 3, 16, VectorEmbeddingType.Single);
+
+            using var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, new Random(42));
+            for (int i = 1; i <= entriesWithSameVector; i++)
+                registration.Register(i, MemoryMarshal.Cast<float, byte>(commonVector));
+
+            registration.Commit(CancellationToken.None);
+            wTx.Commit();
+        }
+
+        using (var rTx = Env.ReadTransaction())
+        {
+            var qV = MemoryMarshal.Cast<float, byte>(commonVector);
+            using var nearest = Hnsw.ExactNearest(rTx.LowLevelTransaction, treeName,
+                numberOfCandidates: 100, qV.ToArray(), minimumSimilarity: 0f, hasFilterMatch: true);
+
+            var filter = new GrowableBitArray(Allocator, entriesWithSameVector + 1);
+            using var __ = filter;
+
+            for (int i = 1; i <= entriesWithSameVector; i++)
+                filter.Add(i);
+            filter.Count = entriesWithSameVector;
+
+            var matches = new long[matchesBufferSize];
+            var distances = new float[matchesBufferSize];
+            List<long> allResults = new();
+
+            int read;
+            do
+            {
+                read = nearest.Fill(matches, distances, filter);
+                allResults.AddRange(matches[..read]);
+            } while (read != 0);
+
+            Assert.Equal(entriesWithSameVector, allResults.Count);
+            allResults.Sort();
+            Assert.Equal(Enumerable.Range(1, entriesWithSameVector).Select(x => (long)x), allResults);
+        }
+    }
+
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
     [InlineDataWithRandomSeed]
     [InlineDataWithRandomSeed]
@@ -30,7 +147,7 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
         Dictionary<long, float[]> storage = new();
         for (int i = 1; i <= numberOfEntries; ++i)
             storage.Add(i, Enumerable.Range(0, vectorSize).Select(_ => GetNextDim()).ToArray());
-        
+
         using (var wTx = Env.WriteTransaction())
         {
             Hnsw.Create(wTx.LowLevelTransaction, treeName, vectorSizeInBytes, 3, 16, VectorEmbeddingType.Single);
@@ -39,10 +156,10 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
             {
                 foreach (var (id, vector) in storage)
                     registration.Register(id, MemoryMarshal.Cast<float, byte>(vector));
-                
+
                 registration.Commit(CancellationToken.None);
             }
-            
+
             wTx.Commit();
         }
 
@@ -55,7 +172,7 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
             var matches = new long[64];
             var distances = new float[64];
             List<long> returnedDocuments = new();
-            
+
             var read = 0;
             do
             {
@@ -63,11 +180,11 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
                 totalReturned += read;
                 returnedDocuments.AddRange(matches[..read]);
             } while (read != 0);
-            
+
             Assert.Equal(numberOfEntries, totalReturned);
         }
-        
-        
+
+
         float GetNextDim() => random.NextSingle() * (random.Next() % 2 == 0 ? 1 : -1);
     }
 }


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26263

### Additional description

- Fixes an invalid currentLimit value when reading small posting lists.
- Fixes an incorrect boundary when decoding IDs from large posting lists.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
