### PR TITLE
RavenDB-26159 fix failing test

### DIFF
--- a/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
+++ b/src/Raven.Server/Documents/SchemaValidation/SchemaValidatorCache.cs
@@ -153,7 +153,7 @@ public class SchemaValidatorCache : IDisposable
             return false;
 
         var schemaValidatorsPerCollection = _schemaValidatorsPerCollection;
-        if (collections == null)
+        if (collections == null || collections.Length == 0)
             return schemaValidatorsPerCollection.Any(x => x.Value.Disabled == false);
 
         foreach (var collection in collections)

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -409,7 +409,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.Smuggler)]
+    [RavenFact(RavenTestCategory.Smuggler | RavenTestCategory.BackupExportImport)]
     public async Task SchemaValidation_WhenRestoreInvalidData_ShouldRestore()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
@@ -460,7 +460,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         Assert.StartsWith("Raven.Client.Exceptions.SchemaValidation.SchemaValidationException: The value at 'Prop' must be '\"123\"', but it is '\"1234\"'.", e.Message);
     }
 
-    [RavenFact(RavenTestCategory.JavaScript)]
+    [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Etl)]
     public async Task SchemaValidation_WhenEtl_ShouldValidateAndFailInNeeded()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
@@ -527,7 +527,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.JavaScript)]
+    [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Replication)]
     public async Task SchemaValidation_WhenInternalReplicateInvalidData_ShouldNotThrow()
     {
         var (nodes, _) = await CreateRaftCluster(3);
@@ -629,7 +629,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         Assert.Contains("The value of 'properties' must be an object, but received 'ShouldBeObject' of type 'string'. Schema path '#/properties'.", e.Message);
     }
     
-    [RavenFact(RavenTestCategory.JavaScript)]
+    [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Revisions)]
     public async Task SchemaValidation_WhenRevertRevisionAndSchemaIsEnabled_ShouldThrowWhen()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.Const] = "123" } } };
@@ -680,7 +680,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
         }
     }
 
-    [RavenFact(RavenTestCategory.JavaScript)]
+    [RavenFact(RavenTestCategory.JavaScript | RavenTestCategory.Revisions)]
     public async Task SchemaValidation_WhenRevertRevisionByTimeSchemaIsEnabled_ShouldThrow()
     {
         var schemaDefinitionObj = new DynamicJsonValue { [SVC.Properties] = new DynamicJsonValue { ["Prop"] = new DynamicJsonValue { [SVC.MaxLength] = 3 } } };
@@ -737,7 +737,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
     
     private static void AssertError(string expected, string actual)
     {
-        if(actual.Contains(expected) == false)
+        if (actual.Contains(expected) == false)
             Assert.Fail($"expected: {expected}, actual: {actual}");
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26159

### Additional description

The method `IsSchemaEnabledForAny` should treat zero length collection same as null

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
