### PR TITLE
RavenDB-26209 fix failing tests

### DIFF
--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -228,10 +228,10 @@ namespace Raven.Embedded
                         _logger.Info($"Killing global server PID {process.Id}.");
 
                     process.Kill();
-                    if (process.WaitForExit(5_000) == false)
+                    if (process.WaitForExit((int)_serverOptions!.ProcessKillTimeout.TotalMilliseconds) == false)
                     {
                         if (_logger.IsInfoEnabled)
-                            _logger.Info($"Process {process.Id} did not exit after Kill() within 5 seconds.");
+                            _logger.Info($"Process {process.Id} did not exit after Kill() within {_serverOptions!.ProcessKillTimeout.ToString()} seconds.");
                     }
                 }
                 catch (Exception e)

--- a/src/Raven.Embedded/EmbeddedServer.cs
+++ b/src/Raven.Embedded/EmbeddedServer.cs
@@ -228,6 +228,11 @@ namespace Raven.Embedded
                         _logger.Info($"Killing global server PID {process.Id}.");
 
                     process.Kill();
+                    if (process.WaitForExit(5_000) == false)
+                    {
+                        if (_logger.IsInfoEnabled)
+                            _logger.Info($"Process {process.Id} did not exit after Kill() within 5 seconds.");
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Raven.Embedded/ServerOptions.cs
+++ b/src/Raven.Embedded/ServerOptions.cs
@@ -33,6 +33,8 @@ namespace Raven.Embedded
 
         public TimeSpan GracefulShutdownTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
+        public TimeSpan ProcessKillTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
         public TimeSpan MaxServerStartupTimeDuration { get; set; } = TimeSpan.FromMinutes(1);
 
         public List<string> CommandLineArgs { get; set; } = new List<string>();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26209

### Additional description
Wasn't able to reproduce - Possible race condition between server process exit and file cleanup in EmbeddedServer disposal

The test was failing with an UnauthorizedAccessException when trying to delete Raven.voron during cleanup. This happened because the server process was still holding a lock on the file when Dispose() attempted to delete it — the process hadn't fully exited yet after Kill() was called.
The fix adds a WaitForExit(5_000) call after Kill(), which waits for the process to fully exit before cleanup proceeds. If the process doesn't exit within 5 seconds, a warning is logged and cleanup continues anyway.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
