### PR TITLE
RavenDB-26240 Leading whitespace in pull-replication path filters is effectively hidden and very hard to diagnose

### DIFF
--- a/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkEditModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/ongoingTaskReplicationSinkEditModel.ts
@@ -84,8 +84,8 @@ class ongoingTaskReplicationSinkEditModel extends ongoingTaskEditModel {
             AccessName: accessInfo.replicationAccessName(),
             CertificatePassword: certificatePassphrase,
             CertificateWithPrivateKey: this.replicationAccess().serverCertificateSelected() ? null : certificate,
-            AllowedHubToSinkPaths: accessInfo.hubToSinkPrefixes()?.map(x => x.path()),
-            AllowedSinkToHubPaths: accessInfo.sinkToHubPrefixes()?.map(x => x.path())
+            AllowedHubToSinkPaths: accessInfo.getHubToSinkPrefixesToSave(),
+            AllowedSinkToHubPaths: accessInfo.getSinkToHubPrefixesToSave()
         } as Raven.Client.Documents.Operations.Replication.PullReplicationAsSink;
     }
 

--- a/src/Raven.Studio/typescript/models/database/tasks/prefixPathModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/prefixPathModel.ts
@@ -2,6 +2,14 @@
     path = ko.observable<string>();
     validationGroup: KnockoutValidationGroup;
 
+    static normalize(path: string): string {
+        if (path == null) {
+            return path;
+        }
+
+        return path.trim();
+    }
+
     constructor(prefixPath: string) {
 
         this.path(prefixPath);
@@ -13,14 +21,16 @@
             validation: [
                 {
                     validator: () => {
-                        if (this.path()) {
-                            const pathLength = this.path().length;
+                        const normalizedPath = prefixPathModel.normalize(this.path());
+
+                        if (normalizedPath) {
+                            const pathLength = normalizedPath.length;
                             if (pathLength === 1) {
                                 return true;
                             }
                             
-                            const lastChar = this.path().charAt(pathLength - 1);
-                            const prevChar = this.path().charAt(pathLength - 2);
+                            const lastChar = normalizedPath.charAt(pathLength - 1);
+                            const prevChar = normalizedPath.charAt(pathLength - 2);
                             return lastChar != '*' || prevChar === '/' || prevChar === '-';
                         }
                         

--- a/src/Raven.Studio/typescript/models/database/tasks/replicationAccessBaseModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/replicationAccessBaseModel.ts
@@ -26,9 +26,21 @@ class replicationAccessBaseModel {
         this.sinkToHubPrefixes(sinkToHub);
         this.certificate(certificate);
       
-        this.samePrefixesForBothDirections(_.isEqual(hubToSink.map(x => x.path()), sinkToHub.map(x => x.path())));
+        this.samePrefixesForBothDirections(_.isEqual(this.getNormalizedPrefixPaths(hubToSink), this.getNormalizedPrefixPaths(sinkToHub)));
        
         this.filteringPathsRequired(filteringPathsRequired);
+    }
+
+    private getNormalizedPrefixPaths(prefixes: prefixPathModel[]) {
+        return _.compact(prefixes.map(x => prefixPathModel.normalize(x.path())));
+    }
+
+    getHubToSinkPrefixesToSave() {
+        return this.getNormalizedPrefixPaths(this.hubToSinkPrefixes());
+    }
+
+    getSinkToHubPrefixesToSave() {
+        return this.getNormalizedPrefixPaths(this.sinkToHubPrefixes());
     }
     
     initObservables() {
@@ -53,7 +65,7 @@ class replicationAccessBaseModel {
         this.hubToSinkPrefixes.extend({
             validation: [
                 {
-                    validator: () => !this.filteringPathsRequired() || this.hubToSinkPrefixes().length,
+                    validator: () => !this.filteringPathsRequired() || this.getHubToSinkPrefixesToSave().length,
                     message: "Please add at least one filtering path"
                 }
             ]
@@ -62,7 +74,7 @@ class replicationAccessBaseModel {
         this.sinkToHubPrefixes.extend({
             validation: [
                 {
-                    validator: () => !this.filteringPathsRequired() || this.samePrefixesForBothDirections() || this.sinkToHubPrefixes().length,
+                    validator: () => !this.filteringPathsRequired() || this.samePrefixesForBothDirections() || this.getSinkToHubPrefixesToSave().length,
                     message: "Please add at least one filtering path, or use the Hub to Sink paths"
                 }
             ]
@@ -70,7 +82,10 @@ class replicationAccessBaseModel {
     }
     
     private hasSingleDocumentPattern(paths: prefixPathModel[]): KnockoutComputed<boolean> {
-        return ko.pureComputed(() => paths.length && !!paths.find(x => !x.path().endsWith("*")));
+        return ko.pureComputed(() => paths.length && !!paths.find(x => {
+            const normalizedPath = prefixPathModel.normalize(x.path());
+            return normalizedPath && !normalizedPath.endsWith("*");
+        }));
     }
     
     getSingleDocumentPatternWarning() {
@@ -78,9 +93,14 @@ class replicationAccessBaseModel {
     }
 
     addHubToSinkInputPrefixWithBlink() {
-        const pathToAdd = this.inputPrefixHubToSink().path();
+        const pathToAdd = prefixPathModel.normalize(this.inputPrefixHubToSink().path());
+
+        if (!pathToAdd) {
+            this.inputPrefixHubToSink().path(null);
+            return;
+        }
         
-        if (!this.hubToSinkPrefixes().find(prefix => prefix.path() === pathToAdd))
+        if (!this.hubToSinkPrefixes().find(prefix => prefixPathModel.normalize(prefix.path()) === pathToAdd))
         { 
             const itemToAdd = new prefixPathModel(pathToAdd);
             this.hubToSinkPrefixes.unshift(itemToAdd);
@@ -91,9 +111,14 @@ class replicationAccessBaseModel {
     }
 
     addSinkToHubInputPrefixWithBlink() {
-        const pathToAdd = this.inputPrefixSinkToHub().path();
+        const pathToAdd = prefixPathModel.normalize(this.inputPrefixSinkToHub().path());
+
+        if (!pathToAdd) {
+            this.inputPrefixSinkToHub().path(null);
+            return;
+        }
         
-        if (!this.sinkToHubPrefixes().find(prefix => prefix.path() === pathToAdd)) {
+        if (!this.sinkToHubPrefixes().find(prefix => prefixPathModel.normalize(prefix.path()) === pathToAdd)) {
             const itemToAdd = new prefixPathModel(pathToAdd);
             this.sinkToHubPrefixes.unshift(itemToAdd);
 
@@ -116,8 +141,8 @@ class replicationAccessBaseModel {
         return {
             Name: this.replicationAccessName(),
             CertificateBase64: this.certificate().publicKey(),
-            AllowedHubToSinkPaths: this.hubToSinkPrefixes().map(prefix => prefix.path()),
-            AllowedSinkToHubPaths: this.sinkToHubPrefixes().map(prefix => prefix.path())
+            AllowedHubToSinkPaths: this.getHubToSinkPrefixesToSave(),
+            AllowedSinkToHubPaths: this.getSinkToHubPrefixesToSave()
         }
     }
 }

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editReplicationHubTask.ts
@@ -541,13 +541,13 @@ class editReplicationHubTask extends shardViewModelBase {
             const certificate = replicationAccessItem.certificate().certificate();
             configurationToExport.Certificate = certificate || null;
 
-            configurationToExport.HubToSinkPrefixes = replicationAccessItem.hubToSinkPrefixes().map(x => x.path());
+            configurationToExport.HubToSinkPrefixes = replicationAccessItem.getHubToSinkPrefixesToSave();
             
             if (this.editedReplicationAccessItem().samePrefixesForBothDirections()) {
                 configurationToExport.UseSamePrefixes = true;
             } else {
                 configurationToExport.UseSamePrefixes = false;
-                configurationToExport.SinkToHubPrefixes = replicationAccessItem.sinkToHubPrefixes().map(x => x.path());
+                configurationToExport.SinkToHubPrefixes = replicationAccessItem.getSinkToHubPrefixesToSave();
             }
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26240/Leading-whitespace-in-pull-replication-path-filters-is-effectively-hidden-and-very-hard-to-diagnose

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
