### PR TITLE
RavenDB-26359: Latent errors in StringSegment and Fast Collections.

### DIFF
--- a/src/Sparrow/Collections/FastList.cs
+++ b/src/Sparrow/Collections/FastList.cs
@@ -300,6 +300,8 @@ namespace Sparrow.Collections
 
             if (index < _size)
                 Array.Copy(_items, index + 1, _items, index, (int)_size - index);
+
+            _items[_size] = default;
             return;
 
             ERROR:

--- a/src/Sparrow/Collections/FastStack.cs
+++ b/src/Sparrow/Collections/FastStack.cs
@@ -92,7 +92,7 @@ namespace Sparrow.Collections
                 array[--dstIndex] = _array[srcIndex++];
         }
 
-        public void CopyTo(FastStack<T> srcStack)
+        public void CopyFrom(FastStack<T> srcStack)
         {
             Debug.Assert(srcStack._array != _array);
 
@@ -110,6 +110,7 @@ namespace Sparrow.Collections
                 destArray[dstIndex++] = srcArray[srcIndex++];
 
             _size += srcSize;
+            _version++;
         }
 
         // Returns an IEnumerator for this Stack.

--- a/src/Sparrow/Collections/FastStack.cs
+++ b/src/Sparrow/Collections/FastStack.cs
@@ -95,7 +95,7 @@ namespace Sparrow.Collections
         public void CopyTo(FastStack<T> srcStack)
         {
             Debug.Assert(srcStack._array != _array);
-           
+
             int srcSize = srcStack._size;
             int dstIndex = _size;
             if (dstIndex + srcSize > _array.Length)
@@ -108,6 +108,8 @@ namespace Sparrow.Collections
             int srcIndex = 0;
             for (int i = 0; i < srcSize; i++)
                 destArray[dstIndex++] = srcArray[srcIndex++];
+
+            _size += srcSize;
         }
 
         // Returns an IEnumerator for this Stack.
@@ -154,7 +156,7 @@ namespace Sparrow.Collections
 
         public bool TryPeek(int depth, out T result)
         {
-            if (_size < depth)
+            if (_size < depth || depth <= 0)
             {
                 result = default(T);
                 return false;

--- a/src/Sparrow/StringSegment.cs
+++ b/src/Sparrow/StringSegment.cs
@@ -337,7 +337,7 @@ namespace Sparrow
             var textLength = text.Length;
             var comparisonLength = Offset + Length - textLength;
 
-            if (HasValue && comparisonLength > 0)
+            if (HasValue && Length >= textLength)
             {
                 result = string.Compare(Buffer, comparisonLength, text, 0, textLength, comparisonType) == 0;
             }
@@ -549,7 +549,7 @@ namespace Sparrow
         {
             var index = -1;
 
-            if (HasValue)
+            if (HasValue && Length > 0)
             {
                 index = Buffer.LastIndexOf(value, Offset + Length - 1, Length);
                 if (index != -1)

--- a/test/FastTests/Sparrow/FastCollectionTests.cs
+++ b/test/FastTests/Sparrow/FastCollectionTests.cs
@@ -9,7 +9,7 @@ namespace FastTests.Sparrow
     public class FastCollectionTests(ITestOutputHelper output) : NoDisposalNeeded(output)
     {
         [RavenFact(RavenTestCategory.Core)]
-        public void FastStack_CopyTo_UpdatesDestinationCount()
+        public void FastStack_CopyFrom_UpdatesDestinationCount()
         {
             var src = new FastStack<int>();
             src.Push(10);
@@ -20,13 +20,13 @@ namespace FastTests.Sparrow
             dst.Push(1);
             dst.Push(2);
 
-            dst.CopyTo(src);
+            dst.CopyFrom(src);
 
             Assert.Equal(5, dst.Count);
         }
 
         [RavenFact(RavenTestCategory.Core)]
-        public void FastStack_CopyTo_ElementsAccessibleAfterCopy()
+        public void FastStack_CopyFrom_ElementsAccessibleAfterCopy()
         {
             var src = new FastStack<int>();
             src.Push(10);
@@ -35,7 +35,7 @@ namespace FastTests.Sparrow
             var dst = new FastStack<int>();
             dst.Push(1);
 
-            dst.CopyTo(src);
+            dst.CopyFrom(src);
 
             Assert.Equal(3, dst.Count);
             // Pop should return the last-pushed (copied) element

--- a/test/FastTests/Sparrow/FastCollectionTests.cs
+++ b/test/FastTests/Sparrow/FastCollectionTests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using Sparrow.Collections;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public class FastCollectionTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenFact(RavenTestCategory.Core)]
+        public void FastStack_CopyTo_UpdatesDestinationCount()
+        {
+            var src = new FastStack<int>();
+            src.Push(10);
+            src.Push(20);
+            src.Push(30);
+
+            var dst = new FastStack<int>();
+            dst.Push(1);
+            dst.Push(2);
+
+            dst.CopyTo(src);
+
+            Assert.Equal(5, dst.Count);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void FastStack_CopyTo_ElementsAccessibleAfterCopy()
+        {
+            var src = new FastStack<int>();
+            src.Push(10);
+            src.Push(20);
+
+            var dst = new FastStack<int>();
+            dst.Push(1);
+
+            dst.CopyTo(src);
+
+            Assert.Equal(3, dst.Count);
+            // Pop should return the last-pushed (copied) element
+            Assert.Equal(20, dst.Pop());
+            Assert.Equal(10, dst.Pop());
+            Assert.Equal(1, dst.Pop());
+            Assert.Equal(0, dst.Count);
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData(0, false, 0)]   // depth=0 is invalid, must return false
+        [InlineData(1, true, 99)]   // depth=1 = top of stack
+        [InlineData(2, true, 42)]   // depth=2 = second from top
+        [InlineData(3, false, 0)]   // depth exceeds size, must return false
+        public void FastStack_TryPeek_Depth(int depth, bool expectedSuccess, int expectedValue)
+        {
+            var stack = new FastStack<int>();
+            stack.Push(42);
+            stack.Push(99);
+
+            bool success = stack.TryPeek(depth, out int result);
+            Assert.Equal(expectedSuccess, success);
+            if (expectedSuccess)
+                Assert.Equal(expectedValue, result);
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void FastList_RemoveAt_ClearsVacatedSlot()
+        {
+            var list = new FastList<string>();
+            list.Add("a");
+            list.Add("b");
+            list.Add("c");
+
+            list.RemoveAt(0); // removes "a", shifts "b","c" left → Count=2
+
+            Assert.Equal(2, list.Count);
+            Assert.Equal("b", list[0]);
+            Assert.Equal("c", list[1]);
+
+            // Use reflection to verify _items[Count] (the vacated slot) is null
+            var itemsField = typeof(FastList<string>).GetField("_items", BindingFlags.NonPublic | BindingFlags.Instance);
+            var items = (string[])itemsField.GetValue(list);
+            Assert.Null(items[list.Count]); // slot at index 2 should be cleared
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void FastList_Remove_ClearsVacatedSlot()
+        {
+            var list = new FastList<string>();
+            list.Add("x");
+            list.Add("y");
+            list.Add("z");
+
+            bool removed = list.Remove("x"); // calls RemoveAt(0) internally
+            Assert.True(removed);
+            Assert.Equal(2, list.Count);
+
+            var itemsField = typeof(FastList<string>).GetField("_items", BindingFlags.NonPublic | BindingFlags.Instance);
+            var items = (string[])itemsField.GetValue(list);
+            Assert.Null(items[list.Count]); // slot at index 2 should be cleared
+        }
+    }
+}

--- a/test/FastTests/Sparrow/StringSegmentTests.cs
+++ b/test/FastTests/Sparrow/StringSegmentTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Sparrow
+{
+    public class StringSegmentTests(ITestOutputHelper output) : NoDisposalNeeded(output)
+    {
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData("abc", "abc")]
+        [InlineData("hello", "hello")]
+        [InlineData("x", "x")]
+        public void EndsWith_FullMatch_ReturnsTrue(string source, string suffix)
+        {
+            var segment = new StringSegment(source);
+            Assert.True(segment.EndsWith(suffix, StringComparison.Ordinal));
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData("hello world", "world")]
+        [InlineData("abc", "bc")]
+        [InlineData("abc", "c")]
+        public void EndsWith_PartialMatch_ReturnsTrue(string source, string suffix)
+        {
+            var segment = new StringSegment(source);
+            Assert.True(segment.EndsWith(suffix, StringComparison.Ordinal));
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData("abc", "xyz")]
+        [InlineData("abc", "abcd")]
+        public void EndsWith_NoMatch_ReturnsFalse(string source, string suffix)
+        {
+            var segment = new StringSegment(source);
+            Assert.False(segment.EndsWith(suffix, StringComparison.Ordinal));
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData("hello world", 6, 5, "world")]
+        public void EndsWith_WithOffset_FullMatch_ReturnsTrue(string buffer, int offset, int length, string suffix)
+        {
+            var segment = new StringSegment(buffer, offset, length);
+            Assert.True(segment.EndsWith(suffix, StringComparison.Ordinal));
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void EndsWith_WithOffset_DoesNotMatchOutsideSegment()
+        {
+            var segment = new StringSegment("hello world", 6, 5);
+            Assert.False(segment.EndsWith(" world", StringComparison.Ordinal));
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void LastIndexOf_EmptySegment_ReturnsNegativeOne()
+        {
+            var segment = new StringSegment("hello", 0, 0);
+            Assert.Equal(-1, segment.LastIndexOf('h'));
+        }
+
+        [RavenTheory(RavenTestCategory.Core)]
+        [InlineData("hello", 'l', 3)]
+        [InlineData("hello", 'h', 0)]
+        [InlineData("hello", 'o', 4)]
+        [InlineData("hello", 'x', -1)]
+        public void LastIndexOf_ReturnsCorrectIndex(string source, char value, int expected)
+        {
+            var segment = new StringSegment(source);
+            Assert.Equal(expected, segment.LastIndexOf(value));
+        }
+    }
+}


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26359

### Additional description

Fixes latent errors on code that is not exercised properly or edge cases that are rare enough that maybe they are not triggered (but we can't know for sure).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
