### PR TITLE
RavenDB-25135 Reset page locator in CryptoPager.TryReleasePage when buffer is free

### DIFF
--- a/src/Voron/Data/VoronStream.cs
+++ b/src/Voron/Data/VoronStream.cs
@@ -171,7 +171,7 @@ namespace Voron.Data
                 Llt.TryReleasePage(LastPage.PageNumber);
             }
 
-            LastPage = Llt.GetPageWithoutCache(pageNumber);
+            LastPage = Llt.GetPage(pageNumber);
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -615,15 +615,6 @@ namespace Voron.Impl
             return p;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Page GetPageWithoutCache(long pageNumber)
-        {
-            if (_txState != TxState.None)
-                ThrowObjectDisposed();
-
-            return GetPageInternal(pageNumber);
-        }
-
         private Page GetPageInternal(long pageNumber)
         {
             // Check if we can hit the lowest level locality cache.

--- a/src/Voron/Impl/Paging/CryptoPager.cs
+++ b/src/Voron/Impl/Paging/CryptoPager.cs
@@ -274,6 +274,9 @@ namespace Voron.Impl.Paging
             {
                 state.RemoveBuffer(page);
                 ReturnBuffer(buffer);
+
+                if (tx is LowLevelTransaction llt)
+                    llt._pageLocator.Reset(page);
             }
         }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_25135.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_25135.cs
@@ -1,0 +1,113 @@
+using System.IO;
+using FastTests.Voron;
+using Sparrow.Platform;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Impl;
+using Voron.Impl.Paging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Voron.Issues
+{
+    public class RavenDB_25135 : StorageTest
+    {
+        private readonly byte[] _masterKey = Sodium.GenerateRandomBuffer((int)Sodium.crypto_aead_xchacha20poly1305_ietf_keybytes());
+
+        public RavenDB_25135(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        protected override void Configure(StorageEnvironmentOptions options)
+        {
+            base.Configure(options);
+            options.Encryption.MasterKey = (byte[])_masterKey.Clone();
+            options.ManualFlushing = true;
+        }
+
+        [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Encryption)]
+        public void Page_Locator_Must_Be_Invalidated_After_TryReleasePage_Frees_Buffer()
+        {
+            RequireFileBasedPager();
+
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("Data");
+                tree.Add("key1", new MemoryStream(new byte[100]));
+                tx.Commit();
+            }
+
+            Env.FlushLogToDataFile();
+            RestartDatabase();
+
+            using (var tx = Env.ReadTransaction())
+            {
+                var llt = tx.LowLevelTransaction;
+                var pagerTxState = (IPagerLevelTransactionState)llt;
+
+                // After restart, pages come from CryptoPager (not journal)
+                CryptoPager cryptoPager = null;
+                EncryptionBuffer buffer = null;
+                long pageNumber = -1;
+
+                for (long candidate = 0; candidate < 20; candidate++)
+                {
+                    Page page;
+                    try { page = llt.GetPage(candidate); }
+                    catch { continue; }
+                    if (page.IsValid == false) continue;
+
+                    if (pagerTxState.CryptoPagerTransactionState == null) continue;
+
+                    foreach (var kvp in pagerTxState.CryptoPagerTransactionState)
+                    {
+                        if (kvp.Value.TryGetValue(candidate, out buffer))
+                        {
+                            // Only pick buffers that can be returned (not sub-pages of overflow allocations)
+                            if (CryptoPager.CanReturnBuffer(buffer) == false) continue;
+                            if (buffer.Modified) continue;
+
+                            cryptoPager = (CryptoPager)kvp.Key;
+                            pageNumber = candidate;
+                            break;
+                        }
+                    }
+                    if (cryptoPager != null) break;
+                }
+
+                // After restart, data pages MUST be served through CryptoPager
+                Assert.NotNull(cryptoPager);
+                Assert.True(pageNumber >= 0);
+                Assert.Equal(1, buffer.Usages);
+
+                // PageLocator.SetReadable has a guard: it only updates the cache entry if the
+                // bucket has a DIFFERENT page number. If the same page number is already at that
+                // bucket (even with a stale generation), SetReadable is a no-op.
+                // Workaround: Reset the bucket first, then GetPage to get a fresh locator entry.
+                llt._pageLocator.Reset(pageNumber);
+                _ = llt.GetPage(pageNumber); // AcquirePagePointer again -> Usages=2, locator freshly set
+
+                // Precondition: locator must now have a fresh entry for pageNumber
+                Assert.True(llt._pageLocator.TryGetReadOnlyPage(pageNumber, out _),
+                    $"Precondition failed: page {pageNumber} should be in page locator after Reset+GetPage");
+
+                Assert.Equal(2, buffer.Usages);
+
+                // First TryReleasePage: Usages=2->1, CanRelease=false -> buffer stays, locator stays
+                cryptoPager.TryReleasePage(pagerTxState, pageNumber);
+                Assert.Equal(1, buffer.Usages);
+
+                // Second TryReleasePage: Usages=1->0 -> frees buffer (sodium_memzero + ReturnBuffer),
+                // removes from CryptoTransactionState, and resets the page locator entry.
+                cryptoPager.TryReleasePage(pagerTxState, pageNumber);
+                Assert.Equal(0, buffer.Usages);
+
+                // The page locator must be invalidated so the next GetPage() re-decrypts from disk
+                // rather than returning a stale pointer into zeroed/freed memory.
+                Assert.False(llt._pageLocator.TryGetReadOnlyPage(pageNumber, out _),
+                    $"After CryptoPager.TryReleasePage freed the buffer for page {pageNumber}, " +
+                    "the page locator still has a stale entry pointing to zeroed/freed memory.");
+            }
+        }
+    }
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_25135.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_25135.cs
@@ -107,6 +107,13 @@ namespace SlowTests.Voron.Issues
                 Assert.False(llt._pageLocator.TryGetReadOnlyPage(pageNumber, out _),
                     $"After CryptoPager.TryReleasePage freed the buffer for page {pageNumber}, " +
                     "the page locator still has a stale entry pointing to zeroed/freed memory.");
+
+                // GetPage must successfully re-decrypt the page from disk (not crash or return garbage).
+                // This is the VoronStream scenario: after TryReleasePage, GetPage is used to re-fetch
+                // the next page, and it must go through the pager rather than the stale locator entry.
+                var refetched = llt.GetPage(pageNumber);
+                Assert.True(refetched.IsValid);
+                Assert.Equal(pageNumber, refetched.PageNumber);
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25135

### Additional description

PR #16544 added `TryReleasePage` to `VoronStream.UpdateLastPageIfNeeded` - when reading a stream on an encrypted database, the decrypted buffer for the previous page is released back to the pool before fetching the next one, reducing peak memory usage.

However `CryptoPager.TryReleasePage` was not invalidating the page locator cache after freeing the buffer. Instead `GetPageWithoutCache` was introduced to bypass the stale locator entry, 

So in practice the bug was never actually hit. However, leaving `TryReleasePage` without proper page locator invalidation was risky for any future caller that followed `TryReleasePage` with a regular `GetPage`.

Now that `TryReleasePage` properly invalidates the page locator, `GetPageWithoutCache` is no longer needed and has been removed.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
