### PR TITLE
RavenDB-25201 : fixing flaky test

### DIFF
--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24407.cs
@@ -138,7 +138,7 @@ public class RavenDB_24407 : RavenTestBase
         
         await store.AI.CreateAgentAsync(agent, OutputSampleObject.Instance);
 
-        chat.SetUserPrompt("Got anything that tastes better?");
+        chat.SetUserPrompt("use the tool I gave you and try to give me a cheaper alternative");
         r = await chat.RunAsync<OutputSampleObject>(CancellationToken.None);
 
         Assert.NotNull(r.Answer);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25201/SlowTests.Server.Documents.AI.AiAgent.RavenDB24407.CanResumeConversationWithSummarizationoptions-DatabaseMode-Single-config

### Additional description

tried to force the tool with more commanding prompt

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
