### PR TITLE
RavenDB-26248 switched to dictionary

### DIFF
--- a/test/Tests.Infrastructure/TestBase.cs
+++ b/test/Tests.Infrastructure/TestBase.cs
@@ -66,7 +66,7 @@ namespace FastTests
 
         private static RavenServer _globalServer;
 
-        private static long TotalAiTokensUsed;
+        private static readonly ConcurrentDictionary<string, long> AiTokensPerDatabase = new(StringComparer.OrdinalIgnoreCase);
 
         protected static bool IsGlobalServer(RavenServer server)
         {
@@ -155,9 +155,7 @@ namespace FastTests
                 if (usage == null)
                     return;
 
-                var value = Interlocked.Add(ref TotalAiTokensUsed, usage.TotalTokens);
-
-                Console.WriteLine($"Total AI tokens used across all tests: {value} (delta: {usage.TotalTokens}, database: {sender})");
+                AiTokensPerDatabase.AddOrUpdate(sender ?? string.Empty, _ => usage.TotalTokens, (_, l) => l + usage.TotalTokens);
             };
 
             LowMemoryNotification.Instance.SupportsCompactionOfLargeObjectHeap = true;
@@ -395,6 +393,27 @@ namespace FastTests
                     catch (Exception e)
                     {
                         Console.WriteLine($"Could not retrieve list of non-deleted databases. Exception: {e}");
+                    }
+
+                    if (AiTokensPerDatabase.IsEmpty == false)
+                    {
+                        var sb = new StringBuilder();
+                        sb.AppendLine("List of AI tokens used per database:");
+                        var totalTokens = 0L;
+                        foreach (var kvp in AiTokensPerDatabase.OrderByDescending(x => x.Value))
+                        {
+                            totalTokens += kvp.Value;
+
+                            sb
+                                .Append("- ")
+                                .Append(kvp.Key)
+                                .Append(": ")
+                                .AppendLine(kvp.Value.ToString());
+                        }
+
+                        sb.AppendLine($"Total tokens: {totalTokens}");
+
+                        Console.WriteLine(sb.ToString());
                     }
 
                     DisposeServer(copyGlobalServer);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26248

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
