### PR TITLE
RavenDB-26329 Can't compare the current doc with the revision

### DIFF
--- a/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/documents/editDocument.ts
@@ -1226,23 +1226,29 @@ class editDocument extends shardViewModelBase {
         const revisions = await new getDocumentRevisionsCommand(this.document().getId(), this.db, 0, 1024, true)
             .execute();
 
-        const itemToCompare = revisions.items.find(x => x.__metadata.changeVector() === changeVector);
+        const currentChangeVectorItem = revisions.items.find(x => x.__metadata.changeVector() === changeVector);
         
         this.revisionsToCompare(revisions.items.filter(x => !x.__metadata.hasFlag("DeleteRevision")));
 
         this.diffMode("previous");
         
-        if (itemToCompare) {
-            const isLastItem = this.revisionsToCompare().at(-1).__metadata.changeVector() === itemToCompare.__metadata.changeVector();
+        if (currentChangeVectorItem) {
+            const isLastItem = this.revisionsToCompare().at(-1).__metadata.changeVector() === currentChangeVectorItem.__metadata.changeVector();
             if (isLastItem) {
                 this.confirmationMessage("Nothing to compare", "This is the oldest revision. Please choose another revision.", {
                     buttons: ["Ok"]
                 });
+                return;
             } else {
-                return this.changeRightRevision(itemToCompare);
+                return this.changeRightRevision(currentChangeVectorItem);
             }
-            
         }
+        
+        if (this.revisionsToCompare().length) {
+            return this.changeRightRevision(this.revisionsToCompare()[0]);
+        }
+
+        messagePublisher.reportWarning("Could not find any revisions to compare with.");
     }
     
     async revisionNavigate(direction: "older" | "newer", tab: "right" | "left"): Promise<void> {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26329/Cant-compare-the-current-doc-with-the-revision

### Additional description

If revision with change vector equal to current document doesn't exists use the latest revision to compare.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
