### PR TITLE
RavenDB-7070: Commit hook to allow better AI automation and reject patterns that could be potentially problematic. 

### DIFF
--- a/scripts/githubActions/commitMessageConventions.ps1
+++ b/scripts/githubActions/commitMessageConventions.ps1
@@ -23,25 +23,54 @@ $allMatched = $TRUE
 
 echo "$allCommits"
 
+# Attribution patterns that should not appear in commit messages
+$attributionPattern = '(?i)^\s*(co-authored-by|signed-off-by|reviewed-by|helped-by|generated-by|assisted-by)\s*:'
+
 Foreach ($commit in $allCommits)
 {
     $message = $commit.commit.message
     Write-Host "Processing message '$message'"
 
     $loweredMessage = $message.ToLowerInvariant()
-    $match = $loweredMessage -match "ravendb-\d+" -or $loweredMessage -match "rdoc-\d+" -or $loweredMessage -match "rdbqa-\d+" -or $loweredMessage -match "rdbc-\d+" -or $loweredMessage -match "rdbs-\d+" -or $loweredMessage -match "rdbcl-\d+" -or $loweredMessage -match "merge branch" -or $loweredMessage -match "merge remote" -or $loweredMessage -match "merge pull request"
+
+    # Rule 1: Title must contain a recognized issue key or be a merge/bump/WIP commit
+    $match = $loweredMessage -match "^(ravendb|rdoc|rdbqa|rdbc|rdbs|rdbcl|hrint)-\d+" `
+        -or $loweredMessage -match "^merge branch" `
+        -or $loweredMessage -match "^merge remote" `
+        -or $loweredMessage -match "^merge pull request" `
+        -or $loweredMessage -match "^bump version" `
+        -or $loweredMessage -match "^wip($|\s)"
 
     if ($match -eq $FALSE)
     {
         $allMatched = $FALSE
-        Write-Host "Commit message '$message' does not contain issue #"
+        Write-Host "Commit message '$message' does not match allowed title format"
+    }
+
+    # Rule 2: Title with issue key must have a description after the separator
+    if ($loweredMessage -match "^(ravendb|rdoc|rdbqa|rdbc|rdbs|rdbcl|hrint)-\d+$")
+    {
+        $allMatched = $FALSE
+        Write-Host "Commit message '$message' has an issue key but no description"
+    }
+
+    # Rule 3: No attribution lines in the body
+    $lines = $message -split "`n"
+    foreach ($line in $lines)
+    {
+        if ($line -match $attributionPattern)
+        {
+            $allMatched = $FALSE
+            Write-Host "Commit message contains attribution line: '$line'"
+            break
+        }
     }
 }
 
 if ($allMatched -eq $FALSE)
 {
     "false" | Out-File -FilePath status_message.txt -NoNewline
-    throw "Not all commit messages contain issue #"
+    throw "Not all commit messages meet conventions"
 }
 else
 {


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-7070

### Additional description

The commit-msg hook validates every commit message before it's accepted. It checks two rules:

Rule 1 — Title format

The first line must match one of:
  - RavenDB-#### Description (space separator)
  - RavenDB-####: Description (colon separator)
  - RavenDB-#### - Description (dash separator)
  - Same patterns for HRINT-####
  - Merge ... (merge commits)
  - Bump version ... (version bumps)
  - WIP (for work in problem temporary commits)

Anything else (e.g. fix typo, or a bare RavenDB-12345 with no description) is rejected. 

Rule 2 — No attribution lines

Rejects commits whose body contains Co-Authored-By:, Signed-off-by:, Reviewed-by:, Helped-by:, Generated-by:, or Assisted-by:. These are typically auto-appended by AI tools or GitHub and add noise to the history.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
