### PR TITLE
RavenDB-26358: Latent errors in Sparrow Binary and Compression

### DIFF
--- a/src/Sparrow/Binary/BitVector.cs
+++ b/src/Sparrow/Binary/BitVector.cs
@@ -87,7 +87,7 @@ namespace Sparrow.Binary
                 if (result == 0)
                     continue;
 
-                index += LeadingZeroes(result);
+                index += TrailingZeroes(result);
                 goto Done;
             }
 
@@ -118,7 +118,7 @@ namespace Sparrow.Binary
                 if (result == 0)
                     continue;
 
-                index += LeadingZeroes(result);
+                index += TrailingZeroes(result);
                 goto Done;
             }
 
@@ -149,8 +149,10 @@ namespace Sparrow.Binary
                 if (input == 0)
                     continue;
 
-                value = LeadingZeroes(input);
-                return (value < sizeof(long) * 8) ? (int)index * 8 + value : -1;
+                // On little-endian, the first non-zero byte (lowest address) is in the LSB.
+                // TrailingZeroesInBytes finds the byte index of the first non-zero byte.
+                index += TrailingZeroesInBytes(input);
+                goto Done;
             }
 
             for (; index < lengthInBytes; index++)

--- a/src/Sparrow/Binary/Bits.cs
+++ b/src/Sparrow/Binary/Bits.cs
@@ -36,7 +36,14 @@ namespace Sparrow.Binary
                     8, 12, 20, 28, 15, 17, 24, 7, 19, 27, 23, 6, 26, 5, 4, 31
                 };
 
-        private static readonly byte[] DeBruijnBytePos64 = 
+        // De Bruijn lookup table for 32-bit trailing zero count (constant 0x077CB531)
+        private static readonly byte[] TrailingZeroDeBruijnBitPosition =
+                {
+                    0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,
+                    31, 27, 13, 23, 21, 19, 16, 7, 26, 12, 18, 6, 11, 5, 10, 9
+                };
+
+        private static readonly byte[] DeBruijnBytePos64 =
             {
                 0, 0, 0, 0, 0, 1, 1, 2, 0, 3, 1, 3, 1, 4, 2, 7, 0, 2, 3, 6, 1, 5, 3, 5, 1, 3, 4, 4, 2, 5, 6, 7,
                 7, 0, 1, 2, 3, 3, 4, 6, 2, 6, 5, 5, 3, 4, 5, 6, 7, 1, 2, 4, 6, 4, 4, 5, 7, 2, 6, 5, 7, 6, 7, 7
@@ -188,6 +195,18 @@ namespace Sparrow.Binary
             if (n == 0)
                 return 64;
             return 63 - MostSignificantBit(n);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TrailingZeroes(uint n)
+        {
+#if NET6_0_OR_GREATER
+            return BitOperations.TrailingZeroCount(n);
+#else
+            if (n == 0)
+                return 32;
+            return TrailingZeroDeBruijnBitPosition[((n & (uint)(-(int)n)) * 0x077CB531U) >> 27];
 #endif
         }
 

--- a/src/Sparrow/Compression/VariableSizeEncoding.cs
+++ b/src/Sparrow/Compression/VariableSizeEncoding.cs
@@ -302,7 +302,7 @@ namespace Sparrow.Compression
                 else
                     bytesReadWhenOverflow = 3;
 
-                // PERF: We need this for the JIT to understand that this can be profitable. 
+                // PERF: We need this for the JIT to understand that this can be profitable.
                 ref var inputRef = ref Unsafe.Add(ref inputStart, 2);
                 int shift = 2 * bitsToShift;
                 do
@@ -314,10 +314,10 @@ namespace Sparrow.Compression
                     ul |= (b & 0x7Ful) << shift;
                     shift += bitsToShift;
 
-                    inputRef = Unsafe.Add(ref inputRef, 1);
+                    inputRef = ref Unsafe.Add(ref inputRef, 1);
                 }
                 while (b >= 0x80);
-                offset = Unsafe.ByteOffset(ref inputRef, ref inputStart).ToInt32();
+                offset = Unsafe.ByteOffset(ref inputStart, ref inputRef).ToInt32();
 
             End:
                 
@@ -555,14 +555,6 @@ namespace Sparrow.Compression
 
                 if (typeof(T) == typeof(bool))
                     return (T)(object)(destRef == 1);
-                return (T)(object)destRef;
-            }
-
-            if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(byte) || typeof(T) == typeof(bool))
-            {
-                offset = 1;
-                if (typeof(T) == typeof(bool))
-                    return (T)(object)(destRef == 1);
                 return (typeof(T) == typeof(sbyte)) ? (T)(object)(sbyte)destRef : (T)(object)destRef;
             }
 
@@ -687,16 +679,8 @@ namespace Sparrow.Compression
                 else
                     b = (byte)(object)value;
 
-                int i = 0;
-                if (b < 0x80)
-                    goto End;
-                dest[0] = (byte)(b | 0x80);
-                b >>= 7;
-                i++;
-
-            End:
-                dest[i] = b;
-                return i + 1;
+                dest[0] = b;
+                return 1;
             }
 
             if (typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
@@ -818,17 +802,8 @@ namespace Sparrow.Compression
                 else
                     b = (byte)(object)value;
 
-                int i = 0;
-                if (b < 0x80)
-                    goto End;
-
-                destRef = (byte)(b | 0x80);
-                b >>= 7;
-                i++;
-
-            End:
-                Unsafe.Add(ref destRef, i) = b;
-                return i + 1;
+                destRef = b;
+                return 1;
             }
 
             if (typeof(T) == typeof(short) || typeof(T) == typeof(ushort))

--- a/src/Sparrow/Compression/ZigZagEncoding.cs
+++ b/src/Sparrow/Compression/ZigZagEncoding.cs
@@ -13,39 +13,25 @@ namespace Sparrow.Compression
             int sizeOfTInBits = Unsafe.SizeOf<T>() * 8 - 1;
             if (typeof(T) == typeof(sbyte))
             {
-                byte b;
-                if (typeof(T) == typeof(bool))
-                    b = (bool)(object)value ? (byte)1 : (byte)0;
-                else if (typeof(T) == typeof(sbyte))
-                    b = (byte)(sbyte)(object)value;
-                else
-                    b = (byte)(object)value;
+                sbyte sb = (sbyte)(object)value;
 
-                byte uv = (byte)((b << 1) ^ (b >> sizeOfTInBits));
+                byte uv = (byte)((sb << 1) ^ (sb >> sizeOfTInBits));
                 return VariableSizeEncoding.Write(buffer, uv, pos);
             }
 
             if (typeof(T) == typeof(short))
             {
-                ushort us;
-                if (typeof(T) == typeof(short))
-                    us = (ushort)(short)(object)value;
-                else
-                    us = (ushort)(object)value;
+                short ss = (short)(object)value;
 
-                ushort uv = (ushort)((us << 1) ^ (us >> sizeOfTInBits));
+                ushort uv = (ushort)((ss << 1) ^ (ss >> sizeOfTInBits));
                 return VariableSizeEncoding.Write(buffer, uv, pos);
             }
 
             if (typeof(T) == typeof(int))
             {
-                uint ui;
-                if (typeof(T) == typeof(int))
-                    ui = (uint)(int)(object)value;
-                else
-                    ui = (uint)(object)value;
+                int si = (int)(object)value;
 
-                uint uv = ((ui << 1) ^ (ui >> sizeOfTInBits));
+                uint uv = (uint)((si << 1) ^ (si >> sizeOfTInBits));
                 return VariableSizeEncoding.Write(buffer, uv, pos);
             }
 
@@ -66,39 +52,25 @@ namespace Sparrow.Compression
             int sizeOfTInBits = Unsafe.SizeOf<T>() * 8 - 1;
             if (typeof(T) == typeof(sbyte))
             {
-                byte b;
-                if (typeof(T) == typeof(bool))
-                    b = (bool)(object)value ? (byte)1 : (byte)0;
-                else if (typeof(T) == typeof(sbyte))
-                    b = (byte)(sbyte)(object)value;
-                else
-                    b = (byte)(object)value;
+                sbyte sb = (sbyte)(object)value;
 
-                byte uv = (byte)((b << 1) ^ (b >> sizeOfTInBits));
+                byte uv = (byte)((sb << 1) ^ (sb >> sizeOfTInBits));
                 return VariableSizeEncoding.Write(buffer + pos, uv);
             }
 
             if (typeof(T) == typeof(short))
             {
-                ushort us;
-                if (typeof(T) == typeof(short))
-                    us = (ushort)(short)(object)value;
-                else
-                    us = (ushort)(object)value;
+                short ss = (short)(object)value;
 
-                ushort uv = (ushort)((us << 1) ^ (us >> sizeOfTInBits));
+                ushort uv = (ushort)((ss << 1) ^ (ss >> sizeOfTInBits));
                 return VariableSizeEncoding.Write(buffer + pos, uv);
             }
 
             if (typeof(T) == typeof(int))
             {
-                uint ui;
-                if (typeof(T) == typeof(int))
-                    ui = (uint)(int)(object)value;
-                else
-                    ui = (uint)(object)value;
+                int si = (int)(object)value;
 
-                uint uv = ((ui << 1) ^ (ui >> sizeOfTInBits));
+                uint uv = (uint)((si << 1) ^ (si >> sizeOfTInBits));
                 return VariableSizeEncoding.Write(buffer + pos, uv);
             }
 
@@ -170,13 +142,13 @@ namespace Sparrow.Compression
             if (typeof(T) == typeof(sbyte))
             {
                 var b = (byte)(sbyte)(object)value;
-                return (T)(object)((b & 1) != 0 ? (sbyte)(b >> 1) ^ -1 : (sbyte)(b >> 1));
+                return (T)(object)(sbyte)((b & 1) != 0 ? (sbyte)(b >> 1) ^ -1 : (sbyte)(b >> 1));
             }
 
             if (typeof(T) == typeof(short))
             {
                 var us = (ushort)(short)(object)value;
-                return (T)(object)((us & 1) != 0 ? (short)(us >> 1) ^ -1 : (short)(us >> 1));
+                return (T)(object)(short)((us & 1) != 0 ? (short)(us >> 1) ^ -1 : (short)(us >> 1));
             }
 
             if (typeof(T) == typeof(int))

--- a/test/FastTests/Sparrow/Bits.cs
+++ b/test/FastTests/Sparrow/Bits.cs
@@ -167,6 +167,48 @@ namespace FastTests.Sparrow
 
 
         [RavenFact(RavenTestCategory.Core)]
+        public void BitVector_IndexOfFirstSetBit_Scalar()
+        {
+            for (int bitIdx = 0; bitIdx < 256; bitIdx++)
+            {
+                var storage = new byte[32];
+                var bv = new BitVector(storage);
+                bv.Set(bitIdx);
+
+                ref byte storageRef = ref MemoryMarshal.GetReference(storage.AsSpan());
+                Assert.Equal(bitIdx, BitVector.IndexOfFirstSetBitScalar(ref storageRef, storage.Length));
+            }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Core, RavenIntrinsics.Sse)]
+        public void BitVector_IndexOfFirstSetBit_Sse2()
+        {
+            for (int bitIdx = 0; bitIdx < 256; bitIdx++)
+            {
+                var storage = new byte[32];
+                var bv = new BitVector(storage);
+                bv.Set(bitIdx);
+
+                ref byte storageRef = ref MemoryMarshal.GetReference(storage.AsSpan());
+                Assert.Equal(bitIdx, BitVector.IndexOfFirstSetBitSse2(ref storageRef, storage.Length));
+            }
+        }
+
+        [RavenMultiplatformFact(RavenTestCategory.Core, RavenIntrinsics.Avx256)]
+        public void BitVector_IndexOfFirstSetBit_Avx2()
+        {
+            for (int bitIdx = 0; bitIdx < 256; bitIdx++)
+            {
+                var storage = new byte[32];
+                var bv = new BitVector(storage);
+                bv.Set(bitIdx);
+
+                ref byte storageRef = ref MemoryMarshal.GetReference(storage.AsSpan());
+                Assert.Equal(bitIdx, BitVector.IndexOfFirstSetBitAvx2(ref storageRef, storage.Length));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
         public void BitReaderEquivalence()
         {
             for (int i = 0; i <= 255; i++)

--- a/test/FastTests/Sparrow/CompressionTests.cs
+++ b/test/FastTests/Sparrow/CompressionTests.cs
@@ -120,12 +120,12 @@ namespace FastTests.Sparrow
 
             byte* stack = stackalloc byte[16];
 
-            for (int i = 0; i < byte.MaxValue; i++)
+            for (int i = 0; i <= byte.MaxValue; i++)
             {
                 VariableSizeEncoding.Write(stack, (byte)i);
-                var v1 = ReadVariableSizeInt(stack, 0, out _);
-                var v2 = VariableSizeEncoding.Read<byte>(stack, out _);
-                Assert.Equal(v1, v2);
+                var v = VariableSizeEncoding.Read<byte>(stack, out int offset);
+                Assert.Equal((byte)i, v);
+                Assert.Equal(1, offset);
             }
 
             var rnd = new Random(seed);

--- a/test/FastTests/Sparrow/IntegerEncoding.cs
+++ b/test/FastTests/Sparrow/IntegerEncoding.cs
@@ -152,5 +152,74 @@ namespace FastTests.Sparrow
             }
         }
 
+        [RavenFact(RavenTestCategory.Core)]
+        public void VariableSize_ReadSpanWithPos_ReturnsCorrectOffset()
+        {
+            Span<byte> buffer = new byte[16];
+
+            // Value 16384 requires 3 bytes in varint
+            int written = VariableSizeEncoding.Write<int>(buffer, 16384);
+            Assert.True(written >= 3);
+
+            ReadOnlySpan<byte> roBuffer = buffer;
+            int result = VariableSizeEncoding.Read<int>(roBuffer, 0, out int offset, out bool success);
+            Assert.True(success);
+            Assert.Equal(16384, result);
+            Assert.Equal(written, offset);
+
+            // Also test with int.MaxValue (5 byte varint)
+            buffer.Clear();
+            written = VariableSizeEncoding.Write<int>(buffer, int.MaxValue);
+            roBuffer = buffer;
+            result = VariableSizeEncoding.Read<int>(roBuffer, 0, out offset, out success);
+            Assert.True(success);
+            Assert.Equal(int.MaxValue, result);
+            Assert.Equal(written, offset);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void VariableSize_ReadSByte_DoesNotThrow()
+        {
+            Span<byte> buffer = new byte[4];
+            buffer[0] = 42;
+
+            ReadOnlySpan<byte> roBuffer = buffer;
+            sbyte result = VariableSizeEncoding.Read<sbyte>(roBuffer, out int offset);
+            Assert.Equal((sbyte)42, result);
+            Assert.Equal(1, offset);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void VariableSize_Byte_WriteRead_OffsetConsistency()
+        {
+            Span<byte> buffer = new byte[16];
+            byte[] testValues = { 0, 1, 127, 128, 200, 255 };
+            foreach (var value in testValues)
+            {
+                buffer.Clear();
+                int written = VariableSizeEncoding.Write<byte>(buffer, value);
+                ReadOnlySpan<byte> roBuffer = buffer;
+                byte result = VariableSizeEncoding.Read<byte>(roBuffer, out int readLen);
+                Assert.Equal(value, result);
+                Assert.Equal(written, readLen);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void VariableSize_Byte_WriteManyReadMany_Roundtrip()
+        {
+            byte[] values = { 100, 200, 150, 255, 128, 0, 1, 127 };
+            Span<byte> buffer = new byte[64];
+            byte[] readBack = new byte[values.Length];
+
+            int totalWritten = VariableSizeEncoding.WriteMany<byte>(buffer, values.AsSpan());
+            ReadOnlySpan<byte> roBuffer = buffer;
+            int totalRead = VariableSizeEncoding.ReadMany<byte>(roBuffer, values.Length, readBack.AsSpan());
+
+            Assert.Equal(totalWritten, totalRead);
+            for (int i = 0; i < values.Length; i++)
+                Assert.Equal(values[i], readBack[i]);
+        }
+
     }
 }

--- a/test/FastTests/Sparrow/IntegerEncoding.cs
+++ b/test/FastTests/Sparrow/IntegerEncoding.cs
@@ -94,5 +94,63 @@ namespace FastTests.Sparrow
             Assert.Equal(0, values.SequenceCompareTo(decodedValues));
         }
 
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(-1)]
+        [InlineData(-2)]
+        [InlineData(-3)]
+        [InlineData(-127)]
+        [InlineData(-128)]
+        [InlineData(-1000)]
+        [InlineData(int.MinValue)]
+        public void ZigZag_Int_Roundtrip(int expected)
+        {
+            Span<byte> buffer = new byte[16];
+            ZigZagEncoding.Encode<int>(buffer, expected);
+            int decoded = ZigZagEncoding.Decode<int>(buffer);
+            Assert.Equal(expected, decoded);
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData((short)-1)]
+        [InlineData((short)-2)]
+        [InlineData((short)-128)]
+        [InlineData(short.MinValue)]
+        public void ZigZag_Short_Roundtrip(short expected)
+        {
+            Span<byte> buffer = new byte[16];
+            ZigZagEncoding.Encode<short>(buffer, expected);
+            short decoded = ZigZagEncoding.Decode<short>(buffer);
+            Assert.Equal(expected, decoded);
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData((sbyte)-1)]
+        [InlineData((sbyte)-2)]
+        [InlineData(sbyte.MinValue)]
+        public void ZigZag_SByte_Roundtrip(sbyte expected)
+        {
+            Span<byte> buffer = new byte[16];
+            ZigZagEncoding.Encode<sbyte>(buffer, expected);
+            sbyte decoded = ZigZagEncoding.Decode<sbyte>(buffer);
+            Assert.Equal(expected, decoded);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void ZigZag_Int_PointerOverload_NegativeValues_Roundtrip()
+        {
+            Span<byte> buffer = new byte[16];
+            fixed (byte* ptr = buffer)
+            {
+                int[] values = { -1, -2, -1000, int.MinValue };
+                foreach (var expected in values)
+                {
+                    buffer.Clear();
+                    ZigZagEncoding.Encode<int>(ptr, expected);
+                    int decoded = ZigZagEncoding.Decode<int>(ptr, out _);
+                    Assert.Equal(expected, decoded);
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26358

### Additional description

There is code that is not correctly exercised and has latent errors. This PR fixes those and add tests that ensure they don't regress. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
