### PR TITLE
RavenDB-22818 Sparse regions: AllocatedSize vs PhysicalSize distinction in backed and on UI + Storage Report fixes

### DIFF
--- a/bench/TimeSeries.Benchmark/Program.cs
+++ b/bench/TimeSeries.Benchmark/Program.cs
@@ -592,7 +592,7 @@ namespace TimeSeries.Benchmark
             sp.Stop();
             var rate = _numberOfDocs * (TotalMeasuresPerDocument / sp.Elapsed.TotalSeconds);
             var stats = await _store.Maintenance.SendAsync(new GetDetailedStatisticsOperation());
-            return $"Inserting is completed after {sp.Elapsed} with total rate of {(int)rate:N0} measures per second with {stats.SizeOnDisk.HumaneSize} size.";
+            return $"Inserting is completed after {sp.Elapsed} with total rate of {(int)rate:N0} measures per second with {stats.PhysicalSizeOnDisk.HumaneSize} size.";
         }
 
         public async Task BenchmarkInsert(int iterations = 1)

--- a/src/Raven.Client/Documents/Operations/DatabaseStatistics.cs
+++ b/src/Raven.Client/Documents/Operations/DatabaseStatistics.cs
@@ -48,7 +48,9 @@ namespace Raven.Client.Documents.Operations
 
         public DateTime? LastIndexingTime { get; set; }
 
-        public Size SizeOnDisk { get; set; }
+        public Size PhysicalSizeOnDisk { get; set; }
+
+        public Size AllocatedSizeOnDisk { get; set; }
 
         public Size TempBuffersSizeOnDisk { get; set; }
 

--- a/src/Raven.Client/ServerWide/Operations/DatabasesInfo.cs
+++ b/src/Raven.Client/ServerWide/Operations/DatabasesInfo.cs
@@ -83,7 +83,8 @@ namespace Raven.Client.ServerWide.Operations
     public class DatabaseState : IDynamicJson
     {
         public string Name { get; set; }
-        public Size TotalSize { get; set; }
+        public Size TotalPhysicalSize { get; set; }
+        public Size TotalAllocatedSize { get; set; }
         public Size TempBuffersSize { get; set; }
         public TimeSpan? UpTime { get; set; }
         public BackupInfo BackupInfo { get; set; }
@@ -99,10 +100,15 @@ namespace Raven.Client.ServerWide.Operations
             return new DynamicJsonValue
             {
                 [nameof(Name)] = Name,
-                [nameof(TotalSize)] = TotalSize != null ? new DynamicJsonValue
+                [nameof(TotalPhysicalSize)] = TotalPhysicalSize != null ? new DynamicJsonValue
                 {
-                    [nameof(Size.HumaneSize)] = TotalSize.HumaneSize,
-                    [nameof(Size.SizeInBytes)] = TotalSize.SizeInBytes
+                    [nameof(Size.HumaneSize)] = TotalPhysicalSize.HumaneSize,
+                    [nameof(Size.SizeInBytes)] = TotalPhysicalSize.SizeInBytes
+                } : null,
+                [nameof(TotalAllocatedSize)] = TotalAllocatedSize != null ? new DynamicJsonValue
+                {
+                    [nameof(Size.HumaneSize)] = TotalAllocatedSize.HumaneSize,
+                    [nameof(Size.SizeInBytes)] = TotalAllocatedSize.SizeInBytes
                 } : null,
                 [nameof(TempBuffersSize)] = TempBuffersSize != null ? new DynamicJsonValue
                 {

--- a/src/Raven.Server/Documents/DocumentDatabase.cs
+++ b/src/Raven.Server/Documents/DocumentDatabase.cs
@@ -1330,10 +1330,15 @@ namespace Raven.Server.Documents
                 [nameof(ExtendedDatabaseInfo.IsEncrypted)] = DocumentsStorage.Environment.Options.Encryption.IsEnabled,
                 [nameof(ExtendedDatabaseInfo.Name)] = Name,
                 [nameof(ExtendedDatabaseInfo.Disabled)] = false, //TODO: this value should be overwritten by the studio since it is cached
-                [nameof(ExtendedDatabaseInfo.TotalSize)] = new DynamicJsonValue
+                [nameof(ExtendedDatabaseInfo.TotalPhysicalSize)] = new DynamicJsonValue
                 {
-                    [nameof(Size.HumaneSize)] = sizeOnDisk.Data.HumaneSize,
-                    [nameof(Size.SizeInBytes)] = sizeOnDisk.Data.SizeInBytes
+                    [nameof(Size.HumaneSize)] = sizeOnDisk.Physical.HumaneSize,
+                    [nameof(Size.SizeInBytes)] = sizeOnDisk.Physical.SizeInBytes
+                },
+                [nameof(ExtendedDatabaseInfo.TotalAllocatedSize)] = new DynamicJsonValue
+                {
+                    [nameof(Size.HumaneSize)] = sizeOnDisk.Allocated.HumaneSize,
+                    [nameof(Size.SizeInBytes)] = sizeOnDisk.Allocated.SizeInBytes
                 },
                 [nameof(ExtendedDatabaseInfo.TempBuffersSize)] = new DynamicJsonValue
                 {
@@ -1964,13 +1969,14 @@ namespace Raven.Server.Documents
             return _lastTopologyIndex > index;
         }
 
-        public (Size Data, Size TempBuffers) GetSizeOnDisk()
+        public (Size Physical, Size Allocated, Size TempBuffers) GetSizeOnDisk()
         {
             var storageEnvironments = GetAllStoragesEnvironment();
             if (storageEnvironments == null)
-                return (new Size(0), new Size(0));
+                return (new Size(0), new Size(0), new Size(0));
 
-            long dataInBytes = 0;
+            long physicalInBytes = 0;
+            long allocatedInBytes = 0;
             long tempBuffersInBytes = 0;
             foreach (var environment in storageEnvironments)
             {
@@ -1978,11 +1984,12 @@ namespace Raven.Server.Documents
                     continue;
 
                 var sizeOnDisk = environment.Environment.GenerateSizeReport(includeTempBuffers: true);
-                dataInBytes += sizeOnDisk.DataFileInBytes + sizeOnDisk.JournalsInBytes;
+                physicalInBytes += sizeOnDisk.DataFilePhysicalSizeInBytes + sizeOnDisk.JournalsInBytes;
+                allocatedInBytes += sizeOnDisk.DataFileAllocatedSizeInBytes + sizeOnDisk.JournalsInBytes;
                 tempBuffersInBytes += sizeOnDisk.TempBuffersInBytes;
             }
 
-            return (new Size(dataInBytes), new Size(tempBuffersInBytes));
+            return (new Size(physicalInBytes), new Size(allocatedInBytes), new Size(tempBuffersInBytes));
         }
 
         public IEnumerable<MountPointUsage> GetMountPointsUsage(bool includeTempBuffers)

--- a/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/Analyzers/Database/GeneralDatabaseInfoAnalyzer.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/Analyzers/Database/GeneralDatabaseInfoAnalyzer.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations;
 using Raven.Client.ServerWide;
+using Raven.Client.Util;
 using Raven.Server.Documents.Handlers.Debugging.DebugPackage.Analyzers.Errors;
 using Raven.Server.Documents.Handlers.Debugging.DebugPackage.Analyzers.Issues;
 using Raven.Server.Documents.Handlers.Debugging.DebugPackage.Analyzers.Results.Database;
@@ -43,6 +44,17 @@ public class GeneralDatabaseInfoAnalyzer(
             {
                 AddWarning($"Could not retrieve database statistics for '{DatabaseName}' database. Skipping it.");
                 return false;
+            }
+
+            if (stats.PhysicalSizeOnDisk is null && stats.AllocatedSizeOnDisk is null)
+            {
+                // old format of stats - no distinction between allocated and actual size on disk
+
+                if (databaseEntries.TryGetValue<StatsHandler, LegacyDatabaseStatistics>(x => x.Stats(), out var oldStats))
+                {
+                    stats.PhysicalSizeOnDisk = oldStats.SizeOnDisk;
+                    stats.AllocatedSizeOnDisk = oldStats.SizeOnDisk;
+                }
             }
         }
         catch (Exception e)
@@ -119,5 +131,10 @@ public class GeneralDatabaseInfoAnalyzer(
                     IssueCategory.Database));
             }
         }
+    }
+
+    private class LegacyDatabaseStatistics : DatabaseStatistics
+    {
+        public Size SizeOnDisk { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageAnalysisSummary.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/DebugPackage/DebugPackageAnalysisSummary.cs
@@ -91,7 +91,7 @@ public class DebugPackageAnalysisSummary : IDynamicJson
                 var dbDiskUsage = new DatabaseDiskUsage
                 {
                     Database = dbReport.DatabaseName,
-                    Size = dbReport.DatabaseInfo.Stats.SizeOnDisk.SizeInBytes,
+                    Size = dbReport.DatabaseInfo.Stats.PhysicalSizeOnDisk.SizeInBytes,
                     TempBuffersSize = dbReport.DatabaseInfo.Stats.TempBuffersSizeOnDisk.SizeInBytes,
                 };
             

--- a/src/Raven.Server/Documents/Handlers/Processors/Stats/StatsHandlerProcessorForGetDatabaseStatistics.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/Stats/StatsHandlerProcessorForGetDatabaseStatistics.cs
@@ -50,7 +50,8 @@ namespace Raven.Server.Documents.Handlers.Processors.Stats
             stats.CountOfDocumentsConflicts = database.DocumentsStorage.ConflictsStorage.GetNumberOfDocumentsConflicts(context.Documents);
             stats.CountOfTombstones = database.DocumentsStorage.GetNumberOfTombstones(context.Documents);
             stats.CountOfConflicts = database.DocumentsStorage.ConflictsStorage.GetNumberOfConflicts(context.Documents);
-            stats.SizeOnDisk = size.Data;
+            stats.PhysicalSizeOnDisk = size.Physical;
+            stats.AllocatedSizeOnDisk = size.Allocated;
             stats.NumberOfTransactionMergerQueueOperations = database.TxMerger.NumberOfQueuedOperations;
             stats.TempBuffersSizeOnDisk = size.TempBuffers;
             stats.CountOfCounterEntries = database.DocumentsStorage.CountersStorage.GetNumberOfCounterEntries(context.Documents);

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -5200,7 +5200,7 @@ namespace Raven.Server.Documents.Indexes
         public Size CalculateIndexStorageSize()
         {
             var storageReport = _environment.GenerateSizeReport(includeTempBuffers: false);
-            var sizeOnDiskInBytes = storageReport.DataFileInBytes + storageReport.JournalsInBytes;
+            var sizeOnDiskInBytes = storageReport.DataFilePhysicalSizeInBytes + storageReport.JournalsInBytes;
             return new Size(sizeOnDiskInBytes, SizeUnit.Bytes);
         }
 

--- a/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
+++ b/src/Raven.Server/Json/BlittableJsonTextWriterExtensions.cs
@@ -1299,15 +1299,28 @@ namespace Raven.Server.Json
                 writer.WriteNull();
             writer.WriteComma();
 
-            writer.WritePropertyName(nameof(statistics.SizeOnDisk));
+            writer.WritePropertyName(nameof(statistics.PhysicalSizeOnDisk));
             writer.WriteStartObject();
 
-            writer.WritePropertyName(nameof(statistics.SizeOnDisk.HumaneSize));
-            writer.WriteString(statistics.SizeOnDisk.HumaneSize);
+            writer.WritePropertyName(nameof(statistics.PhysicalSizeOnDisk.HumaneSize));
+            writer.WriteString(statistics.PhysicalSizeOnDisk.HumaneSize);
             writer.WriteComma();
 
-            writer.WritePropertyName(nameof(statistics.SizeOnDisk.SizeInBytes));
-            writer.WriteInteger(statistics.SizeOnDisk.SizeInBytes);
+            writer.WritePropertyName(nameof(statistics.PhysicalSizeOnDisk.SizeInBytes));
+            writer.WriteInteger(statistics.PhysicalSizeOnDisk.SizeInBytes);
+
+            writer.WriteEndObject();
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(statistics.AllocatedSizeOnDisk));
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(statistics.AllocatedSizeOnDisk.HumaneSize));
+            writer.WriteString(statistics.AllocatedSizeOnDisk.HumaneSize);
+            writer.WriteComma();
+
+            writer.WritePropertyName(nameof(statistics.AllocatedSizeOnDisk.SizeInBytes));
+            writer.WriteInteger(statistics.AllocatedSizeOnDisk.SizeInBytes);
 
             writer.WriteEndObject();
             writer.WriteComma();

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -3860,7 +3860,7 @@ namespace Raven.Server.ServerWide
             {
                 Name = environment.Name,
                 Type = environment.Type.ToString(),
-                UsedSpace = sizeOnDisk.DataFileInBytes,
+                UsedSpace = sizeOnDisk.DataFilePhysicalSizeInBytes,
                 DiskSpaceResult = FillDiskSpaceResult(diskSpaceResult),
                 UsedSpaceByTempBuffers = 0
             };

--- a/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
+++ b/src/Raven.Server/Web/System/AdminDatabasesHandler.cs
@@ -1273,7 +1273,7 @@ namespace Raven.Server.Web.System
                 throw new InvalidOperationException($"Could not load database '{databaseName}'.");
 
             using (database.PreventFromUnloadingByIdleOperations())
-                return new Size(database.GetSizeOnDisk().Data.SizeInBytes, SizeUnit.Bytes);
+                return new Size(database.GetSizeOnDisk().Physical.SizeInBytes, SizeUnit.Bytes);
         }
 
         [RavenAction("/admin/databases/unused-ids", "POST", AuthorizationStatus.Operator)]

--- a/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
+++ b/src/Raven.Server/Web/System/Processors/Databases/DatabasesHandlerProcessorForGet.cs
@@ -201,14 +201,15 @@ internal sealed class DatabasesHandlerProcessorForGet : AbstractDatabasesHandler
                 // so just report empty values then
             }
 
-            var size = db?.GetSizeOnDisk() ?? (new Size(0), new Size(0));
+            var size = db?.GetSizeOnDisk() ?? (new Size(0), new Size(0), new Size(0));
 
             var databaseInfo = new DatabaseInfo
             {
                 Name = databaseName,
                 Disabled = disabled,
                 LockMode = lockMode,
-                TotalSize = size.Data,
+                TotalPhysicalSize = size.Physical,
+                TotalAllocatedSize = size.Allocated,
                 TempBuffersSize = size.TempBuffers,
 
                 IsAdmin = true,

--- a/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabasesState.cs
+++ b/src/Raven.Server/Web/System/Processors/Studio/StudioDatabasesHandlerForGetDatabasesState.cs
@@ -306,7 +306,8 @@ internal sealed class StudioDatabasesHandlerForGetDatabasesState : AbstractDatab
 
         public static StudioDatabaseState From(string databaseName, StudioDatabaseStatus databaseStatus, DocumentDatabase database, DatabaseInfoCache databaseInfoCache, BackupInfo backupInfo, TimeSpan? upTime, IndexRunningStatus? indexingStatus)
         {
-            Size totalSize = null;
+            Size totalPhysicalSize = null;
+            Size totalAllocatedSize = null;
             Size tempBuffersSize = null;
             long alerts = 0;
             long performanceHints = 0;
@@ -314,8 +315,9 @@ internal sealed class StudioDatabasesHandlerForGetDatabasesState : AbstractDatab
             long documentsCount = 0;
             if (database != null)
             {
-                (Size data, Size tempBuffers) = database.GetSizeOnDisk();
-                totalSize = data;
+                (Size physical, Size allocated, Size tempBuffers) = database.GetSizeOnDisk();
+                totalPhysicalSize = physical;
+                totalAllocatedSize = allocated;
                 tempBuffersSize = tempBuffers;
 
                 alerts = database.NotificationCenter.GetAlertCount();
@@ -333,7 +335,8 @@ internal sealed class StudioDatabasesHandlerForGetDatabasesState : AbstractDatab
                          json.TryGet(nameof(IndexingErrors), out indexingErrors);
                          json.TryGet(nameof(DocumentsCount), out documentsCount);
 
-                         totalSize = GetSize(json, nameof(TotalSize));
+                         totalPhysicalSize = GetSize(json, nameof(TotalPhysicalSize));
+                         totalAllocatedSize = GetSize(json, nameof(TotalAllocatedSize));
                          tempBuffersSize = GetSize(json, nameof(TempBuffersSize));
                      }))
             {
@@ -343,7 +346,8 @@ internal sealed class StudioDatabasesHandlerForGetDatabasesState : AbstractDatab
             return new StudioDatabaseState
             {
                 Name = databaseName,
-                TotalSize = totalSize,
+                TotalPhysicalSize = totalPhysicalSize,
+                TotalAllocatedSize = totalAllocatedSize,
                 TempBuffersSize = tempBuffersSize,
                 UpTime = upTime,
                 BackupInfo = backupInfo,

--- a/src/Raven.Studio/typescript/components/common/shell/databasesSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/databasesSlice.ts
@@ -57,7 +57,8 @@ export function toDatabaseLocalInfo(db: StudioDatabaseState, nodeTag: string): D
         performanceHints: db.PerformanceHints,
         upTime: db.UpTime ? genUtils.timeSpanAsAgo(db.UpTime, false) : null, // we format here to avoid constant updates of UI
         backupInfo: db.BackupInfo,
-        totalSize: db.TotalSize,
+        totalPhysicalSize: db.TotalPhysicalSize,
+        totalAllocatedSize: db.TotalAllocatedSize,
         tempBuffersSize: db.TempBuffersSize,
         databaseStatus: db.DatabaseStatus,
     };

--- a/src/Raven.Studio/typescript/components/models/databases.ts
+++ b/src/Raven.Studio/typescript/components/models/databases.ts
@@ -21,7 +21,8 @@ export interface DatabaseLocalInfo {
     indexingStatus: IndexRunningStatus;
     documentsCount: number;
     tempBuffersSize: Raven.Client.Util.Size;
-    totalSize: Raven.Client.Util.Size;
+    totalPhysicalSize: Raven.Client.Util.Size;
+    totalAllocatedSize: Raven.Client.Util.Size;
     upTime?: string;
     backupInfo: Raven.Client.ServerWide.Operations.BackupInfo;
     databaseStatus: Raven.Server.Web.System.Processors.Studio.StudioDatabasesHandlerForGetDatabasesState.StudioDatabaseStatus;

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
@@ -144,19 +144,12 @@ export function DetailedDatabaseStats() {
                                             message={
                                                 <>
                                                     Data (on disk):{" "}
-                                                    <strong>
-                                                        {genUtils.formatBytesToSize(physicalBytes)}
-                                                    </strong>
+                                                    <strong>{genUtils.formatBytesToSize(physicalBytes)}</strong>
                                                     <br />
                                                     Data (allocated):{" "}
-                                                    <strong>
-                                                        {genUtils.formatBytesToSize(allocatedBytes)}
-                                                    </strong>
+                                                    <strong>{genUtils.formatBytesToSize(allocatedBytes)}</strong>
                                                     <br />
-                                                    Temp:{" "}
-                                                    <strong>
-                                                        {genUtils.formatBytesToSize(tempBytes)}
-                                                    </strong>
+                                                    Temp: <strong>{genUtils.formatBytesToSize(tempBytes)}</strong>
                                                     <br />
                                                     Total (on disk):{" "}
                                                     <strong>
@@ -165,9 +158,7 @@ export function DetailedDatabaseStats() {
                                                 </>
                                             }
                                         >
-                                            <span id={id}>
-                                                {genUtils.formatBytesToSize(physicalBytes + tempBytes)}
-                                            </span>
+                                            <span id={id}>{genUtils.formatBytesToSize(physicalBytes + tempBytes)}</span>
                                         </PopoverWithHoverWrapper>
                                     );
                                 }}

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
@@ -136,9 +136,12 @@ export function DetailedDatabaseStats() {
                             <DetailsBlock>
                                 {(data, location) => {
                                     const id = "js-size-on-disk-" + location.nodeTag + "-" + location.shardNumber;
-                                    const physicalBytes = data.PhysicalSizeOnDisk.SizeInBytes;
-                                    const allocatedBytes = data.AllocatedSizeOnDisk.SizeInBytes;
-                                    const tempBytes = data.TempBuffersSizeOnDisk.SizeInBytes;
+
+                                    const physicalBytes = data.PhysicalSizeOnDisk?.SizeInBytes ?? 0;
+                                    const allocatedBytes = data.AllocatedSizeOnDisk?.SizeInBytes ?? 0;
+                                    const tempBytes = data.TempBuffersSizeOnDisk?.SizeInBytes ?? 0;
+                                    const grandTotalSize = tempBytes + physicalBytes;
+
                                     return (
                                         <PopoverWithHoverWrapper
                                             message={
@@ -152,13 +155,11 @@ export function DetailedDatabaseStats() {
                                                     Temp: <strong>{genUtils.formatBytesToSize(tempBytes)}</strong>
                                                     <br />
                                                     Total (on disk):{" "}
-                                                    <strong>
-                                                        {genUtils.formatBytesToSize(physicalBytes + tempBytes)}
-                                                    </strong>
+                                                    <strong>{genUtils.formatBytesToSize(grandTotalSize)}</strong>
                                                 </>
                                             }
                                         >
-                                            <span id={id}>{genUtils.formatBytesToSize(physicalBytes + tempBytes)}</span>
+                                            <span id={id}>{genUtils.formatBytesToSize(grandTotalSize)}</span>
                                         </PopoverWithHoverWrapper>
                                     );
                                 }}

--- a/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/status/statistics/partials/DetailedDatabaseStats.tsx
@@ -136,36 +136,37 @@ export function DetailedDatabaseStats() {
                             <DetailsBlock>
                                 {(data, location) => {
                                     const id = "js-size-on-disk-" + location.nodeTag + "-" + location.shardNumber;
+                                    const physicalBytes = data.PhysicalSizeOnDisk.SizeInBytes;
+                                    const allocatedBytes = data.AllocatedSizeOnDisk.SizeInBytes;
+                                    const tempBytes = data.TempBuffersSizeOnDisk.SizeInBytes;
                                     return (
                                         <PopoverWithHoverWrapper
                                             message={
                                                 <>
-                                                    Data:{" "}
+                                                    Data (on disk):{" "}
                                                     <strong>
-                                                        {genUtils.formatBytesToSize(data.SizeOnDisk.SizeInBytes)}
+                                                        {genUtils.formatBytesToSize(physicalBytes)}
+                                                    </strong>
+                                                    <br />
+                                                    Data (allocated):{" "}
+                                                    <strong>
+                                                        {genUtils.formatBytesToSize(allocatedBytes)}
                                                     </strong>
                                                     <br />
                                                     Temp:{" "}
                                                     <strong>
-                                                        {genUtils.formatBytesToSize(
-                                                            data.TempBuffersSizeOnDisk.SizeInBytes
-                                                        )}
+                                                        {genUtils.formatBytesToSize(tempBytes)}
                                                     </strong>
                                                     <br />
-                                                    Total:{" "}
+                                                    Total (on disk):{" "}
                                                     <strong>
-                                                        {genUtils.formatBytesToSize(
-                                                            data.SizeOnDisk.SizeInBytes +
-                                                                data.TempBuffersSizeOnDisk.SizeInBytes
-                                                        )}
+                                                        {genUtils.formatBytesToSize(physicalBytes + tempBytes)}
                                                     </strong>
                                                 </>
                                             }
                                         >
                                             <span id={id}>
-                                                {genUtils.formatBytesToSize(
-                                                    data.SizeOnDisk.SizeInBytes + data.TempBuffersSizeOnDisk.SizeInBytes
-                                                )}
+                                                {genUtils.formatBytesToSize(physicalBytes + tempBytes)}
                                             </span>
                                         </PopoverWithHoverWrapper>
                                     );

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/SizeOnDisk.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/SizeOnDisk.tsx
@@ -1,17 +1,13 @@
 ﻿import { DatabaseLocalInfo } from "components/models/databases";
 import genUtils from "common/generalUtils";
-import useUniqueId from "components/hooks/useUniqueId";
-import OverlayTrigger from "react-bootstrap/OverlayTrigger";
-import Tooltip from "react-bootstrap/Tooltip";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 
 export function SizeOnDisk(props: { info: DatabaseLocalInfo }) {
     const { info } = props;
-
-    const tooltipId = useUniqueId("size-on-disk-tooltip");
-
     if (!info) {
         return null;
     }
+
     const tempBufferSize = info.tempBuffersSize?.SizeInBytes ?? 0;
     const physicalSize = info.totalPhysicalSize?.SizeInBytes ?? 0;
     const allocatedSize = info.totalAllocatedSize?.SizeInBytes ?? 0;
@@ -19,9 +15,9 @@ export function SizeOnDisk(props: { info: DatabaseLocalInfo }) {
 
     return (
         <div>
-            <OverlayTrigger
-                overlay={
-                    <Tooltip id={tooltipId}>
+            <PopoverWithHoverWrapper
+                message={
+                    <>
                         Data (on disk): <strong>{genUtils.formatBytesToSize(physicalSize)}</strong>
                         <br />
                         Data (allocated): <strong>{genUtils.formatBytesToSize(allocatedSize)}</strong>
@@ -29,11 +25,11 @@ export function SizeOnDisk(props: { info: DatabaseLocalInfo }) {
                         Temp: <strong>{genUtils.formatBytesToSize(tempBufferSize)}</strong>
                         <br />
                         Total: <strong>{genUtils.formatBytesToSize(grandTotalSize)}</strong>
-                    </Tooltip>
+                    </>
                 }
             >
-                <div>{genUtils.formatBytesToSize(grandTotalSize)}</div>
-            </OverlayTrigger>
+                {genUtils.formatBytesToSize(grandTotalSize)}
+            </PopoverWithHoverWrapper>
         </div>
     );
 }

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/SizeOnDisk.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/SizeOnDisk.tsx
@@ -13,15 +13,18 @@ export function SizeOnDisk(props: { info: DatabaseLocalInfo }) {
         return null;
     }
     const tempBufferSize = info.tempBuffersSize?.SizeInBytes ?? 0;
-    const totalSize = info.totalSize?.SizeInBytes ?? 0;
-    const grandTotalSize = tempBufferSize + totalSize;
+    const physicalSize = info.totalPhysicalSize?.SizeInBytes ?? 0;
+    const allocatedSize = info.totalAllocatedSize?.SizeInBytes ?? 0;
+    const grandTotalSize = tempBufferSize + physicalSize;
 
     return (
         <div>
             <OverlayTrigger
                 overlay={
                     <Tooltip id={tooltipId}>
-                        Data: <strong>{genUtils.formatBytesToSize(totalSize)}</strong>
+                        Data (on disk): <strong>{genUtils.formatBytesToSize(physicalSize)}</strong>
+                        <br />
+                        Data (allocated): <strong>{genUtils.formatBytesToSize(allocatedSize)}</strong>
                         <br />
                         Temp: <strong>{genUtils.formatBytesToSize(tempBufferSize)}</strong>
                         <br />

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.spec.tsx
@@ -84,17 +84,19 @@ describe("ValidDatabasePropertiesPanel", () => {
                 const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
                     getDatabaseLocalInfo({
                         location: { nodeTag: "A" },
-                        totalSize: { SizeInBytes: 1, HumaneSize: "1 B" },
+                        totalPhysicalSize: { SizeInBytes: 1, HumaneSize: "1 B" },
+                        totalAllocatedSize: { SizeInBytes: 1, HumaneSize: "1 B" },
                         tempBuffersSize: { SizeInBytes: 2, HumaneSize: "2 B" },
                     }),
                     getDatabaseLocalInfo({
                         location: { nodeTag: "B" },
-                        totalSize: { SizeInBytes: 3, HumaneSize: "3 B" },
+                        totalPhysicalSize: { SizeInBytes: 3, HumaneSize: "3 B" },
+                        totalAllocatedSize: { SizeInBytes: 3, HumaneSize: "3 B" },
                         tempBuffersSize: { SizeInBytes: 4, HumaneSize: "4 B" },
                     }),
                 ];
 
-                // totalSizeWithTempBuffers is totalSize + tempBuffersSize
+                // totalSizeWithTempBuffers is totalPhysicalSize + tempBuffersSize
                 expect(getLocalGeneralInfo(dbStates, "A").totalSizeWithTempBuffers).toBe(3);
                 expect(getLocalGeneralInfo(dbStates, "B").totalSizeWithTempBuffers).toEqual(7);
             });
@@ -170,17 +172,19 @@ describe("ValidDatabasePropertiesPanel", () => {
                 const dbStates: locationAwareLoadableData<DatabaseLocalInfo>[] = [
                     getDatabaseLocalInfo({
                         location: { nodeTag: "A", shardNumber: 0 },
-                        totalSize: { SizeInBytes: 1, HumaneSize: "1 B" },
+                        totalPhysicalSize: { SizeInBytes: 1, HumaneSize: "1 B" },
+                        totalAllocatedSize: { SizeInBytes: 1, HumaneSize: "1 B" },
                         tempBuffersSize: { SizeInBytes: 2, HumaneSize: "2 B" },
                     }),
                     getDatabaseLocalInfo({
                         location: { nodeTag: "A", shardNumber: 1 },
-                        totalSize: { SizeInBytes: 3, HumaneSize: "3 B" },
+                        totalPhysicalSize: { SizeInBytes: 3, HumaneSize: "3 B" },
+                        totalAllocatedSize: { SizeInBytes: 3, HumaneSize: "3 B" },
                         tempBuffersSize: { SizeInBytes: 4, HumaneSize: "4 B" },
                     }),
                 ];
 
-                // totalSizeWithTempBuffers is totalSize + tempBuffersSize
+                // totalSizeWithTempBuffers is totalPhysicalSize + tempBuffersSize
 
                 const shard0TotalSize = 3;
                 const shard1TotalSize = 7;
@@ -222,7 +226,8 @@ describe("ValidDatabasePropertiesPanel", () => {
             status = "success",
             location,
             loadError,
-            totalSize,
+            totalPhysicalSize,
+            totalAllocatedSize,
             tempBuffersSize,
             documentsCount,
             backupInfo,
@@ -232,7 +237,8 @@ describe("ValidDatabasePropertiesPanel", () => {
             loadError?: string;
             documentsCount?: number;
             tempBuffersSize?: Raven.Client.Util.Size;
-            totalSize?: Raven.Client.Util.Size;
+            totalPhysicalSize?: Raven.Client.Util.Size;
+            totalAllocatedSize?: Raven.Client.Util.Size;
             backupInfo?: BackupInfo;
         }): locationAwareLoadableData<DatabaseLocalInfo> {
             return {
@@ -243,7 +249,8 @@ describe("ValidDatabasePropertiesPanel", () => {
                     databaseStatus: "Online",
                     indexingStatus: "Running",
                     documentsCount,
-                    totalSize,
+                    totalPhysicalSize,
+                    totalAllocatedSize,
                     tempBuffersSize,
                     location,
                     indexingErrors: null,

--- a/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/databases/partials/ValidDatabasePropertiesPanel.tsx
@@ -347,7 +347,7 @@ function getLocalGeneralInfo(
 
     const totalSizeWithTempBuffers = sumBy(
         localDbStatesWithoutErrors,
-        (x) => (x.data?.totalSize?.SizeInBytes ?? 0) + (x.data?.tempBuffersSize?.SizeInBytes ?? 0)
+        (x) => (x.data?.totalPhysicalSize?.SizeInBytes ?? 0) + (x.data?.tempBuffersSize?.SizeInBytes ?? 0)
     );
 
     const totalDocuments = sumBy(localDbStatesWithoutErrors, (x) => x.data?.documentsCount ?? 0);

--- a/src/Raven.Studio/typescript/models/database/status/storageReportItem.ts
+++ b/src/Raven.Studio/typescript/models/database/status/storageReportItem.ts
@@ -8,6 +8,7 @@ class storageReportItem {
     type: string;
     internalChildren: storageReportItem[];
     size?: number;
+    physicalSize?: number;
     length?: number;
     x?: number;
     y?: number;

--- a/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
+++ b/src/Raven.Studio/typescript/test/stubs/DatabasesStubs.ts
@@ -237,7 +237,11 @@ export class DatabasesStubs {
             Alerts: 1,
             PerformanceHints: 2,
             IndexingErrors: 3,
-            TotalSize: {
+            TotalPhysicalSize: {
+                SizeInBytes: 5,
+                HumaneSize: "5 Bytes",
+            },
+            TotalAllocatedSize: {
                 SizeInBytes: 5,
                 HumaneSize: "5 Bytes",
             },
@@ -263,7 +267,11 @@ export class DatabasesStubs {
             NumberOfTransactionMergerQueueOperations: 0,
             DatabaseId: "jMR/KF8hz0uMKFDXnmrQJA",
             CountOfCompareExchangeTombstones: 44,
-            SizeOnDisk: {
+            PhysicalSizeOnDisk: {
+                HumaneSize: "295.44 MBytes",
+                SizeInBytes: 309788672,
+            },
+            AllocatedSizeOnDisk: {
                 HumaneSize: "295.44 MBytes",
                 SizeInBytes: 309788672,
             },

--- a/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
@@ -49,6 +49,9 @@ class storageReport extends shardViewModelBase {
     showPagesColumn: KnockoutObservable<boolean>;
     showEntriesColumn: KnockoutObservable<boolean>;
     showTempFiles: KnockoutObservable<boolean>;
+    showOnDiskColumn: KnockoutObservable<boolean>;
+    allocatedNodeSize: KnockoutComputed<string>;
+    onDiskNodeSize: KnockoutComputed<string>;
 
     documentsCompressionUrl: KnockoutComputed<string>;
 
@@ -105,7 +108,17 @@ class storageReport extends shardViewModelBase {
         
         this.showTempFiles = ko.pureComputed(() => {
             return this.node() == this.root;
-        })
+        });
+
+        this.showOnDiskColumn = ko.pureComputed(() =>
+            !!(this.node().internalChildren || []).find(x => x.physicalSize != null)
+        );
+        this.allocatedNodeSize = ko.pureComputed(() =>
+            generalUtils.formatBytesToSize(this.node().size)
+        );
+        this.onDiskNodeSize = ko.pureComputed(() =>
+            generalUtils.formatBytesToSize(this.node().physicalSize ?? this.node().size)
+        );
 
         this.documentsCompressionUrl = ko.pureComputed(() => appUrl.forDocumentsCompression(this.db));
     }
@@ -115,7 +128,9 @@ class storageReport extends shardViewModelBase {
 
         const mappedData = data.map(x => this.mapReport(x));
         const totalSize = mappedData.reduce((p, c) => p + c.size, 0);
+        const totalPhysicalSize = mappedData.reduce((p, c) => p + (c.physicalSize ?? c.size), 0);
         const item = new storageReportItem("/", "Database", false, totalSize, mappedData);
+        item.physicalSize = totalPhysicalSize;
 
         this.root = item;
 
@@ -137,11 +152,17 @@ class storageReport extends shardViewModelBase {
         const journals = this.mapJournals(reportItem.Report);
         const tempFiles = this.mapTempFiles(reportItem.Report);
 
-        return new storageReportItem(reportItem.Name,
+        const item = new storageReportItem(reportItem.Name,
             reportItem.Type.toLowerCase(),
             storageReport.showDisplayReportType(reportItem.Type),
             dataFile.size + journals.size + tempFiles.size,
             [dataFile, journals, tempFiles]);
+
+        if (dataFile.physicalSize != null) {
+            item.physicalSize = dataFile.physicalSize + journals.size + tempFiles.size;
+        }
+
+        return item;
     }
 
     private static showDisplayReportType(reportType: string): boolean {
@@ -153,6 +174,7 @@ class storageReport extends shardViewModelBase {
 
         const storageItem = new storageReportItem("Datafile", "data", false, dataFile.AllocatedSpaceInBytes);
         storageItem.lazyLoadChildren = true;
+        storageItem.physicalSize = dataFile.PhysicalSpaceInBytes;
 
         return storageItem;
     }
@@ -164,6 +186,18 @@ class storageReport extends shardViewModelBase {
         const trees = this.mapTrees(report.Trees, "Trees");
         const freeSpace = new storageReportItem("Free", "free", false, report.DataFile.FreeSpaceInBytes, []);
         const preallocatedBuffers = this.mapPreAllocatedBuffers(report.PreAllocatedBuffers);
+
+        const sparseRegionsSavings = report.DataFile.AllocatedSpaceInBytes - report.DataFile.PhysicalSpaceInBytes;
+        if (sparseRegionsSavings > 0) {
+            const freeFormatted = generalUtils.formatBytesToSize(report.DataFile.FreeSpaceInBytes);
+            const savingsFormatted = generalUtils.formatBytesToSize(sparseRegionsSavings);
+            freeSpace.customSizeProvider = (header: boolean) => {
+                if (header) {
+                    return freeFormatted;
+                }
+                return `${freeFormatted} <small>(Sparse regions: ${savingsFormatted})</small>`;
+            };
+        }
 
         d.internalChildren = [tables, trees, freeSpace, preallocatedBuffers];
     }
@@ -677,6 +711,10 @@ class storageReport extends shardViewModelBase {
 
         const tempFiles = item.internalChildren.find(x => x.type === "tempFiles");
         return generalUtils.formatBytesToSize(tempFiles.size);
+    }
+
+    onDiskSizeFormatted(item: storageReportItem) {
+        return generalUtils.formatBytesToSize(item.physicalSize ?? item.size);
     }
 
     compactDatabase() {

--- a/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/status/storageReport.ts
@@ -111,7 +111,7 @@ class storageReport extends shardViewModelBase {
         });
 
         this.showOnDiskColumn = ko.pureComputed(() =>
-            !!(this.node().internalChildren || []).find(x => x.physicalSize != null)
+            !!(this.node().internalChildren || []).find(x => x.physicalSize != null && x.physicalSize < x.size)
         );
         this.allocatedNodeSize = ko.pureComputed(() =>
             generalUtils.formatBytesToSize(this.node().size)

--- a/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
@@ -95,7 +95,7 @@ class storageReport extends viewModelBase {
         });
 
         this.showOnDiskColumn = ko.pureComputed(() =>
-            !!(this.node().internalChildren || []).find(x => x.physicalSize != null)
+            !!(this.node().internalChildren || []).find(x => x.physicalSize != null && x.physicalSize < x.size)
         );
         this.allocatedNodeSize = ko.pureComputed(() =>
             generalUtils.formatBytesToSize(this.node().size)

--- a/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/storageReport.ts
@@ -37,6 +37,9 @@ class storageReport extends viewModelBase {
     showPagesColumn: KnockoutObservable<boolean>;
     showEntriesColumn: KnockoutObservable<boolean>;
     showTempFiles: KnockoutObservable<boolean>;
+    showOnDiskColumn: KnockoutObservable<boolean>;
+    allocatedNodeSize: KnockoutComputed<string>;
+    onDiskNodeSize: KnockoutComputed<string>;
 
     constructor() {
         super();
@@ -89,7 +92,17 @@ class storageReport extends viewModelBase {
         
         this.showTempFiles = ko.pureComputed(() => {
             return this.node() == this.root;
-        })
+        });
+
+        this.showOnDiskColumn = ko.pureComputed(() =>
+            !!(this.node().internalChildren || []).find(x => x.physicalSize != null)
+        );
+        this.allocatedNodeSize = ko.pureComputed(() =>
+            generalUtils.formatBytesToSize(this.node().size)
+        );
+        this.onDiskNodeSize = ko.pureComputed(() =>
+            generalUtils.formatBytesToSize(this.node().physicalSize ?? this.node().size)
+        );
     }
 
     private processData() {
@@ -113,24 +126,44 @@ class storageReport extends viewModelBase {
         const journals = this.mapJournals(reportItem.Report);
         const tempFiles = this.mapTempFiles(reportItem.Report);
 
-        return new storageReportItem(reportItem.Environment,
+        const item = new storageReportItem(reportItem.Environment,
             reportItem.Type.toLowerCase(),
             true,
             dataFile.size + journals.size + tempFiles.size,
             [dataFile, journals, tempFiles]);
+
+        if (dataFile.physicalSize != null) {
+            item.physicalSize = dataFile.physicalSize + journals.size + tempFiles.size;
+        }
+
+        return item;
     }
 
     private mapDataFile(report: Voron.Debugging.DetailedStorageReport): storageReportItem {
         const dataFile = report.DataFile;
 
         const d = new storageReportItem("Datafile", "data", false, dataFile.AllocatedSpaceInBytes);
+        d.physicalSize = dataFile.PhysicalSpaceInBytes;
+
         const tables = this.mapTables(report.Tables);
         const trees = this.mapTrees(report.Trees, "Trees");
         const freeSpace = new storageReportItem("Free", "free", false, report.DataFile.FreeSpaceInBytes, []);
         const preallocatedBuffers = this.mapPreAllocatedBuffers(report.PreAllocatedBuffers);
 
+        const sparseRegionsSavings = dataFile.AllocatedSpaceInBytes - dataFile.PhysicalSpaceInBytes;
+        if (sparseRegionsSavings > 0) {
+            const freeFormatted = generalUtils.formatBytesToSize(report.DataFile.FreeSpaceInBytes);
+            const savingsFormatted = generalUtils.formatBytesToSize(sparseRegionsSavings);
+            freeSpace.customSizeProvider = (header: boolean) => {
+                if (header) {
+                    return freeFormatted;
+                }
+                return `${freeFormatted} <small>(Sparse regions: ${savingsFormatted})</small>`;
+            };
+        }
+
         d.internalChildren = [tables, trees, freeSpace, preallocatedBuffers];
-        
+
         return d;
     }
 
@@ -493,6 +526,10 @@ class storageReport extends viewModelBase {
         this.tooltip.transition()
             .duration(500)
             .style("opacity", 0);
+    }
+
+    onDiskSizeFormatted(item: storageReportItem) {
+        return generalUtils.formatBytesToSize(item.physicalSize ?? item.size);
     }
 }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/status/storageReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/status/storageReport.html
@@ -38,7 +38,8 @@
                 <th data-bind="visible: showEntriesColumn()">Entries</th>
                 <th data-bind="visible: showTempFiles()">Data + Journals</th>
                 <th data-bind="visible: showTempFiles()">Temporary Buffers</th>
-                <th><span data-bind="visible: showTempFiles()">Total</span> Size (&sum; <span data-bind="text: node().formatSize(true)"></span>)</th>
+                <th><span data-bind="visible: showTempFiles()">Total</span> Allocated (&sum; <span data-bind="text: allocatedNodeSize"></span>)</th>
+                <th data-bind="visible: showOnDiskColumn">On Disk (&sum; <span data-bind="text: onDiskNodeSize"></span>)</th>
                 <th>% Total</th>
             </tr>
         </thead>
@@ -57,6 +58,7 @@
                 <td data-bind="visible: $root.showTempFiles, text: $root.dataSizeFormatted($data)"></td>
                 <td data-bind="visible: $root.showTempFiles, text: $root.tempSizeFormatted($data)"></td>
                 <td data-bind="html: formatSize(false)"></td>
+                <td data-bind="visible: $root.showOnDiskColumn, text: $root.onDiskSizeFormatted($data)"></td>
                 <td data-bind="text: formatPercentage($parent.node().size)"></td>
             </tr>
         </tbody>

--- a/src/Raven.Studio/wwwroot/App/views/manage/storageReport.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/storageReport.html
@@ -22,7 +22,8 @@
                 <th class="column-min-width">Name</th>
                 <th data-bind="visible: showPagesColumn()"># Pages</th>
                 <th data-bind="visible: showEntriesColumn()">Entries</th>
-                <th><span data-bind="visible: showTempFiles()">Total</span> Size (&sum; <span data-bind="text: node().formatSize(true)"></span>)</th>
+                <th><span data-bind="visible: showTempFiles()">Total</span> Allocated (&sum; <span data-bind="text: allocatedNodeSize"></span>)</th>
+                <th data-bind="visible: showOnDiskColumn">On Disk (&sum; <span data-bind="text: onDiskNodeSize"></span>)</th>
                 <th>% Total</th>
             </tr>
         </thead>
@@ -39,6 +40,7 @@
                 <td data-bind="visible: $root.showPagesColumn(), text: pageCount ? pageCount.toLocaleString() : 0"></td>
                 <td data-bind="visible: $root.showEntriesColumn(), text: numberOfEntries ? numberOfEntries.toLocaleString() : 0"></td>
                 <td data-bind="html: formatSize(false)"></td>
+                <td data-bind="visible: $root.showOnDiskColumn, text: $root.onDiskSizeFormatted($data)"></td>
                 <td data-bind="text: formatPercentage($parent.node().size)"></td>
             </tr>
         </tbody>

--- a/src/Voron/Data/Tables/Table.cs
+++ b/src/Voron/Data/Tables/Table.cs
@@ -581,6 +581,7 @@ namespace Voron.Data.Tables
                 {
                     _tx.LowLevelTransaction.FreePage(page.PageNumber + i);
                 }
+                _stats.OverflowPageCount -= numberOfPages;
             }
 
             _stats.NumberOfEntries--;

--- a/src/Voron/Debugging/DetailedStorageReport.cs
+++ b/src/Voron/Debugging/DetailedStorageReport.cs
@@ -11,7 +11,8 @@ namespace Voron.Debugging
 {
     public sealed class SizeReport
     {
-        public long DataFileInBytes { get; set; }
+        public long DataFilePhysicalSizeInBytes { get; set; }
+        public long DataFileAllocatedSizeInBytes { get; set; }
         public long JournalsInBytes { get; set; }
         public long TempBuffersInBytes { get; set; }
     }
@@ -65,7 +66,7 @@ namespace Voron.Debugging
         }
 
         public required long AllocatedSpaceInBytes { get; set; }
-        public required long ActualSpaceInBytes { get; set; }
+        public required long PhysicalSpaceInBytes { get; set; }
         public required long UsedSpaceInBytes { get; set; }
         public required long FreeSpaceInBytes { get; set; }
     }

--- a/src/Voron/Debugging/StorageReportGenerator.cs
+++ b/src/Voron/Debugging/StorageReportGenerator.cs
@@ -31,7 +31,8 @@ namespace Voron.Debugging
         public List<JournalFile> Journals;
         public JournalFile[] FlushedJournals { get; set; }
 
-        public required long ActualSizeInBytes { get; set; }
+        public required long AllocatedSizeInBytes { get; set; }
+        public long PhysicalSizeInBytes { get; set; }
         public long NumberOfAllocatedPages { get; set; }
         public int NumberOfFreePages { get; set; }
         public long NextPageNumber { get; set; }
@@ -79,7 +80,7 @@ namespace Voron.Debugging
 
         public StorageReport Generate(ReportInput input)
         {
-            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber, input.ActualSizeInBytes);
+            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber, input.PhysicalSizeInBytes);
 
             var journals = GenerateJournalsReport(input.Journals, input.FlushedJournals);
 
@@ -91,7 +92,7 @@ namespace Voron.Debugging
                 Journals = journals,
                 TempFiles = tempBuffers,
                 CountOfTables = input.CountOfTables,
-                CountOfTrees = input.CountOfTrees
+                CountOfTrees = input.CountOfTrees,
             };
         }
 
@@ -99,7 +100,7 @@ namespace Voron.Debugging
 
         public unsafe DetailedStorageReport Generate(DetailedReportInput input)
         {
-            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber, input.ActualSizeInBytes);
+            var dataFile = GenerateDataFileReport(input.NumberOfAllocatedPages, input.NumberOfFreePages, input.NextPageNumber, input.PhysicalSizeInBytes);
 
             long streamsAllocatedSpaceInBytes = 0;
             long treesAllocatedSpaceInBytes = 0;
@@ -275,13 +276,13 @@ namespace Voron.Debugging
             };
         }
 
-        private DataFileReport GenerateDataFileReport(long numberOfAllocatedPages, long numberOfFreePages, long nextPageNumber, long actualSizeInBytes)
+        private DataFileReport GenerateDataFileReport(long numberOfAllocatedPages, long numberOfFreePages, long nextPageNumber, long physicalSizeInBytes)
         {
             var unallocatedPagesAtEndOfFile = numberOfAllocatedPages - (nextPageNumber - 1);
 
             return new DataFileReport
             {
-                ActualSpaceInBytes = actualSizeInBytes,
+                PhysicalSpaceInBytes = physicalSizeInBytes,
                 AllocatedSpaceInBytes = PagesToBytes(numberOfAllocatedPages),
                 UsedSpaceInBytes = PagesToBytes((nextPageNumber - 1) - numberOfFreePages),
                 FreeSpaceInBytes = PagesToBytes(numberOfFreePages + unallocatedPagesAtEndOfFile)

--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1454,7 +1454,7 @@ namespace Voron.Impl.Journal
                         if (pages.IsEmpty)
                             return dataPagerState;
                         dataPager.EnsureContinuous(ref dataPagerState, pages[^1].page_num, pages[^1].count_of_pages);
-                        (dataPagerState.TotalFileSize, dataPagerState.TotalDiskSpace) = dataPager.GetFileSize(dataPagerState);
+                        (dataPagerState.TotalAllocatedSize, dataPagerState.TotalPhysicalSpace) = dataPager.GetFileSize(dataPagerState);
                         fixed (Pal.page_to_write* ptr = pages)
                         {
                             var rc = dataPager.Write(dataPagerState.Handle, ptr, pages.Length,  out var errorCode);

--- a/src/Voron/Impl/Paging/Pager.State.cs
+++ b/src/Voron/Impl/Paging/Pager.State.cs
@@ -26,8 +26,8 @@ public unsafe partial class Pager
             ReadAddress = readAddress;
             WriteAddress = writeMemory;
             TotalAllocatedSize = totalAllocatedSize;
-            NumberOfAllocatedPages = totalAllocatedSize / pageSize;
             Handle = handle;
+            _pageSize = pageSize;
 
             Pager = pager;
             WeakSelf = new WeakReference<State>(this);
@@ -37,14 +37,14 @@ public unsafe partial class Pager
 
         public readonly byte* ReadAddress;
         public readonly byte* WriteAddress;
-        public long NumberOfAllocatedPages;
+        public long NumberOfAllocatedPages => TotalAllocatedSize / _pageSize;
         public long TotalAllocatedSize;
-        public long TotalFileSize;
-        public long TotalDiskSpace;
+        public long TotalPhysicalSpace;
 
         public bool Disposed;
 
         public void* Handle;
+        private readonly int _pageSize;
 
         public void Dispose()
         {

--- a/src/Voron/Impl/Paging/Pager.cs
+++ b/src/Voron/Impl/Paging/Pager.cs
@@ -60,7 +60,7 @@ public unsafe partial class Pager : IDisposable
 
         pager.Write = Pal.rvn_get_writer(handle);
         var state = new State(pager, readOnlyMemory, writeMemory, memorySize, handle, pageSize ?? options.PageSize);
-        (state.TotalFileSize, state.TotalDiskSpace) = pager.GetFileSize(state);
+        (state.TotalAllocatedSize, state.TotalPhysicalSpace) = pager.GetFileSize(state);
         pager.InstallState(state);
         pager.Initialize(memorySize);
         return (pager, state);

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -930,11 +930,10 @@ namespace Voron
                 }
             }
 
-            var numberOfAllocatedPages = GetNumberOfAllocatedPages();
-
             return new SizeReport
             {
-                DataFileInBytes = _currentStateRecord.DataPagerState.TotalDiskSpace,
+                DataFilePhysicalSizeInBytes = _currentStateRecord.DataPagerState.TotalPhysicalSpace,
+                DataFileAllocatedSizeInBytes = _currentStateRecord.DataPagerState.TotalAllocatedSize,
                 JournalsInBytes = journalsSize,
                 TempBuffersInBytes = tempBuffers,
             };
@@ -996,9 +995,8 @@ namespace Voron
 
             return generator.Generate(new ReportInput
             {
-                // we need to use the actual file size (not the disk size), because we are looking at the max
-                // size that the file has been allocated as
-                ActualSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalFileSize,
+                AllocatedSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalAllocatedSize,
+                PhysicalSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalPhysicalSpace,
                 NumberOfAllocatedPages = numberOfAllocatedPages,
                 NumberOfFreePages = numberOfFreePages,
                 NextPageNumber = NextPageNumber,
@@ -1267,7 +1265,8 @@ namespace Voron
 
             var detailedReportInput = new DetailedReportInput
             {
-                ActualSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalDiskSpace,
+                AllocatedSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalAllocatedSize,
+                PhysicalSizeInBytes = tx.LowLevelTransaction.CurrentStateRecord.DataPagerState.TotalPhysicalSpace,
                 NumberOfAllocatedPages = numberOfAllocatedPages,
                 NumberOfFreePages = numberOfFreePages,
                 NextPageNumber = NextPageNumber,

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -187,7 +187,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
 
         using (var wtx = Env.WriteTransaction())
         {
-            // delete ~36MB of data (pages 7-25), which will create sparse regions after flush
+            // delete ~36MB of data (pages 7-24), which will create sparse regions after flush
             for (int i = 7; i < 25; i++)
             {
                 for (int j = 0; j < 256; j++)
@@ -208,7 +208,7 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
 
         if (PlatformDetails.RunningOnMacOsx is false)
         {
-            // After hole punching, ActualSpaceInBytes (physical disk space) must be less than AllocatedSpaceInBytes
+            // After hole punching, PhysicalSpaceInBytes (physical disk space) must be less than AllocatedSpaceInBytes
             Assert.True(report.DataFile.PhysicalSpaceInBytes < report.DataFile.AllocatedSpaceInBytes,
                 $"PhysicalSpaceInBytes ({new Size(report.DataFile.PhysicalSpaceInBytes, SizeUnit.Bytes)}) should be less than " +
                 $"AllocatedSpaceInBytes ({new Size(report.DataFile.AllocatedSpaceInBytes, SizeUnit.Bytes)}) after hole punching");

--- a/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
+++ b/test/FastTests/Voron/NextGenPagers/SparseRegions.cs
@@ -163,4 +163,55 @@ public class SparseRegions(ITestOutputHelper output) : StorageTest(output)
 
         Assert.Equal(expectedResult , inputSource);
     }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public unsafe void StorageReport_ShouldReflectPhysicalDiskSpaceAfterHolePunching()
+    {
+        Options.ManualFlushing = true;
+        var pages = new List<long>();
+        using (var wtx = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                // 2MB
+                Page allocatePage = wtx.LowLevelTransaction.AllocatePage(256);
+                allocatePage.Flags = PageFlags.Overflow | PageFlags.Single;
+                allocatePage.OverflowSize = (256 * Constants.Storage.PageSize) - PageHeader.SizeOf;
+                Memory.Set(allocatePage.DataPointer, 1, allocatePage.OverflowSize);
+                pages.Add(allocatePage.PageNumber);
+            }
+            wtx.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        using (var wtx = Env.WriteTransaction())
+        {
+            // delete ~36MB of data (pages 7-25), which will create sparse regions after flush
+            for (int i = 7; i < 25; i++)
+            {
+                for (int j = 0; j < 256; j++)
+                {
+                    wtx.LowLevelTransaction.FreePage(pages[i] + j);
+                }
+            }
+            wtx.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        using var rtx = Env.ReadTransaction();
+        var report = Env.GenerateReport(rtx);
+
+        // AllocatedSpaceInBytes reflects the total logical file size (128MB)
+        Assert.Equal(128 * 1024 * 1024, report.DataFile.AllocatedSpaceInBytes);
+
+        if (PlatformDetails.RunningOnMacOsx is false)
+        {
+            // After hole punching, ActualSpaceInBytes (physical disk space) must be less than AllocatedSpaceInBytes
+            Assert.True(report.DataFile.PhysicalSpaceInBytes < report.DataFile.AllocatedSpaceInBytes,
+                $"PhysicalSpaceInBytes ({new Size(report.DataFile.PhysicalSpaceInBytes, SizeUnit.Bytes)}) should be less than " +
+                $"AllocatedSpaceInBytes ({new Size(report.DataFile.AllocatedSpaceInBytes, SizeUnit.Bytes)}) after hole punching");
+        }
+    }
 }

--- a/test/SlowTests/Voron/Issues/RavenDB_22818.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_22818.cs
@@ -1,0 +1,122 @@
+using System.Linq;
+using FastTests.Voron;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.RawData;
+using Voron.Data.Tables;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_22818 : StorageTest
+{
+    private static readonly TableSchema Schema;
+
+    static RavenDB_22818()
+    {
+        using (StorageEnvironment.GetStaticContext(out var ctx))
+        {
+            Slice.From(ctx, "Key", ByteStringType.Immutable, out var keySlice);
+            Schema = new TableSchema()
+                .DefineKey(new TableSchema.IndexDef
+                {
+                    StartIndex = 0,
+                    Count = 1
+                });
+        }
+    }
+
+    public RavenDB_22818(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public unsafe void TableStorageReport_ShouldNotDoubleCountFreedOverflowPages()
+    {
+        // Large values (> MaxItemSize) are stored as overflow pages and _stats.OverflowPageCount
+        // is incremented on insert. Before the fix, OverflowPageCount was never decremented on
+        // delete, so TableReport.AllocatedSpaceInBytes included those freed pages even though
+        // they were already counted in DataFile.FreeSpaceInBytes - causing the Storage Report
+        // to show >100% at the Datafile level.
+
+        const string tableName = "test";
+        const int entryCount = 10;
+
+        // A value exceeding MaxItemSize guarantees overflow page storage
+        var largeValue = new byte[RawDataSection.MaxItemSize + 1];
+
+        using (var tx = Env.WriteTransaction())
+        {
+            Schema.Create(tx, tableName, 16);
+            tx.Commit();
+        }
+
+        var keys = new string[entryCount];
+        using (var tx = Env.WriteTransaction())
+        {
+            var table = tx.OpenTable(Schema, tableName);
+            for (int i = 0; i < entryCount; i++)
+            {
+                keys[i] = "key/" + i;
+                Slice.From(tx.Allocator, keys[i], ByteStringType.Immutable, out var keySlice);
+                fixed (byte* valuePtr = largeValue)
+                {
+                    var tvb = new TableValueBuilder
+                    {
+                        { keySlice.Content.Ptr, keySlice.Content.Length },
+                        { valuePtr, largeValue.Length }
+                    };
+                    table.Set(tvb);
+                }
+            }
+            tx.Commit();
+        }
+
+        long tableAllocatedAfterInsert;
+        using (var tx = Env.ReadTransaction())
+        {
+            var report = Env.GenerateDetailedReport(tx, includeDetails: false);
+            tableAllocatedAfterInsert = report.Tables.Single(t => t.Name == tableName).AllocatedSpaceInBytes;
+        }
+
+        // Delete all entries - this is the operation that exposed the bug:
+        // overflow pages go to the free space handler but OverflowPageCount is not decremented.
+        using (var tx = Env.WriteTransaction())
+        {
+            var table = tx.OpenTable(Schema, tableName);
+            for (int i = 0; i < entryCount; i++)
+            {
+                Slice.From(tx.Allocator, keys[i], ByteStringType.Immutable, out var keySlice);
+                table.DeleteByKey(keySlice);
+            }
+            tx.Commit();
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            var report = Env.GenerateDetailedReport(tx, includeDetails: false);
+            var tableReport = report.Tables.Single(t => t.Name == tableName);
+
+            Assert.Equal(0, tableReport.NumberOfEntries);
+
+            // After deleting all large (overflow) entries the table's AllocatedSpaceInBytes must
+            // shrink by at least the space occupied by those overflow pages.
+            // Before the fix, OverflowPageCount was never decremented, so AllocatedSpaceInBytes
+            // remained the same after deletion - the freed pages were double-counted in both
+            // DataFile.FreeSpaceInBytes and TableReport.AllocatedSpaceInBytes.
+            var tableAllocatedAfterDelete = tableReport.AllocatedSpaceInBytes;
+            var freedOverflowSpace = tableAllocatedAfterInsert - tableAllocatedAfterDelete;
+
+            // Each of the entryCount large values occupies at least one overflow page (8 KB).
+            var minExpectedFreed = (long)entryCount * Constants.Storage.PageSize;
+
+            Assert.True(
+                freedOverflowSpace >= minExpectedFreed,
+                $"Expected table AllocatedSpaceInBytes to decrease by at least {minExpectedFreed:N0} bytes " +
+                $"after deleting {entryCount} large entries, but it only decreased by {freedOverflowSpace:N0} bytes. " +
+                $"Before deletion: {tableAllocatedAfterInsert:N0}, after deletion: {tableAllocatedAfterDelete:N0}.");
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22818

### Additional description

**Backend: AllocatedSize vs PhysicalSize distinction** 
- Introduces the separation between `AllocatedSize` (logical file extent) and `PhysicalSize` (actual disk usage after hole punching) throughout the storage pipeline: from `Pager` through `StorageEnvironment.GenerateSizeReport()`, `GetSizeOnDisk()`, stats handlers, and client API. 

 **Studio: Databases list and Storage Report views** 
 
 - Databases view: Now we have `Data (on disk)` and `Data (allocated)` (previously just `Data`)
 
 
<img width="432" height="388" alt="image" src="https://github.com/user-attachments/assets/0c525e17-4e0f-4931-8327-ebfd3fa44bd1" />

 
 - Updates the Storage Report to surface the new size distinction through a dedicated "On Disk" column (visible only when sparse regions are active) alongside the existing "Allocated" column. 
 
 
<img width="1176" height="273" alt="image" src="https://github.com/user-attachments/assets/0551b027-4af5-4b28-94ec-dbfdee791a9c" />

<img width="1180" height="371" alt="image" src="https://github.com/user-attachments/assets/23e72268-e6ee-42c2-a52a-326ad1566be7" />

- Shows sparse-region savings inline on the Free space row. 

<img width="1179" height="342" alt="image" src="https://github.com/user-attachments/assets/2896de46-56f2-4c12-b673-fe67fdeeff13" />


**Bug fix: Table `OverflowPageCount` never decremented on delete** 
-  Fixed a pre-existing bug where `_stats.OverflowPageCount` was incremented when large values were inserted but never decremented when they were deleted. This caused `TableReport.AllocatedSpaceInBytes` to include freed overflow pages that were already counted in `DataFile.FreeSpaceInBytes`, making the Storage Report show >100% in the `% Total` column at the Datafile level. One-line fix in `Table.DeleteInternal()`. 
- ~~This is not 8.0 specific issue but was easier visible with sparse regions (we might consider the backport)~~ - it is 8.0 specific

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [x] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
