### PR TITLE
RavenDB-26268 Add prompt_cache_key to AI chat completion requests

### DIFF
--- a/src/Raven.Client/Documents/Operations/AI/OpenAiBaseSettings.cs
+++ b/src/Raven.Client/Documents/Operations/AI/OpenAiBaseSettings.cs
@@ -62,6 +62,14 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings, IAiSettings
     /// </summary>
     public double? Temperature { get; set; } = null;
 
+    /// <summary>
+    /// Enables sending a <c>prompt_cache_key</c> field in chat completion requests,
+    /// allowing providers that support it to cache and reuse prompt prefixes across
+    /// requests with the same key.
+    /// When <c>null</c>, the server applies a provider-specific default
+    /// </summary>
+    public bool? EnablePromptCache { get; set; }
+
     public override void ValidateFields(List<string> errors)
     {
         if (string.IsNullOrWhiteSpace(ApiKey))
@@ -100,6 +108,9 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings, IAiSettings
             (Temperature.HasValue && openAiSettings.Temperature.HasValue && Temperature.Value.AlmostEquals(openAiSettings.Temperature.Value) == false))
             differences |= AiSettingsCompareDifferences.EndpointConfiguration;
 
+        if (EnablePromptCache != openAiSettings.EnablePromptCache)
+            differences |= AiSettingsCompareDifferences.EndpointConfiguration;
+
         return differences;
     }
 
@@ -117,6 +128,9 @@ public abstract class OpenAiBaseSettings : AbstractAiSettings, IAiSettings
 
         if (Temperature.HasValue)
             json[nameof(Temperature)] = Temperature;
+
+        if (EnablePromptCache.HasValue)
+            json[nameof(EnablePromptCache)] = EnablePromptCache.Value;
 
         return json;
     }

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -425,7 +425,8 @@ public class ChatCompletionClient : IDisposable
         List<BlittableJsonReaderObject> tools,
         bool useTools,
         bool streaming,
-        string schema)
+        string schema,
+        string promptCacheKey = null)
      {
 
         if (_settings.Model is null)
@@ -441,9 +442,9 @@ public class ChatCompletionClient : IDisposable
                     return;
                 }
 
-                WriteCompletionRequestPayload(writer, ctx, 
+                WriteCompletionRequestPayload(writer, ctx,
                     messages.Where(IsValidMessage) // IEnumerable of valid messages
-                    , attachments, tools, useTools, streaming, schema);
+                    , attachments, tools, useTools, streaming, schema, promptCacheKey);
             }
         }, ConventionsToUse);
 
@@ -463,7 +464,7 @@ public class ChatCompletionClient : IDisposable
     }
 
     public void WriteCompletionRequestPayload(AsyncBlittableJsonTextWriter writer, JsonOperationContext ctx, IEnumerable<BlittableJsonReaderObject> messages, List<AiAttachment> attachments, List<BlittableJsonReaderObject> tools, bool useTools, bool streaming,
-        string schema)
+        string schema, string promptCacheKey = null)
     {
         writer.WriteStartObject();
 
@@ -518,6 +519,13 @@ public class ChatCompletionClient : IDisposable
             writer.WritePropertyName(Constants.RequestFields.IncludeUsage);
             writer.WriteBool(true);
             writer.WriteEndObject();
+        }
+
+        if (promptCacheKey != null)
+        {
+            writer.WriteComma();
+            writer.WritePropertyName(Constants.RequestFields.PromptCacheKey);
+            writer.WriteString(promptCacheKey);
         }
 
         _settings.HandleCompletionRequestPayload(writer);
@@ -1046,6 +1054,7 @@ public class ChatCompletionClient : IDisposable
             public const string Stream = "stream";
             public const string StreamOptions = "stream_options";
             public const string IncludeUsage = "include_usage";
+            public const string PromptCacheKey = "prompt_cache_key";
         }
 
         public static class AttachmentsRequestFields

--- a/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
+++ b/src/Raven.Server/Documents/AI/ChatCompletionClient.cs
@@ -521,7 +521,7 @@ public class ChatCompletionClient : IDisposable
             writer.WriteEndObject();
         }
 
-        if (promptCacheKey != null)
+        if (promptCacheKey != null && _settings.EnablePromptCaching)
         {
             writer.WriteComma();
             writer.WritePropertyName(Constants.RequestFields.PromptCacheKey);

--- a/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractChatCompletionClientSettings.cs
@@ -19,6 +19,8 @@ internal abstract class AbstractChatCompletionClientSettings
 
     public virtual bool SupportStrictTools => true;
 
+    public virtual bool EnablePromptCaching => true;
+
     public Uri GetBaseEndpointUri() => _settings.GetBaseEndpointUri();
 
     protected AbstractChatCompletionClientSettings(IAiSettings settings)

--- a/src/Raven.Server/Documents/AI/Settings/AbstractOpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AbstractOpenAiChatCompletionClientSettings.cs
@@ -5,9 +5,11 @@ namespace Raven.Server.Documents.AI.Settings;
 
 internal abstract class AbstractOpenAiChatCompletionClientSettings : AbstractChatCompletionClientSettings
 {
-    private readonly OpenAiBaseSettings _settings;
+    protected readonly OpenAiBaseSettings _settings;
 
-    protected AbstractOpenAiChatCompletionClientSettings(OpenAiBaseSettings settings) 
+    public override bool EnablePromptCaching => _settings.EnablePromptCache ?? true;
+
+    protected AbstractOpenAiChatCompletionClientSettings(OpenAiBaseSettings settings)
         : base(settings)
     {
         _settings = settings;

--- a/src/Raven.Server/Documents/AI/Settings/GoogleChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/GoogleChatCompletionClientSettings.cs
@@ -16,6 +16,7 @@ internal class GoogleChatCompletionClientSettings : AbstractOpenAiChatCompletion
 {
     private readonly string _aiVersion;
     public override bool SupportStrictTools => false;  // Google AI does not support strict tools, so we set this to false by default.
+    public override bool EnablePromptCaching => _settings.EnablePromptCache ?? false; // Google AI returns errors if we send this
 
     public GoogleChatCompletionClientSettings(GoogleSettings settings) : base(settings)
     {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/Talker.cs
@@ -32,7 +32,7 @@ internal class Talker(ConversationHandler handler, JsonOperationContext context,
     public HttpRequestMessage CreateCompletionRequest(List<AiAttachment> attachments)
     {
         AiUsage = new();
-        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: document.RemainingToolIterations-- > 0, streaming != null, _schema);
+        return Client.CreateCompletionRequest(context, document.Messages, attachments, _tools, useTools: document.RemainingToolIterations-- > 0, streaming != null, _schema, promptCacheKey: document.Id);
     }
 
     public async Task<AiResponse> RunAsync(IMemoryContextPool contextPool, HttpRequestMessage request, CancellationToken token)

--- a/src/Raven.Server/package-lock.json
+++ b/src/Raven.Server/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Raven.Server",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/Raven.Server/package-lock.json
+++ b/src/Raven.Server/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Raven.Server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
@@ -140,6 +140,7 @@ export interface AiConnection extends ConnectionBase {
         deploymentName?: string;
         dimensions?: number;
         embeddingsMaxConcurrentBatches?: number;
+        enablePromptCache?: boolean;
         isSetTemperature?: boolean;
         temperature?: number;
     };
@@ -150,6 +151,7 @@ export interface AiConnection extends ConnectionBase {
         dimensions?: number;
         endpoint?: string;
         embeddingsMaxConcurrentBatches?: number;
+        enablePromptCache?: boolean;
     };
     huggingFaceSettings?: {
         apiKey?: string;
@@ -176,6 +178,7 @@ export interface AiConnection extends ConnectionBase {
         projectId?: string;
         dimensions?: number;
         embeddingsMaxConcurrentBatches?: number;
+        enablePromptCache?: boolean;
         isSetTemperature?: boolean;
         temperature?: number;
     };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils.ts
@@ -156,6 +156,7 @@ const schema = yupObjectSchema<FormData>({
             }),
         dimensions: getDimensionsSchema("azureOpenAiSettings"),
         embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("azureOpenAiSettings"),
+        enablePromptCache: yup.boolean().nullable(),
         isSetTemperature: yup.boolean().nullable(),
         temperature: getTemperatureSchema("azureOpenAiSettings"),
     }),
@@ -178,6 +179,7 @@ const schema = yupObjectSchema<FormData>({
             }),
         dimensions: getDimensionsSchema("googleSettings"),
         embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("googleSettings"),
+        enablePromptCache: yup.boolean().nullable(),
     }),
     huggingFaceSettings: yupObjectSchema<FormData["huggingFaceSettings"]>({
         apiKey: yup
@@ -240,6 +242,7 @@ const schema = yupObjectSchema<FormData>({
         projectId: yup.string().nullable(),
         dimensions: getDimensionsSchema("openAiSettings"),
         embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("openAiSettings"),
+        enablePromptCache: yup.boolean().nullable(),
         isSetTemperature: yup.boolean().nullable(),
         temperature: getTemperatureSchema("openAiSettings"),
     }),
@@ -308,6 +311,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 deploymentName: null,
                 dimensions: null,
                 embeddingsMaxConcurrentBatches: null,
+                enablePromptCache: null,
                 isSetTemperature: false,
                 temperature: null,
             } satisfies Required<FormData["azureOpenAiSettings"]>,
@@ -318,6 +322,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 dimensions: null,
                 endpoint: null,
                 embeddingsMaxConcurrentBatches: null,
+                enablePromptCache: null,
             } satisfies Required<FormData["googleSettings"]>,
             huggingFaceSettings: {
                 apiKey: null,
@@ -344,6 +349,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 projectId: null,
                 dimensions: null,
                 embeddingsMaxConcurrentBatches: null,
+                enablePromptCache: null,
                 isSetTemperature: false,
                 temperature: null,
             } satisfies Required<FormData["openAiSettings"]>,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
@@ -18,6 +18,7 @@ import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesFiel
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
 import { SelectOption } from "components/common/select/Select";
 import TemperatureField from "./TemperatureField";
+import PromptCacheField from "./PromptCacheField";
 
 export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: boolean }) {
     const { control, trigger } = useFormContext<ConnectionFormData<AiConnection>>();
@@ -35,6 +36,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
         return tasksService.testAiConnectionString(databaseName, "AzureOpenAi", formValues.modelType, {
             ApiKey: formValues.azureOpenAiSettings.apiKey,
             Endpoint: formValues.azureOpenAiSettings.endpoint,
+            EnablePromptCache: formValues.azureOpenAiSettings.enablePromptCache,
             Model: formValues.azureOpenAiSettings.model,
             DeploymentName: formValues.azureOpenAiSettings.deploymentName,
             Dimensions: formValues.azureOpenAiSettings.dimensions,
@@ -153,6 +155,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
                     />
                 </div>
             )}
+            <PromptCacheField baseName="azureOpenAiSettings" />
             <TemperatureField baseName="azureOpenAiSettings" />
             {formValues.modelType === "TextEmbeddings" && (
                 <EmbeddingsMaxConcurrentBatches baseName="azureOpenAiSettings" />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
@@ -18,6 +18,7 @@ import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import RichAlert from "components/common/RichAlert";
 import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesField";
 import assertUnreachable from "components/utils/assertUnreachable";
+import PromptCacheField from "./PromptCacheField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -37,6 +38,7 @@ export default function GoogleSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         return tasksService.testAiConnectionString(databaseName, "Google", formValues.modelType, {
             AiVersion: formValues.googleSettings.aiVersion,
             ApiKey: formValues.googleSettings.apiKey,
+            EnablePromptCache: formValues.googleSettings.enablePromptCache,
             Model: formValues.googleSettings.model,
             Endpoint: formValues.googleSettings.endpoint,
         });
@@ -106,6 +108,7 @@ export default function GoogleSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     options={getModelOptions(formValues.modelType)}
                 />
             </div>
+            <PromptCacheField baseName="googleSettings" />
             <div className="mb-2">
                 <FormLabel>
                     Dimensions <OptionalLabel />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
@@ -18,6 +18,7 @@ import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesFiel
 import { SelectOption } from "components/common/select/Select";
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
 import TemperatureField from "./TemperatureField";
+import PromptCacheField from "./PromptCacheField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -37,6 +38,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         return tasksService.testAiConnectionString(databaseName, "OpenAi", formValues.modelType, {
             ApiKey: formValues.openAiSettings.apiKey,
             Endpoint: formValues.openAiSettings.endpoint,
+            EnablePromptCache: formValues.openAiSettings.enablePromptCache,
             Model: formValues.openAiSettings.model,
             OrganizationId: formValues.openAiSettings.organizationId,
             ProjectId: formValues.openAiSettings.projectId,
@@ -191,6 +193,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     />
                 </div>
             )}
+            <PromptCacheField baseName="openAiSettings" />
             <TemperatureField baseName="openAiSettings" />
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="openAiSettings" />}
             <div className="d-flex mb-2">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
@@ -1,0 +1,62 @@
+import { FormLabel, FormSelect } from "components/common/Form";
+import { Icon } from "components/common/Icon";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { SelectOption } from "components/common/select/Select";
+import {
+    ConnectionFormData,
+    AiConnection,
+} from "components/pages/database/settings/connectionStrings/connectionStringsTypes";
+import { FieldPath, useFormContext, useWatch } from "react-hook-form";
+
+type FormData = ConnectionFormData<AiConnection>;
+
+interface PromptCacheFieldProps {
+    baseName: Extract<FormData["connectorType"], "azureOpenAiSettings" | "googleSettings" | "openAiSettings">;
+}
+
+export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
+    const { control } = useFormContext<FormData>();
+
+    const modelType = useWatch({ control, name: "modelType" });
+
+    if (modelType !== "Chat") {
+        return null;
+    }
+
+    const fieldName = `${baseName}.enablePromptCache` satisfies FieldPath<FormData>;
+
+    return (
+        <div className="mb-2">
+            <FormLabel>
+                Prompt Cache Key
+                <PopoverWithHoverWrapper
+                    message={
+                        <>
+                            Controls whether RavenDB sends <code>prompt_cache_key</code> with chat completion requests.
+                            <ul className="mb-0">
+                                <li className="mt-1">
+                                    <strong>Default:</strong> use the server&apos;s provider-specific behavior.
+                                </li>
+                                <li className="mt-1">
+                                    <strong>True:</strong> always send the field.
+                                </li>
+                                <li className="mt-1">
+                                    <strong>False:</strong> never send the field.
+                                </li>
+                            </ul>
+                        </>
+                    }
+                >
+                    <Icon icon="info" color="info" margin="ms-1" />
+                </PopoverWithHoverWrapper>
+            </FormLabel>
+            <FormSelect control={control} name={fieldName} options={promptCacheOptions} />
+        </div>
+    );
+}
+
+const promptCacheOptions: SelectOption<boolean>[] = [
+    { label: "Default", value: null },
+    { label: "True", value: true },
+    { label: "False", value: false },
+];

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
@@ -381,6 +381,7 @@ export function mapAiConnectionsFromDto(
                     deploymentName: connection.AzureOpenAiSettings?.DeploymentName,
                     dimensions: connection.AzureOpenAiSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.AzureOpenAiSettings?.EmbeddingsMaxConcurrentBatches,
+                    enablePromptCache: connection.AzureOpenAiSettings?.EnablePromptCache ?? null,
                     isSetTemperature: connection.AzureOpenAiSettings?.Temperature != null,
                     temperature: connection.AzureOpenAiSettings?.Temperature ?? null,
                 },
@@ -390,6 +391,7 @@ export function mapAiConnectionsFromDto(
                     model: connection.GoogleSettings?.Model,
                     dimensions: connection.GoogleSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.GoogleSettings?.EmbeddingsMaxConcurrentBatches,
+                    enablePromptCache: connection.GoogleSettings?.EnablePromptCache ?? null,
                 },
                 huggingFaceSettings: {
                     apiKey: connection.HuggingFaceSettings?.ApiKey,
@@ -416,6 +418,7 @@ export function mapAiConnectionsFromDto(
                     projectId: connection.OpenAiSettings?.ProjectId,
                     dimensions: connection.OpenAiSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.OpenAiSettings?.EmbeddingsMaxConcurrentBatches,
+                    enablePromptCache: connection.OpenAiSettings?.EnablePromptCache ?? null,
                     isSetTemperature: connection.OpenAiSettings?.Temperature != null,
                     temperature: connection.OpenAiSettings?.Temperature ?? null,
                 },

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -218,6 +218,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       DeploymentName: connection.azureOpenAiSettings.deploymentName,
                       Dimensions: mapDimensionsToDto(connection),
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      EnablePromptCache: connection.azureOpenAiSettings.enablePromptCache,
                       Temperature: mapTemperatureToDto(connection),
                   }
                 : null,
@@ -230,6 +231,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       Dimensions: mapDimensionsToDto(connection),
                       Endpoint: connection.googleSettings.endpoint,
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      EnablePromptCache: connection.googleSettings.enablePromptCache,
                   }
                 : null,
         HuggingFaceSettings:
@@ -269,6 +271,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       ProjectId: connection.openAiSettings.projectId,
                       Dimensions: mapDimensionsToDto(connection),
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      EnablePromptCache: connection.openAiSettings.enablePromptCache,
                       Temperature: mapTemperatureToDto(connection),
                   }
                 : null,

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentMockLlmTests.cs
@@ -1,23 +1,13 @@
-﻿using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json.Linq;
 using Orders;
 using Raven.Client.Documents.AI;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Server.Documents;
-using Raven.Server.Documents.AI;
-using Raven.Server.Documents.AI.Settings;
 using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.ServerWide.Context;
-using Raven.Server.Web;
 using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
@@ -30,11 +20,10 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         {
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CannotOverrideAgentParameters(Options options, GenAiConfiguration config)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CannotOverrideAgentParameters()
         {
-            using var store = GetDocumentStore(options);
+            using var store = GetDocumentStore();
 
             using (var session = store.OpenAsyncSession())
             {
@@ -66,9 +55,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 await session.SaveChangesAsync();
             }
 
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
-
-            var agent = new AiAgentConfiguration("shopping assistant", config.ConnectionStringName,
+            var agent = new AiAgentConfiguration("shopping assistant", "fake-connection",
                 "You are an AI agent of an online shop, helping customers answer queries about that topic only. When talking about orders or products, include the ids as well.");
 
             agent.Parameters.Add(new AiAgentParameter("company"));
@@ -88,17 +75,31 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 var blittable = context.ReadObject(creation.ToJson(), "fake-params");
                 blittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
 
-                var x = new EvilLmHandler(Server.ServerStore, database)
+                // The "evil" part: the mock LLM tries to override the company parameter to access unauthorized data
+                bool toolCalled = false;
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: _ =>
+                    {
+                        if (toolCalled)
+                            return null; // fall through to default tool result handling
+                        toolCalled = true;
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(MockLlm.CreateToolCallResponse("RecentOrder",
+                                "{\"company\":[\"companies/2-A\"]}"))
+                        };
+                    })
                 {
                     Authentication = null
                 };
-                x.Initialize(agent, "Dummy", new RequestBody
+
+                handler.Initialize(agent, "Dummy", new RequestBody
                 {
                     Parameters = parameters,
                     CreationOptions = new AiConversationCreationOptions(),
                     UserPrompt = "fetch my orders"
                 }, changeVector: null);
-                var r = await x.HandleRequest(context, CancellationToken.None);
+                var r = await handler.HandleRequest(context, CancellationToken.None);
 
                 var response = r.Response.ToString();
 
@@ -106,65 +107,5 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 Assert.DoesNotContain("secret", response);
             }
         }
-
-        private class EvilLmHandler : ConversationHandler
-        {
-            private readonly DocumentDatabase _database;
-
-            public EvilLmHandler(Raven.Server.ServerWide.ServerStore server, DocumentDatabase database) 
-                : base(server, database)
-            {
-                _database = database;
-            }
-            
-            protected internal override ChatCompletionClient CreateClient()
-            {
-                var connection = GetAiConnectionString();
-                if (AbstractChatCompletionClientSettings.TryGetParameters(connection, out var settings) == false)
-                {
-                    var connectorType = connection.GetActiveProvider();
-                    throw new NotSupportedException($"The specified provider (\"{connectorType.ToString()}\") is not supported.");
-                }
-
-                return new EvilLlm(_database.DocumentsStorage.ContextPool, settings, ChatCompletionClient.ConventionsToUse);
-            }
-        }
-
-        internal class EvilLlm : ChatCompletionClient
-        {
-            internal EvilLlm(IMemoryContextPool contextPool, AbstractChatCompletionClientSettings settings, DocumentConventions conventions = null)
-                : base(contextPool, settings, conventions)
-            {
-            }
-
-            protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
-            {
-                var r = await request.Content.ReadAsStringAsync(token);
-                var o = JObject.Parse(r);
-                foreach (var t in o["messages"])
-                {
-                    switch (t["role"].ToString())
-                    {
-                        case "tool":
-                            // simply return the tool response as the response
-                            return new HttpResponseMessage(HttpStatusCode.OK)
-                            {
-                                Content = new StringContent(CreateMockResponse(t["content"].ToString()))
-                            };
-                    }
-                }
-
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(MockToolResponse)
-                };
-            }
-        }
-
-        public static string CreateMockResponse(string content) =>
-            $"{{\"id\": \"chatcmpl-C1olOxqfiaBhqmb5IrRmlckmdUTla\",\"object\": \"chat.completion\",\"created\": 1754549498,\"model\": \"gpt-4o-2024-08-06\",\"choices\": [{{\"index\": 0,\"message\": {{\"role\": \"assistant\",\"content\": \'{{\"Answer\":{content}}}\',\"refusal\": null,\"annotations\": []}},\"logprobs\": null,\"finish_reason\": \"done\"}}],\"usage\": {{\"prompt_tokens\": 268,\"completion_tokens\": 16,\"total_tokens\": 284,\"prompt_tokens_details\": {{\"cached_tokens\": 0,\"audio_tokens\": 0}},\"completion_tokens_details\": {{\"reasoning_tokens\": 0,\"audio_tokens\": 0,\"accepted_prediction_tokens\": 0,\"rejected_prediction_tokens\": 0}}}},\"service_tier\": \"default\",\"system_fingerprint\": \"fp_07871e2ad8\"}}";
-
-        public static string MockToolResponse =
-            "{\"id\": \"chatcmpl-C1olOxqfiaBhqmb5IrRmlckmdUTla\",\"object\": \"chat.completion\",\"created\": 1754549498,\"model\": \"gpt-4o-2024-08-06\",\"choices\": [{\"index\": 0,\"message\": {\"role\": \"assistant\",\"content\": null,\"tool_calls\": [{\"id\": \"call_hfJlPcKhQ4uaElhBETgHTuCq\",\"type\": \"function\",\"function\": {\"name\": \"RecentOrder\",\"arguments\": \"{\\\"company\\\":[\\\"companies/2-A\\\"]}\"}}],\"refusal\": null,\"annotations\": []},\"logprobs\": null,\"finish_reason\": \"tool_calls\"}],\"usage\": {\"prompt_tokens\": 268,\"completion_tokens\": 16,\"total_tokens\": 284,\"prompt_tokens_details\": {\"cached_tokens\": 0,\"audio_tokens\": 0},\"completion_tokens_details\": {\"reasoning_tokens\": 0,\"audio_tokens\": 0,\"accepted_prediction_tokens\": 0,\"rejected_prediction_tokens\": 0}},\"service_tier\": \"default\",\"system_fingerprint\": \"fp_07871e2ad8\"}";
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
@@ -21,14 +21,15 @@ internal class MockLlmConversationHandler(
     Raven.Server.ServerWide.ServerStore server,
     DocumentDatabase database,
     Func<JObject, HttpResponseMessage> onRequest = null,
-    Func<JObject, string, HttpResponseMessage> onToolResult = null)
+    Func<JObject, string, HttpResponseMessage> onToolResult = null,
+    AbstractChatCompletionClientSettings clientSettings = null)
     : ConversationHandler(server, database)
 {
     private readonly DocumentDatabase _database = database;
 
     protected internal override ChatCompletionClient CreateClient()
     {
-        var settings = new OpenAiChatCompletionClientSettings(new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o"));
+        var settings = clientSettings ?? new OpenAiChatCompletionClientSettings(new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o"));
         return new MockLlm(_database.DocumentsStorage.ContextPool, settings, onRequest, onToolResult, ChatCompletionClient.ConventionsToUse);
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/MockLlmHelper.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Server.Documents;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Settings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Sparrow.Json;
+
+namespace SlowTests.Server.Documents.AI.AiAgent;
+
+/// <summary>
+/// A conversation handler that uses a mock LLM instead of a real one.
+/// </summary>
+internal class MockLlmConversationHandler(
+    Raven.Server.ServerWide.ServerStore server,
+    DocumentDatabase database,
+    Func<JObject, HttpResponseMessage> onRequest = null,
+    Func<JObject, string, HttpResponseMessage> onToolResult = null)
+    : ConversationHandler(server, database)
+{
+    private readonly DocumentDatabase _database = database;
+
+    protected internal override ChatCompletionClient CreateClient()
+    {
+        var settings = new OpenAiChatCompletionClientSettings(new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o"));
+        return new MockLlm(_database.DocumentsStorage.ContextPool, settings, onRequest, onToolResult, ChatCompletionClient.ConventionsToUse);
+    }
+}
+
+/// <summary>
+/// A mock ChatCompletionClient that intercepts HTTP requests and returns predetermined responses.
+/// <para>
+/// The request handling pipeline is:
+/// 1. <c>onRequest</c> is called with the full payload — return non-null to short-circuit.
+/// 2. If any message has role "tool", <c>onToolResult</c> is called with the payload and tool content.
+///    Default: echoes the tool content back as the answer.
+/// 3. Falls through to a simple "mock response" answer.
+/// </para>
+/// </summary>
+internal class MockLlm : ChatCompletionClient
+{
+    private readonly Func<JObject, HttpResponseMessage> _onRequest;
+    private readonly Func<JObject, string, HttpResponseMessage> _onToolResult;
+
+    internal MockLlm(
+        IMemoryContextPool contextPool,
+        AbstractChatCompletionClientSettings settings,
+        Func<JObject, HttpResponseMessage> onRequest = null,
+        Func<JObject, string, HttpResponseMessage> onToolResult = null,
+        DocumentConventions conventions = null)
+        : base(contextPool, settings, conventions)
+    {
+        _onRequest = onRequest;
+        _onToolResult = onToolResult;
+    }
+
+    protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
+    {
+        var body = await request.Content!.ReadAsStringAsync(token);
+        var payload = JObject.Parse(body);
+
+        var response = _onRequest?.Invoke(payload);
+        if (response != null)
+            return response;
+
+        foreach (var msg in payload["messages"])
+        {
+            if (msg["role"].ToString() == "tool")
+            {
+                var toolContent = msg["content"].ToString();
+                if (_onToolResult != null)
+                    return _onToolResult(payload, toolContent);
+
+                return Ok(CreateAnswerResponse(toolContent));
+            }
+        }
+
+        return Ok(CreateAnswerResponse("\"mock response\""));
+    }
+
+    private static HttpResponseMessage Ok(string content) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(content)
+    };
+
+    private static string UsageJson(int promptTokens) => $$"""
+        "usage": {
+            "prompt_tokens": {{promptTokens}},
+            "completion_tokens": 10,
+            "total_tokens": {{promptTokens + 10}},
+            "prompt_tokens_details": {
+                "cached_tokens": 0,
+                "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+                "reasoning_tokens": 0,
+                "audio_tokens": 0,
+                "accepted_prediction_tokens": 0,
+                "rejected_prediction_tokens": 0
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Creates a mock tool call response that instructs the agent to call the specified tool.
+    /// </summary>
+    public static string CreateToolCallResponse(string toolName, string arguments = "{}", int promptTokens = 100)
+    {
+        var escapedArgs = arguments.Replace("\"", "\\\"");
+        return $$"""
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1754549498,
+                "model": "gpt-4o-2024-08-06",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_mock",
+                            "type": "function",
+                            "function": {
+                                "name": "{{toolName}}",
+                                "arguments": "{{escapedArgs}}"
+                            }
+                        }],
+                        "refusal": null,
+                        "annotations": []
+                    },
+                    "logprobs": null,
+                    "finish_reason": "tool_calls"
+                }],
+                {{UsageJson(promptTokens)}},
+                "service_tier": "default",
+                "system_fingerprint": "fp_mock"
+            }
+            """;
+    }
+
+    /// <summary>
+    /// Creates a mock tool call response with multiple tool calls.
+    /// </summary>
+    public static string CreateMultipleToolCallsResponse(int promptTokens = 100, params (string toolName, string arguments)[] tools)
+    {
+        var toolCalls = string.Join(",\n", Array.ConvertAll(tools, t =>
+        {
+            var escapedArgs = t.arguments.Replace("\"", "\\\"");
+            return $$"""
+                        {
+                            "id": "call_mock_{{t.toolName}}",
+                            "type": "function",
+                            "function": {
+                                "name": "{{t.toolName}}",
+                                "arguments": "{{escapedArgs}}"
+                            }
+                        }
+                """;
+        }));
+
+        return $$"""
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1754549498,
+                "model": "gpt-4o-2024-08-06",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{{toolCalls}}],
+                        "refusal": null,
+                        "annotations": []
+                    },
+                    "logprobs": null,
+                    "finish_reason": "tool_calls"
+                }],
+                {{UsageJson(promptTokens)}},
+                "service_tier": "default",
+                "system_fingerprint": "fp_mock"
+            }
+            """;
+    }
+
+    /// <summary>
+    /// Creates a mock answer response (no tool calls).
+    /// </summary>
+    public static string CreateAnswerResponse(string content, int promptTokens = 100)
+    {
+        var escapedContent = content.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        return $$"""
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "created": 1754549498,
+                "model": "gpt-4o-2024-08-06",
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "{\"Answer\":{{escapedContent}}}",
+                        "refusal": null,
+                        "annotations": []
+                    },
+                    "logprobs": null,
+                    "finish_reason": "done"
+                }],
+                {{UsageJson(promptTokens)}},
+                "service_tier": "default",
+                "system_fingerprint": "fp_mock"
+            }
+            """;
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24789.cs
@@ -1,16 +1,23 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Server.Config;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.NotificationCenter.Notifications.Details;
+using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
@@ -61,14 +68,13 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             Assert.True(ValidateDatabaseAlert(db, expectActionTool: true, expectQueryTool: false));
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task ShouldRaiseServerAlertOnExceededQueryToolResponse(Options options, GenAiConfiguration config)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task ShouldRaiseServerAlertOnExceededQueryToolResponse()
         {
-            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "100";
+            var options = new Options();
+            options.ModifyDatabaseRecord = r => r.Settings[RavenConfiguration.GetKey(x => x.Ai.ToolsTokenUsageThreshold)] = "50";
 
             using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
             using (var session = store.OpenAsyncSession())
             {
@@ -80,8 +86,8 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 await session.SaveChangesAsync();
             }
 
-            var agentConfig = new AiAgentConfiguration("alert-tester", config.ConnectionStringName,
-                "You are a test agent. Your only purpose is to run the 'get_all_products' tool, no matter what the user says.")
+            var agentConfig = new AiAgentConfiguration("alert-tester", "fake-connection",
+                "You are a test agent.")
             {
                 Queries =
                 [
@@ -92,15 +98,41 @@ namespace SlowTests.Server.Documents.AI.AiAgent
                 ],
                 SampleObject = JsonConvert.SerializeObject(new { answer = "string" })
             };
-            var agent = await store.AI.CreateAgentAsync(agentConfig);
 
-            var conversation = store.AI.Conversation(agent.Identifier, "chats/", creationOptions: null);
-            conversation.SetUserPrompt("Please run the tool.");
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                // First request: call the query tool. On tool result: respond with high token count to trigger the alert.
+                bool toolCalled = false;
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: _ =>
+                    {
+                        if (toolCalled)
+                            return null; // fall through to default
+                        toolCalled = true;
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(MockLlm.CreateToolCallResponse("get_all_products"))
+                        };
+                    },
+                    onToolResult: (_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(MockLlm.CreateAnswerResponse("\"done\"", promptTokens: 200))
+                    })
+                {
+                    Authentication = null
+                };
 
-            await conversation.RunAsync<object>();
+                handler.Initialize(agentConfig, "chats/alert-query", new RequestBody
+                {
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "Please run the tool."
+                }, changeVector: null);
 
-            var db = await Server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(store.Database);
-            Assert.True(ValidateDatabaseAlert(db, expectActionTool: false, expectQueryTool: true));
+                await handler.HandleRequest(context, CancellationToken.None);
+
+                Assert.True(ValidateDatabaseAlert(database, expectActionTool: false, expectQueryTool: true));
+            }
         }
 
         [RavenTheory(RavenTestCategory.Ai)]
@@ -161,7 +193,7 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             using var store = GetDocumentStore(options);
             await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
 
-            var agentConfig = new AiAgentConfiguration("payment-agent", config.ConnectionStringName, 
+            var agentConfig = new AiAgentConfiguration("payment-agent", config.ConnectionStringName,
                 "You are payment assistant that knows how to charge a customer (make payment).  if you got \"status: succeeded\" do not charge the customer again!")
             {
                 Actions = [new AiAgentToolAction { Name = "ChargeCustomer", Description = "Charge a customer.", ParametersSampleObject = "{}" }],

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24845.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24845.cs
@@ -152,7 +152,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         public async Task CanSetUserPromptWithMultipleStringsAndNull()
         {
             using var store = GetDocumentStore();
-            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
             var chat = store.AI.Conversation("fake-agent", "chats/", new AiConversationCreationOptions());
             var e = Assert.Throws<ArgumentNullException>(() => chat.AddUserPrompt("single string", null, "third string"));
             Assert.Contains("Value cannot be null.", e.Message);
@@ -162,7 +161,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
         public async Task CanSetUserPromptWithMultipleStringsAndEmptyString()
         {
             using var store = GetDocumentStore();
-            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
             var chat = store.AI.Conversation("fake-agent", "chats/", new AiConversationCreationOptions());
             var e = Assert.Throws<ArgumentException>(() => chat.AddUserPrompt("single string", "", "third string"));
             Assert.Contains("cannot be null or empty", e.Message);

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24845.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24845.cs
@@ -1,14 +1,16 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.AI;
-using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Client.Documents.Operations.ConnectionStrings;
-using Raven.Client.Exceptions;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -39,206 +41,245 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
         public string[] ExpectedStrings = new[] { "single string", "second string", "third string" };
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithSingleString(Options options, GenAiConfiguration configuration)
+        private static AiAgentConfiguration CreateTestAgent() => new("Test Agent", "fake-connection", "test")
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+            SampleObject = "{\"Answer\":\"your answer\"}"
+        };
 
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
-            chat.SetUserPrompt("single string");
-            var result = await chat.RunAsync<OutputSchema>();
-            
-            Assert.Equal(AiConversationResult.Done, result.Status);
-            using (var session = store.OpenAsyncSession())
+        private static BlittableJsonReaderArray CreateMultiPartPrompt(JsonOperationContext context, params string[] parts)
+        {
+            var array = new DynamicJsonArray();
+            foreach (var part in parts)
             {
-                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
-                Assert.NotNull(conversationDoc);
-                
-                var lastMessage = conversationDoc.Messages.Last(m => m.Role =="user");
-                Assert.Equal("user", lastMessage.Role);
+                array.Add(new DynamicJsonValue
+                {
+                    ["type"] = "text",
+                    ["text"] = part
+                });
+            }
+            var blittable = context.ReadObject(new DynamicJsonValue { ["prompt"] = array }, "prompt");
+            blittable.TryGet("prompt", out BlittableJsonReaderArray result);
+            return result;
+        }
 
-                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
-                Assert.Single(contentArr);
-                var firstPart = contentArr[0];
-                Assert.Equal("text", firstPart["type"]?.ToString());
-                Assert.Equal("single string", firstPart["text"]?.ToString());
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithSingleString()
+        {
+            using var store = GetDocumentStore();
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database) { Authentication = null };
+                // The client API always wraps single strings into [{type:"text", text:"..."}] format
+                handler.Initialize(CreateTestAgent(), "chats/1", new RequestBody
+                {
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = CreateMultiPartPrompt(context, "single string")
+                }, changeVector: null);
+
+                var result = await handler.HandleRequest(context, CancellationToken.None);
+                Assert.NotNull(result.Response);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var conversationDoc = await session.LoadAsync<ConversationTestDto>("chats/1");
+                    Assert.NotNull(conversationDoc);
+
+                    var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                    Assert.Equal("user", lastMessage.Role);
+
+                    var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                    Assert.Single(contentArr);
+                    var firstPart = contentArr[0];
+                    Assert.Equal("text", firstPart["type"]?.ToString());
+                    Assert.Equal("single string", firstPart["text"]?.ToString());
+                }
             }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithEmptyString(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithEmptyString()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
-
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            using var store = GetDocumentStore();
+            var chat = store.AI.Conversation("fake-agent", "chats/", new AiConversationCreationOptions());
             var e1 = Assert.Throws<ArgumentException>(() => chat.SetUserPrompt(string.Empty));
             Assert.Contains("cannot be null or empty", e1.Message);
             var e2 = Assert.Throws<ArgumentException>(() => chat.AddUserPrompt(string.Empty));
             Assert.Contains("cannot be null or empty", e2.Message);
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithMultipleStrings(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithMultipleStrings()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+            using var store = GetDocumentStore();
 
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
-            chat.AddUserPrompt("single string", "second string", "third string");
-            var result = await chat.RunAsync<OutputSchema>();
-            Assert.Equal(AiConversationResult.Done, result.Status);
-            using (var session = store.OpenAsyncSession())
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
-                Assert.NotNull(conversationDoc);
-
-                var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
-                Assert.Equal("user", lastMessage.Role);
-
-                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
-                Assert.Equal(3, contentArr.Count);
-
-                for (int i = 0; i < contentArr.Count; i++)
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database) { Authentication = null };
+                handler.Initialize(CreateTestAgent(), "chats/1", new RequestBody
                 {
-                    var part = contentArr[i];
-                    Assert.Equal("text", part["type"]?.ToString());
-                    Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = CreateMultiPartPrompt(context, "single string", "second string", "third string")
+                }, changeVector: null);
+
+                var result = await handler.HandleRequest(context, CancellationToken.None);
+                Assert.NotNull(result.Response);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var conversationDoc = await session.LoadAsync<ConversationTestDto>("chats/1");
+                    Assert.NotNull(conversationDoc);
+
+                    var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                    Assert.Equal("user", lastMessage.Role);
+
+                    var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                    Assert.Equal(3, contentArr.Count);
+
+                    for (int i = 0; i < contentArr.Count; i++)
+                    {
+                        var part = contentArr[i];
+                        Assert.Equal("text", part["type"]?.ToString());
+                        Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                    }
                 }
             }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithMultipleStringsAndNull(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithMultipleStringsAndNull()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
-
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            var chat = store.AI.Conversation("fake-agent", "chats/", new AiConversationCreationOptions());
             var e = Assert.Throws<ArgumentNullException>(() => chat.AddUserPrompt("single string", null, "third string"));
             Assert.Contains("Value cannot be null.", e.Message);
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithMultipleStringsAndEmptyString(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithMultipleStringsAndEmptyString()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
-
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            var chat = store.AI.Conversation("fake-agent", "chats/", new AiConversationCreationOptions());
             var e = Assert.Throws<ArgumentException>(() => chat.AddUserPrompt("single string", "", "third string"));
             Assert.Contains("cannot be null or empty", e.Message);
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithEmptyArray(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithEmptyArray()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+            using var store = GetDocumentStore();
 
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
-            chat.AddUserPrompt(Array.Empty<string>());
-            var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<OutputSchema>());
-            Assert.Contains("without a user prompt.", e.Message);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database) { Authentication = null };
+                handler.Initialize(CreateTestAgent(), "chats/1", new RequestBody
+                {
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = CreateMultiPartPrompt(context)
+                }, changeVector: null);
+
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => handler.HandleRequest(context, CancellationToken.None));
+                Assert.Contains("without a user prompt", e.Message);
+            }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithStringArray(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithStringArray()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+            using var store = GetDocumentStore();
 
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
-            chat.AddUserPrompt(ExpectedStrings);
-            var result = await chat.RunAsync<OutputSchema>();
-
-            Assert.Equal(AiConversationResult.Done, result.Status);
-            using (var session = store.OpenAsyncSession())
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
-                Assert.NotNull(conversationDoc);
-
-                var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
-                Assert.Equal("user", lastMessage.Role);
-
-                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
-                Assert.Equal(3, contentArr.Count);
-                for (int i = 0; i < contentArr.Count; i++)
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database) { Authentication = null };
+                handler.Initialize(CreateTestAgent(), "chats/1", new RequestBody
                 {
-                    var part = contentArr[i];
-                    Assert.Equal("text", part["type"]?.ToString());
-                    Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = CreateMultiPartPrompt(context, ExpectedStrings)
+                }, changeVector: null);
+
+                var result = await handler.HandleRequest(context, CancellationToken.None);
+                Assert.NotNull(result.Response);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var conversationDoc = await session.LoadAsync<ConversationTestDto>("chats/1");
+                    Assert.NotNull(conversationDoc);
+
+                    var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                    Assert.Equal("user", lastMessage.Role);
+
+                    var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                    Assert.Equal(3, contentArr.Count);
+                    for (int i = 0; i < contentArr.Count; i++)
+                    {
+                        var part = contentArr[i];
+                        Assert.Equal("text", part["type"]?.ToString());
+                        Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                    }
                 }
             }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithEmptyList(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithEmptyList()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+            using var store = GetDocumentStore();
 
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
-            chat.AddUserPrompt(new List<string>());
-            var e = await Assert.ThrowsAsync<AiException>(() => chat.RunAsync<OutputSchema>());
-            Assert.Contains("without a user prompt.", e.Message);
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database) { Authentication = null };
+                handler.Initialize(CreateTestAgent(), "chats/1", new RequestBody
+                {
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = CreateMultiPartPrompt(context)
+                }, changeVector: null);
+
+                var e = await Assert.ThrowsAsync<InvalidOperationException>(() => handler.HandleRequest(context, CancellationToken.None));
+                Assert.Contains("without a user prompt", e.Message);
+            }
         }
 
-        [RavenTheory(RavenTestCategory.Ai)]
-        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
-        public async Task CanSetUserPromptWithStringList(Options options, GenAiConfiguration configuration)
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CanSetUserPromptWithStringList()
         {
-            using var store = GetDocumentStore(options);
-            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(configuration.Connection));
-            var agent = new AiAgentConfiguration("Test Agent", configuration.ConnectionStringName, "test");
-            var agentId = (await store.AI.CreateAgentAsync(agent, OutputSchema.Instance)).Identifier;
+            using var store = GetDocumentStore();
 
-            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
-            var list = ExpectedStrings.ToList();
-            chat.AddUserPrompt(list);
-            var result = await chat.RunAsync<OutputSchema>();
-            
-            Assert.Equal(AiConversationResult.Done, result.Status);
-            using (var session = store.OpenAsyncSession())
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
             {
-                var conversationDoc = await session.LoadAsync<ConversationTestDto>(chat.Id);
-                Assert.NotNull(conversationDoc);
-
-                var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
-                Assert.Equal("user", lastMessage.Role);
-
-                var contentArr = Assert.IsType<JArray>(lastMessage.Content);
-                Assert.Equal(3, contentArr.Count);
-                for (int i = 0; i < contentArr.Count; i++)
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database) { Authentication = null };
+                handler.Initialize(CreateTestAgent(), "chats/1", new RequestBody
                 {
-                    var part = contentArr[i];
-                    Assert.Equal("text", part["type"]?.ToString());
-                    Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = CreateMultiPartPrompt(context, ExpectedStrings)
+                }, changeVector: null);
+
+                var result = await handler.HandleRequest(context, CancellationToken.None);
+                Assert.NotNull(result.Response);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    var conversationDoc = await session.LoadAsync<ConversationTestDto>("chats/1");
+                    Assert.NotNull(conversationDoc);
+
+                    var lastMessage = conversationDoc.Messages.Last(m => m.Role == "user");
+                    Assert.Equal("user", lastMessage.Role);
+
+                    var contentArr = Assert.IsType<JArray>(lastMessage.Content);
+                    Assert.Equal(3, contentArr.Count);
+                    for (int i = 0; i < contentArr.Count; i++)
+                    {
+                        var part = contentArr[i];
+                        Assert.Equal("text", part["type"]?.ToString());
+                        Assert.Equal(ExpectedStrings[i], part["text"]?.ToString());
+                    }
                 }
             }
         }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26268.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26268.cs
@@ -3,15 +3,9 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
-using Newtonsoft.Json.Linq;
 using Orders;
 using Raven.Client.Documents.AI;
-using Raven.Client.Documents.Conventions;
-using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
-using Raven.Server.Documents;
-using Raven.Server.Documents.AI;
-using Raven.Server.Documents.AI.Settings;
 using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -66,10 +60,12 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
                 string capturedPromptCacheKey = null;
 
-                var handler = new MockHandler(Server.ServerStore, database, onRequest: payload =>
-                {
-                    capturedPromptCacheKey ??= payload["prompt_cache_key"]?.ToString();
-                })
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        capturedPromptCacheKey ??= payload["prompt_cache_key"]?.ToString();
+                        return null; // fall through to default handling
+                    })
                 {
                     Authentication = null
                 };
@@ -85,60 +81,6 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
                 Assert.NotNull(capturedPromptCacheKey);
                 Assert.Equal("conversations/1-A", capturedPromptCacheKey);
-            }
-        }
-
-        private class MockHandler : ConversationHandler
-        {
-            private readonly DocumentDatabase _database;
-            private readonly System.Action<JObject> _onRequest;
-
-            public MockHandler(Raven.Server.ServerWide.ServerStore server, DocumentDatabase database, System.Action<JObject> onRequest)
-                : base(server, database)
-            {
-                _database = database;
-                _onRequest = onRequest;
-            }
-
-            protected internal override ChatCompletionClient CreateClient()
-            {
-                var settings = new OpenAiChatCompletionClientSettings(new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o"));
-                return new MockLlm(_database.DocumentsStorage.ContextPool, settings, _onRequest, ChatCompletionClient.ConventionsToUse);
-            }
-        }
-
-        private class MockLlm : ChatCompletionClient
-        {
-            private readonly System.Action<JObject> _onRequest;
-
-            internal MockLlm(IMemoryContextPool contextPool, AbstractChatCompletionClientSettings settings, System.Action<JObject> onRequest, DocumentConventions conventions = null)
-                : base(contextPool, settings, conventions)
-            {
-                _onRequest = onRequest;
-            }
-
-            protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
-            {
-                var r = await request.Content.ReadAsStringAsync(token);
-                var payload = JObject.Parse(r);
-
-                _onRequest(payload);
-
-                foreach (var t in payload["messages"])
-                {
-                    if (t["role"].ToString() == "tool")
-                    {
-                        return new HttpResponseMessage(HttpStatusCode.OK)
-                        {
-                            Content = new StringContent(AiAgentMockLlmTests.CreateMockResponse(t["content"].ToString()))
-                        };
-                    }
-                }
-
-                return new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(AiAgentMockLlmTests.MockToolResponse)
-                };
             }
         }
     }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26268.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26268.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Orders;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Server.Documents;
+using Raven.Server.Documents.AI;
+using Raven.Server.Documents.AI.Settings;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_26268(ITestOutputHelper output) : RavenTestBase(output)
+    {
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task ShouldIncludePromptCacheKeyInRequest()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Company = "companies/1-A",
+                    Lines =
+                    [
+                        new OrderLine
+                        {
+                            ProductName = "Laptop",
+                            Quantity = 1
+                        }
+                    ]
+                });
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("test assistant", "fake-connection",
+                "You are a test assistant.");
+
+            agent.Parameters.Add(new AiAgentParameter("company"));
+            agent.Queries =
+            [
+                new AiAgentToolQuery("RecentOrder", "Get recent orders", "from Orders where Company = $company limit 5")
+                {
+                    ParametersSampleObject = "{}"
+                }
+            ];
+            agent.SampleObject = "{\"Answer\":\"The answer\"}";
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var creation = new AiConversationCreationOptions().AddParameter("company", "companies/1-A");
+                var blittable = context.ReadObject(creation.ToJson(), "fake-params");
+                blittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
+
+                string capturedPromptCacheKey = null;
+
+                var handler = new MockHandler(Server.ServerStore, database, onRequest: payload =>
+                {
+                    capturedPromptCacheKey ??= payload["prompt_cache_key"]?.ToString();
+                })
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(agent, "conversations/1-A", new RequestBody
+                {
+                    Parameters = parameters,
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "show my orders"
+                }, changeVector: null);
+
+                await handler.HandleRequest(context, CancellationToken.None);
+
+                Assert.NotNull(capturedPromptCacheKey);
+                Assert.Equal("conversations/1-A", capturedPromptCacheKey);
+            }
+        }
+
+        private class MockHandler : ConversationHandler
+        {
+            private readonly DocumentDatabase _database;
+            private readonly System.Action<JObject> _onRequest;
+
+            public MockHandler(Raven.Server.ServerWide.ServerStore server, DocumentDatabase database, System.Action<JObject> onRequest)
+                : base(server, database)
+            {
+                _database = database;
+                _onRequest = onRequest;
+            }
+
+            protected internal override ChatCompletionClient CreateClient()
+            {
+                var settings = new OpenAiChatCompletionClientSettings(new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o"));
+                return new MockLlm(_database.DocumentsStorage.ContextPool, settings, _onRequest, ChatCompletionClient.ConventionsToUse);
+            }
+        }
+
+        private class MockLlm : ChatCompletionClient
+        {
+            private readonly System.Action<JObject> _onRequest;
+
+            internal MockLlm(IMemoryContextPool contextPool, AbstractChatCompletionClientSettings settings, System.Action<JObject> onRequest, DocumentConventions conventions = null)
+                : base(contextPool, settings, conventions)
+            {
+                _onRequest = onRequest;
+            }
+
+            protected override async Task<HttpResponseMessage> SendRequestAsync(HttpRequestMessage request, CancellationToken token)
+            {
+                var r = await request.Content.ReadAsStringAsync(token);
+                var payload = JObject.Parse(r);
+
+                _onRequest(payload);
+
+                foreach (var t in payload["messages"])
+                {
+                    if (t["role"].ToString() == "tool")
+                    {
+                        return new HttpResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new StringContent(AiAgentMockLlmTests.CreateMockResponse(t["content"].ToString()))
+                        };
+                    }
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(AiAgentMockLlmTests.MockToolResponse)
+                };
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26268.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26268.cs
@@ -1,11 +1,11 @@
-using System.Net;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FastTests;
 using Orders;
 using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Server.Documents.AI.Settings;
 using Raven.Server.Documents.Handlers.AI.Agents;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
@@ -81,6 +81,150 @@ namespace SlowTests.Server.Documents.AI.AiAgent
 
                 Assert.NotNull(capturedPromptCacheKey);
                 Assert.Equal("conversations/1-A", capturedPromptCacheKey);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task ShouldNotIncludePromptCacheKeyForGoogle()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Company = "companies/1-A",
+                    Lines =
+                    [
+                        new OrderLine
+                        {
+                            ProductName = "Laptop",
+                            Quantity = 1
+                        }
+                    ]
+                });
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("test assistant", "fake-connection",
+                "You are a test assistant.");
+
+            agent.Parameters.Add(new AiAgentParameter("company"));
+            agent.Queries =
+            [
+                new AiAgentToolQuery("RecentOrder", "Get recent orders", "from Orders where Company = $company limit 5")
+                {
+                    ParametersSampleObject = "{}"
+                }
+            ];
+            agent.SampleObject = "{\"Answer\":\"The answer\"}";
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var creation = new AiConversationCreationOptions().AddParameter("company", "companies/1-A");
+                var blittable = context.ReadObject(creation.ToJson(), "fake-params");
+                blittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
+
+                bool promptCacheKeySeen = false;
+
+                var googleSettings = new GoogleChatCompletionClientSettings(new GoogleSettings("gemini-2.0-flash", "fake-key"));
+
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        if (payload["prompt_cache_key"] != null)
+                            promptCacheKeySeen = true;
+                        return null;
+                    },
+                    clientSettings: googleSettings)
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(agent, "conversations/1-A", new RequestBody
+                {
+                    Parameters = parameters,
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "show my orders"
+                }, changeVector: null);
+
+                await handler.HandleRequest(context, CancellationToken.None);
+
+                Assert.False(promptCacheKeySeen, "prompt_cache_key should not be sent for Google provider");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task ShouldRespectExplicitEnablePromptCacheSetting()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Company = "companies/1-A",
+                    Lines =
+                    [
+                        new OrderLine
+                        {
+                            ProductName = "Laptop",
+                            Quantity = 1
+                        }
+                    ]
+                });
+                await session.SaveChangesAsync();
+            }
+
+            var agent = new AiAgentConfiguration("test assistant", "fake-connection",
+                "You are a test assistant.");
+
+            agent.Parameters.Add(new AiAgentParameter("company"));
+            agent.Queries =
+            [
+                new AiAgentToolQuery("RecentOrder", "Get recent orders", "from Orders where Company = $company limit 5")
+                {
+                    ParametersSampleObject = "{}"
+                }
+            ];
+            agent.SampleObject = "{\"Answer\":\"The answer\"}";
+
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var creation = new AiConversationCreationOptions().AddParameter("company", "companies/1-A");
+                var blittable = context.ReadObject(creation.ToJson(), "fake-params");
+                blittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
+
+                bool promptCacheKeySeen = false;
+
+                // Explicitly disable prompt cache on an OpenAI connection
+                var openAiSettings = new OpenAiSettings("fake-key", "https://fake.openai.com", "gpt-4o") { EnablePromptCache = false };
+                var settings = new OpenAiChatCompletionClientSettings(openAiSettings);
+
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: payload =>
+                    {
+                        if (payload["prompt_cache_key"] != null)
+                            promptCacheKeySeen = true;
+                        return null;
+                    },
+                    clientSettings: settings)
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(agent, "conversations/1-A", new RequestBody
+                {
+                    Parameters = parameters,
+                    CreationOptions = new AiConversationCreationOptions(),
+                    UserPrompt = "show my orders"
+                }, changeVector: null);
+
+                await handler.HandleRequest(context, CancellationToken.None);
+
+                Assert.False(promptCacheKeySeen, "prompt_cache_key should not be sent when EnablePromptCache is explicitly false");
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26268

### Additional description

Adds `prompt_cache_key` to chat completion request payloads sent to AI providers. The conversation ID is used as the cache key, which helps providers (especially OpenAI) route requests with shared prefixes to the same KV cache partition, improving cache hit rates and reducing cost/latency.

**Changes:**
- `ChatCompletionClient.cs` — Added optional `promptCacheKey` parameter to `CreateCompletionRequest` and `WriteCompletionRequestPayload`. Writes `prompt_cache_key` in the JSON payload when provided.
- `Talker.cs` — Passes `document.Id` (conversation ID) as the prompt cache key.
- Added test `RavenDB-26268` verifying the field is present in the request payload with the correct value, using a mock LLM handler.

The field is sent to all providers (OpenAI, Azure, Ollama, Google) since they all use the OpenAI-compatible API format. Providers that don't support it will simply ignore the unknown field.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed