### PR TITLE
RavenDB-26053 Certificates view: 'About to expire' certificates should be accounted for when filtering for 'Valid' certificates

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesAuthEnabled.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesAuthEnabled.tsx
@@ -1,25 +1,11 @@
-import { Icon } from "components/common/Icon";
-import { MultiCheckboxToggle } from "components/common/toggles/MultiCheckboxToggle";
-import Select, {
-    OptionWithIconAndSeparator,
-    SelectOption,
-    SelectOptionWithIconAndSeparator,
-    SingleValueWithIcon,
-} from "components/common/select/Select";
-import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
 import CertificatesClientList from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesClientList";
 import CertificatesServerList from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesServerList";
 import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
 import { certificatesSelectors } from "components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors";
-import { CertificatesSortMode } from "components/pages/resources/manageServer/certificates/utils/certificatesTypes";
 import { useAppDispatch, useAppSelector } from "components/store";
 import { useCallback, useEffect, useRef } from "react";
-import Dropdown from "react-bootstrap/Dropdown";
-import Button from "react-bootstrap/Button";
 import endpoints from "endpoints";
 import CertificatesGenerateModal from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesGenerateModal";
-import { ConditionalPopover } from "components/common/ConditionalPopover";
-import useDebouncedInput from "components/hooks/useDebouncedInput";
 import CertificatesUploadModal from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesUploadModal";
 import CertificatesReplaceServerModal from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesReplaceServerModal";
 import { StickyHeader } from "components/common/StickyHeader";
@@ -27,37 +13,19 @@ import CertificatesCloneModal from "components/pages/resources/manageServer/cert
 import CertificatesEditModal from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesEditModal";
 import CertificatesWellKnownList from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesWellKnownList";
 import { useChanges } from "components/hooks/useChanges";
-import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { LoadingView } from "components/common/LoadingView";
 import { LoadError } from "components/common/LoadError";
-import Form from "react-bootstrap/Form";
-import SelectCreatable from "components/common/select/SelectCreatable";
+import CertificatesFilters from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesFilters";
+import CertificatesManageDropdown from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesManageDropdown";
 
 export default function CertificatesAuthEnabled() {
     const dispatch = useAppDispatch();
-    const { reportEvent } = useEventsCollector();
-
     const exportServerCertFormRef = useRef<HTMLFormElement>(null);
-
     const isInitialLoad = useAppSelector(certificatesSelectors.isInitialLoad);
     const loadStatus = useAppSelector(certificatesSelectors.loadStatus);
     const isGenerateModalOpen = useAppSelector(certificatesSelectors.isGenerateModalOpen);
     const isUploadModalOpen = useAppSelector(certificatesSelectors.isUploadModalOpen);
     const isReplaceServerModalOpen = useAppSelector(certificatesSelectors.isReplaceServerModalOpen);
-    const hasClusterNodeCertificate = useAppSelector(certificatesSelectors.hasClusterNodeCertificate);
-    const nameOrThumbprintFilter = useAppSelector(certificatesSelectors.nameOrThumbprintFilter);
-    const allCertificatesCount = useAppSelector(certificatesSelectors.certificates).length;
-    const clearanceFilter = useAppSelector(certificatesSelectors.clearanceFilter);
-    const clearanceFilterOptions = useAppSelector(certificatesSelectors.clearanceFilterOptions);
-    const stateFilter = useAppSelector(certificatesSelectors.stateFilter);
-    const stateFilterOptions = useAppSelector(certificatesSelectors.stateFilterOptions);
-    const databaseFilter = useAppSelector(certificatesSelectors.databaseFilter);
-    const databaseOptions: SelectOption[] = useAppSelector(databaseSelectors.allDatabaseNames).map((x) => ({
-        value: x,
-        label: x,
-    }));
-    const sortMode = useAppSelector(certificatesSelectors.sortMode);
-
     const certificateToEdit = useAppSelector(certificatesSelectors.certificateToEdit);
     const certificateToClone = useAppSelector(certificatesSelectors.certificateToClone);
 
@@ -91,161 +59,12 @@ export default function CertificatesAuthEnabled() {
         }
     }, [handleAlert, serverNotifications]);
 
-    const { localValue: nameOrThumbprintFilterInputValue, handleChange: nameOrThumbprintFilterInputHandleChange } =
-        useDebouncedInput({
-            value: nameOrThumbprintFilter,
-            onDebouncedUpdate: (value: string) => dispatch(certificatesActions.nameOrThumbprintFilterSet(value)),
-        });
-
     return (
         <div className="vstack gap-2 pb-4">
             <StickyHeader>
-                {!isInitialLoad && (
-                    <Dropdown>
-                        <Dropdown.Toggle title="Manage certificates" variant="primary" className="rounded-pill">
-                            Manage certificates
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu>
-                            <Dropdown.Header className="small-label">Client</Dropdown.Header>
-                            <Dropdown.Item onClick={() => dispatch(certificatesActions.isGenerateModalOpenToggled())}>
-                                <Icon icon="certificate" addon="plus" />
-                                Generate client certificate
-                            </Dropdown.Item>
-                            <Dropdown.Item onClick={() => dispatch(certificatesActions.isUploadModalOpenToggled())}>
-                                <Icon icon="upload" />
-                                Upload client certificate
-                            </Dropdown.Item>
-                            <Dropdown.Divider />
-                            <Dropdown.Header className="small-label">Server</Dropdown.Header>
-                            <ConditionalPopover
-                                conditions={[
-                                    {
-                                        isActive: !hasClusterNodeCertificate,
-                                        message: "You need to have a server certificate to export it",
-                                    },
-                                    {
-                                        isActive: true,
-                                        message: (
-                                            <span>
-                                                Export the server certificate(s) without their private key into a .pfx
-                                                file. These certificates can be used during a manual cluster setup, when
-                                                you need to register server certificates to be trusted on other nodes.
-                                            </span>
-                                        ),
-                                    },
-                                ]}
-                                popoverPlacement="right"
-                            >
-                                <Dropdown.Item
-                                    onClick={() => {
-                                        reportEvent("certificates", "export-certs");
-                                        exportServerCertFormRef.current?.submit();
-                                    }}
-                                    disabled={!hasClusterNodeCertificate}
-                                >
-                                    <Icon icon="download" />
-                                    Export server certificate
-                                </Dropdown.Item>
-                            </ConditionalPopover>
-                            <ConditionalPopover
-                                conditions={{
-                                    isActive: !hasClusterNodeCertificate,
-                                    message: "You need to have a server certificate to replace it",
-                                }}
-                            >
-                                <Dropdown.Item
-                                    onClick={() => dispatch(certificatesActions.isReplaceServerModalOpenToggled())}
-                                    disabled={!hasClusterNodeCertificate}
-                                >
-                                    <Icon icon="refresh" />
-                                    Replace server certificate
-                                </Dropdown.Item>
-                            </ConditionalPopover>
-                        </Dropdown.Menu>
-                    </Dropdown>
-                )}
-                <div className="hstack gap-2 mt-2 flex-wrap">
-                    <div className="flex-grow">
-                        <span className="small-label">Filter by name/thumbprint</span>
-                        <div className="clearable-input">
-                            <Form.Control
-                                onChange={(x) => nameOrThumbprintFilterInputHandleChange(x.target.value)}
-                                value={nameOrThumbprintFilterInputValue}
-                                placeholder="e.g. johndoe.certificate"
-                                className="rounded-pill pe-4"
-                            />
-                            {nameOrThumbprintFilter && (
-                                <div className="clear-button">
-                                    <Button
-                                        variant="secondary"
-                                        size="sm"
-                                        onClick={() => nameOrThumbprintFilterInputHandleChange("")}
-                                    >
-                                        <Icon icon="clear" margin="m-0" />
-                                    </Button>
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                    <div>
-                        <span className="small-label">Filter by database</span>
-                        <SelectCreatable<SelectOption>
-                            options={databaseOptions}
-                            onChange={(x) => dispatch(certificatesActions.databaseFilterSet(x?.value))}
-                            value={databaseOptions.find((x) => x.value === databaseFilter)}
-                            className="rounded-pill"
-                            placeholder="Select a database"
-                            isRoundedPill
-                            isClearable
-                            styles={{
-                                container: (base) => ({
-                                    ...base,
-                                    width: "250px",
-                                }),
-                            }}
-                        />
-                    </div>
-                    <div>
-                        <span className="small-label">Filter by security clearance</span>
-                        <MultiCheckboxToggle
-                            inputItems={clearanceFilterOptions}
-                            selectedItems={clearanceFilter}
-                            setSelectedItems={(x) => {
-                                dispatch(certificatesActions.clearanceFilterSet(x));
-                            }}
-                            selectAll
-                            selectAllLabel="All"
-                            selectAllCount={allCertificatesCount}
-                        />
-                    </div>
-                    <div>
-                        <span className="small-label">Filter by state</span>
-                        <MultiCheckboxToggle
-                            inputItems={stateFilterOptions}
-                            selectedItems={stateFilter}
-                            setSelectedItems={(x) => {
-                                dispatch(certificatesActions.stateFilterSet(x));
-                            }}
-                            selectAll
-                            selectAllLabel="All"
-                            selectAllCount={allCertificatesCount}
-                        />
-                    </div>
-                    <div style={{ minWidth: 250 }}>
-                        <span className="small-label">Sort</span>
-                        <Select<SelectOptionWithIconAndSeparator<CertificatesSortMode>>
-                            options={sortOptions}
-                            onChange={(x) => dispatch(certificatesActions.sortModeSet(x.value))}
-                            value={sortOptions.find((x) => x.value === sortMode)}
-                            className="rounded-pill"
-                            placeholder="Select a database"
-                            components={{ Option: OptionWithIconAndSeparator, SingleValue: SingleValueWithIcon }}
-                            isRoundedPill
-                        />
-                    </div>
-                </div>
+                {!isInitialLoad && <CertificatesManageDropdown />}
+                <CertificatesFilters />
             </StickyHeader>
-
             {isInitialLoad && loadStatus === "loading" && <LoadingView />}
             {loadStatus === "failure" && (
                 <LoadError
@@ -277,30 +96,3 @@ export default function CertificatesAuthEnabled() {
         </div>
     );
 }
-
-const sortOptions: SelectOptionWithIconAndSeparator<CertificatesSortMode>[] = (
-    [
-        { value: "By Name - Asc", icon: "arrow-up" },
-        { value: "By Name - Desc", icon: "arrow-down", horizontalSeparatorLine: true },
-        { value: "By Expiration Date - Asc", icon: "arrow-up" },
-        {
-            value: "By Expiration Date - Desc",
-            icon: "arrow-down",
-            horizontalSeparatorLine: true,
-        },
-        { value: "By Valid-From Date - Asc", icon: "arrow-up" },
-        {
-            value: "By Valid-From Date - Desc",
-            icon: "arrow-down",
-            horizontalSeparatorLine: true,
-        },
-        { value: "By Last Used Date - Asc", icon: "arrow-up" },
-        {
-            value: "By Last Used Date - Desc",
-            icon: "arrow-down",
-        },
-    ] satisfies Omit<SelectOptionWithIconAndSeparator<CertificatesSortMode>, "label">[]
-).map((x) => ({
-    ...x,
-    label: x.value,
-}));

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesFilters.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesFilters.tsx
@@ -1,0 +1,150 @@
+import { Icon } from "components/common/Icon";
+import Select, {
+    SelectOption,
+    SelectOptionWithIconAndSeparator,
+    OptionWithIconAndSeparator,
+    SingleValueWithIcon,
+} from "components/common/select/Select";
+import SelectCreatable from "components/common/select/SelectCreatable";
+import { databaseSelectors } from "components/common/shell/databaseSliceSelectors";
+import { MultiCheckboxToggle } from "components/common/toggles/MultiCheckboxToggle";
+import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
+import { certificatesSelectors } from "components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors";
+import { CertificatesSortMode } from "components/pages/resources/manageServer/certificates/utils/certificatesTypes";
+import { useAppDispatch, useAppSelector } from "components/store";
+import Form from "react-bootstrap/Form";
+import Button from "react-bootstrap/Button";
+import useDebouncedInput from "components/hooks/useDebouncedInput";
+
+export default function CertificatesFilters() {
+    const dispatch = useAppDispatch();
+
+    const nameOrThumbprintFilter = useAppSelector(certificatesSelectors.nameOrThumbprintFilter);
+    const allCertificatesCount = useAppSelector(certificatesSelectors.certificates).length;
+    const clearanceFilter = useAppSelector(certificatesSelectors.clearanceFilter);
+    const clearanceFilterOptions = useAppSelector(certificatesSelectors.clearanceFilterOptions);
+    const stateFilter = useAppSelector(certificatesSelectors.stateFilter);
+    const stateFilterOptions = useAppSelector(certificatesSelectors.stateFilterOptions);
+    const databaseFilter = useAppSelector(certificatesSelectors.databaseFilter);
+    const databaseOptions: SelectOption[] = useAppSelector(databaseSelectors.allDatabaseNames).map((x) => ({
+        value: x,
+        label: x,
+    }));
+    const sortMode = useAppSelector(certificatesSelectors.sortMode);
+
+    const { localValue: nameOrThumbprintFilterInputValue, handleChange: nameOrThumbprintFilterInputHandleChange } =
+        useDebouncedInput({
+            value: nameOrThumbprintFilter,
+            onDebouncedUpdate: (value: string) => dispatch(certificatesActions.nameOrThumbprintFilterSet(value)),
+        });
+
+    return (
+        <div className="hstack gap-2 mt-2 flex-wrap">
+            <div className="flex-grow">
+                <span className="small-label">Filter by name/thumbprint</span>
+                <div className="clearable-input">
+                    <Form.Control
+                        onChange={(x) => nameOrThumbprintFilterInputHandleChange(x.target.value)}
+                        value={nameOrThumbprintFilterInputValue}
+                        placeholder="e.g. johndoe.certificate"
+                        className="rounded-pill pe-4"
+                    />
+                    {nameOrThumbprintFilter && (
+                        <div className="clear-button">
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => nameOrThumbprintFilterInputHandleChange("")}
+                            >
+                                <Icon icon="clear" margin="m-0" />
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            </div>
+            <div>
+                <span className="small-label">Filter by database</span>
+                <SelectCreatable<SelectOption>
+                    options={databaseOptions}
+                    onChange={(x) => dispatch(certificatesActions.databaseFilterSet(x?.value))}
+                    value={databaseOptions.find((x) => x.value === databaseFilter)}
+                    className="rounded-pill"
+                    placeholder="Select a database"
+                    isRoundedPill
+                    isClearable
+                    styles={{
+                        container: (base) => ({
+                            ...base,
+                            width: "250px",
+                        }),
+                    }}
+                />
+            </div>
+            <div>
+                <span className="small-label">Filter by security clearance</span>
+                <MultiCheckboxToggle
+                    inputItems={clearanceFilterOptions}
+                    selectedItems={clearanceFilter}
+                    setSelectedItems={(x) => {
+                        dispatch(certificatesActions.clearanceFilterSet(x));
+                    }}
+                    selectAll
+                    selectAllLabel="All"
+                    selectAllCount={allCertificatesCount}
+                />
+            </div>
+            <div>
+                <span className="small-label">Filter by state</span>
+                <MultiCheckboxToggle
+                    inputItems={stateFilterOptions}
+                    selectedItems={stateFilter}
+                    setSelectedItems={(x) => {
+                        dispatch(certificatesActions.stateFilterSet(x));
+                    }}
+                    selectAll
+                    selectAllLabel="All"
+                    selectAllCount={allCertificatesCount}
+                />
+            </div>
+            <div style={{ minWidth: 250 }}>
+                <span className="small-label">Sort</span>
+                <Select<SelectOptionWithIconAndSeparator<CertificatesSortMode>>
+                    options={sortOptions}
+                    onChange={(x) => dispatch(certificatesActions.sortModeSet(x.value))}
+                    value={sortOptions.find((x) => x.value === sortMode)}
+                    className="rounded-pill"
+                    placeholder="Select a database"
+                    components={{ Option: OptionWithIconAndSeparator, SingleValue: SingleValueWithIcon }}
+                    isRoundedPill
+                />
+            </div>
+        </div>
+    );
+}
+
+const sortOptions: SelectOptionWithIconAndSeparator<CertificatesSortMode>[] = (
+    [
+        { value: "By Name - Asc", icon: "arrow-up" },
+        { value: "By Name - Desc", icon: "arrow-down", horizontalSeparatorLine: true },
+        { value: "By Expiration Date - Asc", icon: "arrow-up" },
+        {
+            value: "By Expiration Date - Desc",
+            icon: "arrow-down",
+            horizontalSeparatorLine: true,
+        },
+        { value: "By Valid-From Date - Asc", icon: "arrow-up" },
+        {
+            value: "By Valid-From Date - Desc",
+            icon: "arrow-down",
+            horizontalSeparatorLine: true,
+        },
+        { value: "By Last Used Date - Asc", icon: "arrow-up" },
+        {
+            value: "By Last Used Date - Desc",
+            icon: "arrow-down",
+        },
+    ] satisfies Omit<SelectOptionWithIconAndSeparator<CertificatesSortMode>, "label">[]
+).map((x) => ({
+    ...x,
+    label: x.value,
+}));

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesItemStatus.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesItemStatus.tsx
@@ -1,0 +1,13 @@
+import { RichPanelStatus } from "components/common/RichPanel";
+import { CertificatesState } from "components/pages/resources/manageServer/certificates/utils/certificatesTypes";
+import { certificatesUtils } from "components/pages/resources/manageServer/certificates/utils/certificatesUtils";
+
+interface CertificatesItemStatusProps {
+    state: CertificatesState;
+}
+
+export default function CertificatesItemStatus({ state }: CertificatesItemStatusProps) {
+    const statusText = state === "About to expire" ? "Valid" : state;
+
+    return <RichPanelStatus color={certificatesUtils.getStateColor(state)}>{statusText}</RichPanelStatus>;
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesListItem.tsx
@@ -11,12 +11,12 @@ import {
     RichPanelDetails,
     RichPanelHeader,
     RichPanelNameMultiLine,
-    RichPanelStatus,
 } from "components/common/RichPanel";
 import { accessManagerSelectors } from "components/common/shell/accessManagerSliceSelectors";
 import { useEventsCollector } from "components/hooks/useEventsCollector";
 import { useServices } from "components/hooks/useServices";
 import { ThemeColor } from "components/models/common";
+import CertificatesItemStatus from "components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesItemStatus";
 import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
 import { certificatesSelectors } from "components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors";
 import { CertificateItem } from "components/pages/resources/manageServer/certificates/utils/certificatesTypes";
@@ -113,13 +113,24 @@ export default function CertificatesListItem({ certificate }: CertificatesListIt
 
     return (
         <RichPanel className="flex-row with-status" hover>
-            <RichPanelStatus color={certificatesUtils.getStateColor(state)}>{state}</RichPanelStatus>
-
+            <CertificatesItemStatus state={state} />
             <div className="flex-grow">
                 <RichPanelHeader>
                     <div>
                         <RichPanelNameMultiLine className="d-flex align-items-center">
                             {certificate.Name ?? "<empty name>"}
+                            {state === "About to expire" && (
+                                <Badge
+                                    bg="warning"
+                                    className="ms-1 fs-6 hstack"
+                                    pill
+                                    title="This certificate is about to expire"
+                                    style={{ gap: "2px" }}
+                                >
+                                    <Icon icon="clock" margin="m-0" />
+                                    About to expire
+                                </Badge>
+                            )}
                             {isCurrentBrowserCert && (
                                 <Badge
                                     bg="success"

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesManageDropdown.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/partials/authEnabled/CertificatesManageDropdown.tsx
@@ -1,0 +1,80 @@
+import { Icon } from "components/common/Icon";
+import { certificatesActions } from "components/pages/resources/manageServer/certificates/store/certificatesSlice";
+import { certificatesSelectors } from "components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors";
+import { useAppDispatch, useAppSelector } from "components/store";
+import { useRef } from "react";
+import Dropdown from "react-bootstrap/Dropdown";
+import { ConditionalPopover } from "components/common/ConditionalPopover";
+import { useEventsCollector } from "components/hooks/useEventsCollector";
+
+export default function CertificatesManageDropdown() {
+    const dispatch = useAppDispatch();
+    const { reportEvent } = useEventsCollector();
+    const exportServerCertFormRef = useRef<HTMLFormElement>(null);
+    const hasClusterNodeCertificate = useAppSelector(certificatesSelectors.hasClusterNodeCertificate);
+
+    return (
+        <Dropdown>
+            <Dropdown.Toggle title="Manage certificates" variant="primary" className="rounded-pill">
+                Manage certificates
+            </Dropdown.Toggle>
+            <Dropdown.Menu>
+                <Dropdown.Header className="small-label">Client</Dropdown.Header>
+                <Dropdown.Item onClick={() => dispatch(certificatesActions.isGenerateModalOpenToggled())}>
+                    <Icon icon="certificate" addon="plus" />
+                    Generate client certificate
+                </Dropdown.Item>
+                <Dropdown.Item onClick={() => dispatch(certificatesActions.isUploadModalOpenToggled())}>
+                    <Icon icon="upload" />
+                    Upload client certificate
+                </Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Header className="small-label">Server</Dropdown.Header>
+                <ConditionalPopover
+                    conditions={[
+                        {
+                            isActive: !hasClusterNodeCertificate,
+                            message: "You need to have a server certificate to export it",
+                        },
+                        {
+                            isActive: true,
+                            message: (
+                                <span>
+                                    Export the server certificate(s) without their private key into a .pfx file. These
+                                    certificates can be used during a manual cluster setup, when you need to register
+                                    server certificates to be trusted on other nodes.
+                                </span>
+                            ),
+                        },
+                    ]}
+                    popoverPlacement="right"
+                >
+                    <Dropdown.Item
+                        onClick={() => {
+                            reportEvent("certificates", "export-certs");
+                            exportServerCertFormRef.current?.submit();
+                        }}
+                        disabled={!hasClusterNodeCertificate}
+                    >
+                        <Icon icon="download" />
+                        Export server certificate
+                    </Dropdown.Item>
+                </ConditionalPopover>
+                <ConditionalPopover
+                    conditions={{
+                        isActive: !hasClusterNodeCertificate,
+                        message: "You need to have a server certificate to replace it",
+                    }}
+                >
+                    <Dropdown.Item
+                        onClick={() => dispatch(certificatesActions.isReplaceServerModalOpenToggled())}
+                        disabled={!hasClusterNodeCertificate}
+                    >
+                        <Icon icon="refresh" />
+                        Replace server certificate
+                    </Dropdown.Item>
+                </ConditionalPopover>
+            </Dropdown.Menu>
+        </Dropdown>
+    );
+}

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/store/certificatesSliceSelectors.ts
@@ -48,6 +48,8 @@ const selectStateFilterOptions = createSelector(
             }
             if (state === "About to expire") {
                 aboutToExpireCount++;
+                // About to expire certificates are still valid
+                validCount++;
             }
             if (state === "Expired") {
                 expiredCount++;
@@ -91,7 +93,12 @@ const selectFilteredCertificates = createSelector(
                 return false;
             }
 
-            if (stateFilter.length > 0 && !stateFilter.includes(certificatesUtils.getState(cert.NotAfter))) {
+            const state = certificatesUtils.getState(cert.NotAfter);
+            if (stateFilter.includes("Valid") && (state === "Valid" || state === "About to expire")) {
+                return true;
+            }
+
+            if (stateFilter.length > 0 && !stateFilter.includes(state)) {
                 return false;
             }
 

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/utils/certificatesUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/certificates/utils/certificatesUtils.ts
@@ -70,7 +70,6 @@ function getStateColor(state: CertificatesState): ThemeColor {
         case "Expired":
             return "danger";
         case "About to expire":
-            return "warning";
         case "Valid":
             return "success";
         default:


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26053/Certificates-view-About-to-expire-certificates-should-be-accounted-for-when-filtering-for-Valid-certificates

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
