### PR TITLE
RavenDB-26240 - Normalize pull replication path filters on client and server

### DIFF
--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using Raven.Client.Documents.Replication;
 using Sparrow.Json.Parsing;

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -91,7 +91,6 @@ namespace Raven.Client.Documents.Operations.Replication
             if (string.IsNullOrEmpty(HubName))
                 throw new ArgumentException("Must be not empty", nameof(HubName));
 
-            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name ?? HubName);
             var djv = base.ToJson();
 
             djv[nameof(Mode)] = Mode;
@@ -106,7 +105,6 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public override DynamicJsonValue ToAuditJson()
         {
-            PullReplicationPathFilterUtils.Normalize(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths);
             var djv = base.ToAuditJson();
 
             djv[nameof(Mode)] = Mode;

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationAsSink.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using Raven.Client.Documents.Replication;
 using Sparrow.Json.Parsing;
@@ -91,6 +91,7 @@ namespace Raven.Client.Documents.Operations.Replication
             if (string.IsNullOrEmpty(HubName))
                 throw new ArgumentException("Must be not empty", nameof(HubName));
 
+            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name ?? HubName);
             var djv = base.ToJson();
 
             djv[nameof(Mode)] = Mode;
@@ -105,6 +106,7 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public override DynamicJsonValue ToAuditJson()
         {
+            PullReplicationPathFilterUtils.Normalize(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths);
             var djv = base.ToAuditJson();
 
             djv[nameof(Mode)] = Mode;

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationPathFilterUtils.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationPathFilterUtils.cs
@@ -12,20 +12,7 @@ namespace Raven.Client.Documents.Operations.Replication
             return normalizedPaths;
         }
 
-        public static void NormalizeAndValidate(ref string[] allowedHubToSinkPaths, ref string[] allowedSinkToHubPaths, string name)
-        {
-            Normalize(ref allowedHubToSinkPaths, ref allowedSinkToHubPaths);
-            Validate(allowedHubToSinkPaths, name);
-            Validate(allowedSinkToHubPaths, name);
-        }
-
-        public static void Normalize(ref string[] allowedHubToSinkPaths, ref string[] allowedSinkToHubPaths)
-        {
-            allowedHubToSinkPaths = Normalize(allowedHubToSinkPaths);
-            allowedSinkToHubPaths = Normalize(allowedSinkToHubPaths);
-        }
-
-        private static string[] Normalize(string[] allowedPaths)
+        public static string[] Normalize(string[] allowedPaths)
         {
             if (allowedPaths == null)
                 return null;

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationPathFilterUtils.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationPathFilterUtils.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace Raven.Client.Documents.Operations.Replication
+{
+    internal static class PullReplicationPathFilterUtils
+    {
+        public static string[] NormalizeAndValidate(string[] allowedPaths, string name)
+        {
+            var normalizedPaths = Normalize(allowedPaths);
+            Validate(normalizedPaths, name);
+            return normalizedPaths;
+        }
+
+        public static void NormalizeAndValidate(ref string[] allowedHubToSinkPaths, ref string[] allowedSinkToHubPaths, string name)
+        {
+            Normalize(ref allowedHubToSinkPaths, ref allowedSinkToHubPaths);
+            Validate(allowedHubToSinkPaths, name);
+            Validate(allowedSinkToHubPaths, name);
+        }
+
+        public static void Normalize(ref string[] allowedHubToSinkPaths, ref string[] allowedSinkToHubPaths)
+        {
+            allowedHubToSinkPaths = Normalize(allowedHubToSinkPaths);
+            allowedSinkToHubPaths = Normalize(allowedSinkToHubPaths);
+        }
+
+        private static string[] Normalize(string[] allowedPaths)
+        {
+            if (allowedPaths == null)
+                return null;
+
+            List<string> normalized = null;
+
+            foreach (var path in allowedPaths)
+            {
+                var normalizedPath = path?.Trim();
+                if (string.IsNullOrEmpty(normalizedPath))
+                    continue;
+
+                normalized ??= new List<string>(allowedPaths.Length);
+                normalized.Add(normalizedPath);
+            }
+
+            return normalized?.ToArray() ?? [];
+        }
+
+        private static void Validate(string[] allowedPaths, string name)
+        {
+            if ((allowedPaths?.Length ?? 0) == 0)
+                return;
+
+            foreach (var path in allowedPaths)
+            {
+                if (path[path.Length - 1] != '*')
+                    continue;
+
+                if (path.Length > 1 && path[path.Length - 2] != '/' && path[path.Length - 2] != '-')
+                    throw new InvalidOperationException(
+                        $"When using '*' at the end of the allowed path, the previous character must be '/' or '-', but got: {path} for {name}");
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/Replication/RegisterReplicationHubAccessOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/RegisterReplicationHubAccessOperation.cs
@@ -56,6 +56,7 @@ namespace Raven.Client.Documents.Operations.Replication
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/tasks/pull-replication/hub/access?name={Uri.EscapeDataString(_hubName)}";
 
+                PullReplicationPathFilterUtils.NormalizeAndValidate(ref _access.AllowedHubToSinkPaths, ref _access.AllowedSinkToHubPaths, _access.Name);
                 var blittable = ctx.ReadObject(_access.ToJson(), "register-access");
 
                 var request = new HttpRequestMessage

--- a/src/Raven.Client/Documents/Operations/Replication/RegisterReplicationHubAccessOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/RegisterReplicationHubAccessOperation.cs
@@ -56,7 +56,8 @@ namespace Raven.Client.Documents.Operations.Replication
             {
                 url = $"{node.Url}/databases/{node.Database}/admin/tasks/pull-replication/hub/access?name={Uri.EscapeDataString(_hubName)}";
 
-                PullReplicationPathFilterUtils.NormalizeAndValidate(ref _access.AllowedHubToSinkPaths, ref _access.AllowedSinkToHubPaths, _access.Name);
+                _access.AllowedHubToSinkPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(_access.AllowedHubToSinkPaths, _access.Name);
+                _access.AllowedSinkToHubPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(_access.AllowedSinkToHubPaths, _access.Name);
                 var blittable = ctx.ReadObject(_access.ToJson(), "register-access");
 
                 var request = new HttpRequestMessage

--- a/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccess.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccess.cs
@@ -29,6 +29,8 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public DynamicJsonValue ToJson()
         {
+            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
+
             return new DynamicJsonValue
             {
                 [nameof(Name)] = Name,
@@ -43,9 +45,11 @@ namespace Raven.Client.Documents.Operations.Replication
             if (string.IsNullOrEmpty(Name))
                 throw new ArgumentNullException(nameof(Name));
 
+            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
+
             if (filteringIsRequired)
             {
-                if ((AllowedHubToSinkPaths?.Length ?? 0) == 0 && (AllowedSinkToHubPaths?.Length == 0))
+                if ((AllowedHubToSinkPaths?.Length ?? 0) == 0 && (AllowedSinkToHubPaths?.Length ?? 0) == 0)
                     throw new InvalidOperationException(
                         $"Either {nameof(AllowedSinkToHubPaths)} or {nameof(AllowedHubToSinkPaths)} must have a value, but both were null or empty");
             }
@@ -54,30 +58,9 @@ namespace Raven.Client.Documents.Operations.Replication
                 if (AllowedHubToSinkPaths?.Length > 0 || AllowedSinkToHubPaths?.Length > 0)
                     throw new InvalidOperationException(
                         $"Filtering replication is not set for this Replication Hub task." +
-                        $" {nameof(AllowedSinkToHubPaths)} and {nameof(AllowedHubToSinkPaths)} cannot have a value.");  
-            }
-
-            ValidateAllowedPaths(AllowedHubToSinkPaths);
-            ValidateAllowedPaths(AllowedSinkToHubPaths);
-        }
-
-        private void ValidateAllowedPaths(string[] allowedPaths)
-        {
-            if ((allowedPaths?.Length ?? 0) == 0)
-                return;
-
-            foreach (string path in allowedPaths)
-            {
-                if (string.IsNullOrEmpty(path))
-                    throw new InvalidOperationException("Filtered replication AllowedPaths cannot have an empty / null filter");
-
-                if (path[path.Length - 1] != '*')
-                    continue;
-
-                if (path.Length > 1 && path[path.Length - 2] != '/' && path[path.Length - 2] != '-')
-                    throw new InvalidOperationException(
-                        $"When using '*' at the end of the allowed path, the previous character must be '/' or '-', but got: {path} for {Name}");
+                        $" {nameof(AllowedSinkToHubPaths)} and {nameof(AllowedHubToSinkPaths)} cannot have a value.");
             }
         }
+
     }
 }

--- a/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccess.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccess.cs
@@ -29,8 +29,6 @@ namespace Raven.Client.Documents.Operations.Replication
 
         public DynamicJsonValue ToJson()
         {
-            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
-
             return new DynamicJsonValue
             {
                 [nameof(Name)] = Name,

--- a/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccess.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ReplicationHubAccess.cs
@@ -43,7 +43,8 @@ namespace Raven.Client.Documents.Operations.Replication
             if (string.IsNullOrEmpty(Name))
                 throw new ArgumentNullException(nameof(Name));
 
-            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
+            AllowedHubToSinkPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(AllowedHubToSinkPaths, Name);
+            AllowedSinkToHubPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(AllowedSinkToHubPaths, Name);
 
             if (filteringIsRequired)
             {

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Net.Http;
 using Raven.Client.Documents.Conventions;
@@ -70,7 +70,8 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
-                PullReplicationPathFilterUtils.NormalizeAndValidate(ref pullReplication.AllowedHubToSinkPaths, ref pullReplication.AllowedSinkToHubPaths, pullReplication.Name ?? pullReplication.HubName);
+                pullReplication.AllowedHubToSinkPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(pullReplication.AllowedHubToSinkPaths, pullReplication.Name ?? pullReplication.HubName);
+                pullReplication.AllowedSinkToHubPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(pullReplication.AllowedSinkToHubPaths, pullReplication.Name ?? pullReplication.HubName);
                 DynamicJsonValue replication = pullReplication.ToJson();
                 
                 // Aligned with ServerStore.UpdatePullReplicationAsSink to not introduce breaking changes

--- a/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/UpdatePullReplicationAsSinkOperation.cs
@@ -70,6 +70,7 @@ namespace Raven.Client.Documents.Operations.Replication
         {
             public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
             {
+                PullReplicationPathFilterUtils.NormalizeAndValidate(ref pullReplication.AllowedHubToSinkPaths, ref pullReplication.AllowedSinkToHubPaths, pullReplication.Name ?? pullReplication.HubName);
                 DynamicJsonValue replication = pullReplication.ToJson();
                 
                 // Aligned with ServerStore.UpdatePullReplicationAsSink to not introduce breaking changes

--- a/src/Raven.Server/Documents/Replication/AllowedPathsValidator.cs
+++ b/src/Raven.Server/Documents/Replication/AllowedPathsValidator.cs
@@ -57,7 +57,7 @@ namespace Raven.Server.Documents.Replication
             _allowedPaths = new List<LazyStringValue>();
             _allowedPathsPrefixes = new List<LazyStringValue>();
 
-            var normalizedAllowedPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(allowedPaths, name: "pull replication path filter");
+            var normalizedAllowedPaths = PullReplicationPathFilterUtils.Normalize(allowedPaths);
             if ((normalizedAllowedPaths?.Length ?? 0) == 0)
                 return;
 

--- a/src/Raven.Server/Documents/Replication/AllowedPathsValidator.cs
+++ b/src/Raven.Server/Documents/Replication/AllowedPathsValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Raven.Client.Documents.Operations.Replication;
 using Raven.Server.Documents.Replication.ReplicationItems;
 using Sparrow.Json;
 using Voron;
@@ -11,7 +12,7 @@ namespace Raven.Server.Documents.Replication
         private readonly JsonOperationContext _allowedPathsContext;
         private readonly List<LazyStringValue> _allowedPaths;
         private readonly List<LazyStringValue> _allowedPathsPrefixes;
-        private DocumentInfoHelper _documentInfoHelper;
+        private readonly DocumentInfoHelper _documentInfoHelper;
         private LazyStringValue GetDocumentId(Slice key) => _documentInfoHelper.GetDocumentId(key);
         public string GetItemInformation(ReplicationBatchItem item) => _documentInfoHelper.GetItemInformation(item);
         
@@ -23,7 +24,7 @@ namespace Raven.Server.Documents.Replication
                 AttachmentTombstoneReplicationItem at => AllowId(GetDocumentId(at.Key)),
                 CounterReplicationItem c => AllowId(c.Id),
                 DocumentReplicationItem d => AllowId(d.Id),
-                RevisionTombstoneReplicationItem _ => true, // revision tombstones doesn't contain any info about the doc. The id here is the change-vector of the deleted revision
+                RevisionTombstoneReplicationItem _ => true, // revision tombstones don't contain any info about the doc. The id here is the change-vector of the deleted revision
                 TimeSeriesDeletedRangeItem td => AllowId(GetDocumentId(td.Key)),
                 TimeSeriesReplicationItem t => AllowId(GetDocumentId(t.Key)),
                 _ => throw new ArgumentOutOfRangeException($"{nameof(item)} - {item}")
@@ -55,11 +56,17 @@ namespace Raven.Server.Documents.Replication
             _documentInfoHelper = new DocumentInfoHelper(_allowedPathsContext);
             _allowedPaths = new List<LazyStringValue>();
             _allowedPathsPrefixes = new List<LazyStringValue>();
-            foreach (var t in allowedPaths)
+
+            var normalizedAllowedPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(allowedPaths, name: "pull replication path filter");
+            if ((normalizedAllowedPaths?.Length ?? 0) == 0)
+                return;
+
+            foreach (var allowedPath in normalizedAllowedPaths)
             {
-                var lazyStringValue = _allowedPathsContext.GetLazyString(t);
+                var lazyStringValue = _allowedPathsContext.GetLazyString(allowedPath);
                 if (lazyStringValue.Size == 0)
                     continue; // shouldn't happen, but let's be safe
+
                 if (lazyStringValue[lazyStringValue.Size - 1] == '*')
                 {
                     lazyStringValue.Truncate(lazyStringValue.Size - 1);

--- a/src/Raven.Server/ServerWide/Commands/RegisterReplicationHubAccessCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RegisterReplicationHubAccessCommand.cs
@@ -62,7 +62,6 @@ namespace Raven.Server.ServerWide.Commands
             CertificateBase64 = access.CertificateBase64;
             AllowedHubToSinkPaths = access.AllowedHubToSinkPaths;
             AllowedSinkToHubPaths = access.AllowedSinkToHubPaths;
-            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
 
             if (certificate != null)
             {
@@ -98,7 +97,8 @@ namespace Raven.Server.ServerWide.Commands
 
         public DynamicJsonValue PrepareForStorage()
         {
-            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
+            AllowedHubToSinkPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(AllowedHubToSinkPaths, Name);
+            AllowedSinkToHubPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(AllowedSinkToHubPaths, Name);
 
             return new DynamicJsonValue
             {

--- a/src/Raven.Server/ServerWide/Commands/RegisterReplicationHubAccessCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/RegisterReplicationHubAccessCommand.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.ServerWide.Commands
             CertificateBase64 = access.CertificateBase64;
             AllowedHubToSinkPaths = access.AllowedHubToSinkPaths;
             AllowedSinkToHubPaths = access.AllowedSinkToHubPaths;
+            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
 
             if (certificate != null)
             {
@@ -97,6 +98,8 @@ namespace Raven.Server.ServerWide.Commands
 
         public DynamicJsonValue PrepareForStorage()
         {
+            PullReplicationPathFilterUtils.NormalizeAndValidate(ref AllowedHubToSinkPaths, ref AllowedSinkToHubPaths, Name);
+
             return new DynamicJsonValue
             {
                 [nameof(Name)] = Name,

--- a/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsSinkCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Raven.Client.Documents.Operations.Replication;
 using Raven.Client.ServerWide;
 using Sparrow.Json.Parsing;
@@ -23,6 +23,8 @@ namespace Raven.Server.ServerWide.Commands
         {
             if (PullReplicationAsSink == null)
                 return ;
+
+            PullReplicationPathFilterUtils.NormalizeAndValidate(ref PullReplicationAsSink.AllowedHubToSinkPaths, ref PullReplicationAsSink.AllowedSinkToHubPaths, PullReplicationAsSink.Name ?? PullReplicationAsSink.HubName);
 
             if (PullReplicationAsSink.TaskId == 0)
             {

--- a/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsSinkCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/UpdatePullReplicationAsSinkCommand.cs
@@ -24,7 +24,8 @@ namespace Raven.Server.ServerWide.Commands
             if (PullReplicationAsSink == null)
                 return ;
 
-            PullReplicationPathFilterUtils.NormalizeAndValidate(ref PullReplicationAsSink.AllowedHubToSinkPaths, ref PullReplicationAsSink.AllowedSinkToHubPaths, PullReplicationAsSink.Name ?? PullReplicationAsSink.HubName);
+            PullReplicationAsSink.AllowedHubToSinkPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(PullReplicationAsSink.AllowedHubToSinkPaths, PullReplicationAsSink.Name ?? PullReplicationAsSink.HubName);
+            PullReplicationAsSink.AllowedSinkToHubPaths = PullReplicationPathFilterUtils.NormalizeAndValidate(PullReplicationAsSink.AllowedSinkToHubPaths, PullReplicationAsSink.Name ?? PullReplicationAsSink.HubName);
 
             if (PullReplicationAsSink.TaskId == 0)
             {

--- a/test/FastTests/Server/Basic/AllowedPathsValidatorTests.cs
+++ b/test/FastTests/Server/Basic/AllowedPathsValidatorTests.cs
@@ -1,0 +1,30 @@
+using Raven.Server.Documents.Replication;
+using Raven.Server.Documents.Replication.ReplicationItems;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Server.Basic
+{
+    public class AllowedPathsValidatorTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenFact(RavenTestCategory.Replication)]
+        public void Should_trim_whitespace_and_ignore_empty_allowed_paths()
+        {
+            using var validator = new AllowedPathsValidator(["   ", " issues/ABCD/* "]);
+            using var context = JsonOperationContext.ShortTermSingleUse();
+
+            using var matchingItem = new DocumentReplicationItem();
+            matchingItem.Type = ReplicationBatchItem.ReplicationItemType.Document;
+            matchingItem.Id = context.GetLazyString("issues/ABCD/1");
+
+            using var nonMatchingItem = new DocumentReplicationItem();
+            nonMatchingItem.Type = ReplicationBatchItem.ReplicationItemType.Document;
+            nonMatchingItem.Id = context.GetLazyString("tasks/1");
+
+            Assert.True(validator.ShouldAllow(matchingItem));
+            Assert.False(validator.ShouldAllow(nonMatchingItem));
+        }
+    }
+}

--- a/test/FastTests/Server/Basic/AllowedPathsValidatorTests.cs
+++ b/test/FastTests/Server/Basic/AllowedPathsValidatorTests.cs
@@ -26,5 +26,23 @@ namespace FastTests.Server.Basic
             Assert.True(validator.ShouldAllow(matchingItem));
             Assert.False(validator.ShouldAllow(nonMatchingItem));
         }
+
+        [RavenFact(RavenTestCategory.Replication)]
+        public void Should_keep_legacy_invalid_wildcard_patterns_operational_at_runtime()
+        {
+            using var validator = new AllowedPathsValidator([" issues* "]);
+            using var context = JsonOperationContext.ShortTermSingleUse();
+
+            using var matchingItem = new DocumentReplicationItem();
+            matchingItem.Type = ReplicationBatchItem.ReplicationItemType.Document;
+            matchingItem.Id = context.GetLazyString("issues/ABCD/1");
+
+            using var nonMatchingItem = new DocumentReplicationItem();
+            nonMatchingItem.Type = ReplicationBatchItem.ReplicationItemType.Document;
+            nonMatchingItem.Id = context.GetLazyString("tasks/1");
+
+            Assert.True(validator.ShouldAllow(matchingItem));
+            Assert.False(validator.ShouldAllow(nonMatchingItem));
+        }
     }
 }

--- a/test/SlowTests/Issues/FilteredReplicationTests.cs
+++ b/test/SlowTests/Issues/FilteredReplicationTests.cs
@@ -197,6 +197,41 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task Can_setup_filtered_replication_trimming_whitespace_in_hub_access_paths()
+        {
+            var certificates = Certificates.SetupServerAuthentication();
+            var dbNameA = GetDatabaseName();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var storeA = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = s => dbNameA
+            });
+
+            var pullCert = certificates.ClientCertificate2.Value;
+            await storeA.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "pull",
+                WithFiltering = true
+            }));
+            await storeA.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("pull",
+                new ReplicationHubAccess
+                {
+                    Name = "Arava",
+                    CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+                    AllowedHubToSinkPaths = new[] { " users/ayende/* ", "   " },
+                    AllowedSinkToHubPaths = new[] { " orders/1 ", "\t" }
+                }));
+
+            var access = Assert.Single(await storeA.Maintenance.SendAsync(new GetReplicationHubAccessOperation("pull")));
+            Assert.Equal(new[] { "users/ayende/*" }, access.AllowedHubToSinkPaths);
+            Assert.Equal(new[] { "orders/1" }, access.AllowedSinkToHubPaths);
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
         public async Task Cannot_setup_partial_filtered_replication()
         {
             var certificates = Certificates.SetupServerAuthentication();
@@ -1494,6 +1529,93 @@ namespace SlowTests.Issues
                    })
                ));
 
+            Assert.Contains("Either AllowedSinkToHubPaths or AllowedHubToSinkPaths must have a value, but both were null or empty", ex.InnerException.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task Can_setup_filtered_replication_trimming_whitespace_in_sink_paths()
+        {
+            var certificates = Certificates.SetupServerAuthentication();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var hubStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+            using var sinkStore = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+            });
+
+            var pullCert = certificates.ClientCertificate2.Value;
+            await hubStore.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "pull",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                WithFiltering = true
+            }));
+
+            await sinkStore.Maintenance.SendAsync(new PutConnectionStringOperation<RavenConnectionString>(new RavenConnectionString
+            {
+                Database = hubStore.Database,
+                Name = "HubConStr",
+                TopologyDiscoveryUrls = hubStore.Urls
+            }));
+
+            var result = await sinkStore.Maintenance.SendAsync(new UpdatePullReplicationAsSinkOperation(new PullReplicationAsSink
+            {
+                ConnectionStringName = "HubConStr",
+                CertificateWithPrivateKey = Convert.ToBase64String(pullCert.Export(X509ContentType.Pfx)),
+                HubName = "pull",
+                Mode = PullReplicationMode.SinkToHub | PullReplicationMode.HubToSink,
+                AllowedHubToSinkPaths = [" issues/ABCD/* ", "   "],
+                AllowedSinkToHubPaths = [" DeliveryApprovals/* ", "\t"]
+            }));
+
+            var sinkTask = (OngoingTaskPullReplicationAsSink)await sinkStore.Maintenance.SendAsync(
+                new GetOngoingTaskInfoOperation(result.TaskId, OngoingTaskType.PullReplicationAsSink));
+
+            Assert.Equal(new[] { "issues/ABCD/*" }, sinkTask.AllowedHubToSinkPaths);
+            Assert.Equal(new[] { "DeliveryApprovals/*" }, sinkTask.AllowedSinkToHubPaths);
+        }
+
+        [RavenFact(RavenTestCategory.Replication | RavenTestCategory.Certificates)]
+        public async Task Must_use_access_paths_if_filtering_is_set_even_when_values_trim_to_empty()
+        {
+            var certificates = Certificates.SetupServerAuthentication();
+            var dbNameA = GetDatabaseName();
+            var adminCert = Certificates.RegisterClientCertificate(certificates.ServerCertificateForCommunication.Value, certificates
+                .ClientCertificate1.Value, new Dictionary<string, DatabaseAccess>(), SecurityClearance.ClusterAdmin);
+
+            using var storeA = GetDocumentStore(new Options
+            {
+                AdminCertificate = adminCert,
+                ClientCertificate = adminCert,
+                ModifyDatabaseName = s => dbNameA
+            });
+
+            var pullCert = certificates.ClientCertificate2.Value;
+            await storeA.Maintenance.SendAsync(new PutPullReplicationAsHubOperation(new PullReplicationDefinition
+            {
+                Name = "pull",
+                WithFiltering = true
+            }));
+
+            var ex = await Assert.ThrowsAsync<RavenException>(async () =>
+               await storeA.Maintenance.SendAsync(new RegisterReplicationHubAccessOperation("pull",
+                   new ReplicationHubAccess
+                   {
+                       Name = "Arava",
+                       CertificateBase64 = Convert.ToBase64String(pullCert.Export(X509ContentType.Cert)),
+                       AllowedHubToSinkPaths = ["   ", "\t"],
+                       AllowedSinkToHubPaths = [" "]
+                   })
+               ));
+
+            Assert.True(ex.InnerException != null, "ex.InnerException is null but expected an exception");
             Assert.Contains("Either AllowedSinkToHubPaths or AllowedHubToSinkPaths must have a value, but both were null or empty", ex.InnerException.Message);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26240

### Additional description

Pull replication path filters preserved leading and trailing whitespace, which made valid-looking filters fail to match and was hard to diagnose. This change normalizes filters on save and at match time, reuses the same validation for hub and sink configurations, and adds coverage for trimmed persistence, legacy matching, and empty-after-trim validation.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
- https://github.com/ravendb/ravendb/pull/22573