### PR TITLE
RavenDB-26285 Allow to inline small attachments

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Lucene/LuceneIndexPersistence.cs
@@ -282,13 +282,13 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
 
             var directoryFiles = new IndexTransactionCache.DirectoryFiles();
             newCache.DirectoriesByName[_directory.Name] = directoryFiles;
-            FillLuceneFilesChunks(tx, directoryFiles.ChunksByName, _directory.Name);
+            FillLuceneFilesChunks(tx, directoryFiles, _directory.Name);
 
             foreach (var (name, _) in _suggestionsDirectories)
             {
                 directoryFiles = new IndexTransactionCache.DirectoryFiles();
                 newCache.DirectoriesByName[name] = directoryFiles;
-                FillLuceneFilesChunks(tx, directoryFiles.ChunksByName, name);
+                FillLuceneFilesChunks(tx, directoryFiles, name);
             }
 
             return newCache;
@@ -375,7 +375,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
             }
         }
 
-        private void FillLuceneFilesChunks(Transaction tx, Dictionary<string, Tree.ChunkDetails[]> cache, string name)
+        private unsafe void FillLuceneFilesChunks(Transaction tx, IndexTransactionCache.DirectoryFiles cache, string name)
         {
             var filesTree = tx.ReadTree(name);
             if (filesTree == null)
@@ -386,10 +386,23 @@ namespace Raven.Server.Documents.Indexes.Persistence.Lucene
                 {
                     do
                     {
-                        var chunkDetails = filesTree.ReadTreeChunks(it.CurrentKey, out _);
+                        var key = it.CurrentKey;
+                        
+                        if (filesTree.IsInlineStream(key, out var inlineData, out _, out var page))
+                        {
+                            var header = (Tree.InlineStreamHeader*)inlineData;
+                            var tagSize = header->Info.TagSize;
+                            var dataSize = (int)header->Info.TotalSize;
+                            var dataOffsetInPage = (int)(inlineData + Tree.InlineStreamHeader.SizeOf + tagSize - page.Base);
+                            cache.InlinesByName[key.ToString()] = new IndexTransactionCache.InlineFileLocation(
+                                page.PageNumber, dataOffsetInPage, dataSize);
+                            continue;
+                        }
+
+                        var chunkDetails = filesTree.ReadTreeChunks(key, out _);
                         if (chunkDetails == null)
                             continue;
-                        cache[it.CurrentKey.ToString()] = chunkDetails;
+                        cache.ChunksByName[key.ToString()] = chunkDetails;
                     } while (it.MoveNext());
                 }
             }

--- a/src/Raven.Server/Indexing/IndexTransactionCache.cs
+++ b/src/Raven.Server/Indexing/IndexTransactionCache.cs
@@ -24,7 +24,11 @@ namespace Raven.Server.Indexing
         public sealed class DirectoryFiles
         {
             public Dictionary<string, Tree.ChunkDetails[]> ChunksByName = new Dictionary<string, Tree.ChunkDetails[]>(StringComparer.OrdinalIgnoreCase);
+
+            public Dictionary<string, InlineFileLocation> InlinesByName = new Dictionary<string, InlineFileLocation>(StringComparer.OrdinalIgnoreCase);
         }
+        
+        public readonly record struct InlineFileLocation(long PageNumber, int DataOffsetInPage, int DataSize);
 
         public Dictionary<string, DirectoryFiles> DirectoriesByName = new Dictionary<string, DirectoryFiles>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, CollectionEtags> Collections = new Dictionary<string, CollectionEtags>(StringComparer.OrdinalIgnoreCase);

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -31,7 +31,6 @@ public sealed unsafe class LuceneVoronStream
         _name = name;
         _voronStream = new VoronStream(chunksDetails, llt);
         Stream = _voronStream;
-        _name = name;
         _llt = llt;
         RegisterTransactionCleanup();
     }
@@ -90,8 +89,7 @@ public sealed unsafe class LuceneVoronStream
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void UpdateCurrentTransaction(Transaction tx)
     {
-        if (tx == null)
-            ThrowTransactionIsNull();
+        ArgumentNullException.ThrowIfNull(tx);
 
         if (_llt == tx.LowLevelTransaction)
             return;
@@ -113,12 +111,6 @@ public sealed unsafe class LuceneVoronStream
             _voronStream.Llt = tx.LowLevelTransaction;
             _voronStream.LastPage = default(Page);
         }
-    }
-
-    [DoesNotReturn]
-    private static void ThrowTransactionIsNull()
-    {
-        throw new ArgumentNullException("tx");
     }
 
     [DoesNotReturn]

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -17,20 +17,19 @@ namespace Raven.Server.Indexing;
 /// </summary>
 public sealed unsafe class LuceneVoronStream
 {
-    public Stream Stream { get; }
-
     private readonly VoronStream _voronStream;     // non-null when chunk-based
     private readonly UnmanagedVoronStream _inlineStream;  // non-null when inline
     private readonly string _treeName;
     private readonly string _name;
     private LowLevelTransaction _llt;
+    private Stream _stream;
 
     /// <summary>Chunk-based stream constructor.</summary>
     public LuceneVoronStream(string name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
     {
         _name = name;
         _voronStream = new VoronStream(chunksDetails, llt);
-        Stream = _voronStream;
+        _stream = _voronStream;
         _llt = llt;
         RegisterTransactionCleanup();
     }
@@ -41,7 +40,7 @@ public sealed unsafe class LuceneVoronStream
         _name = name;
         _treeName = treeName;
         _inlineStream = new UnmanagedVoronStream(inlineDataPtr, inlineDataSize);
-        Stream = _inlineStream;
+        _stream = _inlineStream;
         _llt = llt;
         RegisterTransactionCleanup();
     }
@@ -49,28 +48,28 @@ public sealed unsafe class LuceneVoronStream
     public long Position
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Stream.Position;
+        get => _stream.Position;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => Stream.Position = value;
+        set => _stream.Position = value;
     }
 
     public long Length
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Stream.Length;
+        get => _stream.Length;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int ReadByte() => Stream.ReadByte();
+    public int ReadByte() => _stream.ReadByte();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int Read(byte[] buffer, int offset, int count) => Stream.Read(buffer, offset, count);
+    public int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void ReadEntireBlock(byte[] buffer, int offset, int count) => Stream.ReadEntireBlock(buffer, offset, count);
+    public void ReadEntireBlock(byte[] buffer, int offset, int count) => _stream.ReadEntireBlock(buffer, offset, count);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public long Seek(long offset, SeekOrigin origin) => Stream.Seek(offset, origin);
+    public long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
 
     private void RegisterTransactionCleanup()
     {

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -10,8 +10,16 @@ namespace Raven.Server.Indexing;
 
 public sealed class LuceneVoronStream : VoronStream
 {
+    private readonly string _treeName;
+
     public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
     {
+        RegisterTransactionCleanup();
+    }
+
+    public unsafe LuceneVoronStream(Slice name, string treeName, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt) : base(name, inlineDataPtr, inlineDataSize, llt)
+    {
+        _treeName = treeName;
         RegisterTransactionCleanup();
     }
 
@@ -29,20 +37,32 @@ public sealed class LuceneVoronStream : VoronStream
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UpdateCurrentTransaction(Transaction tx)
+    public unsafe void UpdateCurrentTransaction(Transaction tx)
     {
-        if (tx != null)
+        if (tx == null)
         {
-            if (Llt == tx.LowLevelTransaction)
-                return;
-
-            Llt = tx.LowLevelTransaction;
-            RegisterTransactionCleanup();
-            LastPage = default(Page);
-            return;
+            ThrowTransactionIsNull();
         }
 
-        ThrowTransactionIsNull();
+        if (Llt == tx.LowLevelTransaction)
+            return;
+
+        Llt = tx.LowLevelTransaction;
+        RegisterTransactionCleanup();
+        if (IsInline)
+        {
+            var tree = tx.ReadTree(_treeName);
+            byte* inlineData = null;
+            if (tree == null || tree.IsInlineStream(Name, out inlineData, out _) == false)
+                ThrowMissingInlineStream();
+            var header = (Tree.InlineStreamHeader*)inlineData;
+            InlineDataPtr = inlineData + Tree.InlineStreamHeader.SizeOf + header->Info.TagSize;
+        }
+        else
+        {
+            LastPage = default(Page);
+        }
+        return;
     }
 
     [DoesNotReturn]
@@ -50,4 +70,8 @@ public sealed class LuceneVoronStream : VoronStream
     {
         throw new ArgumentNullException("tx");
     }
+
+    [DoesNotReturn]
+    private void ThrowMissingInlineStream() =>
+        throw new InvalidOperationException($"Inline stream '{Name}' in tree '{_treeName}' not found after transaction refresh.");
 }

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -101,7 +101,7 @@ public sealed unsafe class LuceneVoronStream
         {
             var tree = tx.ReadTree(_treeName);
             byte* inlineData = null;
-            if (tree == null || tree.IsInlineStream(_name, out inlineData, out _) == false)
+            if (tree == null || tree.IsInlineStream(_name, out inlineData, out _, out _) == false)
                 ThrowMissingInlineStream();
             var header = (Tree.InlineStreamHeader*)inlineData;
             _inlineStream.UpdatePtr(inlineData + Tree.InlineStreamHeader.SizeOf + header->Info.TagSize);

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -21,22 +21,23 @@ public sealed unsafe class LuceneVoronStream
 
     private readonly VoronStream _voronStream;     // non-null when chunk-based
     private readonly UnmanagedVoronStream _inlineStream;  // non-null when inline
-    private readonly Slice _name;
     private readonly string _treeName;
+    private readonly string _name;
     private LowLevelTransaction _llt;
 
     /// <summary>Chunk-based stream constructor.</summary>
-    public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
+    public LuceneVoronStream(string name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
     {
         _name = name;
-        _voronStream = new VoronStream(name, chunksDetails, llt);
+        _voronStream = new VoronStream(chunksDetails, llt);
         Stream = _voronStream;
+        _name = name;
         _llt = llt;
         RegisterTransactionCleanup();
     }
 
     /// <summary>Inline (unmanaged pointer) stream constructor.</summary>
-    public LuceneVoronStream(Slice name, string treeName, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt)
+    public LuceneVoronStream(string name, string treeName, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt)
     {
         _name = name;
         _treeName = treeName;

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.CompilerServices;
+using Raven.Client.Extensions.Streams;
 using Voron;
 using Voron.Data;
 using Voron.Data.BTrees;
@@ -8,61 +10,108 @@ using Voron.Impl;
 
 namespace Raven.Server.Indexing;
 
-public sealed class LuceneVoronStream : VoronStream
+/// <summary>
+/// Wraps either a chunk-based <see cref="VoronStream"/> or an inline <see cref="UnmanagedVoronStream"/>
+/// for use by Lucene index inputs. Supports cross-transaction reuse by refreshing the underlying
+/// stream's transaction state (page cache reset or inline pointer update).
+/// </summary>
+public sealed unsafe class LuceneVoronStream
 {
+    public Stream Stream { get; }
+
+    private readonly VoronStream _voronStream;     // non-null when chunk-based
+    private readonly UnmanagedVoronStream _inlineStream;  // non-null when inline
+    private readonly Slice _name;
     private readonly string _treeName;
+    private LowLevelTransaction _llt;
 
-    public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt) : base(name, chunksDetails, llt)
+    /// <summary>Chunk-based stream constructor.</summary>
+    public LuceneVoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
     {
+        _name = name;
+        _voronStream = new VoronStream(name, chunksDetails, llt);
+        Stream = _voronStream;
+        _llt = llt;
         RegisterTransactionCleanup();
     }
 
-    public unsafe LuceneVoronStream(Slice name, string treeName, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt) : base(name, inlineDataPtr, inlineDataSize, llt)
+    /// <summary>Inline (unmanaged pointer) stream constructor.</summary>
+    public LuceneVoronStream(Slice name, string treeName, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt)
     {
+        _name = name;
         _treeName = treeName;
+        _inlineStream = new UnmanagedVoronStream(inlineDataPtr, inlineDataSize);
+        Stream = _inlineStream;
+        _llt = llt;
         RegisterTransactionCleanup();
     }
+
+    public long Position
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Stream.Position;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => Stream.Position = value;
+    }
+
+    public long Length
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Stream.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ReadByte() => Stream.ReadByte();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Read(byte[] buffer, int offset, int count) => Stream.Read(buffer, offset, count);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ReadEntireBlock(byte[] buffer, int offset, int count) => Stream.ReadEntireBlock(buffer, offset, count);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public long Seek(long offset, SeekOrigin origin) => Stream.Seek(offset, origin);
 
     private void RegisterTransactionCleanup()
     {
-        Llt.Transaction.LowLevelTransaction.OnDispose += _ =>
+        _llt.Transaction.LowLevelTransaction.OnDispose += _ =>
         {
-            // Lucene caches VoronStream instances (via SegmentReader) per thread, so they can outlive
-            // the transaction that created them. Nulling _llt here allows the GC to collect the
-            // disposed LowLevelTransaction and its associated structures (page positions, journal
-            // references, etc.), which can be substantial depending on the indexing batch size.
+            // Lucene caches these instances (via SegmentReader) per thread, so they can outlive
+            // the transaction that created them. Nulling the fields here allows the GC to collect the
+            // disposed LowLevelTransaction and its associated structures.
             // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
-            Llt = null;
+            _llt = null;
+            _inlineStream.UpdatePtr(null);
+            _voronStream.Reset();
         };
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public unsafe void UpdateCurrentTransaction(Transaction tx)
+    public void UpdateCurrentTransaction(Transaction tx)
     {
         if (tx == null)
-        {
             ThrowTransactionIsNull();
-        }
 
-        if (Llt == tx.LowLevelTransaction)
+        if (_llt == tx.LowLevelTransaction)
             return;
 
-        Llt = tx.LowLevelTransaction;
+        _llt = tx.LowLevelTransaction;
         RegisterTransactionCleanup();
-        if (IsInline)
+
+        if (_inlineStream != null)
         {
             var tree = tx.ReadTree(_treeName);
             byte* inlineData = null;
-            if (tree == null || tree.IsInlineStream(Name, out inlineData, out _) == false)
+            if (tree == null || tree.IsInlineStream(_name, out inlineData, out _) == false)
                 ThrowMissingInlineStream();
             var header = (Tree.InlineStreamHeader*)inlineData;
-            InlineDataPtr = inlineData + Tree.InlineStreamHeader.SizeOf + header->Info.TagSize;
+            _inlineStream.UpdatePtr(inlineData + Tree.InlineStreamHeader.SizeOf + header->Info.TagSize);
         }
         else
         {
-            LastPage = default(Page);
+            _voronStream.Llt = tx.LowLevelTransaction;
+            _voronStream.LastPage = default(Page);
         }
-        return;
     }
 
     [DoesNotReturn]
@@ -73,5 +122,5 @@ public sealed class LuceneVoronStream : VoronStream
 
     [DoesNotReturn]
     private void ThrowMissingInlineStream() =>
-        throw new InvalidOperationException($"Inline stream '{Name}' in tree '{_treeName}' not found after transaction refresh.");
+        throw new InvalidOperationException($"Inline stream '{_name}' in tree '{_treeName}' not found after transaction refresh.");
 }

--- a/src/Raven.Server/Indexing/LuceneVoronStream.cs
+++ b/src/Raven.Server/Indexing/LuceneVoronStream.cs
@@ -81,8 +81,8 @@ public sealed unsafe class LuceneVoronStream
             // disposed LowLevelTransaction and its associated structures.
             // When the stream is reused, UpdateCurrentTransaction will set a fresh transaction.
             _llt = null;
-            _inlineStream.UpdatePtr(null);
-            _voronStream.Reset();
+            _inlineStream?.UpdatePtr(null);
+            _voronStream?.Reset();
         };
     }
 

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Lucene.Net.Store;
 using Raven.Client.Extensions.Streams;
 using Voron;
+using Voron.Data.BTrees;
 using Voron.Impl;
 
 namespace Raven.Server.Indexing
@@ -35,7 +36,7 @@ namespace Raven.Server.Indexing
             return _name;
         }
 
-        internal static LuceneVoronStream OpenVoronStream(Transaction transaction, LuceneVoronDirectory directory, string name, string treeName)
+        internal static unsafe LuceneVoronStream OpenVoronStream(Transaction transaction, LuceneVoronDirectory directory, string name, string treeName)
         {
             if (transaction.IsWriteTransaction == false)
             {
@@ -60,6 +61,15 @@ namespace Raven.Server.Indexing
 
             using (Slice.From(transaction.Allocator, name, out Slice fileName))
             {
+                if (fileTree.IsInlineStream(fileName, out var inlineData, out _))
+                {
+                    var header = (Tree.InlineStreamHeader*)inlineData;
+                    var tagSize = header->Info.TagSize;
+                    var dataSize = (int)header->Info.TotalSize;
+                    var dataPtr = inlineData + Tree.InlineStreamHeader.SizeOf + tagSize;
+                    return new LuceneVoronStream(fileName.Clone(transaction.Allocator), treeName, dataPtr, dataSize, fileTree.Llt);
+                }
+
                 var details = fileTree.ReadTreeChunks(fileName, out var tree);
                 if (details == null)
                     throw new FileNotFoundException("Could not find index input", name);

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -58,7 +58,7 @@ namespace Raven.Server.Indexing
 
             using (Slice.From(transaction.Allocator, name, out Slice fileName))
             {
-                if (fileTree.IsInlineStream(fileName, out var inlineData, out _))
+                if (fileTree.IsInlineStream(fileName, out var inlineData, out _, out _))
                 {
                     var header = (Tree.InlineStreamHeader*)inlineData;
                     var tagSize = header->Info.TagSize;

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Lucene.Net.Store;
 using Voron;
 using Voron.Data.BTrees;
+using Voron.Global;
 using Voron.Impl;
 
 namespace Raven.Server.Indexing
@@ -50,6 +51,9 @@ namespace Raven.Server.Indexing
 
                         if (files.InlinesByName.TryGetValue(name, out var inline))
                         {
+                            if (inline.DataOffsetInPage <= 0 || inline.DataOffsetInPage + inline.DataSize > Constants.Storage.PageSize)
+                                ThrowInvalidInlineStreamLocation(name, inline);
+
                             var llt = transaction.LowLevelTransaction;
                             var dataPtr = llt.GetPage(inline.PageNumber).Pointer + inline.DataOffsetInPage;
                             return new LuceneVoronStream(name, treeName, dataPtr, inline.DataSize, llt);
@@ -238,6 +242,13 @@ namespace Raven.Server.Indexing
         private void ThrowInvalidSeekPosition(long pos)
         {
             throw new InvalidOperationException($"Cannot set stream position to {pos} because the length of '{_name}' stream is {_stream.Length}");
+        }
+
+        [DoesNotReturn]
+        private static void ThrowInvalidInlineStreamLocation(string name, IndexTransactionCache.InlineFileLocation inline)
+        {
+            throw new InvalidOperationException(
+                $"Cached inline stream location for '{name}' is out of page bounds: PageNumber={inline.PageNumber}, DataOffsetInPage={inline.DataOffsetInPage}, DataSize={inline.DataSize}");
         }
     }
 }

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Lucene.Net.Store;
-using Raven.Client.Extensions.Streams;
 using Voron;
 using Voron.Data.BTrees;
 using Voron.Impl;
@@ -46,7 +45,14 @@ namespace Raven.Server.Indexing
                     {
                         if (files.ChunksByName.TryGetValue(name, out var details))
                         {
-                           return new LuceneVoronStream(name, details, transaction.LowLevelTransaction);
+                            return new LuceneVoronStream(name, details, transaction.LowLevelTransaction);
+                        }
+
+                        if (files.InlinesByName.TryGetValue(name, out var inline))
+                        {
+                            var llt = transaction.LowLevelTransaction;
+                            var dataPtr = llt.GetPage(inline.PageNumber).Pointer + inline.DataOffsetInPage;
+                            return new LuceneVoronStream(name, treeName, dataPtr, inline.DataSize, llt);
                         }
                     }
                 }

--- a/src/Raven.Server/Indexing/VoronIndexInput.cs
+++ b/src/Raven.Server/Indexing/VoronIndexInput.cs
@@ -46,10 +46,7 @@ namespace Raven.Server.Indexing
                     {
                         if (files.ChunksByName.TryGetValue(name, out var details))
                         {
-                            // we don't dispose here explicitly, the fileName needs to be
-                            // alive as long as the transaction is
-                            Slice.From(transaction.Allocator, name, out Slice fileName);
-                            return new LuceneVoronStream(fileName, details, transaction.LowLevelTransaction);
+                           return new LuceneVoronStream(name, details, transaction.LowLevelTransaction);
                         }
                     }
                 }
@@ -67,14 +64,14 @@ namespace Raven.Server.Indexing
                     var tagSize = header->Info.TagSize;
                     var dataSize = (int)header->Info.TotalSize;
                     var dataPtr = inlineData + Tree.InlineStreamHeader.SizeOf + tagSize;
-                    return new LuceneVoronStream(fileName.Clone(transaction.Allocator), treeName, dataPtr, dataSize, fileTree.Llt);
+                    return new LuceneVoronStream(name, treeName, dataPtr, dataSize, fileTree.Llt);
                 }
 
                 var details = fileTree.ReadTreeChunks(fileName, out var tree);
                 if (details == null)
                     throw new FileNotFoundException("Could not find index input", name);
 
-                return new LuceneVoronStream(tree.Name, details, fileTree.Llt);
+                return new LuceneVoronStream(name, details, fileTree.Llt);
             }
         }
         

--- a/src/Voron/Constants.cs
+++ b/src/Voron/Constants.cs
@@ -8,7 +8,7 @@ namespace Voron.Global
 {
     public sealed unsafe class Constants
     {
-        public const int CurrentVersion = 23;
+        public const int CurrentVersion = 24;
 
         public const ulong MagicMarker = 0xB16BAADC0DEF0015;
         public const ulong TransactionHeaderMarker = 0x1A4C92AD90ABC123;

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -53,6 +53,7 @@ namespace Voron.Data.BTrees
         /// <summary>
         /// Header for streams stored inline in the tree node.
         /// Layout: [RootObjectType (1 byte)][StreamInfo (16 bytes)][Tag (TagSize bytes)][Data (TotalSize bytes)]
+        /// Note: Unlike chunked streams (which store data first, then metadata), inline streams store metadata first, then data.
         /// </summary>
         [StructLayout(LayoutKind.Explicit, Size = SizeOf)]
         public struct InlineStreamHeader
@@ -250,7 +251,9 @@ namespace Voron.Data.BTrees
         private bool TryAddInlineStream(Slice key, Stream stream, Slice? tag)
         {
             var tagSize = tag?.Size ?? 0;
-            var maxInlineSize = _llt.DataPager.NodeMaxSize - Constants.Tree.NodeHeaderSize - key.Size - InlineStreamHeader.SizeOf - tagSize;
+            // maxInlineSize calculates space available for the value (header + tag + data).
+            // Key.Size is not subtracted because DirectAdd(key, len, ...) only accounts for value length.
+            var maxInlineSize = _llt.DataPager.NodeMaxSize - Constants.Tree.NodeHeaderSize - InlineStreamHeader.SizeOf - tagSize;
             if (maxInlineSize <= 0)
                 return false;
 
@@ -347,6 +350,11 @@ namespace Voron.Data.BTrees
             var nodeDataSize = node->DataSize;
 
             if (nodeDataSize < InlineStreamHeader.SizeOf)
+                return false;
+
+            // Defensive check: verify we have the Streams flag set 
+            // This prevents misidentification if another structure's first byte happens to match RootObjectType.InlineStream.
+            if ((State.Header.Flags & TreeFlags.Streams) == 0)
                 return false;
 
             if (((RootObjectType*)nodeData)[0] != RootObjectType.InlineStream)

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Sparrow;
 using Sparrow.Server;
@@ -247,7 +246,6 @@ namespace Voron.Data.BTrees
             writer.Write(stream);
         }
 
-        [SkipLocalsInit]
         private bool TryAddInlineStream(Slice key, Stream stream, Slice? tag)
         {
             var tagSize = tag?.Size ?? 0;
@@ -257,13 +255,14 @@ namespace Voron.Data.BTrees
             if (maxInlineSize <= 0)
                 return false;
 
-
             var nodeMaxSize = _llt.DataPager.NodeMaxSize;
-            Span<byte> buffer = stackalloc byte[nodeMaxSize];
+
+            var buffer = _llt.Transaction.StreamBuffer;
+            var localBuffer = buffer.AsSpan().Slice(0, nodeMaxSize);
             var totalRead = 0;
             while (totalRead < nodeMaxSize)
             {
-                var read = stream.Read(buffer.Slice(totalRead));
+                var read = stream.Read(localBuffer.Slice(totalRead));
                 if (read == 0)
                     break;
                 totalRead += read;
@@ -294,10 +293,7 @@ namespace Voron.Data.BTrees
                     dest += tagSize;
                 }
 
-                fixed (byte* src = buffer)
-                {
-                    Memory.Copy(dest, src, totalRead);
-                }
+                Memory.Copy(dest, buffer.Pointer, totalRead);
             }
 
             return true;

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -315,7 +315,7 @@ namespace Voron.Data.BTrees
                 var dataSize = (int)header->Info.TotalSize;
                 var dataPtr = inlineData + InlineStreamHeader.SizeOf + tagSize;
 
-                return new VoronStream(key.Clone(_tx.Allocator), dataPtr, dataSize, _llt);
+                return new UnmanagedVoronStream(dataPtr, dataSize);
             }
 
             var pieces = ReadTreeChunks(key, out var tree);

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -321,10 +321,16 @@ namespace Voron.Data.BTrees
             var pieces = ReadTreeChunks(key, out var tree);
             if (pieces == null)
                 return null;
-            return new VoronStream(tree.Name, pieces, _llt);
+            return new VoronStream(pieces, _llt);
         }
 
-        internal bool IsInlineStream(Slice key, out byte* data, out int dataSize)
+        public bool IsInlineStream(string key, out byte* data, out int dataSize)
+        {
+            using (Slice.From(_tx.Allocator, key, out Slice str))
+                return IsInlineStream(str, out data, out dataSize);
+        }
+
+        public bool IsInlineStream(Slice key, out byte* data, out int dataSize)
         {
             data = null;
             dataSize = 0;

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Sparrow;
 using Sparrow.Server;
@@ -49,6 +50,22 @@ namespace Voron.Data.BTrees
             }
         }
 
+        /// <summary>
+        /// Header for streams stored inline in the tree node.
+        /// Layout: [RootObjectType (1 byte)][StreamInfo (16 bytes)][Tag (TagSize bytes)][Data (TotalSize bytes)]
+        /// </summary>
+        [StructLayout(LayoutKind.Explicit, Size = SizeOf)]
+        public struct InlineStreamHeader
+        {
+            public const int SizeOf = 1 + StreamInfo.SizeOf; // 17 bytes
+
+            [FieldOffset(0)]
+            public RootObjectType Type; // = RootObjectType.InlineStream
+
+            [FieldOffset(1)]
+            public StreamInfo Info;
+        }
+
         private const int MaxNumberOfPagerPerChunk = 4 * Constants.Size.Megabyte / Constants.Storage.PageSize;
         
         private struct StreamToPageWriter
@@ -71,63 +88,61 @@ namespace Voron.Data.BTrees
             {
                 _parent = parent;
                 _numberOfPagesPerChunk = 1;
-                _tree = _parent.FixedTreeFor(key, ChunkDetails.SizeOf);
                 _version = _parent.DeleteStream(key).Version;
+                _tree = _parent.FixedTreeFor(key, ChunkDetails.SizeOf);
                 _numberOfPagesPerChunk = initialNumberOfPagesPerChunk ?? 1;
                 _tag = tag;
             }
 
             public void Write(Stream stream)
             {
+                AllocateNextPage();
+
+                ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
+
+                var buffer = stream != Stream.Null ? _parent.Llt.Transaction.StreamBuffer : StreamBufferAllocator.Buffer.Null;
+                var localBuffer = buffer.AsSpan();
+
                 {
-                    AllocateNextPage();
-
-                    ((StreamPageHeader*)_currentPage.Pointer)->StreamPageFlags |= StreamPageFlags.First;
-
-                    var buffer = stream != Stream.Null ? _parent.Llt.Transaction.StreamBuffer : StreamBufferAllocator.Buffer.Null;
-                    var localBuffer = buffer.AsSpan();
-
+                    while (true)
                     {
+                        var read = stream.Read(localBuffer);
+                        if (read == 0)
+                            break;
+
+                        var toWrite = 0L;
                         while (true)
                         {
-                            var read = stream.Read(localBuffer);
-                            if (read == 0)
+                            toWrite += WriteBufferToPage(buffer.Pointer + toWrite, read - toWrite);
+                            if (toWrite == read)
                                 break;
 
-                            var toWrite = 0L;
-                            while (true)
-                            {
-                                toWrite += WriteBufferToPage(buffer.Pointer + toWrite, read - toWrite);
-                                if (toWrite == read)
-                                    break;
-
-                                // run out of room, need to allocate more
-                                RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
-                                AllocateNextPage();
-                            }
-                        }
-
-                        var chunkSize = (int)(_writePos - _currentPage.DataPointer);
-                        RecordChunkPage(_currentPage.PageNumber, chunkSize);
-
-                        var remaining = _writePosEnd - _writePos;
-                        var infoSize = StreamInfo.SizeOf;
-
-                        if (_tag != null)
-                            infoSize += _tag.Value.Size;
-
-                        if (remaining < infoSize)
-                        {
-                            _numberOfPagesPerChunk = 1;
+                            // run out of room, need to allocate more
+                            RecordChunkPage(_currentPage.PageNumber, (int)(_writePos - _currentPage.DataPointer));
                             AllocateNextPage();
-                            chunkSize = 0;
-                            RecordChunkPage(_currentPage.PageNumber, chunkSize);
                         }
-
-                        RecordStreamInfo();
-
-                        _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
                     }
+
+                    var chunkSize = (int)(_writePos - _currentPage.DataPointer);
+                    RecordChunkPage(_currentPage.PageNumber, chunkSize);
+
+                    var remaining = _writePosEnd - _writePos;
+                    var infoSize = StreamInfo.SizeOf;
+
+                    if (_tag != null)
+                        infoSize += _tag.Value.Size;
+
+                    if (remaining < infoSize)
+                    {
+                        _numberOfPagesPerChunk = 1;
+                        AllocateNextPage();
+                        chunkSize = 0;
+                        RecordChunkPage(_currentPage.PageNumber, chunkSize);
+                    }
+
+                    RecordStreamInfo();
+
+                    _parent._tx.LowLevelTransaction.ShrinkOverflowPage(_currentPage.PageNumber, chunkSize + infoSize, _parent.State);
                 }
             }
 
@@ -215,33 +230,134 @@ namespace Voron.Data.BTrees
 
         public void AddStream(Slice key, Stream stream, Slice? tag = null, int? initialNumberOfPagesPerChunk = null)
         {
-            var writer = new StreamToPageWriter();
-            writer.Init(this, key, tag, initialNumberOfPagesPerChunk);
-            writer.Write(stream);
-
+            Debug.Assert(stream.CanSeek, "Stream must be seekable, we need it to simplify reseting position when stream is too large for inline storage");
+            
             if ((State.Header.Flags & TreeFlags.Streams) != TreeFlags.Streams)
             {
                 ref var state = ref State.Modify();
                 state.Flags |= TreeFlags.Streams;
             }
+
+            if (TryAddInlineStream(key, stream, tag))
+                return;
+
+            var writer = new StreamToPageWriter();
+            writer.Init(this, key, tag, initialNumberOfPagesPerChunk);
+            writer.Write(stream);
         }
 
-        public VoronStream ReadStream(string key)
+        [SkipLocalsInit]
+        private bool TryAddInlineStream(Slice key, Stream stream, Slice? tag)
+        {
+            var tagSize = tag?.Size ?? 0;
+            var maxInlineSize = _llt.DataPager.NodeMaxSize - Constants.Tree.NodeHeaderSize - key.Size - InlineStreamHeader.SizeOf - tagSize;
+            if (maxInlineSize <= 0)
+                return false;
+
+
+            var nodeMaxSize = _llt.DataPager.NodeMaxSize;
+            Span<byte> buffer = stackalloc byte[nodeMaxSize];
+            var totalRead = 0;
+            while (totalRead < nodeMaxSize)
+            {
+                var read = stream.Read(buffer.Slice(totalRead));
+                if (read == 0)
+                    break;
+                totalRead += read;
+            }
+
+            if (totalRead > maxInlineSize)
+            {
+                // Stream is too large for inline storage, reset and fall back
+                stream.Position = 0;
+                return false;
+            }
+
+            // The entire stream fits inline
+            var version = DeleteStream(key).Version;
+            var inlineSize = InlineStreamHeader.SizeOf + tagSize + totalRead;
+            using (DirectAdd(key, inlineSize, out byte* ptr))
+            {
+                var header = (InlineStreamHeader*)ptr;
+                header->Type = RootObjectType.InlineStream;
+                header->Info.TotalSize = totalRead;
+                header->Info.Version = version + 1;
+                header->Info.TagSize = tagSize;
+
+                var dest = ptr + InlineStreamHeader.SizeOf;
+                if (tag != null)
+                {
+                    tag.Value.CopyTo(dest);
+                    dest += tagSize;
+                }
+
+                fixed (byte* src = buffer)
+                {
+                    Memory.Copy(dest, src, totalRead);
+                }
+            }
+
+            return true;
+        }
+
+        public Stream ReadStream(string key)
         {
             using (Slice.From(_tx.Allocator, key, out Slice str))
                 return ReadStream(str);
         }
 
-        public VoronStream ReadStream(Slice key)
+        public Stream ReadStream(Slice key)
         {
+            if (IsInlineStream(key, out var inlineData, out _))
+            {
+                var header = (InlineStreamHeader*)inlineData;
+                var tagSize = header->Info.TagSize;
+                var dataSize = (int)header->Info.TotalSize;
+                var dataPtr = inlineData + InlineStreamHeader.SizeOf + tagSize;
+
+                return new VoronStream(key.Clone(_tx.Allocator), dataPtr, dataSize, _llt);
+            }
+
             var pieces = ReadTreeChunks(key, out var tree);
             if (pieces == null)
                 return null;
             return new VoronStream(tree.Name, pieces, _llt);
         }
 
+        internal bool IsInlineStream(Slice key, out byte* data, out int dataSize)
+        {
+            data = null;
+            dataSize = 0;
+
+            var p = FindPageFor(key, out TreeNodeHeader* node);
+            if (p.LastMatch != 0 || node == null)
+                return false;
+
+            if (node->Flags == TreeNodeFlags.PageRef)
+                return false;
+
+            var nodeData = (byte*)node + node->KeySize + Constants.Tree.NodeHeaderSize;
+            var nodeDataSize = node->DataSize;
+
+            if (nodeDataSize < InlineStreamHeader.SizeOf)
+                return false;
+
+            if (((RootObjectType*)nodeData)[0] != RootObjectType.InlineStream)
+                return false;
+
+            data = nodeData;
+            dataSize = nodeDataSize;
+            return true;
+        }
+
         public ChunkDetails[] ReadTreeChunks(Slice key, out FixedSizeTree tree)
         {
+            if (IsInlineStream(key, out _, out _))
+            {
+                tree = null;
+                return null;
+            }
+
             tree = FixedTreeFor(key, ChunkDetails.SizeOf);
             var numberOfChunks = tree.NumberOfEntries;
 
@@ -273,12 +389,24 @@ namespace Voron.Data.BTrees
 
         public bool StreamExist(Slice key)
         {
-            var tree = FixedTreeFor(key, ChunkDetails.SizeOf);
-            return tree.NumberOfEntries > 0;
+            return Exists(key);
         }
 
         public int TouchStream(Slice key)
         {
+            if (IsInlineStream(key, out var inlineData, out _))
+            {
+                // Need writable page. The FindPageFor in IsInlineStream gave us a read-only pointer.
+                var p = FindPageFor(key, out TreeNodeHeader* node);
+                Debug.Assert(p.LastMatch == 0 && node != null);
+                _llt.ModifyPage(p.PageNumber);
+                // re-find node after modification since the page pointer may have changed
+                p = FindPageFor(key, out node);
+                var data = (byte*)node + node->KeySize + Constants.Tree.NodeHeaderSize;
+                var header = (InlineStreamHeader*)data;
+                return ++header->Info.Version;
+            }
+
             var info = GetStreamInfo(key, writable: true);
 
             if (info == null)
@@ -290,6 +418,20 @@ namespace Voron.Data.BTrees
         public StreamInfo? GetStreamInfoForReporting(Slice key, out string tag)
         {
             tag = null;
+
+            if (IsInlineStream(key, out var inlineData, out _))
+            {
+                var header = (InlineStreamHeader*)inlineData;
+                var infoPtr = &header->Info;
+                tag = GetStreamTag(infoPtr);
+
+                return new StreamInfo
+                {
+                    TagSize = infoPtr->TagSize,
+                    TotalSize = infoPtr->TotalSize,
+                    Version = infoPtr->Version
+                };
+            }
 
             if (TryGetLastChunkDetailsForStream(key, out var lastChunk) == false)
                 return null;
@@ -374,6 +516,21 @@ namespace Voron.Data.BTrees
 
         public StreamInfo* GetStreamInfo(Slice key, bool writable)
         {
+            if (IsInlineStream(key, out var inlineData, out _))
+            {
+                if (writable)
+                {
+                    var p = FindPageFor(key, out TreeNodeHeader* node);
+                    Debug.Assert(p.LastMatch == 0 && node != null);
+                    _llt.ModifyPage(p.PageNumber);
+                    // re-find after modification since page pointer may have changed
+                    p = FindPageFor(key, out node);
+                    inlineData = (byte*)node + node->KeySize + Constants.Tree.NodeHeaderSize;
+                }
+
+                return &((InlineStreamHeader*)inlineData)->Info;
+            }
+
             if (TryGetLastChunkDetailsForStream(key, out var lastChunk) == false)
                 return null;
 
@@ -424,6 +581,15 @@ namespace Voron.Data.BTrees
         {
             int version = 0;
             long size = 0;
+            if (IsInlineStream(key, out var inlineData, out _))
+            {
+                var header = (InlineStreamHeader*)inlineData;
+                version = header->Info.Version;
+                size = header->Info.TotalSize;
+                Delete(key); // Regular tree key deletion — no overflow pages to free
+                return (version, size);
+            }
+
 
             var info = GetStreamInfo(key, writable: false);
 

--- a/src/Voron/Data/BTrees/Tree.Stream.cs
+++ b/src/Voron/Data/BTrees/Tree.Stream.cs
@@ -308,7 +308,7 @@ namespace Voron.Data.BTrees
 
         public Stream ReadStream(Slice key)
         {
-            if (IsInlineStream(key, out var inlineData, out _))
+            if (IsInlineStream(key, out var inlineData, out _, out _))
             {
                 var header = (InlineStreamHeader*)inlineData;
                 var tagSize = header->Info.TagSize;
@@ -324,16 +324,17 @@ namespace Voron.Data.BTrees
             return new VoronStream(pieces, _llt);
         }
 
-        public bool IsInlineStream(string key, out byte* data, out int dataSize)
+        public bool IsInlineStream(string key, out byte* data, out int dataSize, out TreePage treePage)
         {
             using (Slice.From(_tx.Allocator, key, out Slice str))
-                return IsInlineStream(str, out data, out dataSize);
+                return IsInlineStream(str, out data, out dataSize, out treePage);
         }
 
-        public bool IsInlineStream(Slice key, out byte* data, out int dataSize)
+        public bool IsInlineStream(Slice key, out byte* data, out int dataSize, out TreePage treePage)
         {
             data = null;
             dataSize = 0;
+            treePage = default;
 
             var p = FindPageFor(key, out TreeNodeHeader* node);
             if (p.LastMatch != 0 || node == null)
@@ -353,12 +354,13 @@ namespace Voron.Data.BTrees
 
             data = nodeData;
             dataSize = nodeDataSize;
+            treePage = p;
             return true;
         }
 
         public ChunkDetails[] ReadTreeChunks(Slice key, out FixedSizeTree tree)
         {
-            if (IsInlineStream(key, out _, out _))
+            if (IsInlineStream(key, out _, out _, out _))
             {
                 tree = null;
                 return null;
@@ -400,14 +402,12 @@ namespace Voron.Data.BTrees
 
         public int TouchStream(Slice key)
         {
-            if (IsInlineStream(key, out var inlineData, out _))
+            if (IsInlineStream(key, out var inlineData, out _, out var inlinePage))
             {
-                // Need writable page. The FindPageFor in IsInlineStream gave us a read-only pointer.
-                var p = FindPageFor(key, out TreeNodeHeader* node);
-                Debug.Assert(p.LastMatch == 0 && node != null);
-                _llt.ModifyPage(p.PageNumber);
-                // re-find node after modification since the page pointer may have changed
-                p = FindPageFor(key, out node);
+                // The page from IsInlineStream may be read-only, so call ModifyPage to get
+                // a writable copy (preserving search position).
+                var p = ModifyPage(inlinePage);
+                var node = p.GetNode(p.LastSearchPosition);
                 var data = (byte*)node + node->KeySize + Constants.Tree.NodeHeaderSize;
                 var header = (InlineStreamHeader*)data;
                 return ++header->Info.Version;
@@ -425,7 +425,7 @@ namespace Voron.Data.BTrees
         {
             tag = null;
 
-            if (IsInlineStream(key, out var inlineData, out _))
+            if (IsInlineStream(key, out var inlineData, out _, out _))
             {
                 var header = (InlineStreamHeader*)inlineData;
                 var infoPtr = &header->Info;
@@ -522,15 +522,14 @@ namespace Voron.Data.BTrees
 
         public StreamInfo* GetStreamInfo(Slice key, bool writable)
         {
-            if (IsInlineStream(key, out var inlineData, out _))
+            if (IsInlineStream(key, out var inlineData, out _, out var inlinePage))
             {
                 if (writable)
                 {
-                    var p = FindPageFor(key, out TreeNodeHeader* node);
-                    Debug.Assert(p.LastMatch == 0 && node != null);
-                    _llt.ModifyPage(p.PageNumber);
-                    // re-find after modification since page pointer may have changed
-                    p = FindPageFor(key, out node);
+                    // The page from IsInlineStream may be read-only, so call ModifyPage to get
+                    // a writable copy (preserving search position).
+                    var p = ModifyPage(inlinePage);
+                    var node = p.GetNode(p.LastSearchPosition);
                     inlineData = (byte*)node + node->KeySize + Constants.Tree.NodeHeaderSize;
                 }
 
@@ -587,7 +586,7 @@ namespace Voron.Data.BTrees
         {
             int version = 0;
             long size = 0;
-            if (IsInlineStream(key, out var inlineData, out _))
+            if (IsInlineStream(key, out var inlineData, out _, out _))
             {
                 var header = (InlineStreamHeader*)inlineData;
                 version = header->Info.Version;

--- a/src/Voron/Data/BTrees/Tree.cs
+++ b/src/Voron/Data/BTrees/Tree.cs
@@ -1365,9 +1365,14 @@ namespace Voron.Data.BTrees
                         if (State.Header.RootObjectType == RootObjectType.Table) // tables might have mixed values, fixed size trees inside have dedicated handling
                             continue;
                         
-                        if ((State.Header.Flags & TreeFlags.FixedSizeTrees) == TreeFlags.FixedSizeTrees)
+                        if ((State.Header.Flags & TreeFlags.FixedSizeTrees) == TreeFlags.FixedSizeTrees ||
+                            (State.Header.Flags & TreeFlags.Streams) == TreeFlags.Streams)
                         {
                             var valueReader = GetValueReaderFromHeader(node);
+
+                            // Check if this is an inline stream - no extra pages to collect
+                            if (valueReader.Length >= 1 && ((RootObjectType*)valueReader.Base)[0] == RootObjectType.InlineStream)
+                                continue;
 
                             var valueSize = ((FixedSizeTreeHeader.Embedded*)valueReader.Base)->ValueSize;
 

--- a/src/Voron/Data/RootObjectType.cs
+++ b/src/Voron/Data/RootObjectType.cs
@@ -12,5 +12,6 @@
         Set = 7,
         Container = 8,
         PersistentDictionary = 9,
+        InlineStream = 10,
     }
 }

--- a/src/Voron/Data/UnmanagedVoronStream.cs
+++ b/src/Voron/Data/UnmanagedVoronStream.cs
@@ -57,7 +57,7 @@ namespace Voron.Data
                 throw new ArgumentNullException(nameof(buffer));
             if (offset < 0 || offset > buffer.Length)
                 throw new ArgumentOutOfRangeException(nameof(offset));
-            if (count < 0 || offset + count > buffer.Length)
+            if (count < 0 || count > buffer.Length - offset)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
             var remaining = _length - _position;

--- a/src/Voron/Data/UnmanagedVoronStream.cs
+++ b/src/Voron/Data/UnmanagedVoronStream.cs
@@ -41,7 +41,7 @@ namespace Voron.Data
         public override long Position
         {
             get => _position;
-            set => _position = (int)Math.Min(value, _length);
+            set => _position = (int)Math.Clamp(value, 0, _length);
         }
 
         public override int ReadByte()
@@ -53,6 +53,13 @@ namespace Voron.Data
 
         public override int Read(byte[] buffer, int offset, int count)
         {
+            if (buffer == null)
+                throw new ArgumentNullException(nameof(buffer));
+            if (offset < 0 || offset > buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            if (count < 0 || offset + count > buffer.Length)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
             var remaining = _length - _position;
             if (remaining <= 0)
                 return 0;

--- a/src/Voron/Data/UnmanagedVoronStream.cs
+++ b/src/Voron/Data/UnmanagedVoronStream.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Sparrow;
+using Voron.Impl;
+
+namespace Voron.Data
+{
+    /// <summary>
+    /// A read-only stream over an unmanaged (byte*) buffer.
+    /// Used for inline streams stored directly in tree nodes.
+    /// The pointer must remain valid for the lifetime of this stream (i.e., the current transaction).
+    /// </summary>
+    public sealed unsafe class UnmanagedVoronStream : Stream
+    {
+        private byte* _ptr;
+        private readonly int _length;
+        private int _position;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public sealed override long Length => _length;
+
+        public UnmanagedVoronStream(byte* ptr, int length)
+        {
+            _ptr = ptr;
+            _length = length;
+            _position = 0;
+        }
+
+        /// <summary>
+        /// Updates the pointer to point to a new transaction's page memory.
+        /// The length must remain the same.
+        /// </summary>
+        public void UpdatePtr(byte* ptr)
+        {
+            _ptr = ptr;
+        }
+
+        public override long Position
+        {
+            get => _position;
+            set => _position = (int)Math.Min(value, _length);
+        }
+
+        public override int ReadByte()
+        {
+            if (_position >= _length)
+                return -1;
+            return _ptr[_position++];
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var remaining = _length - _position;
+            if (remaining <= 0)
+                return 0;
+
+            var toRead = Math.Min(count, remaining);
+            fixed (byte* dst = buffer)
+            {
+                Memory.Copy(dst + offset, _ptr + _position, toRead);
+            }
+            _position += toRead;
+            return toRead;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    Position = offset;
+                    break;
+                case SeekOrigin.Current:
+                    Position += offset;
+                    break;
+                case SeekOrigin.End:
+                    Position = _length + offset;
+                    break;
+            }
+            return Position;
+        }
+
+        public override void Flush() => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -16,14 +16,8 @@ namespace Voron.Data
         private readonly bool _encrypted;
         private long _position;
         private int _index;
-        protected LowLevelTransaction Llt;
-        protected Page LastPage;
-
-        // Inline stream support: data stored directly in the tree node.
-        // The pointer is valid for the lifetime of the current transaction.
-        protected byte* InlineDataPtr;
-        private readonly int _inlineDataSize;
-        protected bool IsInline => InlineDataPtr != null;
+        internal LowLevelTransaction Llt;
+        internal Page LastPage;
 
         public override bool CanRead => true;
         public override bool CanSeek => true;
@@ -33,21 +27,6 @@ namespace Voron.Data
         public override string ToString()
         {
             return Name.ToString();
-        }
-
-        /// <summary>
-        /// Creates a VoronStream backed by inline data stored in a tree node.
-        /// The pointer must remain valid for the lifetime of the current transaction.
-        /// Call RefreshInlinePointer when switching transactions.
-        /// </summary>
-        public VoronStream(Slice name, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt)
-        {
-            Name = name;
-            InlineDataPtr = inlineDataPtr;
-            _inlineDataSize = inlineDataSize;
-            Length = inlineDataSize;
-            Llt = llt;
-            _position = 0;
         }
 
         public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
@@ -80,12 +59,6 @@ namespace Voron.Data
             }
             set
             {
-                if (IsInline)
-                {
-                    _position = Math.Min(value, _inlineDataSize);
-                    return;
-                }
-
                 if (value >= Length)
                 {
                     //Out of stream
@@ -123,13 +96,6 @@ namespace Voron.Data
 
         public override int ReadByte()
         {
-            if (IsInline)
-            {
-                if (_position >= _inlineDataSize)
-                    return -1;
-                return InlineDataPtr[_position++];
-            }
-
             var chunk = _chunksDetails[_index];
 
             if (_position - _chunksOffsets[_index] == chunk.ChunkSize)
@@ -153,21 +119,6 @@ namespace Voron.Data
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            if (IsInline)
-            {
-                var remaining = _inlineDataSize - (int)_position;
-                if (remaining <= 0)
-                    return 0;
-
-                var toRead = Math.Min(count, remaining);
-                fixed (byte* dst = buffer)
-                {
-                    Memory.Copy(dst + offset, InlineDataPtr + _position, toRead);
-                }
-                _position += toRead;
-                return toRead;
-            }
-
             var len = _chunksDetails[_index].ChunkSize;
 
             if (_position == _chunksOffsets[_index] + len)
@@ -262,6 +213,12 @@ namespace Voron.Data
         private static void ThrowWhenValueIsEqualOrLessZero(long position)
         {
             throw new ArgumentException($"Position {position} is not possible inside {nameof(VoronStream)}.");
+        }
+
+        internal void Reset()
+        {
+            Llt = null;
+            LastPage = default(Page);
         }
     }
 }

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -19,6 +19,12 @@ namespace Voron.Data
         protected LowLevelTransaction Llt;
         protected Page LastPage;
 
+        // Inline stream support: data stored directly in the tree node.
+        // The pointer is valid for the lifetime of the current transaction.
+        protected byte* InlineDataPtr;
+        private readonly int _inlineDataSize;
+        protected bool IsInline => InlineDataPtr != null;
+
         public override bool CanRead => true;
         public override bool CanSeek => true;
         public override bool CanWrite => false;
@@ -27,6 +33,21 @@ namespace Voron.Data
         public override string ToString()
         {
             return Name.ToString();
+        }
+
+        /// <summary>
+        /// Creates a VoronStream backed by inline data stored in a tree node.
+        /// The pointer must remain valid for the lifetime of the current transaction.
+        /// Call RefreshInlinePointer when switching transactions.
+        /// </summary>
+        public VoronStream(Slice name, byte* inlineDataPtr, int inlineDataSize, LowLevelTransaction llt)
+        {
+            Name = name;
+            InlineDataPtr = inlineDataPtr;
+            _inlineDataSize = inlineDataSize;
+            Length = inlineDataSize;
+            Llt = llt;
+            _position = 0;
         }
 
         public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
@@ -59,6 +80,12 @@ namespace Voron.Data
             }
             set
             {
+                if (IsInline)
+                {
+                    _position = Math.Min(value, _inlineDataSize);
+                    return;
+                }
+
                 if (value >= Length)
                 {
                     //Out of stream
@@ -96,6 +123,13 @@ namespace Voron.Data
 
         public override int ReadByte()
         {
+            if (IsInline)
+            {
+                if (_position >= _inlineDataSize)
+                    return -1;
+                return InlineDataPtr[_position++];
+            }
+
             var chunk = _chunksDetails[_index];
 
             if (_position - _chunksOffsets[_index] == chunk.ChunkSize)
@@ -119,6 +153,21 @@ namespace Voron.Data
 
         public override int Read(byte[] buffer, int offset, int count)
         {
+            if (IsInline)
+            {
+                var remaining = _inlineDataSize - (int)_position;
+                if (remaining <= 0)
+                    return 0;
+
+                var toRead = Math.Min(count, remaining);
+                fixed (byte* dst = buffer)
+                {
+                    Memory.Copy(dst + offset, InlineDataPtr + _position, toRead);
+                }
+                _position += toRead;
+                return toRead;
+            }
+
             var len = _chunksDetails[_index].ChunkSize;
 
             if (_position == _chunksOffsets[_index] + len)

--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -9,8 +9,6 @@ namespace Voron.Data
 {
     public unsafe class VoronStream : Stream
     {
-        public Slice Name { get; }
-
         private readonly Tree.ChunkDetails[] _chunksDetails;
         private readonly long[] _chunksOffsets;
         private readonly bool _encrypted;
@@ -24,14 +22,8 @@ namespace Voron.Data
         public override bool CanWrite => false;
         public sealed override long Length { get; }
 
-        public override string ToString()
+        public VoronStream(Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
         {
-            return Name.ToString();
-        }
-
-        public VoronStream(Slice name, Tree.ChunkDetails[] chunksDetails, LowLevelTransaction llt)
-        {
-            Name = name;
             _chunksDetails = chunksDetails;
             _chunksOffsets = new long[_chunksDetails.Length];
 

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -580,7 +580,7 @@ namespace Voron.Debugging
             {
                 multiValues = CreateMultiValuesReport(tree);
             }
-            else if (state.Flags == (TreeFlags.FixedSizeTrees | TreeFlags.Streams))
+            else if ((state.Flags & TreeFlags.Streams) == TreeFlags.Streams)
             {
                 streams = CreateStreamsReport(tree, includeDetails);
             }
@@ -653,12 +653,26 @@ namespace Voron.Debugging
                     if (info.HasValue == false)
                         continue;
 
-                    long numberOfAllocatedPages = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(info.Value.TotalSize + info.Value.TagSize + Tree.StreamInfo.SizeOf);
+                    long numberOfAllocatedPages;
+                    TreeReport chunksTreeReport;
 
-                    var chunksTree = tree.GetStreamChunksTree(it.CurrentKey);
+                    if (tree.IsInlineStream(it.CurrentKey, out _, out _))
+                    {
+                        // Inline stream — data is stored in the tree node, no overflow pages or FST
+                        numberOfAllocatedPages = 0;
+                        chunksTreeReport = new TreeReport();
+                    }
+                    else
+                    {
+                        numberOfAllocatedPages = VirtualPagerLegacyExtensions.GetNumberOfOverflowPages(info.Value.TotalSize + info.Value.TagSize + Tree.StreamInfo.SizeOf);
 
-                    if (chunksTree.Type == RootObjectType.FixedSizeTree) // only if large fst, embedded already counted in parent
-                        numberOfAllocatedPages += chunksTree.PageCount;
+                        var chunksTree = tree.GetStreamChunksTree(it.CurrentKey);
+
+                        if (chunksTree.Type == RootObjectType.FixedSizeTree) // only if large fst, embedded already counted in parent
+                            numberOfAllocatedPages += chunksTree.PageCount;
+
+                        chunksTreeReport = GetReport(chunksTree, false);
+                    }
 
                     var name = tag ?? it.CurrentKey.ToString();
 
@@ -669,7 +683,7 @@ namespace Voron.Debugging
                         Version = info.Value.Version,
                         NumberOfAllocatedPages = numberOfAllocatedPages,
                         AllocatedSpaceInBytes = PagesToBytes(numberOfAllocatedPages),
-                        ChunksTree = GetReport(chunksTree, false),
+                        ChunksTree = chunksTreeReport,
                     });
 
                     totalNumberOfAllocatedPages += numberOfAllocatedPages;

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -656,7 +656,7 @@ namespace Voron.Debugging
                     long numberOfAllocatedPages;
                     TreeReport chunksTreeReport;
 
-                    if (tree.IsInlineStream(it.CurrentKey, out _, out _))
+                    if (tree.IsInlineStream(it.CurrentKey, out _, out _, out _))
                     {
                         // Inline stream — data is stored in the tree node, no overflow pages or FST
                         numberOfAllocatedPages = 0;

--- a/src/Voron/Impl/Compaction/StorageCompaction.cs
+++ b/src/Voron/Impl/Compaction/StorageCompaction.cs
@@ -331,7 +331,7 @@ namespace Voron.Impl.Compaction
                                     transactionSize += value.Length;
                                 }
                             }
-                            else if (existingTree.State.Header.Flags == (TreeFlags.FixedSizeTrees | TreeFlags.Streams))
+                            else if ((existingTree.State.Header.Flags & TreeFlags.Streams) == TreeFlags.Streams)
                             {
                                 var tag = existingTree.GetStreamTag(key);
 

--- a/src/Voron/Schema/Updates/From23.cs
+++ b/src/Voron/Schema/Updates/From23.cs
@@ -9,10 +9,10 @@ namespace Voron.Schema.Updates
             // Version 24 adds support for inline streams in trees.
             // Small streams (attachments) that fit within a tree node's max value size
             // are stored inline instead of using separate overflow pages + FixedSizeTree.
-            // This is a forward-compatible change: existing data remains valid,
-            // new inline streams use RootObjectType.InlineStream to distinguish them
-            // from the FixedSizeTree-based storage.
-            // No data migration is needed - existing streams continue to work as before.
+            // Backward-compatible with existing v23 data: existing chunked streams continue to work as before.
+            // One-way upgrade: once v24 inline streams are written, older binaries cannot read them.
+            // New inline streams use RootObjectType.InlineStream to distinguish them from FixedSizeTree-based storage.
+            // No data migration is needed - existing streams continue to work unchanged on upgrade.
 
             versionAfterUpgrade = 24;
 

--- a/src/Voron/Schema/Updates/From23.cs
+++ b/src/Voron/Schema/Updates/From23.cs
@@ -1,0 +1,22 @@
+using Voron.Impl.FileHeaders;
+
+namespace Voron.Schema.Updates
+{
+    public sealed class From23 : IVoronSchemaUpdate
+    {
+        public bool Update(int currentVersion, StorageEnvironmentOptions options, HeaderAccessor headerAccessor, out int versionAfterUpgrade)
+        {
+            // Version 24 adds support for inline streams in trees.
+            // Small streams (attachments) that fit within a tree node's max value size
+            // are stored inline instead of using separate overflow pages + FixedSizeTree.
+            // This is a forward-compatible change: existing data remains valid,
+            // new inline streams use RootObjectType.InlineStream to distinguish them
+            // from the FixedSizeTree-based storage.
+            // No data migration is needed - existing streams continue to work as before.
+
+            versionAfterUpgrade = 24;
+
+            return true;
+        }
+    }
+}

--- a/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
+++ b/test/FastTests/Client/Indexing/TimeSeries/BasicTimeSeriesIndexes.cs
@@ -568,8 +568,6 @@ namespace FastTests.Client.Indexing.TimeSeries
 
                 terms = store.Maintenance.Send(new GetTermsOperation(indexName, "HeartBeat", null));
                 Assert.Equal(0, terms.Length);
-
-                WaitForUserToContinueTheTest(store);
             }
         }
 

--- a/test/SlowTests.Issues/Issues/RavenDB_26285.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26285.cs
@@ -2,6 +2,9 @@ using System;
 using System.IO;
 using System.Linq;
 using FastTests.Voron;
+using Raven.Server.Indexing;
+using Sparrow;
+using Sparrow.Platform;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Voron;
@@ -283,6 +286,321 @@ namespace SlowTests.Issues
                 Assert.NotNull(large);
                 Assert.Equal(0, small.NumberOfAllocatedPages);
                 Assert.True(large.NumberOfAllocatedPages > 0);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void UnmanagedVoronStream_PositionClamping()
+        {
+            // Test that UnmanagedVoronStream safely clamps Position to valid range [0, Length]
+            // when callers set it beyond bounds. This is used internally for inline stream reading.
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                var data = new byte[256];
+                new Random(42).NextBytes(data);
+                tree.AddStream("stream/1", new MemoryStream(data));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using var stream = tree.ReadStream("stream/1");
+
+                // Reading to end should work
+                var buffer = new byte[256];
+                var read = stream.Read(buffer, 0, 256);
+                Assert.Equal(256, read);
+
+                // Setting position beyond length should clamp to length
+                stream.Position = 500;
+                Assert.Equal(256, stream.Position);
+
+                // Setting negative position should clamp to 0
+                stream.Position = -10;
+                Assert.Equal(0, stream.Position);
+
+                // Seeking should work correctly
+                stream.Seek(100, SeekOrigin.Begin);
+                Assert.Equal(100, stream.Position);
+
+                stream.Seek(-50, SeekOrigin.Current);
+                Assert.Equal(50, stream.Position);
+
+                stream.Seek(-100, SeekOrigin.End);
+                Assert.Equal(156, stream.Position);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void InlineStream_CrossTransactionAccess()
+        {
+            // Tests cross-transaction access to inline streams, which exercises
+            // the path that LuceneVoronStream.UpdateCurrentTransaction uses when
+            // refreshing stream access across transaction boundaries.
+            // This is the scenario where Lucene/Corax maintains per-thread readers
+            // that cache stream pointers and need to refresh them on new transactions.
+
+            var data = new byte[1024];
+            new Random(99).NextBytes(data);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(data));
+                tx.Commit();
+            }
+
+            // First transaction: read and cache position
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using var stream = tree.ReadStream("stream/1");
+                stream.Position = 100;
+                Assert.Equal(100, stream.Position);
+
+                var buffer = new byte[100];
+                var read = stream.Read(buffer, 0, 100);
+                Assert.Equal(100, read);
+            }
+
+            // Second transaction: read again from scratch
+            // This simulates Lucene needing to refresh its stream accessor
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using var stream = tree.ReadStream("stream/1");
+
+                // Position should start fresh
+                Assert.Equal(0, stream.Position);
+
+                // But we should still be able to read the same data
+                var buffer = new byte[1024];
+                var read = stream.Read(buffer, 0, 1024);
+                Assert.Equal(1024, read);
+                Assert.Equal(data, buffer);
+            }
+
+            // Third transaction: seek and read
+            // Further exercise the cross-transaction robustness
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using var stream = tree.ReadStream("stream/1");
+
+                stream.Seek(500, SeekOrigin.Begin);
+                Assert.Equal(500, stream.Position);
+
+                var buffer = new byte[24];
+                var read = stream.Read(buffer, 0, 24);
+                Assert.Equal(24, read);
+                Assert.Equal(data.Skip(500).Take(24).ToArray(), buffer);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void StreamSizeTransition_SimulatesV24Upgrade()
+        {
+            // This test simulates the v23→v24 upgrade scenario where a stream claims to be
+            // large (chunked storage), but after reading, we discover it's actually small.
+            // This can happen with v23 data that claimed to be large but isn't.
+            //
+            // Strategy:
+            // 1. Create actual large data and store it chunked
+            // 2. Read it back partially and re-add as a tiny stream
+            // 3. Verify it's now inline after re-adding
+            // 4. Verify data is still readable
+
+            const int largeSize = 8192;  // Larger than inline limit
+            const int tinySize = 128;    // Fits inline
+
+            var largeData = new byte[largeSize];
+            new Random(99).NextBytes(largeData);
+            var tinyData = largeData.Take(tinySize).ToArray();
+
+            // Step 1: Store large stream as chunked
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/transition", new MemoryStream(largeData));
+                tx.Commit();
+            }
+
+            // Step 2: Verify it was stored as chunked (because it's > inline limit)
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                Assert.False(tree.IsInlineStream("stream/transition", out _, out _, out _),
+                    "Stream should be chunked (it's 8KB > inline limit)");
+            }
+
+            // Step 3: Simulate v23→v24 upgrade: read small portion and re-add as tiny stream
+            // (In real compaction, only the used data would be copied, making it small)
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+
+                // Delete large chunked stream
+                tree.Delete("stream/transition");
+
+                // Re-add with only the small portion (simulating compaction)
+                tree.AddStream("stream/transition", new MemoryStream(tinyData));
+                tx.Commit();
+            }
+
+            // Step 4: Verify stream is now inline (actual size is 128 bytes)
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                Assert.True(tree.IsInlineStream("stream/transition", out _, out _, out _),
+                    "After re-add with small data, stream should be inline");
+
+                // Verify data is correct
+                using var stream = tree.ReadStream("stream/transition");
+                var buffer = new byte[tinySize];
+                var bytesRead = stream.Read(buffer, 0, tinySize);
+                Assert.Equal(tinySize, bytesRead);
+                Assert.Equal(tinyData, buffer);
+            }
+        }
+    }
+
+    public unsafe class RavenDB_26285_Encrypted : StorageTest
+    {
+        public RavenDB_26285_Encrypted(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            options.Encryption.MasterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+        }
+
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
+        public void InlineStreamsWithEncryption()
+        {
+            // Tests inline stream storage with encryption enabled.
+            // Inline stream data is stored directly in encrypted tree node pages.
+            // This verifies that reads correctly decrypt and return the inline data.
+
+            var smallData = new byte[256];
+            new Random(42).NextBytes(smallData);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("EncryptedStreams");
+                tree.AddStream("stream/1", new MemoryStream(smallData));
+                tx.Commit();
+            }
+
+            // Verify inline stream can be read back correctly with encryption
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("EncryptedStreams");
+                using var stream = tree.ReadStream("stream/1");
+                Assert.NotNull(stream);
+                Assert.Equal(smallData.Length, stream.Length);
+
+                var readBack = new byte[smallData.Length];
+                var bytesRead = stream.Read(readBack, 0, readBack.Length);
+                Assert.Equal(smallData.Length, bytesRead);
+                Assert.Equal(smallData, readBack);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void InlineStreams_LongKeysStillGetInlined()
+        {
+            // Tests that maxInlineSize calculation doesn't incorrectly subtract key.Size.
+            // Streams with longer keys should still be inlined if the value fits.
+            // This verifies the fix for the size calculation bug.
+
+            var smallData = new byte[512];
+            new Random(55).NextBytes(smallData);
+
+            // Use a very long key to test that it doesn't prevent inlining
+            var longKey = "stream/" + new string('x', 500);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream(longKey, new MemoryStream(smallData));
+                tx.Commit();
+            }
+
+            // Verify the stream was inlined despite the long key
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                Assert.True(tree.IsInlineStream(longKey, out _, out _, out _),
+                    "Small stream should be inlined even with long key");
+
+                using var stream = tree.ReadStream(longKey);
+                Assert.NotNull(stream);
+                Assert.Equal(smallData.Length, stream.Length);
+
+                var readBack = new byte[smallData.Length];
+                var bytesRead = stream.Read(readBack, 0, readBack.Length);
+                Assert.Equal(smallData.Length, bytesRead);
+                Assert.Equal(smallData, readBack);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public unsafe void InlineStreams_CrossTransactionAccessAfterRebind()
+        {
+            // Tests the cross-transaction refresh path for inline streams.
+            // This exercises the scenario that LuceneVoronStream.UpdateCurrentTransaction handles:
+            // a single stream instance is created in one transaction, then after that transaction
+            // closes, the same instance is rebound to a different transaction and read again.
+            // This simulates Lucene's per-thread reader cache being reused across transactions.
+
+            var tinyData = new byte[128];
+            new Random(77).NextBytes(tinyData);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Files");
+                tree.AddStream("tiny_file", new MemoryStream(tinyData));
+                tx.Commit();
+            }
+
+            // Create and partially read inline stream in Transaction 1
+            LuceneVoronStream cachedStream = null;
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Files");
+                byte* inlinePtr = null;
+                int inlineSize = 0;
+
+                // Get inline stream details
+                if (tree.IsInlineStream("tiny_file", out inlinePtr, out inlineSize, out _))
+                {
+                    // Create LuceneVoronStream instance (simulating Lucene's reader cache)
+                    cachedStream = new LuceneVoronStream("tiny_file", "Files", inlinePtr, inlineSize, tx.LowLevelTransaction);
+
+                    // Read partway through stream
+                    byte[] readData = new byte[64];
+                    var bytesRead = cachedStream.Read(readData, 0, 64);
+                    Assert.Equal(64, bytesRead);
+                }
+            }
+
+            // Reuse the cached stream instance in Transaction 2
+            Assert.NotNull(cachedStream);
+            using (var tx = Env.ReadTransaction())
+            {
+                // Rebind the cached stream to the new transaction
+                cachedStream.UpdateCurrentTransaction(tx);
+
+                // Read entire stream from fresh position to verify refresh worked
+                var fullData = new byte[128];
+                cachedStream.Position = 0;  // Reset position
+                var bytesRead = cachedStream.Read(fullData, 0, 128);
+                Assert.Equal(128, bytesRead);
+                Assert.Equal(tinyData, fullData);
             }
         }
     }

--- a/test/SlowTests.Issues/Issues/RavenDB_26285.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26285.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26285 : StorageTest
+    {
+        public RavenDB_26285(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void SmallStreams_ShouldBeStoredInline_WithoutAllocatingNewPages()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                tx.CreateTree("Streams");
+                tx.Commit();
+            }
+
+            var pagesBefore = Env.NextPageNumber;
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                var data = new byte[128];
+
+                for (int i = 0; i < 10; i++)
+                {
+                    tree.AddStream($"stream/{i}", new MemoryStream(data));
+                }
+
+                tx.Commit();
+            }
+
+            var pagesAfter = Env.NextPageNumber;
+
+            Assert.Equal(pagesBefore, pagesAfter);
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_26285.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26285.cs
@@ -1,11 +1,15 @@
+using System;
 using System.IO;
+using System.Linq;
 using FastTests.Voron;
+using Sparrow.Server;
 using Tests.Infrastructure;
+using Voron;
 using Xunit;
 
 namespace SlowTests.Issues
 {
-    public class RavenDB_26285 : StorageTest
+    public unsafe class RavenDB_26285 : StorageTest
     {
         public RavenDB_26285(ITestOutputHelper output) : base(output)
         {
@@ -38,6 +42,248 @@ namespace SlowTests.Issues
             var pagesAfter = Env.NextPageNumber;
 
             Assert.Equal(pagesBefore, pagesAfter);
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanDeleteInlineStream()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(new byte[128]));
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using (Slice.From(tx.Allocator, "stream/1", out Slice key))
+                {
+                    Assert.True(tree.StreamExist(key));
+                    tree.DeleteStream(key);
+                    Assert.False(tree.StreamExist(key));
+                }
+                tx.Commit();
+            }
+
+            // Verify it stays deleted after commit
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                Assert.Null(tree.ReadStream("stream/1"));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanUpdateInlineStream()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(new byte[64]));
+                tx.Commit();
+            }
+
+            // Overwrite with different data
+            var newData = new byte[100];
+            new Random(42).NextBytes(newData);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(newData));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using var stream = tree.ReadStream("stream/1");
+                Assert.NotNull(stream);
+
+                var readBack = new byte[100];
+                var bytesRead = stream.Read(readBack, 0, readBack.Length);
+                Assert.Equal(newData.Length, bytesRead);
+                Assert.Equal(newData, readBack);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Voron)]
+        [InlineData(1)]
+        [InlineData(16)]
+        [InlineData(64)]
+        [InlineData(128)]
+        [InlineData(256)]
+        [InlineData(512)]
+        [InlineData(1024)]
+        [InlineData(2048)]
+        public void InlineStream_VariousSizes(int size)
+        {
+            var data = new byte[size];
+            new Random(size).NextBytes(data);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(data));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+
+                using var stream = tree.ReadStream("stream/1");
+                Assert.NotNull(stream);
+                Assert.Equal(size, stream.Length);
+
+                var readBack = new byte[size];
+                var totalRead = 0;
+                while (totalRead < size)
+                {
+                    var read = stream.Read(readBack, totalRead, size - totalRead);
+                    if (read == 0)
+                        break;
+                    totalRead += read;
+                }
+
+                Assert.Equal(size, totalRead);
+                Assert.Equal(data, readBack);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void TouchStream_WorksForInlineStreams()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(new byte[128]));
+                tx.Commit();
+            }
+
+            int version;
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using (Slice.From(tx.Allocator, "stream/1", out Slice key))
+                    version = tree.TouchStream(key);
+                Assert.True(version > 0);
+                tx.Commit();
+            }
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+                using (Slice.From(tx.Allocator, "stream/1", out Slice key))
+                {
+                    var version2 = tree.TouchStream(key);
+                    Assert.Equal(version + 1, version2);
+                }
+                tx.Commit();
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void StorageReport_IncludesInlineStreams()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/1", new MemoryStream(new byte[64]));
+                tree.AddStream("stream/2", new MemoryStream(new byte[128]));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var report = Env.GenerateDetailedReport(tx, includeDetails: true);
+                var streamsTree = report.Trees.FirstOrDefault(t => t.Name == "Streams");
+                Assert.NotNull(streamsTree);
+                Assert.NotNull(streamsTree.Streams);
+                Assert.Equal(2, streamsTree.Streams.NumberOfStreams);
+                Assert.Equal(2, streamsTree.Streams.Streams.Count);
+
+                // Inline streams should not allocate overflow pages
+                foreach (var stream in streamsTree.Streams.Streams)
+                {
+                    Assert.Equal(0, stream.NumberOfAllocatedPages);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void CanMixInlineAndChunkBasedStreams()
+        {
+            var smallData = new byte[64];
+            var largeData = new byte[64 * 1024]; // 64KB - too large for inline
+            new Random(1).NextBytes(smallData);
+            new Random(2).NextBytes(largeData);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/small", new MemoryStream(smallData));
+                tree.AddStream("stream/large", new MemoryStream(largeData));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Streams");
+
+                using (Slice.From(tx.Allocator, "stream/small", out Slice smallKey))
+                using (Slice.From(tx.Allocator, "stream/large", out Slice largeKey))
+                {
+                    Assert.True(tree.StreamExist(smallKey));
+                    Assert.True(tree.StreamExist(largeKey));
+
+                    // Verify small is inline
+                    Assert.True(tree.IsInlineStream("stream/small", out _, out _, out _));
+                    Assert.False(tree.IsInlineStream("stream/large", out _, out _, out _));
+                }
+
+                // Verify data integrity for both
+                using var smallStream = tree.ReadStream("stream/small");
+                var smallReadBack = new byte[64];
+                var read = smallStream.Read(smallReadBack, 0, smallReadBack.Length);
+                Assert.Equal(64, read);
+                Assert.Equal(smallData, smallReadBack);
+
+                using var largeStream = tree.ReadStream("stream/large");
+                using var ms = new MemoryStream();
+                largeStream.CopyTo(ms);
+                Assert.Equal(largeData, ms.ToArray());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void StorageReport_MixedInlineAndChunkStreams()
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Streams");
+                tree.AddStream("stream/small", new MemoryStream(new byte[64]));
+                tree.AddStream("stream/large", new MemoryStream(new byte[64 * 1024]));
+                tx.Commit();
+            }
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var report = Env.GenerateDetailedReport(tx, includeDetails: true);
+                var streamsTree = report.Trees.FirstOrDefault(t => t.Name == "Streams");
+                Assert.NotNull(streamsTree);
+                Assert.NotNull(streamsTree.Streams);
+                Assert.Equal(2, streamsTree.Streams.NumberOfStreams);
+
+                var small = streamsTree.Streams.Streams.FirstOrDefault(s => s.Length == 64);
+                var large = streamsTree.Streams.Streams.FirstOrDefault(s => s.Length == 64 * 1024);
+
+                Assert.NotNull(small);
+                Assert.NotNull(large);
+                Assert.Equal(0, small.NumberOfAllocatedPages);
+                Assert.True(large.NumberOfAllocatedPages > 0);
+            }
         }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB_26285.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26285.cs
@@ -8,6 +8,8 @@ using Sparrow.Platform;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Voron;
+using Voron.Data.BTrees;
+using Voron.Impl;
 using Xunit;
 
 namespace SlowTests.Issues
@@ -403,15 +405,10 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Voron)]
         public void StreamSizeTransition_SimulatesV24Upgrade()
         {
-            // This test simulates the v23→v24 upgrade scenario where a stream claims to be
-            // large (chunked storage), but after reading, we discover it's actually small.
-            // This can happen with v23 data that claimed to be large but isn't.
-            //
-            // Strategy:
-            // 1. Create actual large data and store it chunked
-            // 2. Read it back partially and re-add as a tiny stream
-            // 3. Verify it's now inline after re-adding
-            // 4. Verify data is still readable
+            // This test simulates the v23→v24 upgrade scenario where a large chunked stream
+            // becomes small enough to inline during compaction.
+            // In reality: large data was stored chunked in v23, but after compaction only
+            // the used portion remains (small), so it can be stored inline in v24.
 
             const int largeSize = 8192;  // Larger than inline limit
             const int tinySize = 128;    // Fits inline
@@ -428,41 +425,101 @@ namespace SlowTests.Issues
                 tx.Commit();
             }
 
-            // Step 2: Verify it was stored as chunked (because it's > inline limit)
+            // Step 2: Verify it was stored as chunked
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("Streams");
                 Assert.False(tree.IsInlineStream("stream/transition", out _, out _, out _),
-                    "Stream should be chunked (it's 8KB > inline limit)");
+                    "Stream should be chunked (8KB > inline limit)");
             }
 
-            // Step 3: Simulate v23→v24 upgrade: read small portion and re-add as tiny stream
-            // (In real compaction, only the used data would be copied, making it small)
+            // Step 3: Simulate compaction: delete large and re-add with only used portion
             using (var tx = Env.WriteTransaction())
             {
                 var tree = tx.ReadTree("Streams");
-
-                // Delete large chunked stream
                 tree.Delete("stream/transition");
-
-                // Re-add with only the small portion (simulating compaction)
                 tree.AddStream("stream/transition", new MemoryStream(tinyData));
                 tx.Commit();
             }
 
-            // Step 4: Verify stream is now inline (actual size is 128 bytes)
+            // Step 4: Verify stream is now inline
             using (var tx = Env.ReadTransaction())
             {
                 var tree = tx.ReadTree("Streams");
                 Assert.True(tree.IsInlineStream("stream/transition", out _, out _, out _),
-                    "After re-add with small data, stream should be inline");
+                    "After compaction with small data, stream should be inline");
 
-                // Verify data is correct
                 using var stream = tree.ReadStream("stream/transition");
                 var buffer = new byte[tinySize];
                 var bytesRead = stream.Read(buffer, 0, tinySize);
                 Assert.Equal(tinySize, bytesRead);
                 Assert.Equal(tinyData, buffer);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public unsafe void InlineStreams_CrossTransactionAccessAfterRebind()
+        {
+            // Tests the cross-transaction refresh path for inline streams.
+            // Single LuceneVoronStream instance persists across transaction boundaries:
+            // - TX1: create instance and read
+            // - Close TX1 (cleanup handler runs: nulls _llt, calls UpdatePtr(null))
+            // - TX2: call UpdateCurrentTransaction to rebind to new transaction
+            // - TX2: read from same instance
+            // This simulates Lucene's per-thread reader cache outliving individual transactions.
+
+            var tinyData = new byte[128];
+            new Random(77).NextBytes(tinyData);
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Files");
+                tree.AddStream("tiny_file", new MemoryStream(tinyData));
+                tx.Commit();
+            }
+
+            // TX1: Create a single LuceneVoronStream instance
+            LuceneVoronStream cachedStream = null;
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var tree = tx.ReadTree("Files");
+                byte* inlinePtr = null;
+                int inlineSize = 0;
+
+                if (tree.IsInlineStream("tiny_file", out inlinePtr, out inlineSize, out _))
+                {
+                    // IsInlineStream returns pointer to header. Skip past header and tag to get actual data.
+                    var header = (Tree.InlineStreamHeader*)inlinePtr;
+                    byte* dataPtr = inlinePtr + Tree.InlineStreamHeader.SizeOf + header->Info.TagSize;
+                    int dataSize = inlineSize - Tree.InlineStreamHeader.SizeOf - header->Info.TagSize;
+
+                    // Create the instance (holds reference to TX1's LowLevelTransaction)
+                    cachedStream = new LuceneVoronStream("tiny_file", "Files", dataPtr, dataSize, tx.LowLevelTransaction);
+
+                    // Read partway to verify it works in TX1
+                    byte[] readData = new byte[64];
+                    var bytesRead = cachedStream.Read(readData, 0, 64);
+                    Assert.Equal(64, bytesRead);
+                    Assert.Equal(tinyData.Take(64).ToArray(), readData);
+                }
+            } // TX1 closes here: cleanup handler fires, _inlineStream._ptr = null
+
+            // Verify we have the instance (it survived TX1 close)
+            Assert.NotNull(cachedStream);
+
+            // TX2: Rebind same instance to a new transaction
+            using (var tx = Env.ReadTransaction())
+            {
+                // Rebind the cached stream to TX2
+                cachedStream.UpdateCurrentTransaction(tx);
+
+                // Now read from the same instance in TX2 (pointer was refreshed)
+                var fullData = new byte[128];
+                cachedStream.Position = 0;  // Reset position
+                var bytesRead = cachedStream.Read(fullData, 0, 128);
+                Assert.Equal(128, bytesRead);
+                Assert.Equal(tinyData, fullData);
             }
         }
     }
@@ -545,62 +602,6 @@ namespace SlowTests.Issues
                 var bytesRead = stream.Read(readBack, 0, readBack.Length);
                 Assert.Equal(smallData.Length, bytesRead);
                 Assert.Equal(smallData, readBack);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Voron)]
-        public unsafe void InlineStreams_CrossTransactionAccessAfterRebind()
-        {
-            // Tests the cross-transaction refresh path for inline streams.
-            // This exercises the scenario that LuceneVoronStream.UpdateCurrentTransaction handles:
-            // a single stream instance is created in one transaction, then after that transaction
-            // closes, the same instance is rebound to a different transaction and read again.
-            // This simulates Lucene's per-thread reader cache being reused across transactions.
-
-            var tinyData = new byte[128];
-            new Random(77).NextBytes(tinyData);
-
-            using (var tx = Env.WriteTransaction())
-            {
-                var tree = tx.CreateTree("Files");
-                tree.AddStream("tiny_file", new MemoryStream(tinyData));
-                tx.Commit();
-            }
-
-            // Create and partially read inline stream in Transaction 1
-            LuceneVoronStream cachedStream = null;
-            using (var tx = Env.ReadTransaction())
-            {
-                var tree = tx.ReadTree("Files");
-                byte* inlinePtr = null;
-                int inlineSize = 0;
-
-                // Get inline stream details
-                if (tree.IsInlineStream("tiny_file", out inlinePtr, out inlineSize, out _))
-                {
-                    // Create LuceneVoronStream instance (simulating Lucene's reader cache)
-                    cachedStream = new LuceneVoronStream("tiny_file", "Files", inlinePtr, inlineSize, tx.LowLevelTransaction);
-
-                    // Read partway through stream
-                    byte[] readData = new byte[64];
-                    var bytesRead = cachedStream.Read(readData, 0, 64);
-                    Assert.Equal(64, bytesRead);
-                }
-            }
-
-            // Reuse the cached stream instance in Transaction 2
-            Assert.NotNull(cachedStream);
-            using (var tx = Env.ReadTransaction())
-            {
-                // Rebind the cached stream to the new transaction
-                cachedStream.UpdateCurrentTransaction(tx);
-
-                // Read entire stream from fresh position to verify refresh worked
-                var fullData = new byte[128];
-                cachedStream.Position = 0;  // Reset position
-                var bytesRead = cachedStream.Read(fullData, 0, 128);
-                Assert.Equal(128, bytesRead);
-                Assert.Equal(tinyData, fullData);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26285 

### Additional description

We can now put small attachments (< ~4kb) directly in the attachment tree.
That massively reduces the internal fragmentation we have when using a lot of such attachments.
Vectors / embedding are often at those sizes, so that is quite important.

To apply to an existing database, run compaction.

*NOTE*: changed Voron schema - this will do transparent (cheap) migration. Cannot go back afterward.


### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [x] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

We do automatic migration, but you cannot go back

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
