### PR TITLE
HRINT-4694 Remove windows 2019 image from multiarch

### DIFF
--- a/docker/common.ps1
+++ b/docker/common.ps1
@@ -132,7 +132,6 @@ function GetImageTagsForManifest {
         "${repo}:6.2-ubuntu-latest",
         "${repo}:6.2-ubuntu-arm32v7-latest",
         "${repo}:6.2-ubuntu-arm64v8-latest",
-        "${repo}:6.2-windows-1809-latest",
         "${repo}:6.2-windows-ltsc2022-latest"
     )
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/HRINT-4694

### Additional description

Windows 2019 is out of support

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
