### PR TITLE
RavenDB-17305 Trust server's own certificate before checking expiration

### DIFF
--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -1961,6 +1961,10 @@ namespace Raven.Server
             {
                 authenticationStatus.Status = AuthenticationStatus.NoCertificateProvided;
             }
+            else if (IsServerCertificate(certificate))
+            {
+                authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
+            }
             else if (certificate.NotAfter.ToUniversalTime() < DateTime.UtcNow)
             {
                 authenticationStatus.Status = AuthenticationStatus.Expired;
@@ -1968,10 +1972,6 @@ namespace Raven.Server
             else if (certificate.NotBefore.ToUniversalTime() > DateTime.UtcNow)
             {
                 authenticationStatus.Status = AuthenticationStatus.NotYetValid;
-            }
-            else if (IsServerCertificate(certificate))
-            {
-                authenticationStatus.Status = AuthenticationStatus.ClusterAdmin;
             }
             else if (wellKnown != null && wellKnown.Contains(certificate.Thumbprint, StringComparer.OrdinalIgnoreCase))
             {

--- a/test/SlowTests.Issues/Issues/RavenDB-17305.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17305.cs
@@ -5,14 +5,13 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using FastTests;
 using Newtonsoft.Json;
-using Raven.Client.Documents;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Tests.Infrastructure;
-using Voron.Util;
 using Xunit;
 
 namespace SlowTests.Issues
@@ -39,15 +38,27 @@ namespace SlowTests.Issues
             ValidateServerCanTalkToItself(certificate);
         }
 
+        [RavenFact(RavenTestCategory.Security)]
+        public void WillExplicitlyTrustOurOwnCertificate_SelfSigned_NotYetValid()
+        {
+            var certificate = CreateCertificateRequest(Environment.MachineName)
+                .CreateSelfSigned(DateTime.Today.AddDays(1), DateTime.Today.AddDays(30));
+            ValidateServerCanTalkToItself(certificate);
+        }
+
         private void ValidateServerCanTalkToItself(X509Certificate2 certificate)
         {
             string certFileName = GetTempFileName();
             File.WriteAllBytes(certFileName, certificate.Export(X509ContentType.Pkcs12));
+            // Reload from file with persistent key storage — ephemeral keys from
+            // CreateSelfSigned are rejected by Windows SChannel for expired certs.
+            var certBytes = certificate.Export(X509ContentType.Pkcs12);
+            var clientCert = CertificateLoaderUtil.CreateCertificate(certBytes);
             var certificates = new TestCertificatesHolder(certFileName, certFileName, certFileName, certFileName, certFileName);
             Certificates.SetupServerAuthentication(certificates: certificates);
             var store = GetDocumentStore(new Options
             {
-                ModifyDocumentStore = documentStore => documentStore.Certificate = X509CertificateLoader.LoadPkcs12FromFile(certFileName, null)
+                ModifyDocumentStore = documentStore => documentStore.Certificate = clientCert
             });
 
             Assert.StartsWith("https", store.Urls[0]);
@@ -89,12 +100,14 @@ namespace SlowTests.Issues
 
             public class PingResult
             {
+#pragma warning disable CS0649 // deserialization targets
                 public string Url;
                 public long TcpInfoTime;
                 public long SendTime;
                 public long ReceiveTime;
                 public string Error;
                 public string[] Log;
+#pragma warning restore CS0649
             }
 
             public class PingCommand : RavenCommand<PingResult[]>

--- a/test/SlowTests.Issues/Issues/RavenDB-17305.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17305.cs
@@ -9,7 +9,6 @@ using Raven.Client.Documents.Conventions;
 using Raven.Client.Http;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.Util;
-using Raven.Server.Utils;
 using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
@@ -25,34 +24,37 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.Security)]
         public void WillExplicitlyTrustOurOwnCertificate_SelfSigned()
         {
+            var now = DateTime.UtcNow;
             var certificate = CreateCertificateRequest(Environment.MachineName)
-                .CreateSelfSigned(DateTime.Today.AddDays(-1), DateTime.Today.AddDays(1));
+                .CreateSelfSigned(now.AddDays(-1), now.AddDays(1));
             ValidateServerCanTalkToItself(certificate);
         }
 
         [RavenFact(RavenTestCategory.Security)]
         public void WillExplicitlyTrustOurOwnCertificate_SelfSigned_Expired()
         {
+            var now = DateTime.UtcNow;
             var certificate = CreateCertificateRequest(Environment.MachineName)
-                .CreateSelfSigned(DateTime.Today.AddDays(-30), DateTime.Today.AddDays(-1));
+                .CreateSelfSigned(now.AddDays(-30), now.AddDays(-1));
             ValidateServerCanTalkToItself(certificate);
         }
 
         [RavenFact(RavenTestCategory.Security)]
         public void WillExplicitlyTrustOurOwnCertificate_SelfSigned_NotYetValid()
         {
+            var now = DateTime.UtcNow;
             var certificate = CreateCertificateRequest(Environment.MachineName)
-                .CreateSelfSigned(DateTime.Today.AddDays(1), DateTime.Today.AddDays(30));
+                .CreateSelfSigned(now.AddDays(1), now.AddDays(30));
             ValidateServerCanTalkToItself(certificate);
         }
 
         private void ValidateServerCanTalkToItself(X509Certificate2 certificate)
         {
-            string certFileName = GetTempFileName();
-            File.WriteAllBytes(certFileName, certificate.Export(X509ContentType.Pkcs12));
-            // Reload from file with persistent key storage — ephemeral keys from
-            // CreateSelfSigned are rejected by Windows SChannel for expired certs.
             var certBytes = certificate.Export(X509ContentType.Pkcs12);
+            string certFileName = GetTempFileName();
+            File.WriteAllBytes(certFileName, certBytes);
+            // Reload with persistent key storage — ephemeral keys from
+            // CreateSelfSigned are rejected by Windows SChannel for expired certs.
             var clientCert = CertificateLoaderUtil.CreateCertificate(certBytes);
             var certificates = new TestCertificatesHolder(certFileName, certFileName, certFileName, certFileName, certFileName);
             Certificates.SetupServerAuthentication(certificates: certificates);

--- a/test/SlowTests.Issues/Issues/RavenDB-17305.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-17305.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using FastTests;
+using Newtonsoft.Json;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.ServerWide.Operations;
+using Raven.Server.Utils;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Voron.Util;
+using Xunit;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17305 : RavenTestBase
+    {
+        public RavenDB_17305(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Security)]
+        public void WillExplicitlyTrustOurOwnCertificate_SelfSigned()
+        {
+            var certificate = CreateCertificateRequest(Environment.MachineName)
+                .CreateSelfSigned(DateTime.Today.AddDays(-1), DateTime.Today.AddDays(1));
+            ValidateServerCanTalkToItself(certificate);
+        }
+
+        [RavenFact(RavenTestCategory.Security)]
+        public void WillExplicitlyTrustOurOwnCertificate_SelfSigned_Expired()
+        {
+            var certificate = CreateCertificateRequest(Environment.MachineName)
+                .CreateSelfSigned(DateTime.Today.AddDays(-30), DateTime.Today.AddDays(-1));
+            ValidateServerCanTalkToItself(certificate);
+        }
+
+        private void ValidateServerCanTalkToItself(X509Certificate2 certificate)
+        {
+            string certFileName = GetTempFileName();
+            File.WriteAllBytes(certFileName, certificate.Export(X509ContentType.Pkcs12));
+            var certificates = new TestCertificatesHolder(certFileName, certFileName, certFileName, certFileName, certFileName);
+            Certificates.SetupServerAuthentication(certificates: certificates);
+            var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = documentStore => documentStore.Certificate = X509CertificateLoader.LoadPkcs12FromFile(certFileName, null)
+            });
+
+            Assert.StartsWith("https", store.Urls[0]);
+
+            var results = store.Maintenance.Server.Send(new PingOperation());
+            Assert.Equal(1, results.Length);
+            Assert.Null(results[0].Error);
+        }
+
+        private static CertificateRequest CreateCertificateRequest(string host)
+        {
+            var key = RSA.Create();
+            var certificateRequest =
+                new CertificateRequest(new X500DistinguishedName("CN=" + host), key, HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1)
+                {
+                    CertificateExtensions =
+                    {
+                        new X509BasicConstraintsExtension(true, false, 0, false),
+                        new X509KeyUsageExtension(
+                            X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.KeyCertSign |
+                            X509KeyUsageFlags.CrlSign | X509KeyUsageFlags.DigitalSignature, false),
+                        new X509EnhancedKeyUsageExtension(new OidCollection
+                        {
+                            new("1.3.6.1.5.5.7.3.2"), // client authentication
+                            new("1.3.6.1.5.5.7.3.1"), // server authentication
+                        }, true)
+                    }
+                };
+            return certificateRequest;
+        }
+
+        private class PingOperation : IServerOperation<PingOperation.PingResult[]>
+        {
+            public RavenCommand<PingResult[]> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+            {
+                return new PingCommand();
+            }
+
+            public class PingResult
+            {
+                public string Url;
+                public long TcpInfoTime;
+                public long SendTime;
+                public long ReceiveTime;
+                public string Error;
+                public string[] Log;
+            }
+
+            public class PingCommand : RavenCommand<PingResult[]>
+            {
+                public override bool IsReadRequest => true;
+
+                public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+                {
+                    url = $"{node.Url}/admin/debug/node/ping";
+                    return new HttpRequestMessage { Method = HttpMethod.Get };
+                }
+
+                public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response,
+                    bool fromCache)
+                {
+                    if (response.TryGetMember("Result", out var results) && results is BlittableJsonReaderArray array)
+                    {
+                        Result = JsonConvert.DeserializeObject<PingResult[]>(array.ToString());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17305

### Additional description
Moved the `IsServerCertificate` check above the expiration/not-yet-valid checks in `AuthenticateConnectionCertificate`. Previously, if the server's own certificate was expired, peer nodes presenting the same certificate would be rejected as expired before `IsServerCertificate` was evaluated. This is inconsistent — if the server itself is running with that certificate, it should trust other nodes using it regardless of expiry state.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed