### PR TITLE
RavenDB-22867 : ETL unable to proceed after Unsupported Incremental Time Seriese Exception

### DIFF
--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -15,7 +15,6 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TimeSeries;
-using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 
@@ -30,6 +29,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
         private RequestExecutor _requestExecutor;
         private string _recentUrl;
+        private bool _incrementalTsAlertRaised;
         public string Url => _recentUrl;
 
         private readonly RavenEtlDocumentTransformer.ScriptInput _script;
@@ -150,26 +150,23 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
             if (ShouldTrackTimeSeries())
             {
-                bool createdNotification = false;
-
                 for (int i = commands.Count - 1; i >= 0; i--)
                 {
                     if (commands[i] is TimeSeriesBatchCommandData tsbc &&
                         TimeSeriesHandlerProcessorForGetTimeSeries.CheckIfIncrementalTs(tsbc.Name))
                     {
-                        if (createdNotification == false)
+                        if (_incrementalTsAlertRaised == false)
                         {
-                            Database.NotificationCenter.Add(
-                                AlertRaised.Create(
-                                    Database.Name,
-                                    "Incremental Time Series Command Ignored",
-                                    $"An incremental time series command for '{tsbc.Name}' was discarded. Incremental time series is not supported in ETL.",
-                                    AlertReason.Etl_Warning,
-                                    NotificationSeverity.Warning
-                                )
-                            );
-                            createdNotification = true;
+                            Database.NotificationCenter.EtlNotifications.AddWarning(
+                                Tag,
+                                Name,
+                                $"Incremental Time Series are not supported and are going to be skipped going forward. First encountered in document '{tsbc.Id}' for time series '{tsbc.Name}'",
+                                tsbc.Id,
+                                tsbc.Name);
+
+                            _incrementalTsAlertRaised = true;
                         }
+
                         commands.RemoveAt(i);
                     }
                 }

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -15,6 +15,7 @@ using Raven.Server.Documents.ETL.Stats;
 using Raven.Server.Documents.Handlers.Processors.TimeSeries;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Raven.Server.Documents.TimeSeries;
+using Raven.Server.NotificationCenter.Notifications;
 using Raven.Server.ServerWide;
 using Raven.Server.ServerWide.Context;
 
@@ -147,20 +148,35 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
             Debug.Assert(commands != null);
 
-            if (commands.Count == 0)
-                return 0;
-
             if (ShouldTrackTimeSeries())
             {
-                foreach (var command in commands)
+                bool createdNotification = false;
+
+                for (int i = commands.Count - 1; i >= 0; i--)
                 {
-                    if (command is TimeSeriesBatchCommandData tsbc)
+                    if (commands[i] is TimeSeriesBatchCommandData tsbc &&
+                        TimeSeriesHandlerProcessorForGetTimeSeries.CheckIfIncrementalTs(tsbc.Name))
                     {
-                        if (TimeSeriesHandlerProcessorForGetTimeSeries.CheckIfIncrementalTs(tsbc.Name))
-                            throw new NotSupportedException($"Load isn't support for incremental time series '{tsbc.Name}' at document '{tsbc.Id}'");
+                        if (createdNotification == false)
+                        {
+                            Database.NotificationCenter.Add(
+                                AlertRaised.Create(
+                                    Database.Name,
+                                    "Incremental Time Series Command Ignored",
+                                    $"An incremental time series command for '{tsbc.Name}' was discarded. Incremental time series is not supported in ETL.",
+                                    AlertReason.Etl_Warning,
+                                    NotificationSeverity.Warning
+                                )
+                            );
+                            createdNotification = true;
+                        }
+                        commands.RemoveAt(i);
                     }
                 }
             }
+
+            if (commands.Count == 0)
+                return 0;
 
             BatchOptions options = null;
             if (Configuration.LoadRequestTimeoutInSec != null)

--- a/src/Raven.Server/NotificationCenter/EtlNotifications.cs
+++ b/src/Raven.Server/NotificationCenter/EtlNotifications.cs
@@ -62,10 +62,26 @@ namespace Raven.Server.NotificationCenter
 
             return alert;
         }
+        public AlertRaised AddWarning(string processTag, string processName, string message, string documentId, string timeSeriesName)
+        {
+            var alert = GetOrCreateAlert<EtlWarningDetails>(
+                processTag,
+                processName,
+                AlertReason.Etl_Warning,
+                message,
+                out var details);
+
+            details.DocumentId = documentId;
+            details.TimeSeriesName = timeSeriesName;
+
+            _notificationCenter.Add(alert);
+            return alert;
+        }
 
         private AlertRaised GetOrCreateAlert<T>(string processTag, string processName, AlertReason etlAlertReason, string message, out T details) where T : INotificationDetails, new()
         {
-            Debug.Assert(etlAlertReason == AlertReason.Etl_LoadError || etlAlertReason == AlertReason.Etl_TransformationError);
+            Debug.Assert(etlAlertReason == AlertReason.Etl_LoadError || etlAlertReason == AlertReason.Etl_TransformationError ||
+                         etlAlertReason == AlertReason.Etl_Warning);
 
             var key = $"{processTag}/{processName}";
 

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/EtlWarningDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/EtlWarningDetails.cs
@@ -1,0 +1,19 @@
+﻿using Sparrow.Json.Parsing;
+
+namespace Raven.Server.NotificationCenter.Notifications.Details
+{
+    public sealed class EtlWarningDetails : INotificationDetails
+    {
+        public string DocumentId { get; set; }
+        public string TimeSeriesName { get; set; }
+
+        public DynamicJsonValue ToJson()
+        {
+            return new DynamicJsonValue
+            {
+                [nameof(DocumentId)] = DocumentId,
+                [nameof(TimeSeriesName)] = TimeSeriesName
+            };
+        }
+    }
+}

--- a/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.ts
+++ b/src/Raven.Studio/typescript/viewmodels/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.ts
@@ -11,23 +11,39 @@ import copyToClipboard = require("common/copyToClipboard");
 import generalUtils = require("common/generalUtils");
 import moment = require("moment");
 
+interface EtlAlertTableItem extends Partial<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo> {
+    TimeSeriesName?: string;
+}
+
 class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
     
     view = require("views/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.html");
 
-    currentDetails = ko.observable<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>();
+    readonly isWarningDetails: boolean;
+
+    currentDetails = ko.observable<EtlAlertTableItem>();
     
-    tableItems: Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo[] = [];
-    private gridController = ko.observable<virtualGridController<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>>();
-    private columnPreview = new columnPreviewPlugin<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>();
+    tableItems: EtlAlertTableItem[] = [];
+    private gridController = ko.observable<virtualGridController<EtlAlertTableItem>>();
+    private columnPreview = new columnPreviewPlugin<EtlAlertTableItem>();
 
     constructor(alert: alert, notificationCenter: notificationCenter) {
         super(alert, notificationCenter);
 
-        this.tableItems = (this.alert.details() as Raven.Server.NotificationCenter.Notifications.Details.EtlErrorsDetails).Errors;
+        this.isWarningDetails = this.alert.alertReason() === "Etl_Warning";
 
-        // newest first
-        this.tableItems.reverse();
+        if (this.isWarningDetails) {
+            const details = this.alert.details() as Raven.Server.NotificationCenter.Notifications.Details.EtlWarningDetails;
+            this.tableItems = [{
+                DocumentId: details.DocumentId,
+                TimeSeriesName: details.TimeSeriesName
+            }];
+        } else {
+            this.tableItems = (this.alert.details() as Raven.Server.NotificationCenter.Notifications.Details.EtlErrorsDetails)
+                .Errors
+                .slice()
+                .reverse();
+        }
     }
 
     compositionComplete() {
@@ -37,21 +53,30 @@ class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
         grid.headerVisible(true);
 
         grid.init(() => this.fetcher(), () => {
+            const documentIdColumn = new textColumn<EtlAlertTableItem>(grid, x => x.DocumentId || ' - ', "Document ID", this.isWarningDetails ? "50%" : "20%", {
+                sortable: x => x.DocumentId,
+                customComparator: generalUtils.sortAlphaNumeric
+            });
+
+            if (this.isWarningDetails) {
+                const timeSeriesNameColumn = new textColumn<EtlAlertTableItem>(grid, x => x.TimeSeriesName || ' - ', "Time Series Name", "50%", {
+                    sortable: x => x.TimeSeriesName,
+                    customComparator: generalUtils.sortAlphaNumeric
+                });
+
+                return [documentIdColumn, timeSeriesNameColumn];
+            }
             
-            const previewColumn = new actionColumn<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>(
+            const previewColumn = new actionColumn<EtlAlertTableItem>(
                 grid, item => this.showDetails(item), "Preview", `<i class="icon-preview"></i>`, "70px",
             {
                 title: () => 'Show item preview'
             });
-            const dateColumn = new textColumn<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>(grid, x => generalUtils.formatUtcDateAsLocal(x.Date), "Date", "20%", {
+            const dateColumn = new textColumn<EtlAlertTableItem>(grid, x => generalUtils.formatUtcDateAsLocal(x.Date), "Date", "20%", {
                 sortable: x => x.Date
             });
-            const errorColumn = new textColumn<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>(grid, x => x.Error, "Error", "50%", {
+            const errorColumn = new textColumn<EtlAlertTableItem>(grid, x => x.Error, "Error", "50%", {
                 sortable: x => x.Error
-            });
-            const documentIdColumn = new textColumn<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>(grid, x => x.DocumentId || ' - ', "Document ID", "20%", {
-                sortable: x => x.DocumentId,
-                customComparator: generalUtils.sortAlphaNumeric
             });
             
             return this.alert.alertReason() === "Etl_LoadError" ?
@@ -60,12 +85,12 @@ class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
             });
 
         this.columnPreview.install(".etlErrorDetails", ".js-etl-error-details-tooltip",
-            (details: Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo,
-             column: textColumn<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>,
+            (details: EtlAlertTableItem,
+             column: textColumn<EtlAlertTableItem>,
              e: JQuery.TriggeredEvent, onValue: (context: any, valueToCopy?: string) => void) => {
                 if (!(column instanceof actionColumn)) {
                     
-                    if (column.header === "Date") {
+                    if (column.header === "Date" && details.Date) {
                         onValue(moment.utc(details.Date), details.Date);       
                     } else {
                         const value = column.getCellValue(details);
@@ -77,16 +102,20 @@ class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
             });
     }
     
-    private showDetails(item: Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo) {
-        this.currentDetails(item);
+    private showDetails(item: EtlAlertTableItem) {
+        if (item.Error) {
+            this.currentDetails(item);
+        }
     }
     
-    copyToClipboard(item: Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo) {
-        copyToClipboard.copy(item.Error, "Error has been copied to clipboard", document.getElementById("js-etl-error-details"));
+    copyToClipboard(item: EtlAlertTableItem) {
+        if (item.Error) {
+            copyToClipboard.copy(item.Error, "Error has been copied to clipboard", document.getElementById("js-etl-error-details"));
+        }
     }
 
-    private fetcher(): JQueryPromise<pagedResult<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>> {
-        return $.Deferred<pagedResult<Raven.Server.NotificationCenter.Notifications.Details.EtlErrorInfo>>()
+    private fetcher(): JQueryPromise<pagedResult<EtlAlertTableItem>> {
+        return $.Deferred<pagedResult<EtlAlertTableItem>>()
             .resolve({
                 items: this.tableItems,
                 totalResultCount: this.tableItems.length
@@ -94,7 +123,10 @@ class etlTransformOrLoadErrorDetails extends abstractAlertDetails {
     }
 
     static supportsDetailsFor(notification: abstractNotification) {
-        return (notification instanceof alert) && (notification.alertReason() == "Etl_LoadError" || notification.alertReason() == "Etl_TransformationError");
+        return (notification instanceof alert) &&
+            (notification.alertReason() == "Etl_LoadError" ||
+                notification.alertReason() == "Etl_TransformationError" ||
+                notification.alertReason() == "Etl_Warning");
     }
 
     static showDetailsFor(alert: alert, center: notificationCenter) {

--- a/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.html
+++ b/src/Raven.Studio/wwwroot/App/views/common/notificationCenter/detailViewer/alerts/etlTransformOrLoadErrorDetails.html
@@ -14,40 +14,42 @@
             <div class="margin-bottom" style="position: relative; height: 300px">
                 <virtual-grid style="height: 300px" class="resizable flex-window" params="controller: gridController"></virtual-grid>
             </div>
-            <div data-bind="with: currentDetails">
-                <div class="flex-horizontal">
-                    <h3>Details:</h3>
-                    <div class="flex-separator"></div>
-                    <div>
-                        <button class="btn btn-default" data-bind="click: $root.copyToClipboard">
-                            <i class="icon-copy"></i>
-                            <span>Copy error to clipboard</span>
-                        </button>
-                    </div>
-                </div>
-                <div class="modal-details">
-                    <div class="details-item">
-                        <div class="row">
-                            <div class="col-sm-3 text-right">
-                                Document ID:
-                            </div>
-                            <div class="col-sm-9 details-value">
-                                <span data-bind="text: DocumentId || ' - '"></span>
-                            </div>
+            <div data-bind="if: !isWarningDetails">
+                <div data-bind="with: currentDetails">
+                    <div class="flex-horizontal">
+                        <h3>Details:</h3>
+                        <div class="flex-separator"></div>
+                        <div>
+                            <button class="btn btn-default" data-bind="click: $root.copyToClipboard">
+                                <i class="icon-copy"></i>
+                                <span>Copy error to clipboard</span>
+                            </button>
                         </div>
                     </div>
-                    <div class="details-item">
-                        <div class="row">
-                            <div class="col-sm-3 text-right">
-                                Date
-                            </div>
-                            <div class="col-sm-9 details-value">
-                                <span data-bind="text: Date"></span>
+                    <div class="modal-details">
+                        <div class="details-item">
+                            <div class="row">
+                                <div class="col-sm-3 text-right">
+                                    Document ID:
+                                </div>
+                                <div class="col-sm-9 details-value">
+                                    <span data-bind="text: DocumentId || ' - '"></span>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="details-item">
-                        <pre style="max-height: 250px;" data-bind="text: Error"></pre>
+                        <div class="details-item">
+                            <div class="row">
+                                <div class="col-sm-3 text-right">
+                                    Date
+                                </div>
+                                <div class="col-sm-9 details-value">
+                                    <span data-bind="text: Date"></span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="details-item">
+                            <pre style="max-height: 250px;" data-bind="text: Error"></pre>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/EtlTimeSeriesTests.cs
@@ -338,38 +338,6 @@ function loadTimeSeriesOfUsersBehavior(doc, ts)
         }
 
         [RavenFact(RavenTestCategory.Etl)]
-        public async Task BlockRavenEtlWithIncrementalTimeSeries()
-        {
-            const string docId = "users/1";
-            const string tsName = Constants.Headers.IncrementalTimeSeriesPrefix + "HeartRate";
-            var baseline = DateTime.UtcNow;
-
-            var (src, dest, _) = Etl.CreateSrcDestAndAddEtl(collections: new[] { "Users" }, script: null);
-
-            using (var session = src.OpenAsyncSession())
-            {
-                await session.StoreAsync(new User(), docId);
-                var tsf = session.IncrementalTimeSeriesFor(docId, tsName);
-                tsf.Increment(baseline, 1);
-
-                await session.SaveChangesAsync();
-            }
-            var connectionStringName = $"{src.Database}@{src.Urls.First()} to {dest.Database}@{dest.Urls.First()}/ETL : {src.Database}@{src.Urls.First()} to {dest.Database}@{dest.Urls.First()}";
-            var database = await Databases.GetDocumentDatabaseInstanceFor(src);
-
-            var alert = await AssertWaitForNotNullAsync(() =>
-            {
-                var alert = database.NotificationCenter.EtlNotifications.GetAlert<EtlErrorsDetails>("Raven ETL", connectionStringName, AlertReason.Etl_LoadError);
-                return Task.FromResult(alert);
-            });
-
-            var details = (EtlErrorsDetails)alert.Details;
-
-            Assert.Contains("Current ETL batch with '2' items was stopped", alert.Message);
-            Assert.Contains("System.NotSupportedException: Load isn't support for incremental time series 'INC:HeartRate' at document 'users/1'", details.Errors.First().Error);
-        }
-
-        [RavenFact(RavenTestCategory.Etl)]
         public async Task RavenEtlWithTimeSeries_WhenStoreDocumentAndTimeSeriesAndLoadToAnotherCollectionToo_ShouldSrcBeAsDest()
         {
             string[] collections = { "Users" };

--- a/test/SlowTests/Server/Documents/ETL/RavenDB-22867.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB-22867.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client;
 using Raven.Client.Documents;
 using Raven.Server.Documents;
 using Raven.Server.NotificationCenter.Notifications;
-using Raven.Server.NotificationCenter.Notifications.Details;
 using Raven.Tests.Core.Utils.Entities;
 using Tests.Infrastructure;
 using Xunit;
@@ -61,11 +59,6 @@ namespace SlowTests.Server.Documents.ETL
                 using var session = dest.OpenAsyncSession();
                 return await session.LoadAsync<User>(goodDocId);
             }, interval: 1000);
-
-            var connectionStringName =
-                $"{src.Database}@{src.Urls.First()} to {dest.Database}@{dest.Urls.First()}/ETL : " +
-                $"{src.Database}@{src.Urls.First()} to {dest.Database}@{dest.Urls.First()}";
-
             var database = await Databases.GetDocumentDatabaseInstanceFor(src);
 
             Assert.True(WaitForValue(() => HasIncrementalTsEtlWarning(database), true));
@@ -82,8 +75,8 @@ namespace SlowTests.Server.Documents.ETL
                         continue;
 
                     if (reason == AlertReason.Etl_Warning.ToString() &&
-                        notification.Json.TryGet("Title", out string title) &&
-                        title == "Incremental Time Series Command Ignored")
+                        notification.Json.TryGet("Message", out string msg) &&
+                        msg == "Incremental Time Series are not supported and are going to be skipped going forward. First encountered in document 'users/1' for time series 'INC:HeartRate'")
                         return true;
                 }
 

--- a/test/SlowTests/Server/Documents/ETL/RavenDB-22867.cs
+++ b/test/SlowTests/Server/Documents/ETL/RavenDB-22867.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client;
+using Raven.Client.Documents;
+using Raven.Server.Documents;
+using Raven.Server.NotificationCenter.Notifications;
+using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Tests.Core.Utils.Entities;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.ETL
+{
+    public class RavenDB_22867 : RavenTestBase
+    {
+        public RavenDB_22867(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task RavenEtlShouldSkipUnsupportedIncrementalTimeSeriesAndContinue()
+        {
+            const string badDocId = "users/1";
+            const string goodDocId = "users/2";
+            const string tsName = Constants.Headers.IncrementalTimeSeriesPrefix + "HeartRate";
+            var baseline = DateTime.UtcNow;
+
+            var (src, dest, _) = Etl.CreateSrcDestAndAddEtl(collections: new[] { "Users" }, script: null);
+            
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "bad" }, badDocId);
+                session.IncrementalTimeSeriesFor(badDocId, tsName).Increment(baseline, 1);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = src.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "good" }, goodDocId);
+                await session.SaveChangesAsync();
+            }
+
+            await Etl.WaitForEtlAsync(src, (n, s) =>
+            {
+                if (s.LoadErrors > 0)
+                    throw new Exception($"Unexpected ETL load errors: {s.LoadErrors}");
+
+                if (s.LastLoadErrorsInCurrentBatch.Errors.Count > 0)
+                    throw new Exception($"Unexpected ETL batch load error details: {s.LastLoadErrorsInCurrentBatch}");
+
+                if (s.WasLatestLoadSuccessful == false)
+                    throw new Exception("Latest ETL load was not successful.");
+
+                return s.LastProcessedEtag > 0;
+            }, TimeSpan.FromSeconds(15));
+
+            await AssertWaitForNotNullAsync(async () =>
+            {
+                using var session = dest.OpenAsyncSession();
+                return await session.LoadAsync<User>(goodDocId);
+            }, interval: 1000);
+
+            var connectionStringName =
+                $"{src.Database}@{src.Urls.First()} to {dest.Database}@{dest.Urls.First()}/ETL : " +
+                $"{src.Database}@{src.Urls.First()} to {dest.Database}@{dest.Urls.First()}";
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(src);
+
+            Assert.True(WaitForValue(() => HasIncrementalTsEtlWarning(database), true));
+        }
+
+
+        private static bool HasIncrementalTsEtlWarning(DocumentDatabase db)
+        {
+            using (db.NotificationCenter.GetStored(out var notifications))
+            {
+                foreach (var notification in notifications)
+                {
+                    if (notification.Json.TryGet("Reason", out string reason) == false)
+                        continue;
+
+                    if (reason == AlertReason.Etl_Warning.ToString() &&
+                        notification.Json.TryGet("Title", out string title) &&
+                        title == "Incremental Time Series Command Ignored")
+                        return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/tools/TypingsGenerator/Program.cs
+++ b/tools/TypingsGenerator/Program.cs
@@ -322,6 +322,7 @@ namespace TypingsGenerator
 
             // alerts
             scripter.AddType(typeof(EtlErrorsDetails));
+            scripter.AddType(typeof(EtlWarningDetails));
             scripter.AddType(typeof(SlowSqlDetails));
             scripter.AddType(typeof(SlowIoDetails));
             scripter.AddType(typeof(ServerLimitsDetails));


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22867/ETL-unable-to-procced-after-Unsupported-Incremental-Time-Series-Exception

### Additional description
Instead of throwing and stopping the ETL we just skip the ITS command and continue with the rest.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
