### PR TITLE
RavenDB-26196 Enhance Azure Queue Storage ETL connection string validation to protect against storing invalid connection strings

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/Queue/AzureQueueStorageConnectionSettings.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/AzureQueueStorageConnectionSettings.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Raven.Client.Documents.Operations.ETL.SQL;
 using Sparrow.Json.Parsing;
 
@@ -30,6 +29,18 @@ public sealed class AzureQueueStorageConnectionSettings
             return false;
         }
 
+        if (string.IsNullOrWhiteSpace(ConnectionString) == false)
+        {
+            try
+            {
+                AssertValidConnectionStringAndGetUrl(ConnectionString);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         return true;
     }
     
@@ -53,14 +64,14 @@ public sealed class AzureQueueStorageConnectionSettings
     {
         if (ConnectionString != null)
         {
-            return GetUrlFromConnectionString(ConnectionString);
+            return AssertValidConnectionStringAndGetUrl(ConnectionString);
         }
 
         string storageAccountName = GetStorageAccountName();
         return $"https://{storageAccountName}.queue.core.windows.net/";
     }
     
-    private string GetUrlFromConnectionString(string connectionString)
+    private string AssertValidConnectionStringAndGetUrl(string connectionString)
     {
         var protocol = SqlConnectionStringParser.GetConnectionStringValue(connectionString, ["DefaultEndpointsProtocol"]);
         if (string.IsNullOrWhiteSpace(protocol))

--- a/test/SlowTests/Issues/RavenDB_26196.cs
+++ b/test/SlowTests/Issues/RavenDB_26196.cs
@@ -1,0 +1,50 @@
+using FastTests;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26196(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenFact(RavenTestCategory.Etl)]
+    public void InvalidHttpConnectionStringWithoutQueueEndpointFailsValidation()
+    {
+        var settings = new AzureQueueStorageConnectionSettings
+        {
+            ConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+        };
+        Assert.False(settings.IsValidConnection());
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void MalformedConnectionStringFailsValidation()
+    {
+        var settings = new AzureQueueStorageConnectionSettings
+        {
+            ConnectionString = "not-a-valid-connection-string"
+        };
+        Assert.False(settings.IsValidConnection());
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void ValidHttpConnectionStringPassesValidation()
+    {
+        var settings = new AzureQueueStorageConnectionSettings
+        {
+            ConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;"
+        };
+        Assert.True(settings.IsValidConnection());
+    }
+
+    [RavenFact(RavenTestCategory.Etl)]
+    public void ValidHttpsConnectionStringPassesValidation()
+    {
+        var settings = new AzureQueueStorageConnectionSettings
+        {
+            ConnectionString = "DefaultEndpointsProtocol=https;AccountName=myexamplestorage;AccountKey=myaccountkey;EndpointSuffix=core.windows.net"
+        };
+        Assert.True(settings.IsValidConnection());
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26196

### Additional description

Validation improment

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
