### PR TITLE
RavenDB-26266 VectorSearch enhancements on sharded database.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -673,7 +673,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 {
                     sortingData = new()
                     {
-                        ScoresBuffer = _index.Configuration.CoraxIncludeDocumentScore && builderParameters is {HasBoost: true}
+                        ScoresBuffer = builderParameters.HasBoost && (_index.Configuration.CoraxIncludeDocumentScore || (IsSharded && query.Metadata.HasVectorSearch))
                             ? ScorePool.Rent(bufferSize)
                             : null,
                         DistancesBuffer = _index.Configuration.CoraxIncludeSpatialDistance && hasOrderByDistance

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -673,7 +673,7 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
                 {
                     sortingData = new()
                     {
-                        ScoresBuffer = builderParameters.HasBoost && (_index.Configuration.CoraxIncludeDocumentScore || (IsSharded && query.Metadata.HasVectorSearch))
+                        ScoresBuffer = builderParameters.NeedsScoresBuffer()
                             ? ScorePool.Rent(bufferSize)
                             : null,
                         DistancesBuffer = _index.Configuration.CoraxIncludeSpatialDistance && hasOrderByDistance

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.Parameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.Parameters.cs
@@ -78,6 +78,9 @@ public partial class CoraxQueryBuilder
             DeduplicationDisabled = deduplicationDisabled;
         }
         
+        public bool NeedsScoresBuffer() => HasBoost
+            && (Index.Configuration.CoraxIncludeDocumentScore || (IndexReadOperation.IsSharded && Metadata.HasVectorSearch));
+
         private static bool HasBoostingAsOrderingType(OrderByField[] orderBy)
         {
             if (orderBy is null)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.Parameters.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.Parameters.cs
@@ -68,17 +68,16 @@ public partial class CoraxQueryBuilder
                 : null;
 
             // in case when we've implicit boosting we've built primitives with scoring enabled
-            HasBoost = index.HasBoostedFields 
-                       || query.Metadata.HasBoost 
+            HasBoost = index.HasBoostedFields
+                       || query.Metadata.HasBoost
                        || IsVectorSingleClause
                        || (query.Metadata.HasVectorSearch && index.Configuration.CoraxVectorSearchOrderByScoreAutomatically)
-                       || (index.Configuration.OrderByScoreAutomaticallyWhenBoostingIsInvolved &&
-                                                      HasBoostingAsOrderingType(query.Metadata.OrderBy));
+                       || HasBoostingAsOrderingType(query.Metadata.OrderBy);
             Allocator = allocator;
             IndexReadOperation = indexReadOperation;
             DeduplicationDisabled = deduplicationDisabled;
         }
-
+        
         private static bool HasBoostingAsOrderingType(OrderByField[] orderBy)
         {
             if (orderBy is null)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -127,7 +127,7 @@ public static partial class CoraxQueryBuilder
             allowObjectsInParameters: false, allowArraysInParameters: true);
 
         (VectorValue? SingleVector, VectorValue[] MultiVector) transformedEmbeddings = (null, null);
-
+        int numberOfDimensions;
         if (VectorHelpers.TryRetrieveEtlTaskName(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
         {
             var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
@@ -136,6 +136,9 @@ public static partial class CoraxQueryBuilder
         else
         {
             VectorOptions vectorOptions = VectorHelpers.GetOptions(builderParameters, fieldName, out indexField);
+            
+            if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out  numberOfDimensions) == false)
+                return CoraxVectorItem.BuildEmpty(builderParameters); // no vector indexed
             if (vectorOptions.SourceEmbeddingType is VectorEmbeddingType.Text)
             {
                 transformedEmbeddings = VectorHelpers.GetVectorValueForTextualInput(builderParameters, vectorOptions, valueType, value);
@@ -189,7 +192,7 @@ public static partial class CoraxQueryBuilder
             }
         }
 
-        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out var numberOfDimensions) == false)
+        if (builderParameters.Index.IndexFieldsPersistence.TryReadNumberOfDimensions(fieldName, out  numberOfDimensions) == false)
             return CoraxVectorItem.BuildEmpty(builderParameters); // no vector indexed
 
         if (transformedEmbeddings.SingleVector != null)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -1308,7 +1308,9 @@ public static partial class CoraxQueryBuilder
                 if (builderParameters.IsVectorSingleClause && index.Configuration.CoraxIncludeDocumentScore == false)
                     return null;
                 
-                builderParameters.IndexReadOperation?.AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved();
+                if (builderParameters.Metadata.HasVectorSearch == false)
+                    builderParameters.IndexReadOperation?.AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved();
+                
                 return new[] { new OrderMetadata(true, MatchCompareFieldType.Score) };
             }
 

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxVectorItem.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/QueryOptimizer/CoraxVectorItem.cs
@@ -63,11 +63,11 @@ public sealed class CoraxVectorItem(CoraxQueryBuilder.Parameters parameters) : I
     {
         if (_isEmpty)
             return parameters.IndexSearcher.EmptyMatch();
-        
+
         IQueryMatch vs;
         if (_documentId != null)
         {
-            vs = parameters.IndexSearcher.VectorSearch(_field, _documentId, _minimumDistance, _numberOfCandidates, _isExact, parameters.IsVectorSingleClause, inner, parameters.Index.Configuration.CoraxVectorSearchScanningThreshold);
+            vs = parameters.IndexSearcher.VectorSearch(_field, _documentId, _minimumDistance, _numberOfCandidates, _isExact, _isVectorSingleClause, inner, parameters.Index.Configuration.CoraxVectorSearchScanningThreshold);
         }
         else if (_vectorsToSearch is not null)
         {

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -72,8 +72,11 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
             if (orderByField.OrderingType == OrderByFieldType.Score)
             {
                 if (query.Metadata.HasVectorSearch)
+                {
+                    currentCoraxOrderIndex++;
                     continue;
-                
+                }
+
                 DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "RavenDB-13927 Order by score");
                 throw new NotSupportedInShardingException("Ordering by score is not supported in sharding");
             }
@@ -187,5 +190,5 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
         return result;
     }
     
-    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.");
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.");
 }

--- a/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Sharding/Persistence/Corax/ShardedCoraxIndexReadOperation.cs
@@ -71,6 +71,9 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
 
             if (orderByField.OrderingType == OrderByFieldType.Score)
             {
+                if (query.Metadata.HasVectorSearch)
+                    continue;
+                
                 DevelopmentHelper.ShardingToDo(DevelopmentHelper.TeamMember.Arek, DevelopmentHelper.Severity.Normal, "RavenDB-13927 Order by score");
                 throw new NotSupportedInShardingException("Ordering by score is not supported in sharding");
             }
@@ -184,5 +187,5 @@ public sealed class ShardedCoraxIndexReadOperation : CoraxIndexReadOperation
         return result;
     }
     
-    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => throw new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.");
+    internal override void AssertCanOrderByScoreAutomaticallyWhenBoostingOrVectorSearchIsInvolved() => new NotSupportedInShardingException($"Ordering by score is not supported in sharding. You received this exception because your index has boosting, and we attempted to sort the results since the configuration `{RavenConfiguration.GetKey(i => i.Indexing.OrderByScoreAutomaticallyWhenBoostingIsInvolved)}` is enabled or, when you used `vector.search` method in the query when having `{RavenConfiguration.GetKey(i => i.Indexing.CoraxVectorSearchOrderByScoreAutomatically)}` enabled.");
 }

--- a/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
@@ -51,12 +51,16 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
 
     public int Compare(BlittableJsonReaderObject x, BlittableJsonReaderObject y)
     {
+        int arrayIndex = 0;
         for (var i = 0; i < _orderByFields.Length; i++)
         {
             ref var orderByField = ref _orderByFields[i];
-            var cmp = CompareField(in orderByField, i, x, y);
+            var cmp = CompareField(in orderByField, arrayIndex, x, y);
             if (cmp != 0)
                 return orderByField.Ascending ? cmp : -cmp;
+
+            if (orderByField.OrderingType != OrderByFieldType.Score)
+                arrayIndex++;
         }
 
         return 0;

--- a/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
+++ b/src/Raven.Server/Documents/Sharding/Comparers/DocumentsComparer.cs
@@ -158,12 +158,25 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
                         return 1;
                     return AlphaNumericFieldComparator.StringAlphanumComparer.Instance.Compare(xVal, yVal);
                 }
+            case OrderByFieldType.Score:
+                {
+                    // Note: reversed parameters. Ascending score is actually descending on values.
+                    var hasX = TryGetScoreValue(y, out double xDbl);
+                    var hasY = TryGetScoreValue(x, out double yDbl);
+                    
+                    if (hasX == false && hasY == false)
+                        return 0;
+                    if (hasX == false)
+                        return 1;
+                    if (hasY == false)
+                        return -1;
+                    return xDbl.CompareTo(yDbl);
+                }
             case OrderByFieldType.Random:
                 return _randoms[index].Next(int.MinValue, int.MaxValue);
 
             case OrderByFieldType.Custom:
                 throw new NotSupportedInShardingException("Custom sorting is not supported in sharding as of yet");
-            case OrderByFieldType.Score:
             default:
                 throw new ArgumentException("Unknown OrderingType: " + order.OrderingType);
         }
@@ -291,6 +304,54 @@ public sealed class DocumentsComparer : IComparer<BlittableJsonReaderObject>
         }
 
         ThrowIfNotExpectedType(nameof(LazyNumberValue), arrayValue);
+        value = 0;
+        return false;
+    }
+
+    private bool TryGetScoreValue(BlittableJsonReaderObject blittable, out double value)
+    {
+        if (blittable.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false)
+        {
+            value = 0;
+            return false;
+        }
+
+        if (metadata.TryGet(Constants.Documents.Metadata.IndexScore, out object scoreValue) == false)
+        {
+            value = 0;
+            return false;
+        }
+
+        if (scoreValue is LazyNumberValue lnv)
+        {
+            value = lnv.ToDouble(CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        if (scoreValue is double d)
+        {
+            value = d;
+            return true;
+        }
+
+        if (scoreValue is float f)
+        {
+            value = f;
+            return true;
+        }
+
+        if (scoreValue is long l)
+        {
+            value = l;
+            return true;
+        }
+
+        if (scoreValue is int i)
+        {
+            value = i;
+            return true;
+        }
+
         value = 0;
         return false;
     }

--- a/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
+++ b/src/Raven.Server/Documents/Sharding/Queries/AbstractShardedQueryProcessor.cs
@@ -480,6 +480,12 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
             }
         }
 
+        if (queryChanges.HasFlag(QueryChanges.AddOrderByScoreForVectorSearch))
+        {
+            clone.OrderBy = [(new MethodExpression("score", new List<QueryExpression>()), OrderByFieldType.Score, true)];
+            Query.Metadata.OrderBy = [new OrderByField(null, OrderByFieldType.Score, ascending: true)];
+        }
+
         modifications[nameof(IndexQuery.Query)] = clone.ToString();
 
         queryTemplate.Modifications = modifications;
@@ -694,6 +700,11 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
 
         if (indexQuery.Metadata.HasTimeBasedFunction)
             queryChanges |= QueryChanges.RewriteTimeBasedFunctions;
+
+        if (indexQuery.Metadata.HasVectorSearch && indexQuery.Metadata.OrderBy is null or {Length: 0})
+        {
+            queryChanges |= QueryChanges.AddOrderByScoreForVectorSearch;
+        }
 
         return queryChanges;
     }
@@ -992,7 +1003,8 @@ public abstract class AbstractShardedQueryProcessor<TCommand, TResult, TCombined
         RewriteForLimitWithOrderByInMapReduce = 1 << 4,
         UpdateOrderByFieldsInMapReduce = 1 << 5,
         UseCachedOrderByFieldsInMapReduce = 1 << 6,
-        RewriteTimeBasedFunctions = 1 << 7
+        RewriteTimeBasedFunctions = 1 << 7,
+        AddOrderByScoreForVectorSearch = 1 << 8
     }
 
     [Flags]

--- a/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
+++ b/test/FastTests/Corax/Vectors/BlittableVectorIntegrationTests.cs
@@ -158,18 +158,18 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
     }
 
     [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(1.0d, 8)]
-    [InlineData(1.0d, 500)]
-    [InlineData(1.0d, 1024)]
-    [InlineData(1.0d, 2048)]
-    [InlineData(1.1d, 8)]
-    [InlineData(1.1d, 500)]
-    [InlineData(1.1d, 1024)]
-    [InlineData(1.1d, 2048)]
-    public async Task CanReadFloatingValuesAsAllTypes(double repeatedValue, int size)
+    [RavenData(1.0d, 8, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.0d, 500, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.0d, 1024, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.0d, 2048, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.1d, 8, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.1d, 500, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.1d, 1024, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1.1d, 2048, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanReadFloatingValuesAsAllTypes(Options options, double repeatedValue, int size)
     {
         var array1 = Enumerable.Repeat(1d, size).ToArray();
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         string id;
         using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
         {
@@ -203,14 +203,14 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
     }
     
     [RavenTheory(RavenTestCategory.Vector)]
-    [InlineData(8)]
-    [InlineData(500)]
-    [InlineData(1024)]
-    [InlineData(2048)]
-    public async Task CanReadNumericValuesAsAllTypes(int size)
+    [RavenData(8, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(500, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(1024, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(2048, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanReadNumericValuesAsAllTypes(Options options, int size)
     {
         var array1 = Enumerable.Repeat(1, size).ToArray();
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         string id;
         using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))
         {
@@ -297,10 +297,11 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
         }
     }
     
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.JavaScript)]
-    public async Task CanReadBlittableVector()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.JavaScript)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanReadBlittableVector(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         string id;
         var array = new[] { 0.1f, 0.1f, 0.1f, 0.1f };
         var array2 = array.Select(x => x * 2f).ToArray();
@@ -321,10 +322,11 @@ public class BlittableVectorIntegrationTests(ITestOutputHelper output) : RavenTe
     }
 
     
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.JavaScript | RavenTestCategory.Patching)]
-    public async Task CanPatchWithBlittableVector()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.JavaScript | RavenTestCategory.Patching)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanPatchWithBlittableVector(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         string id;
         var array = new[] { 0.1f, 0.1f, 0.1f, 0.1f };
         using (var session = store.OpenAsyncSession(new SessionOptions(){NoCaching = true}))

--- a/test/FastTests/Corax/Vectors/IndexVectorExactViaStaticIndexesTests.cs
+++ b/test/FastTests/Corax/Vectors/IndexVectorExactViaStaticIndexesTests.cs
@@ -14,10 +14,11 @@ namespace FastTests.Corax.Vectors;
 
 public class IndexVectorExactViaStaticIndexesTests(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Corax)]
-    public async Task AssertIndexDefinitionViaStaticIndexes()
+    [RavenTheory(RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task AssertIndexDefinitionViaStaticIndexes(Options options)
     {
-        using var store = CreateDocumentStore();
+        using var store = CreateDocumentStore(options);
         var localIndexDefinition = new IndexDefinition()
         {
             Name = "Vector",
@@ -57,23 +58,23 @@ select new
     }
 
     [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
-    [InlineData(VectorEmbeddingType.Binary, 0.7f)]
-    [InlineData(VectorEmbeddingType.Int8, 0.82f)]
-    [InlineData(VectorEmbeddingType.Single, 0.75f)]
-    public async Task CanCreateVectorIndexFromCSharp(VectorEmbeddingType vectorEmbeddingType, float similarity)
-    => await CanCreateVectorIndexBase<TextVectorIndex>(vectorEmbeddingType, similarity);
-    
-    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
-    [InlineData(VectorEmbeddingType.Binary, 0.7f)]
-    [InlineData(VectorEmbeddingType.Int8, 0.82f)]
-    [InlineData(VectorEmbeddingType.Single, 0.75f)]
-    public async Task CanCreateVectorIndexFromJs(VectorEmbeddingType vectorEmbeddingType, float similarity)
-        => await CanCreateVectorIndexBase<TextVectorIndexJs>(vectorEmbeddingType, similarity);
+    [RavenData(VectorEmbeddingType.Binary, 0.7f, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(VectorEmbeddingType.Int8, 0.82f, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(VectorEmbeddingType.Single, 0.75f, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanCreateVectorIndexFromCSharp(Options options, VectorEmbeddingType vectorEmbeddingType, float similarity)
+    => await CanCreateVectorIndexBase<TextVectorIndex>(options, vectorEmbeddingType, similarity);
 
-    private async Task CanCreateVectorIndexBase<TIndex>(VectorEmbeddingType vectorEmbeddingType, float similarity)
+    [RavenMultiplatformTheory(RavenTestCategory.Corax | RavenTestCategory.Vector, RavenArchitecture.AllX64)]
+    [RavenData(VectorEmbeddingType.Binary, 0.7f, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(VectorEmbeddingType.Int8, 0.82f, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(VectorEmbeddingType.Single, 0.75f, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CanCreateVectorIndexFromJs(Options options, VectorEmbeddingType vectorEmbeddingType, float similarity)
+        => await CanCreateVectorIndexBase<TextVectorIndexJs>(options, vectorEmbeddingType, similarity);
+
+    private async Task CanCreateVectorIndexBase<TIndex>(Options options, VectorEmbeddingType vectorEmbeddingType, float similarity)
         where TIndex : AbstractIndexCreationTask, new()
     {
-        using var store = CreateDocumentStore();
+        using var store = CreateDocumentStore(options);
         
         {
             using var session = store.OpenAsyncSession();
@@ -100,14 +101,15 @@ select new
     }
 
 
-    [RavenFact(RavenTestCategory.Corax | RavenTestCategory.Vector)]
-    public async Task CreateVectorIndexFromFloatEmbeddings() => await CreateVectorIndexFromFloatEmbeddingsBase<NumericalVectorIndex>();
-    public async Task CreateVectorIndexFromFloatEmbeddingsJs() => await CreateVectorIndexFromFloatEmbeddingsBase<NumericalVectorIndexJs>();
-    
-    private async Task CreateVectorIndexFromFloatEmbeddingsBase<TIndex>()
+    [RavenTheory(RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public async Task CreateVectorIndexFromFloatEmbeddings(Options options) => await CreateVectorIndexFromFloatEmbeddingsBase<NumericalVectorIndex>(options);
+    public async Task CreateVectorIndexFromFloatEmbeddingsJs() => await CreateVectorIndexFromFloatEmbeddingsBase<NumericalVectorIndexJs>(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+
+    private async Task CreateVectorIndexFromFloatEmbeddingsBase<TIndex>(Options options)
         where TIndex : AbstractIndexCreationTask, new()
     {
-        using var store = CreateDocumentStore();
+        using var store = CreateDocumentStore(options);
         
         using (var session = store.OpenAsyncSession())
         {
@@ -130,7 +132,7 @@ select new
         }
     }
 
-    private IDocumentStore CreateDocumentStore() => GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+    private IDocumentStore CreateDocumentStore(Options options = null) => GetDocumentStore(options ?? Options.ForSearchEngine(RavenSearchEngineMode.Corax));
 
     private class TextVectorIndex : AbstractIndexCreationTask<Document>
     {
@@ -228,45 +230,57 @@ select new
         public object Vector { get; set; }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void EmbeddingTextSourceTest() => StaticIndexApi<EmbeddingTextSource>();
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void EmbeddingTextSourceTest(Options options) => StaticIndexApi<EmbeddingTextSource>(options);
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void EmbeddingTextSourceTestJs() => StaticIndexApi<EmbeddingTextSourceJs>();
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void EmbeddingTextSourceTestJs(Options options) => StaticIndexApi<EmbeddingTextSourceJs>(options);
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void MultiEmbeddingTextIndexTest() => StaticIndexApi<MultiEmbeddingTextIndex>();
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void MultiEmbeddingTextIndexTest(Options options) => StaticIndexApi<MultiEmbeddingTextIndex>(options);
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void MultiEmbeddingTextIndexTestJs() => StaticIndexApi<MultiEmbeddingTextIndexJs>();
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void MultiEmbeddingTextIndexTestJs(Options options) => StaticIndexApi<MultiEmbeddingTextIndexJs>(options);
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void EmbeddingSingleIndexTest() => StaticIndexApi<EmbeddingSingleIndex>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void EmbeddingSingleIndexTestJs() => StaticIndexApi<EmbeddingSingleIndexJs>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void MultiEmbeddingSingleIndexTest() => StaticIndexApi<MultiEmbeddingSingleIndex>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void MultiEmbeddingSingleIndexTestJs() => StaticIndexApi<MultiEmbeddingSingleIndexJs>();
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void EmbeddingSingleIndexTest(Options options) => StaticIndexApi<EmbeddingSingleIndex>(options);
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void EmbeddingSingleAsBase64IndexTest() => StaticIndexApi<EmbeddingSingleAsBase64Index>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void EmbeddingSingleAsBase64IndexTestJs() => StaticIndexApi<EmbeddingSingleAsBase64IndexJs>();
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void EmbeddingSingleIndexTestJs(Options options) => StaticIndexApi<EmbeddingSingleIndexJs>(options);
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void MultiEmbeddingSingleAsBase64IndexTest() => StaticIndexApi<MultiEmbeddingSingleAsBase64Index>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void MultiEmbeddingSingleAsBase64IndexTestJs() => StaticIndexApi<MultiEmbeddingSingleAsBase64IndexJs>();
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void MultiEmbeddingSingleIndexTest(Options options) => StaticIndexApi<MultiEmbeddingSingleIndex>(options);
 
-    private void StaticIndexApi<TIndex>() where TIndex : AbstractIndexCreationTask, new()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void MultiEmbeddingSingleIndexTestJs(Options options) => StaticIndexApi<MultiEmbeddingSingleIndexJs>(options);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void EmbeddingSingleAsBase64IndexTest(Options options) => StaticIndexApi<EmbeddingSingleAsBase64Index>(options);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void EmbeddingSingleAsBase64IndexTestJs(Options options) => StaticIndexApi<EmbeddingSingleAsBase64IndexJs>(options);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void MultiEmbeddingSingleAsBase64IndexTest(Options options) => StaticIndexApi<MultiEmbeddingSingleAsBase64Index>(options);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void MultiEmbeddingSingleAsBase64IndexTestJs(Options options) => StaticIndexApi<MultiEmbeddingSingleAsBase64IndexJs>(options);
+
+    private void StaticIndexApi<TIndex>(Options options) where TIndex : AbstractIndexCreationTask, new()
     {
-        using var store = CreateDocumentStore();
+        using var store = CreateDocumentStore(options);
         using (var session = store.OpenSession())
         {
             float[][] embeddings = [[0.1f, 0.1f], [0.2f, 0.3f]];

--- a/test/FastTests/Corax/Vectors/IndexVectorExactViaStaticIndexesTests.cs
+++ b/test/FastTests/Corax/Vectors/IndexVectorExactViaStaticIndexesTests.cs
@@ -301,13 +301,7 @@ select new
         new TIndex().Execute(store);
         Indexes.WaitForIndexing(store);
 
-        Assert.Equal(0, GetErrorCounts());
-
-        int GetErrorCounts()
-        {
-            var errors = store.Maintenance.Send(new GetIndexErrorsOperation());
-            return errors.First(x => x.Name == new TIndex().IndexName).Errors.Length;
-        }
+        RavenTestHelper.AssertNoIndexErrors(store);
     }
 
     private class DataSource

--- a/test/FastTests/Corax/Vectors/Int8VectorSimilarityTests.cs
+++ b/test/FastTests/Corax/Vectors/Int8VectorSimilarityTests.cs
@@ -14,7 +14,7 @@ public class Int8VectorSimilarityTests : RavenTestBase
     }
 
     [RavenTheory(RavenTestCategory.Indexes)]
-    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void Test(Options options)
     {
         options.ModifyDatabaseRecord += record =>

--- a/test/FastTests/Corax/Vectors/MultiVectorSearchClientAPI.cs
+++ b/test/FastTests/Corax/Vectors/MultiVectorSearchClientAPI.cs
@@ -15,10 +15,11 @@ namespace FastTests.Corax.Vectors;
 
 public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
-    public void CanSearchByMultipleVectorsByTexts()
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanSearchByMultipleVectorsByTexts(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
 
         using (var session = store.OpenSession())
         {
@@ -59,10 +60,11 @@ public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBas
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
-    public void CanSearchByMultipleVectorsByEmbeddings()
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanSearchByMultipleVectorsByEmbeddings(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
 
         using (var session = store.OpenSession())
@@ -111,10 +113,11 @@ public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBas
         }
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
-    public void CanSearchByMultipleVectorsByRavenVector()
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanSearchByMultipleVectorsByRavenVector(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
 
         using (var session = store.OpenSession())
@@ -163,10 +166,11 @@ public class MultiVectorSearchClientAPI(ITestOutputHelper output) : RavenTestBas
         }
     }
     
-     [RavenMultiplatformFact(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
-    public void CanSearchByMultipleVectorsByBase64()
+    [RavenMultiplatformTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Querying, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanSearchByMultipleVectorsByBase64(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
 
         using (var session = store.OpenSession())

--- a/test/FastTests/Corax/Vectors/RavenDB-23656.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB-23656.cs
@@ -10,7 +10,7 @@ namespace FastTests.Corax.Vectors;
 public class RavenDB_23656(ITestOutputHelper output) : RavenTestBase(output)
 {
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
-    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All, SearchEngineMode = RavenSearchEngineMode.Corax)]
     public void DifferentDimensionsWillNotCrashTheServer(Options options)
     {
         using var store = GetDocumentStore(options);

--- a/test/FastTests/Corax/Vectors/RavenDB-23656.cs
+++ b/test/FastTests/Corax/Vectors/RavenDB-23656.cs
@@ -9,10 +9,11 @@ namespace FastTests.Corax.Vectors;
 
 public class RavenDB_23656(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
-    public void DifferentDimensionsWillNotCrashTheServer()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Indexes)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.All)]
+    public void DifferentDimensionsWillNotCrashTheServer(Options options)
     {
-        using var store = GetDocumentStore();
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Store(new Vector
         {

--- a/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
+++ b/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
@@ -44,18 +44,18 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
 
         foreach (var databaseMode in new[] { RavenDatabaseMode.Single, RavenDatabaseMode.Sharded })
         {
-            var options = RavenTestBase.Options.ForMode(databaseMode);
-            options.SearchEngineMode = RavenSearchEngineMode.Corax;
-            options.ModifyDatabaseRecord += record =>
-            {
-                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = "Corax";
-                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = "Corax";
-            };
-
             foreach (var isExact in exactConfig)
             {
                 foreach (var isNative in isNativeVector)
                 {
+                    var options = RavenTestBase.Options.ForMode(databaseMode);
+                    options.SearchEngineMode = RavenSearchEngineMode.Corax;
+                    options.ModifyDatabaseRecord += record =>
+                    {
+                        record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = "Corax";
+                        record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = "Corax";
+                    };
+
                     yield return [options, isExact, isNative, isNative ? primitiveValueFunc : ravenVectorValueFunc];
                 }
             }

--- a/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
+++ b/test/FastTests/Corax/Vectors/VectorAutoIndexClientApi.cs
@@ -6,6 +6,7 @@ using Raven.Client.Documents.Indexes.Vector;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Documents.Queries.Vector;
+using Raven.Server.Config;
 using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
@@ -41,85 +42,96 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
             };
         });
 
-        foreach (var isExact in exactConfig)
+        foreach (var databaseMode in new[] { RavenDatabaseMode.Single, RavenDatabaseMode.Sharded })
         {
-            foreach (var isNative in isNativeVector)
+            var options = RavenTestBase.Options.ForMode(databaseMode);
+            options.SearchEngineMode = RavenSearchEngineMode.Corax;
+            options.ModifyDatabaseRecord += record =>
             {
-                yield return [isExact, isNative, isNative ? primitiveValueFunc : ravenVectorValueFunc];
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.AutoIndexingEngineType)] = "Corax";
+                record.Settings[RavenConfiguration.GetKey(x => x.Indexing.StaticIndexingEngineType)] = "Corax";
+            };
+
+            foreach (var isExact in exactConfig)
+            {
+                foreach (var isNative in isNativeVector)
+                {
+                    yield return [options, isExact, isNative, isNative ? primitiveValueFunc : ravenVectorValueFunc];
+                }
             }
         }
     }
 
     [RavenTheory(RavenTestCategory.Vector)]
     [MemberData(nameof(GenerateScenarios))]
-    public void SinglesToSinglesTest(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+    public void SinglesToSinglesTest(Options options, bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(Singles)",
         fieldRqlSelector: "vector.search(Singles, $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles),
-            embedding(new float[] {0.1f, 0.1f}), isExact: isExact), isExact);
+            embedding(new float[] {0.1f, 0.1f}), isExact: isExact), isExact, options);
 
     [RavenTheory(RavenTestCategory.Vector)]
     [MemberData(nameof(GenerateScenarios))]
-    public void SinglesToInt8Test(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+    public void SinglesToInt8Test(Options options, bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.f32_i8(Singles))",
         fieldRqlSelector: "vector.search(embedding.f32_i8(Singles), $p0)",
-        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Int8), embedding(new float[] { 0.1f, 0.1f }), isExact: isExact), isExact);
+        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Int8), embedding(new float[] { 0.1f, 0.1f }), isExact: isExact), isExact, options);
 
     [RavenTheory(RavenTestCategory.Vector)]
     [MemberData(nameof(GenerateScenarios))]
-    public void SinglesToBinaryTest(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+    public void SinglesToBinaryTest(Options options, bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.f32_i1(Singles))",
         fieldRqlSelector: "vector.search(embedding.f32_i1(Singles), $p0)",
-        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Binary), embedding(new float[]{ 0.1f, 0.1f }), isExact: isExact), isExact);
+        vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Singles).TargetQuantization(VectorEmbeddingType.Binary), embedding(new float[]{ 0.1f, 0.1f }), isExact: isExact), isExact, options);
 
     [RavenTheory(RavenTestCategory.Vector)]
     [MemberData(nameof(GenerateScenarios))]
-    public void Int8Test(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+    public void Int8Test(Options options, bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.i8(Int8))",
         fieldRqlSelector: "vector.search(embedding.i8(Int8), $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Int8, VectorEmbeddingType.Int8),
-            embedding(VectorQuantizer.ToInt8([-1f, 1f])), isExact: isExact), isExact);
+            embedding(VectorQuantizer.ToInt8([-1f, 1f])), isExact: isExact), isExact, options);
 
 
     [RavenTheory(RavenTestCategory.Vector)]
     [MemberData(nameof(GenerateScenarios))]
-    public void Int1Test(bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
+    public void Int1Test(Options options, bool isExact, bool isNative, Func<object, Action<IVectorEmbeddingFieldValueFactory>> embedding) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.i1(Binary))",
         fieldRqlSelector: "vector.search(embedding.i1(Binary), $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithEmbedding(f => f.Binary, VectorEmbeddingType.Binary),
-            embedding(VectorQuantizer.ToInt1([1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])), isExact: isExact), isExact);
+            embedding(VectorQuantizer.ToInt1([1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0])), isExact: isExact), isExact, options);
 
     [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void TextToSinglesTest(bool isExact) => AutoIndexingTestingBase(
+    [RavenData(true, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(false, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TextToSinglesTest(Options options, bool isExact) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.text(Text))",
         fieldRqlSelector: "vector.search(embedding.text(Text), $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text),
-            value => value.ByText("test"), isExact: isExact), isExact);
+            value => value.ByText("test"), isExact: isExact), isExact, options);
 
     [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void TextToInt8Test(bool isExact) => AutoIndexingTestingBase(
+    [RavenData(true, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(false, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TextToInt8Test(Options options, bool isExact) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.text_i8(Text))",
         fieldRqlSelector: "vector.search(embedding.text_i8(Text), $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Int8),
-            value => value.ByText("test"), isExact: isExact), isExact);
+            value => value.ByText("test"), isExact: isExact), isExact, options);
 
     [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void TextToInt1Test(bool isExact) => AutoIndexingTestingBase(
+    [RavenData(true, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(false, SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TextToInt1Test(Options options, bool isExact) => AutoIndexingTestingBase(
         autoIndexName: "Auto/AutoVecDocs/ByVector.search(embedding.text_i1(Text))",
         fieldRqlSelector: "vector.search(embedding.text_i1(Text), $p0)",
         vectorWhere: docs => docs.VectorSearch(field => field.WithText(x => x.Text).TargetQuantization(VectorEmbeddingType.Binary),
-            value => value.ByText("test"), isExact: isExact), isExact);
+            value => value.ByText("test"), isExact: isExact), isExact, options);
 
     private void AutoIndexingTestingBase(string autoIndexName, string fieldRqlSelector, Func<IRavenQueryable<AutoVecDoc>, IRavenQueryable<AutoVecDoc>> vectorWhere,
-        bool isExact)
+        bool isExact, Options options = null)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options ?? Options.ForSearchEngine(RavenSearchEngineMode.Corax));
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc("Test", [1.0f, 1.0f], VectorQuantizer.ToInt8([-1, 1]), VectorQuantizer.ToInt1([1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0])));
         session.SaveChanges();
@@ -134,10 +146,11 @@ public class VectorAutoIndexClientApi(ITestOutputHelper output) : RavenTestBase(
         Assert.Equal(rql, baseQuery.ToString());
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
-    public void NonExistingFieldDoesntEndWithNre()
+    [RavenMultiplatformTheory(RavenTestCategory.Vector, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void NonExistingFieldDoesntEndWithNre(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.SaveChanges();
 

--- a/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
+++ b/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
@@ -70,8 +70,9 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc("test", [.1f, .2f], null, null, 0f, 0f));
         session.SaveChanges();
-        new TIndex().Execute(store);
-        var errors = WaitForIndexingErrorsOnAnyShard(store);
+        var index = new TIndex();
+        index.Execute(store);
+        var errors = WaitForIndexingErrorsOnAnyShard(store, [index.IndexName]);
         Assert.NotNull(errors[0].Errors[0].Error);
         Assert.Contains("tried to index textual value instead", errors[0].Errors[0].Error);
     }
@@ -109,8 +110,9 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc(null, null, [2, -3], null, 0f, 0f));
         session.SaveChanges();
-        new TIndex().Execute(store);
-        var errors = WaitForIndexingErrorsOnAnyShard(store);
+        var index = new TIndex();
+        index.Execute(store);
+        var errors = WaitForIndexingErrorsOnAnyShard(store, [index.IndexName]);
         Assert.NotNull(errors[0].Errors[0].Error);
         Assert.Contains("tried to index spatial value instead", errors[0].Errors[0].Error);
     }

--- a/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
+++ b/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
@@ -1,9 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Indexes.Vector;
+using Raven.Client.Documents.Operations.Indexes;
+using Raven.Client.ServerWide.Operations;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -67,7 +71,7 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         session.Store(new AutoVecDoc("test", [.1f, .2f], null, null, 0f, 0f));
         session.SaveChanges();
         new TIndex().Execute(store);
-        var errors = Indexes.WaitForIndexingErrors(store);
+        var errors = WaitForIndexingErrorsOnAnyShard(store);
         Assert.NotNull(errors[0].Errors[0].Error);
         Assert.Contains("tried to index textual value instead", errors[0].Errors[0].Error);
     }
@@ -83,8 +87,9 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc(null, [.1f, .2f], [2, -3], null, 0f, 0f));
         session.SaveChanges();
-        new TIndex().Execute(store);
-        var errors = Indexes.WaitForIndexingErrors(store);
+        var index = new TIndex();
+        index.Execute(store);
+        var errors = WaitForIndexingErrorsOnAnyShard(store, [index.IndexName]);
         Assert.NotNull(errors[0].Errors[0].Error);
         Assert.Contains("tried to index numerical value instead", errors[0].Errors[0].Error);
     }
@@ -105,9 +110,32 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         session.Store(new AutoVecDoc(null, null, [2, -3], null, 0f, 0f));
         session.SaveChanges();
         new TIndex().Execute(store);
-        var errors = Indexes.WaitForIndexingErrors(store);
+        var errors = WaitForIndexingErrorsOnAnyShard(store);
         Assert.NotNull(errors[0].Errors[0].Error);
         Assert.Contains("tried to index spatial value instead", errors[0].Errors[0].Error);
+    }
+
+    private IndexErrors[] WaitForIndexingErrorsOnAnyShard(IDocumentStore store, string[] indexNames = null)
+    {
+        var databaseRecord = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+        if (databaseRecord.IsSharded == false)
+            return Indexes.WaitForIndexingErrors(store, indexNames);
+
+        var timeout = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromMinutes(1);
+        var sp = Stopwatch.StartNew();
+        while (sp.Elapsed < timeout)
+        {
+            foreach (var shardNumber in databaseRecord.Sharding.Shards.Keys)
+            {
+                var shardErrors = store.Maintenance.ForShard(shardNumber).Send(new GetIndexErrorsOperation(indexNames));
+                var withErrors = shardErrors.Where(e => e.Errors.Length > 0).ToArray();
+                if (withErrors.Length > 0)
+                    return withErrors;
+            }
+            Thread.Sleep(32);
+        }
+
+        throw new TimeoutException($"Got no index error on any shard for more than {timeout}.");
     }
 
     private record AutoVecDoc(string Text, float[] Singles, sbyte[] Int8, byte[] Binary, float lat, float lon, string Id = null);

--- a/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
+++ b/test/FastTests/Corax/Vectors/VectorIndexingWithMixedFields.cs
@@ -11,10 +11,11 @@ namespace FastTests.Corax.Vectors;
 
 public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTestBase(output)
 {
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CanIndexNullWithVector()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanIndexNullWithVector(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc(string.Empty, new float[] { .1f, .2f }, null, null, 0f, 0f));
         session.Store(new AutoVecDoc(string.Empty, null, null, null, 0f, 0f));
@@ -29,10 +30,11 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         Assert.Null(result.Singles);
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void CanIndexNullWhenServerGeneratesTheEmbedding()
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CanIndexNullWhenServerGeneratesTheEmbedding(Options options)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc("animal", null, null, null, 0f, 0f));
         session.Store(new AutoVecDoc(null, null, null, null, 0f, 0f));
@@ -49,16 +51,18 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         Assert.Null(result.Singles);
     }
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CannotMixVectorAndTextualValues() => CannotMixVectorAndTextualValuesBase<TextualWithVectorMixedField>();
-    
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CannotMixVectorAndTextualValuesJs() => CannotMixVectorAndTextualValuesBase<TextualWithVectorMixedFieldJs>();
-    
-    private void CannotMixVectorAndTextualValuesBase<TIndex>()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CannotMixVectorAndTextualValues(Options options) => CannotMixVectorAndTextualValuesBase<TextualWithVectorMixedField>(options);
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CannotMixVectorAndTextualValuesJs(Options options) => CannotMixVectorAndTextualValuesBase<TextualWithVectorMixedFieldJs>(options);
+
+    private void CannotMixVectorAndTextualValuesBase<TIndex>(Options options)
     where  TIndex : AbstractIndexCreationTask, new()
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc("test", [.1f, .2f], null, null, 0f, 0f));
         session.SaveChanges();
@@ -68,13 +72,14 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         Assert.Contains("tried to index textual value instead", errors[0].Errors[0].Error);
     }
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CannotMixVectorAndNumericalValues() => CannotMixVectorAndNumericalValuesBase<NumericalWithVectorMixedField>();
-    public void CannotMixVectorAndNumericalValuesJs() => CannotMixVectorAndNumericalValuesBase<NumericalWithVectorMixedFieldJs>();
-    private void CannotMixVectorAndNumericalValuesBase<TIndex>()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CannotMixVectorAndNumericalValues(Options options) => CannotMixVectorAndNumericalValuesBase<NumericalWithVectorMixedField>(options);
+    public void CannotMixVectorAndNumericalValuesJs() => CannotMixVectorAndNumericalValuesBase<NumericalWithVectorMixedFieldJs>(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+    private void CannotMixVectorAndNumericalValuesBase<TIndex>(Options options)
     where  TIndex : AbstractIndexCreationTask, new()
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc(null, [.1f, .2f], [2, -3], null, 0f, 0f));
         session.SaveChanges();
@@ -84,16 +89,18 @@ public class VectorIndexingWithMixedFields(ITestOutputHelper output) : RavenTest
         Assert.Contains("tried to index numerical value instead", errors[0].Errors[0].Error);
     }
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CannotMixVectorAndSpatialValues() => CannotMixVectorAndSpatialValuesBase<SpatialWithVectorMixedField>();
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CannotMixVectorAndSpatialValues(Options options) => CannotMixVectorAndSpatialValuesBase<SpatialWithVectorMixedField>(options);
 
-    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    public void CannotMixVectorAndSpatialValuesJs() => CannotMixVectorAndSpatialValuesBase<SpatialWithVectorMixedFieldJs>();
-    
-    private void CannotMixVectorAndSpatialValuesBase<TIndex>()
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void CannotMixVectorAndSpatialValuesJs(Options options) => CannotMixVectorAndSpatialValuesBase<SpatialWithVectorMixedFieldJs>(options);
+
+    private void CannotMixVectorAndSpatialValuesBase<TIndex>(Options options)
     where TIndex : AbstractIndexCreationTask, new()
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
         session.Store(new AutoVecDoc(null, null, [2, -3], null, 0f, 0f));
         session.SaveChanges();

--- a/test/FastTests/Corax/Vectors/VectorJavaScriptIndexing.cs
+++ b/test/FastTests/Corax/Vectors/VectorJavaScriptIndexing.cs
@@ -13,12 +13,8 @@ using Xunit;
 
 namespace FastTests.Corax.Vectors;
 
-public class VectorJavaScriptIndexing : RavenTestBase
+public class VectorJavaScriptIndexing(ITestOutputHelper output) : RavenTestBase(output)
 {
-    public VectorJavaScriptIndexing(ITestOutputHelper output) : base(output)
-    {
-    }
-
     [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void TextToSinglesTest(Options options) => JsIndexingTestingBase(options, nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
@@ -30,35 +26,39 @@ public class VectorJavaScriptIndexing : RavenTestBase
     [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     public void TextToInt1Test(Options options) => JsIndexingTestingBase(options, nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
-    
-    
-    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    public void SinglesToSinglesTest(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
     [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    public void SinglesToInt8Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+    public void SinglesToSinglesTest(Options options, string fieldName) =>
+        JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
     [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    public void SinglesToInt1Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+    public void SinglesToInt8Test(Options options, string fieldName) =>
+        JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void SinglesToInt1Test(Options options, string fieldName) =>
+        JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
     [RavenData(nameof(VecDoc.Int8), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.Int8Base64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.Int8Enumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
     [RavenData(nameof(VecDoc.Int8EnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
-    public void Int8Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Int8, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding(VectorQuantizer.ToInt8([-1, 1]))));
+    public void Int8Test(Options options, string fieldName) =>
+        JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Int8, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding(VectorQuantizer.ToInt8([-1, 1]))));
 
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
     [RavenData(nameof(VecDoc.Binary), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
@@ -70,55 +70,68 @@ public class VectorJavaScriptIndexing : RavenTestBase
     private void JsIndexingTestingBase(Options options, string fieldName, VectorEmbeddingType src, VectorEmbeddingType dest, Func<IRavenQueryable<VecDoc>, IRavenQueryable<VecDoc>> vectorWhere)
     {
         using var store = GetDocumentStore(options);
-        using var session = store.OpenSession();
+        using (var session = store.OpenSession())
+        {
+            float[][] singles = [[1.0f, 1.0f], [-1.0f, 1.0f]];
+            var single0Base64 = Convert.ToBase64String(MemoryMarshal.Cast<float, byte>(singles[0]));
+            var single1Base64 = Convert.ToBase64String(MemoryMarshal.Cast<float, byte>(singles[1]));
 
-        float[][] singles = [[1.0f, 1.0f], [-1.0f, 1.0f]];
-        var single0Base64 = Convert.ToBase64String(MemoryMarshal.Cast<float, byte>(singles[0]));
-        var single1Base64 = Convert.ToBase64String(MemoryMarshal.Cast<float, byte>(singles[1]));
-        
-        
-        sbyte[][] i8 = [VectorQuantizer.ToInt8([-1, 1]), VectorQuantizer.ToInt8([-5, 5])];
-        var i8_0Base64 = Convert.ToBase64String(MemoryMarshal.Cast<sbyte, byte>(i8[0]));
-        var i8_1Base64 = Convert.ToBase64String(MemoryMarshal.Cast<sbyte, byte>(i8[1]));
-        
-        
-        byte[][] i1 = [[1, 5], [25, 30]];
-        var i1_0Base64 = Convert.ToBase64String(i1[0]);
-        var i1_1Base64 = Convert.ToBase64String(i1[1]);
-        
-        session.Store(new VecDoc("Test", singles[0], i8[0], i1[0], 
-            ["Test", "tseT"], singles, i8, i1,
-            single0Base64, i8_0Base64, i1_0Base64,
-            [single0Base64, single1Base64], [i8_0Base64, i8_1Base64], [i1_0Base64, i1_1Base64]));
-        session.SaveChanges();
+
+            sbyte[][] i8 = [VectorQuantizer.ToInt8([-1, 1]), VectorQuantizer.ToInt8([-5, 5])];
+            var i8_0Base64 = Convert.ToBase64String(MemoryMarshal.Cast<sbyte, byte>(i8[0]));
+            var i8_1Base64 = Convert.ToBase64String(MemoryMarshal.Cast<sbyte, byte>(i8[1]));
+
+
+            byte[][] i1 = [[1, 5], [25, 30]];
+            var i1_0Base64 = Convert.ToBase64String(i1[0]);
+            var i1_1Base64 = Convert.ToBase64String(i1[1]);
+
+            session.Store(new VecDoc("Test", singles[0], i8[0], i1[0],
+                ["Test", "tseT"], singles, i8, i1,
+                single0Base64, i8_0Base64, i1_0Base64,
+                [single0Base64, single1Base64], [i8_0Base64, i8_1Base64], [i1_0Base64, i1_1Base64]));
+            session.SaveChanges();
+        }
 
         new VectorIndex(fieldName, src, dest).Execute(store);
         Indexes.WaitForIndexing(store);
         var errors = Indexes.WaitForIndexingErrors(store, errorsShouldExists: false);
         Assert.Null(errors);
-        
-        //WaitForUserToContinueTheTest(store);
-        var baseQuery = session.Query<VecDoc, VectorIndex>().Statistics(out var stats).Customize(x => x.WaitForNonStaleResults());
-        baseQuery = vectorWhere(baseQuery);
-        var result = baseQuery.Single(); // evaluate and assert
+
+        using (var session = store.OpenSession())
+        {
+            var results = vectorWhere(session.Query<VecDoc, VectorIndex>()).ToList();
+            Assert.Equal(1, results.Count);
+
+
+            if (options.DatabaseMode is RavenDatabaseMode.Sharded)
+            {
+                var metadata = session.Advanced.GetMetadataFor(results[0]);
+                Assert.True(metadata.ContainsKey("@index-score"));
+                var score = Convert.ToDouble(metadata["@index-score"]);
+                Assert.NotEqual(0, score);
+            }
+        }
     }
-    
-    
+
     private class VectorIndex : AbstractJavaScriptIndexCreationTask
     {
         public VectorIndex()
         {
             //querying    
         }
-        
+
         public VectorIndex(string fieldName, VectorEmbeddingType source, VectorEmbeddingType destination)
         {
-            Maps = [@$"map('VecDocs', function (e) {{
+            Maps =
+            [
+                @$"map('VecDocs', function (e) {{
     return {{ 
         Name: e.Name,
         Vector: createVector(e.{fieldName})
     }};
-}})"];
+}})"
+            ];
 
             Fields = new Dictionary<string, IndexFieldOptions>()
             {
@@ -129,11 +142,22 @@ public class VectorJavaScriptIndexing : RavenTestBase
             };
         }
     }
-    
-    private record VecDoc(string Text, float[] Singles, sbyte[] Int8, byte[] Binary, 
-        string[] TextEnumerable, float[][] SinglesEnumerable, sbyte[][] Int8Enumerable, byte[][] BinaryEnumerable, 
-        string SinglesBase64, string Int8Base64, string BinaryBase64,
-        string[] SinglesEnumerableBase64, string[] Int8EnumerableBase64, string[] BinaryEnumerableBase64, 
 
-        string Id = null, object Vector = null);
+    private record VecDoc(
+        string Text,
+        float[] Singles,
+        sbyte[] Int8,
+        byte[] Binary,
+        string[] TextEnumerable,
+        float[][] SinglesEnumerable,
+        sbyte[][] Int8Enumerable,
+        byte[][] BinaryEnumerable,
+        string SinglesBase64,
+        string Int8Base64,
+        string BinaryBase64,
+        string[] SinglesEnumerableBase64,
+        string[] Int8EnumerableBase64,
+        string[] BinaryEnumerableBase64,
+        string Id = null,
+        object Vector = null);
 }

--- a/test/FastTests/Corax/Vectors/VectorJavaScriptIndexing.cs
+++ b/test/FastTests/Corax/Vectors/VectorJavaScriptIndexing.cs
@@ -19,54 +19,57 @@ public class VectorJavaScriptIndexing : RavenTestBase
     {
     }
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void TextToSinglesTest() => JsIndexingTestingBase(nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
-    
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void TextToInt8Test() => JsIndexingTestingBase(nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TextToSinglesTest(Options options) => JsIndexingTestingBase(options, nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
 
-    [RavenMultiplatformFact(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void TextToInt1Test() => JsIndexingTestingBase(nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TextToInt8Test(Options options) => JsIndexingTestingBase(options, nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
+
+    [RavenMultiplatformTheory(RavenTestCategory.Vector | RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void TextToInt1Test(Options options) => JsIndexingTestingBase(options, nameof(VecDoc.Text), VectorEmbeddingType.Text, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByText("test")));
     
     
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(nameof(VecDoc.Singles))]
-    [InlineData(nameof(VecDoc.SinglesBase64))]
-    [InlineData(nameof(VecDoc.SinglesEnumerable))]
-    [InlineData(nameof(VecDoc.SinglesEnumerableBase64))]
-    public void SinglesToSinglesTest(string fieldName) => JsIndexingTestingBase(fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
-    
+    [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void SinglesToSinglesTest(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Single, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(nameof(VecDoc.Singles))]
-    [InlineData(nameof(VecDoc.SinglesBase64))]
-    [InlineData(nameof(VecDoc.SinglesEnumerable))]
-    [InlineData(nameof(VecDoc.SinglesEnumerableBase64))]
-    public void SinglesToInt8Test(string fieldName) => JsIndexingTestingBase(fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
-    
+    [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void SinglesToInt8Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(nameof(VecDoc.Singles))]
-    [InlineData(nameof(VecDoc.SinglesBase64))]
-    [InlineData(nameof(VecDoc.SinglesEnumerable))]
-    [InlineData(nameof(VecDoc.SinglesEnumerableBase64))]
-    public void SinglesToInt1Test(string fieldName) => JsIndexingTestingBase(fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
-    
+    [RavenData(nameof(VecDoc.Singles), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.SinglesEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void SinglesToInt1Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Single, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1.0f, 1.0f])));
+
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(nameof(VecDoc.Int8))]
-    [InlineData(nameof(VecDoc.Int8Base64))]
-    [InlineData(nameof(VecDoc.Int8Enumerable))]
-    [InlineData(nameof(VecDoc.Int8EnumerableBase64))]
-    public void Int8Test(string fieldName) => JsIndexingTestingBase(fieldName, VectorEmbeddingType.Int8, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding(VectorQuantizer.ToInt8([-1, 1]))));
-        
+    [RavenData(nameof(VecDoc.Int8), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.Int8Base64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.Int8Enumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.Int8EnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void Int8Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Int8, VectorEmbeddingType.Int8, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding(VectorQuantizer.ToInt8([-1, 1]))));
+
     [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
-    [InlineData(nameof(VecDoc.Binary))]
-    [InlineData(nameof(VecDoc.BinaryBase64))]
-    [InlineData(nameof(VecDoc.BinaryEnumerable))]
-    [InlineData(nameof(VecDoc.BinaryEnumerableBase64))]
-    public void Int1Test(string fieldName) => JsIndexingTestingBase(fieldName, VectorEmbeddingType.Binary, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1, 0])));
-    
-    private void JsIndexingTestingBase(string fieldName, VectorEmbeddingType src, VectorEmbeddingType dest, Func<IRavenQueryable<VecDoc>, IRavenQueryable<VecDoc>> vectorWhere)
+    [RavenData(nameof(VecDoc.Binary), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.BinaryBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.BinaryEnumerable), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    [RavenData(nameof(VecDoc.BinaryEnumerableBase64), SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.All)]
+    public void Int1Test(Options options, string fieldName) => JsIndexingTestingBase(options, fieldName, VectorEmbeddingType.Binary, VectorEmbeddingType.Binary, docs => docs.VectorSearch(f => f.WithField(x => x.Vector), v => v.ByEmbedding([1, 0])));
+
+    private void JsIndexingTestingBase(Options options, string fieldName, VectorEmbeddingType src, VectorEmbeddingType dest, Func<IRavenQueryable<VecDoc>, IRavenQueryable<VecDoc>> vectorWhere)
     {
-        using var store = GetDocumentStore(Options.ForSearchEngine(RavenSearchEngineMode.Corax));
+        using var store = GetDocumentStore(options);
         using var session = store.OpenSession();
 
         float[][] singles = [[1.0f, 1.0f], [-1.0f, 1.0f]];

--- a/test/SlowTests/Sharding/Queries/RavenDB_26266.cs
+++ b/test/SlowTests/Sharding/Queries/RavenDB_26266.cs
@@ -64,6 +64,47 @@ public class RavenDB_26266(ITestOutputHelper output) : RavenTestBase(output)
                     .ToList());
 
 
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Sharding)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void ShardedVectorSearchWithOrderByScoreAndAdditionalField(Options options)
+    {
+        using var store = GetDocumentStore(options);
+        var config = Sharding.GetShardingConfiguration(store);
+
+        var sameSimilarityVector = new float[] { 0.8f, 0.6f };
+        var docs = new (float[] Vector, string Name)[]
+        {
+            (HighSimilarityVector, "Charlie"),
+            (sameSimilarityVector, "Bob"),
+            (sameSimilarityVector, "Alice"),
+        };
+
+        using (var session = store.OpenSession())
+        {
+            for (var i = 0; i < docs.Length; i++)
+            {
+                var id = Sharding.GetRandomIdForShard(config, i);
+                session.Store(new NamedVecDoc { Vector = docs[i].Vector, Name = docs[i].Name }, id);
+            }
+
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var results = session.Advanced
+                .RawQuery<NamedVecDoc>("from 'NamedVecDocs' where vector.search(Vector, $q) order by score(), Name")
+                .AddParameter("q", QueryVector)
+                .WaitForNonStaleResults()
+                .ToList();
+
+            Assert.Equal(docs.Length, results.Count);
+            Assert.Equal("Charlie", results[0].Name);
+            Assert.Equal("Alice", results[1].Name);
+            Assert.Equal("Bob", results[2].Name);
+        }
+    }
+
     private void RunVectorSearchTest(Options options, float[][] vectors, Func<IDocumentSession, List<VecDoc>> query)
     {
         using var store = GetDocumentStore(options);
@@ -92,7 +133,7 @@ public class RavenDB_26266(ITestOutputHelper output) : RavenTestBase(output)
 
             for (var i = 0; i < scores.Count - 1; i++)
             {
-                Assert.True(scores[i] > scores[i + 1]);
+                Assert.True(scores[i] >= scores[i + 1]);
             }
         }
     }
@@ -100,5 +141,11 @@ public class RavenDB_26266(ITestOutputHelper output) : RavenTestBase(output)
     private class VecDoc
     {
         public float[] Vector { get; set; }
+    }
+
+    private class NamedVecDoc
+    {
+        public float[] Vector { get; set; }
+        public string Name { get; set; }
     }
 }

--- a/test/SlowTests/Sharding/Queries/RavenDB_26266.cs
+++ b/test/SlowTests/Sharding/Queries/RavenDB_26266.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Sharding.Queries;
+
+public class RavenDB_26266(ITestOutputHelper output) : RavenTestBase(output)
+{
+    private static readonly float[] QueryVector = [1f, 0f];
+    private static readonly float[] HighSimilarityVector = [1.0f, 0.0f];
+    private static readonly float[] MedSimilarityVector = [0.8f, 0.6f];
+    private static readonly float[] LowSimilarityVector = [0.6f, 0.8f];
+
+    private static readonly float[] MultiQueryVector1 = [1f, 0f];
+    private static readonly float[] MultiQueryVector2 = [0f, 1f];
+    private static readonly float[] MultiHighVector = [1.00f, 0.00f];
+    private static readonly float[] MultiSecondHighVector = [0.28f, 0.96f];
+    private static readonly float[] MultiMedVector = [0.80f, 0.60f];
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Sharding)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void ShardedSingleVectorSearchResultsAreSortedByScoreWithExplicitOrderByScore(Options options) =>
+            RunVectorSearchTest(options, [HighSimilarityVector, MedSimilarityVector, LowSimilarityVector], session =>
+                session.Advanced
+                    .RawQuery<VecDoc>("from 'VecDocs' where vector.search(Vector, $q) order by score()")
+                    .AddParameter("q", QueryVector)
+                    .WaitForNonStaleResults()
+                    .ToList());
+
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Sharding)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void ShardedSingleVectorSearchResultsAreSortedByScoreWithoutOrderByScore(Options options) => RunVectorSearchTest(options, [HighSimilarityVector, MedSimilarityVector, LowSimilarityVector], session =>
+            session.Advanced
+                .RawQuery<VecDoc>("from 'VecDocs' where vector.search(Vector, $q)")
+                .AddParameter("q", QueryVector)
+                .WaitForNonStaleResults()
+                .ToList());
+
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Sharding)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void MultiVectorSearchResultsAreSortedByScoreWithExplicitOrderByScore(Options options) => RunVectorSearchTest(options, [MultiHighVector, MultiMedVector, MultiSecondHighVector], session =>
+                session.Query<VecDoc>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .VectorSearch(f => f.WithEmbedding(s => s.Vector),
+                        v => v.ByEmbeddings([MultiQueryVector1, MultiQueryVector2]))
+                    .OrderByScore()
+                    .ToList());
+
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Sharding)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax, DatabaseMode = RavenDatabaseMode.Sharded)]
+    public void MultiVectorSearchResultsAreSortedByScoreWithoutOrderByScore(Options options) => RunVectorSearchTest(options, [MultiHighVector, MultiMedVector, MultiSecondHighVector], session =>
+                session.Query<VecDoc>()
+                    .Customize(x => x.WaitForNonStaleResults())
+                    .VectorSearch(f => f.WithEmbedding(s => s.Vector),
+                        v => v.ByEmbeddings([MultiQueryVector1, MultiQueryVector2]))
+                    .ToList());
+
+
+    private void RunVectorSearchTest(Options options, float[][] vectors, Func<IDocumentSession, List<VecDoc>> query)
+    {
+        using var store = GetDocumentStore(options);
+        var config = Sharding.GetShardingConfiguration(store);
+
+        using (var session = store.OpenSession())
+        {
+            for (var i = 0; i < vectors.Length; i++)
+            {
+                var id = Sharding.GetRandomIdForShard(config, i);
+                session.Store(new VecDoc { Vector = vectors[i] }, id);
+            }
+
+            session.SaveChanges();
+        }
+
+        using (var session = store.OpenSession())
+        {
+            var results = query(session);
+
+            Assert.Equal(vectors.Length, results.Count);
+
+            var scores = results
+                .Select(r => Convert.ToDouble(session.Advanced.GetMetadataFor(r)["@index-score"]))
+                .ToList();
+
+            for (var i = 0; i < scores.Count - 1; i++)
+            {
+                Assert.True(scores[i] > scores[i + 1]);
+            }
+        }
+    }
+
+    private class VecDoc
+    {
+        public float[] Vector { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26266

### Additional description
Order by score() (distance) when using a vector.search() query. The sorting may be influenced by other scores when the query is not strictly a vector search.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
