### PR TITLE
RavenDB-25768 Collect all lag indicators instead of returning on the first one

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
@@ -668,19 +668,18 @@ namespace Raven.Server.ServerWide.Maintenance
             }
 
             // Collect all lag indicators instead of returning on the first one.
+            // PromotablesStatus is a single value; the aggregate demotion message below carries all reasons.
             var lagReasons = new List<string>();
             var promotionStatus = DatabasePromotionStatus.Ok;
 
-            // Check 1: Replication lag
             var timeDiff = mentorCurrClusterStats.LastSuccessfulUpdateDateTime - mentorPrevClusterStats.LastSuccessfulUpdateDateTime > 3 * _supervisorSamplePeriod;
 
             if (lastSentEtag < mentorsEtag || timeDiff)
             {
-                lagReasons.Add($"The mentor hasn't sent all of the documents yet (Last sent Etag: {lastSentEtag:#,#;;0}, Mentor's Etag: {mentorsEtag:#,#;;0})");
+                lagReasons.Add($"The mentor hasn't sent all of the documents yet (Last sent Etag: {lastSentEtag:#,#;;0}, Mentor's Etag: {mentorsEtag:#,#;;0}, mentor cluster-stats time diff exceeded: {timeDiff})");
                 promotionStatus = DatabasePromotionStatus.ChangeVectorNotMerged;
             }
 
-            // Check 2: Compare exchange lag
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Check if we're getting the proper compare exchange for shard databases");
 #pragma warning disable CS0618
             var leaderLastCompareExchangeIndex = _server.Cluster.GetLastCompareExchangeIndexForDatabase(context, dbName);
@@ -692,7 +691,6 @@ namespace Raven.Server.ServerWide.Maintenance
                 promotionStatus = DatabasePromotionStatus.RaftIndexNotUpToDate;
             }
 
-            // Check 3: Index lag
             var databaseEtag = -1L;
             if (state.HasActiveMigrations() == false)
             {
@@ -714,7 +712,6 @@ namespace Raven.Server.ServerWide.Maintenance
                 promotionStatus = DatabasePromotionStatus.IndexNotUpToDate;
             }
 
-            // If no lag detected, promote
             if (lagReasons.Count == 0)
             {
                 _logger.Log($"We try to promote the database '{dbName}' on {promotable} to be a full member", state.ObserverIteration, database: dbName);
@@ -725,8 +722,7 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (true, $"Node {promotable} is up-to-date so promoting it to be member");
             }
 
-            // Build aggregate message with all lag reasons and log once
-            var aggregateMsg = $"The database '{dbName}' on {promotable} not ready to be promoted:" + Environment.NewLine +
+            var aggregateMsg = $"The database '{dbName}' on {promotable} is not ready to be promoted:" + Environment.NewLine +
                                string.Join(Environment.NewLine, lagReasons);
 
             _logger.Log(aggregateMsg, state.ObserverIteration, database: dbName);

--- a/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/DatabaseTopologyUpdater.cs
@@ -667,26 +667,20 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (false, null);
             }
 
+            // Collect all lag indicators instead of returning on the first one.
+            var lagReasons = new List<string>();
+            var promotionStatus = DatabasePromotionStatus.Ok;
+
+            // Check 1: Replication lag
             var timeDiff = mentorCurrClusterStats.LastSuccessfulUpdateDateTime - mentorPrevClusterStats.LastSuccessfulUpdateDateTime > 3 * _supervisorSamplePeriod;
 
             if (lastSentEtag < mentorsEtag || timeDiff)
             {
-                var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because the mentor hasn't sent all of the documents yet." + Environment.NewLine +
-                          $"Last sent Etag: {lastSentEtag:#,#;;0}" + Environment.NewLine +
-                          $"Mentor's Etag: {mentorsEtag:#,#;;0}";
-
-                _logger.Log($"Mentor {mentorNode} hasn't sent all of the documents yet to {promotable} (time diff: {timeDiff}, sent etag: {lastSentEtag:#,#;;0}/{mentorsEtag:#,#;;0})", state.ObserverIteration, database: dbName);
-
-                if (topology.DemotionReasons.TryGetValue(promotable, out var demotionReason) == false ||
-                    msg.Equals(demotionReason) == false)
-                {
-                    topology.DemotionReasons[promotable] = msg;
-                    topology.PromotablesStatus[promotable] = DatabasePromotionStatus.ChangeVectorNotMerged;
-                    return (false, msg);
-                }
-                return (false, null);
+                lagReasons.Add($"The mentor hasn't sent all of the documents yet (Last sent Etag: {lastSentEtag:#,#;;0}, Mentor's Etag: {mentorsEtag:#,#;;0})");
+                promotionStatus = DatabasePromotionStatus.ChangeVectorNotMerged;
             }
 
+            // Check 2: Compare exchange lag
             DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Stav, DevelopmentHelper.Severity.Normal, "Check if we're getting the proper compare exchange for shard databases");
 #pragma warning disable CS0618
             var leaderLastCompareExchangeIndex = _server.Cluster.GetLastCompareExchangeIndexForDatabase(context, dbName);
@@ -694,22 +688,11 @@ namespace Raven.Server.ServerWide.Maintenance
             var promotableLastCompareExchangeIndex = promotableDbStats.LastCompareExchangeIndex;
             if (leaderLastCompareExchangeIndex > promotableLastCompareExchangeIndex)
             {
-                var msg = $"The database '{dbName}' on {promotable} not ready to be promoted, because not all of the compare exchanges have been sent yet." + Environment.NewLine +
-                          $"Last Compare Exchange Raft Index: {promotableLastCompareExchangeIndex}" + Environment.NewLine +
-                          $"Leader's Compare Exchange Raft Index: {leaderLastCompareExchangeIndex}";
-
-                _logger.Log($"Node {promotable} hasn't been promoted because it's raft index isn't updated yet", state.ObserverIteration, database: dbName);
-
-                if (topology.DemotionReasons.TryGetValue(promotable, out var demotionReason) == false ||
-                    msg.Equals(demotionReason) == false)
-                {
-                    topology.DemotionReasons[promotable] = msg;
-                    topology.PromotablesStatus[promotable] = DatabasePromotionStatus.RaftIndexNotUpToDate;
-                    return (false, msg);
-                }
-                return (false, null);
+                lagReasons.Add($"Not all of the compare exchanges have been sent yet (Last Compare Exchange Raft Index: {promotableLastCompareExchangeIndex}, Leader's: {leaderLastCompareExchangeIndex})");
+                promotionStatus = DatabasePromotionStatus.RaftIndexNotUpToDate;
             }
 
+            // Check 3: Index lag
             var databaseEtag = -1L;
             if (state.HasActiveMigrations() == false)
             {
@@ -725,7 +708,14 @@ namespace Raven.Server.ServerWide.Maintenance
                 mentorCurrDbStats.LastIndexStats,
                 out var reason);
 
-            if (indexesCaughtUp)
+            if (indexesCaughtUp == false)
+            {
+                lagReasons.Add($"The indexes are not up-to-date ({reason})");
+                promotionStatus = DatabasePromotionStatus.IndexNotUpToDate;
+            }
+
+            // If no lag detected, promote
+            if (lagReasons.Count == 0)
             {
                 _logger.Log($"We try to promote the database '{dbName}' on {promotable} to be a full member", state.ObserverIteration, database: dbName);
 
@@ -735,15 +725,18 @@ namespace Raven.Server.ServerWide.Maintenance
                 return (true, $"Node {promotable} is up-to-date so promoting it to be member");
             }
 
-            _logger.Log($"The database '{dbName}' on {promotable} is not ready to be promoted, because {reason}{Environment.NewLine}", state.ObserverIteration, database: dbName);
+            // Build aggregate message with all lag reasons and log once
+            var aggregateMsg = $"The database '{dbName}' on {promotable} not ready to be promoted:" + Environment.NewLine +
+                               string.Join(Environment.NewLine, lagReasons);
 
-            if (topology.PromotablesStatus.TryGetValue(promotable, out var currentStatus) == false
-                || currentStatus != DatabasePromotionStatus.IndexNotUpToDate)
+            _logger.Log(aggregateMsg, state.ObserverIteration, database: dbName);
+
+            if (topology.DemotionReasons.TryGetValue(promotable, out var existingDemotionReason) == false ||
+                aggregateMsg.Equals(existingDemotionReason) == false)
             {
-                var msg = $"Node {promotable} not ready to be a member, because the indexes are not up-to-date";
-                topology.PromotablesStatus[promotable] = DatabasePromotionStatus.IndexNotUpToDate;
-                topology.DemotionReasons[promotable] = msg;
-                return (false, msg);
+                topology.DemotionReasons[promotable] = aggregateMsg;
+                topology.PromotablesStatus[promotable] = promotionStatus;
+                return (false, aggregateMsg);
             }
             return (false, null);
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25768

### Additional description

Collect all lag indicators instead of returning on the first one

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
