### PR TITLE
RavenDB-26315 Fixing the test by ensuring the number of duplicates won't exceed the entries count

### DIFF
--- a/test/SlowTests.Issues/Issues/RavenDB_26052.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26052.cs
@@ -57,7 +57,7 @@ public class RavenDB_26052 : StorageTest
                 var random = new Random(seed);
                 
                 entriesCount = random.Next(1, 200);
-                duplicatedValuesCount = random.Next(1, 100);
+                duplicatedValuesCount = random.Next(1, entriesCount + 1);
             }
             
             var create = new List<(Slice, long)>();


### PR DESCRIPTION
…

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26315

### Additional description

For for the test added in https://github.com/ravendb/ravendb/pull/22510

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Test fix

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
