### PR TITLE
RavenDB-16922: Validate certificate type when on Pull replication configuration

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -139,7 +139,7 @@ namespace Raven.Client.Documents.Operations.Replication
             using (var certificate = CertificateLoaderUtil.CreateCertificate(certBytes, CertificatePassword, CertificateLoaderUtil.FlagsForExport))
             {
                 if (certificate.HasPrivateKey == false)
-                    throw new AuthorizationException("Certificate with private key is required.");
+                    throw new InvalidOperationException("Certificate with private key is required.");
             }
         }
     }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text;
 using Raven.Client.Documents.Replication;
+using Raven.Client.Exceptions.Security;
+using Raven.Client.Util;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
@@ -129,5 +131,16 @@ namespace Raven.Client.Documents.Operations.Replication
         }
 
         public override string GetDefaultTaskName() => ToString();
+
+        public void EnsureHasPrivateKey()
+        {
+            var certBytes = Convert.FromBase64String(CertificateWithPrivateKey);
+
+            using (var certificate = CertificateLoaderUtil.CreateCertificate(certBytes, CertificatePassword, CertificateLoaderUtil.FlagsForExport))
+            {
+                if (certificate.HasPrivateKey == false)
+                    throw new AuthorizationException("Certificate with private key is required.");
+            }
+        }
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -132,7 +132,7 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public override string GetDefaultTaskName() => ToString();
 
-        public void EnsureHasPrivateKey()
+        internal void EnsureHasPrivateKey()
         {
             var certBytes = Convert.FromBase64String(CertificateWithPrivateKey);
 

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -132,14 +132,13 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public override string GetDefaultTaskName() => ToString();
 
-        internal void EnsureHasPrivateKey()
+        internal bool HasPrivateKey()
         {
             var certBytes = Convert.FromBase64String(CertificateWithPrivateKey);
 
             using (var certificate = CertificateLoaderUtil.CreateCertificate(certBytes, CertificatePassword, CertificateLoaderUtil.FlagsForExport))
             {
-                if (certificate.HasPrivateKey == false)
-                    throw new InvalidOperationException("Certificate with private key is required.");
+                return certificate.HasPrivateKey;
             }
         }
     }

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -63,8 +63,8 @@ namespace Raven.Client.Documents.Operations.Replication
                         $"When {nameof(useServerCertificate)} is set to true, " +
                         $"{nameof(PullReplicationAsSink.CertificateWithPrivateKey)} should be null to use server certificate.");
 
-                if (skipClientCertificateValidation == false)
-                    pullReplication.EnsureHasPrivateKey();
+                if (skipClientCertificateValidation == false && pullReplication.HasPrivateKey() == false)
+                    throw new AuthorizationException("Certificate with private key is required");
             }
         }
 

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -37,7 +37,7 @@ namespace Raven.Client.Documents.Operations.Replication
         /// <exception cref="AuthorizationException">
         /// Thrown if the provided certificate does not include a private key but is required for secure replication.
         /// </exception>
-        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool useServerCertificate = false)
+        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool useServerCertificate = false, bool skipClientCertificateValidation = false)
         {
             _pullReplication = pullReplication;
             _useServerCertificate = useServerCertificate;
@@ -49,8 +49,8 @@ namespace Raven.Client.Documents.Operations.Replication
                         $"When {nameof(useServerCertificate)} is set to true, " +
                         $"{nameof(PullReplicationAsSink.CertificateWithPrivateKey)} should be null to use server certificate.");
 
-                
-                pullReplication.EnsureHasPrivateKey();
+                if (skipClientCertificateValidation == false)
+                    pullReplication.EnsureHasPrivateKey();
             }
         }
 

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -26,6 +26,20 @@ namespace Raven.Client.Documents.Operations.Replication
         public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication) : this(pullReplication, false)
         {
         }
+
+        /// <inheritdoc cref="UpdatePullReplicationAsSinkOperation"/>
+        /// <param name="pullReplication">
+        /// The <see cref="PullReplicationAsSink"/> object containing the updated configuration for the pull replication sink task.
+        /// This configuration includes details such as the source database, connection strings, allowed paths for data flow 
+        /// between the sink and hub, and an optional private key for a certificate used in secure communication.
+        /// </param>
+        /// <param name="useServerCertificate">Makes the replication use the server certificate. Requires <see cref="PullReplicationAsSink.CertificateWithPrivateKey"/> to be null.</param>
+        /// <exception cref="AuthorizationException">
+        /// Thrown if the provided certificate does not include a private key but is required for secure replication.
+        /// </exception>
+        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool useServerCertificate = false) : this(pullReplication, useServerCertificate,false)
+        {
+        }
         
         /// <inheritdoc cref="UpdatePullReplicationAsSinkOperation"/>
         /// <param name="pullReplication">
@@ -37,7 +51,7 @@ namespace Raven.Client.Documents.Operations.Replication
         /// <exception cref="AuthorizationException">
         /// Thrown if the provided certificate does not include a private key but is required for secure replication.
         /// </exception>
-        public UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool useServerCertificate = false, bool skipClientCertificateValidation = false)
+        internal UpdatePullReplicationAsSinkOperation(PullReplicationAsSink pullReplication, bool useServerCertificate = false, bool skipClientCertificateValidation = false)
         {
             _pullReplication = pullReplication;
             _useServerCertificate = useServerCertificate;

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -48,16 +48,9 @@ namespace Raven.Client.Documents.Operations.Replication
                     throw new ArgumentException(
                         $"When {nameof(useServerCertificate)} is set to true, " +
                         $"{nameof(PullReplicationAsSink.CertificateWithPrivateKey)} should be null to use server certificate.");
+
                 
-                
-                var certBytes = Convert.FromBase64String(pullReplication.CertificateWithPrivateKey);
-                using (var certificate = CertificateLoaderUtil.CreateCertificate(certBytes,
-                    pullReplication.CertificatePassword,
-                    CertificateLoaderUtil.FlagsForExport))
-                {
-                    if (certificate.HasPrivateKey == false)
-                        throw new AuthorizationException("Certificate with private key is required");
-                }
+                pullReplication.EnsureHasPrivateKey();
             }
         }
 

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1998,6 +1998,8 @@ namespace Raven.Server.ServerWide
 
             pullReplicationAsSink = JsonDeserializationClient.PullReplicationAsSink(pullReplicationBlittable);
 
+            pullReplicationAsSink.EnsureHasPrivateKey();
+
             var replicationAsSinkCommand = new UpdatePullReplicationAsSinkCommand(dbName, raftRequestId)
             {
                 PullReplicationAsSink = pullReplicationAsSink,

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1998,9 +1998,9 @@ namespace Raven.Server.ServerWide
 
             pullReplicationAsSink = JsonDeserializationClient.PullReplicationAsSink(pullReplicationBlittable);
 
-            if (pullReplicationAsSink.CertificateWithPrivateKey != null)
+            if (pullReplicationAsSink.CertificateWithPrivateKey != null && pullReplicationAsSink.HasPrivateKey() == false)
             {
-                pullReplicationAsSink.EnsureHasPrivateKey();
+                throw new InvalidOperationException("Certificate with private key is required.");
             }
 
             var replicationAsSinkCommand = new UpdatePullReplicationAsSinkCommand(dbName, raftRequestId)

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -1998,7 +1998,10 @@ namespace Raven.Server.ServerWide
 
             pullReplicationAsSink = JsonDeserializationClient.PullReplicationAsSink(pullReplicationBlittable);
 
-            pullReplicationAsSink.EnsureHasPrivateKey();
+            if (pullReplicationAsSink.CertificateWithPrivateKey != null)
+            {
+                pullReplicationAsSink.EnsureHasPrivateKey();
+            }
 
             var replicationAsSinkCommand = new UpdatePullReplicationAsSinkCommand(dbName, raftRequestId)
             {

--- a/src/Raven.Studio/typescript/common/certificateUtils.ts
+++ b/src/Raven.Studio/typescript/common/certificateUtils.ts
@@ -23,7 +23,7 @@ class certificateUtils {
         const keyBags = p12.getBags({
             bagType: forge.pki.oids.pkcs8ShroudedKeyBag
         });
-        if (!keyBags[forge.pki.oids.pkcs8ShroudedKeyBag] || keyBags[forge.pki.oids.pkcs8ShroudedKeyBag].length === 0) {
+        if (!keyBags[forge.pki.oids.pkcs8ShroudedKeyBag]?.length) {
             throw new Error("The provided certificate file does not contain a private key. Please provide a PFX file with a private key.");
         }
 

--- a/src/Raven.Studio/typescript/common/certificateUtils.ts
+++ b/src/Raven.Studio/typescript/common/certificateUtils.ts
@@ -19,11 +19,18 @@ class certificateUtils {
         const der = forge.util.decode64(base64EncodedCertificate);
         const asn1 = forge.asn1.fromDer(der, { parseAllBytes: false, strict: true, decodeBitStrings: true });
         const p12 = forge.pkcs12.pkcs12FromAsn1(asn1, password);
-        
+
+        const keyBags = p12.getBags({
+            bagType: forge.pki.oids.pkcs8ShroudedKeyBag
+        });
+        if (!keyBags[forge.pki.oids.pkcs8ShroudedKeyBag] || keyBags[forge.pki.oids.pkcs8ShroudedKeyBag].length === 0) {
+            throw new Error("The provided certificate file does not contain a private key. Please provide a PFX file with a private key.");
+        }
+
         const bags = p12.getBags({
             bagType: forge.pki.oids.certBag
         });
-        
+
         return bags[forge.pki.oids.certBag].map(x => forge.pki.certificateToPem(x.cert));
     }
     

--- a/src/Raven.Studio/typescript/models/database/tasks/replicationAccessSinkModel.ts
+++ b/src/Raven.Studio/typescript/models/database/tasks/replicationAccessSinkModel.ts
@@ -59,10 +59,10 @@ class replicationAccessSinkModel extends replicationAccessBaseModel {
 
     onCertificateSelected(certAsBase64: string) {
         this.selectedFileCertificate(certAsBase64);
-        this.tryReadCertificate();
+        this.tryReadCertificate(false);
     }
 
-    tryReadCertificate(): boolean {
+    tryReadCertificate(reportErrors = true): boolean {
         const certificate = this.selectedFileCertificate();
         const password = this.selectedFilePassphrase() || undefined;
 
@@ -74,8 +74,12 @@ class replicationAccessSinkModel extends replicationAccessBaseModel {
                 this.certificateExtracted(true);
                 return true;
             } catch ($e) {
-                messagePublisher.reportError("Unable to extract certificate from file. " +
-                    "Verify file is .pfx containing a single private key and check provided password.", $e);
+                if (reportErrors) {
+                    const errorMessage = $e instanceof Error && $e.message.includes("private key")
+                        ? $e.message
+                        : "Unable to extract certificate from file. Verify file is .pfx containing a single private key and check provided password.";
+                    messagePublisher.reportError(errorMessage, $e);
+                }
                 this.certificateExtracted(false);
                 return false;
             }

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Operations.OngoingTasks;
@@ -12,12 +14,17 @@ using Raven.Client.Exceptions.Sharding;
 using Raven.Client.Exceptions;
 using Raven.Client.Exceptions.Database;
 using Raven.Client.Extensions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Json.Serialization;
 using Raven.Client.ServerWide.Commands;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
 using Raven.Server.Config;
 using Raven.Server.Utils;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 using Sparrow.Server;
 using Tests.Infrastructure;
 using Xunit;
@@ -975,6 +982,101 @@ namespace SlowTests.Server.Replication
 
                 Assert.True(WaitForDocument(hub, "foo/bar/322", timeout * 5), hub.Identifier);
             }
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task ShouldRejectPullReplicationSinkCertificateWithoutPrivateKey()
+        {
+            var certificates = Certificates.SetupServerAuthentication();
+            using var server = GetNewServer();
+
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                Server = server,
+                ClientCertificate = certificates.ServerCertificateForCommunication.Value,
+                AdminCertificate = certificates.ServerCertificateForCommunication.Value
+            });
+
+            // Export certificate as public-only (no private key)
+            var publicOnlyCert = Convert.ToBase64String(certificates.ClientCertificate1.Value.Export(X509ContentType.Cert));
+
+            var pull = new PullReplicationAsSink
+            {
+                ConnectionStringName = "dummy",
+                HubName = "hub",
+                CertificateWithPrivateKey = publicOnlyCert
+            };
+
+            // Set up a dummy connection string so the server doesn't fail on that
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = sinkStore.Database,
+                Name = "dummy",
+                TopologyDiscoveryUrls = sinkStore.Urls
+            }));
+
+            // Bypass client-side validation by sending a raw command directly to the server endpoint
+            var command = new UpdatePullReplicationAsSinkWithoutClientValidationCommand(sinkStore.Conventions, pull);
+
+            var exception = await Assert.ThrowsAsync<RavenException>(async () =>
+            {
+                using var requestExecutor = sinkStore.GetRequestExecutor();
+                using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
+                {
+                    await requestExecutor.ExecuteAsync(command, context);
+                }
+            });
+
+            Assert.Contains("does not contain a private key", exception.Message);
+        }
+
+        /// <summary>
+        /// A custom command that sends the pull replication sink configuration to the server
+        /// without performing the client-side certificate validation.
+        /// Used to test the server-side validation in isolation.
+        /// </summary>
+        private class UpdatePullReplicationAsSinkWithoutClientValidationCommand : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
+        {
+            private readonly DocumentConventions _conventions;
+            private readonly PullReplicationAsSink _pullReplication;
+
+            public UpdatePullReplicationAsSinkWithoutClientValidationCommand(DocumentConventions conventions, PullReplicationAsSink pullReplication)
+            {
+                _conventions = conventions;
+                _pullReplication = pullReplication;
+            }
+
+            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+            {
+                url = $"{node.Url}/databases/{node.Database}/admin/tasks/sink-pull-replication";
+
+                var request = new HttpRequestMessage
+                {
+                    Method = HttpMethod.Post,
+                    Content = new BlittableJsonContent(async stream =>
+                    {
+                        var json = new DynamicJsonValue
+                        {
+                            ["PullReplicationAsSink"] = _pullReplication.ToJson()
+                        };
+
+                        await ctx.WriteAsync(stream, ctx.ReadObject(json, "update-pull-replication")).ConfigureAwait(false);
+                    }, _conventions)
+                };
+
+                return request;
+            }
+
+            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+            {
+                if (response == null)
+                    ThrowInvalidResponse();
+
+                Result = JsonDeserializationClient.ModifyOngoingTaskResult(response);
+            }
+
+            public override bool IsReadRequest => false;
+            public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
         }
 
         //TODO write test for deletion! - make sure replication is stopped after we delete hub!

--- a/test/SlowTests/Server/Replication/PullReplicationTests.cs
+++ b/test/SlowTests/Server/Replication/PullReplicationTests.cs
@@ -987,8 +987,12 @@ namespace SlowTests.Server.Replication
         [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task ShouldRejectPullReplicationSinkCertificateWithoutPrivateKey()
         {
-            var certificates = Certificates.SetupServerAuthentication();
-            using var server = GetNewServer();
+            var customSettings = new Dictionary<string, string>();
+            var certificates = Certificates.SetupServerAuthentication(customSettings: customSettings);
+            using var server = GetNewServer(new ServerCreationOptions
+            {
+                CustomSettings = customSettings
+            });
 
             using var sinkStore = GetDocumentStore(new Options
             {
@@ -1015,68 +1019,13 @@ namespace SlowTests.Server.Replication
                 TopologyDiscoveryUrls = sinkStore.Urls
             }));
 
-            // Bypass client-side validation by sending a raw command directly to the server endpoint
-            var command = new UpdatePullReplicationAsSinkWithoutClientValidationCommand(sinkStore.Conventions, pull);
-
+            // Skip client-side validation to test the server-side validation in isolation
             var exception = await Assert.ThrowsAsync<RavenException>(async () =>
             {
-                using var requestExecutor = sinkStore.GetRequestExecutor();
-                using (requestExecutor.ContextPool.AllocateOperationContext(out var context))
-                {
-                    await requestExecutor.ExecuteAsync(command, context);
-                }
+                await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(pull, skipClientCertificateValidation: true));
             });
 
-            Assert.Contains("does not contain a private key", exception.Message);
-        }
-
-        /// <summary>
-        /// A custom command that sends the pull replication sink configuration to the server
-        /// without performing the client-side certificate validation.
-        /// Used to test the server-side validation in isolation.
-        /// </summary>
-        private class UpdatePullReplicationAsSinkWithoutClientValidationCommand : RavenCommand<ModifyOngoingTaskResult>, IRaftCommand
-        {
-            private readonly DocumentConventions _conventions;
-            private readonly PullReplicationAsSink _pullReplication;
-
-            public UpdatePullReplicationAsSinkWithoutClientValidationCommand(DocumentConventions conventions, PullReplicationAsSink pullReplication)
-            {
-                _conventions = conventions;
-                _pullReplication = pullReplication;
-            }
-
-            public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
-            {
-                url = $"{node.Url}/databases/{node.Database}/admin/tasks/sink-pull-replication";
-
-                var request = new HttpRequestMessage
-                {
-                    Method = HttpMethod.Post,
-                    Content = new BlittableJsonContent(async stream =>
-                    {
-                        var json = new DynamicJsonValue
-                        {
-                            ["PullReplicationAsSink"] = _pullReplication.ToJson()
-                        };
-
-                        await ctx.WriteAsync(stream, ctx.ReadObject(json, "update-pull-replication")).ConfigureAwait(false);
-                    }, _conventions)
-                };
-
-                return request;
-            }
-
-            public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
-            {
-                if (response == null)
-                    ThrowInvalidResponse();
-
-                Result = JsonDeserializationClient.ModifyOngoingTaskResult(response);
-            }
-
-            public override bool IsReadRequest => false;
-            public string RaftUniqueRequestId { get; } = RaftIdGenerator.NewId();
+            Assert.Contains("private key", exception.Message);
         }
 
         //TODO write test for deletion! - make sure replication is stopped after we delete hub!


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-16922/Validate-certificate-type-when-creating-Pull-replication-configuration

### Additional description

A fix to make the check coherent, both for the update as in the server store. A minor change in the UI provided.


https://github.com/user-attachments/assets/cc8c9961-6cc3-486c-a749-a02bc543f2a7



### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
