### PR TITLE
RavenDB-26268 Add enablePromptCache option to AI connection strings

### DIFF
--- a/src/Raven.Server/package-lock.json
+++ b/src/Raven.Server/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Raven.Server",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/connectionStringsTypes.ts
@@ -140,6 +140,7 @@ export interface AiConnection extends ConnectionBase {
         deploymentName?: string;
         dimensions?: number;
         embeddingsMaxConcurrentBatches?: number;
+        enablePromptCache?: boolean;
         isSetTemperature?: boolean;
         temperature?: number;
     };
@@ -150,6 +151,7 @@ export interface AiConnection extends ConnectionBase {
         dimensions?: number;
         endpoint?: string;
         embeddingsMaxConcurrentBatches?: number;
+        enablePromptCache?: boolean;
     };
     huggingFaceSettings?: {
         apiKey?: string;
@@ -176,6 +178,7 @@ export interface AiConnection extends ConnectionBase {
         projectId?: string;
         dimensions?: number;
         embeddingsMaxConcurrentBatches?: number;
+        enablePromptCache?: boolean;
         isSetTemperature?: boolean;
         temperature?: number;
     };

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiConnectionStringUtils.ts
@@ -156,6 +156,7 @@ const schema = yupObjectSchema<FormData>({
             }),
         dimensions: getDimensionsSchema("azureOpenAiSettings"),
         embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("azureOpenAiSettings"),
+        enablePromptCache: yup.boolean().nullable(),
         isSetTemperature: yup.boolean().nullable(),
         temperature: getTemperatureSchema("azureOpenAiSettings"),
     }),
@@ -178,6 +179,7 @@ const schema = yupObjectSchema<FormData>({
             }),
         dimensions: getDimensionsSchema("googleSettings"),
         embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("googleSettings"),
+        enablePromptCache: yup.boolean().nullable(),
     }),
     huggingFaceSettings: yupObjectSchema<FormData["huggingFaceSettings"]>({
         apiKey: yup
@@ -240,6 +242,7 @@ const schema = yupObjectSchema<FormData>({
         projectId: yup.string().nullable(),
         dimensions: getDimensionsSchema("openAiSettings"),
         embeddingsMaxConcurrentBatches: getEmbeddingsMaxConcurrentBatchesSchema("openAiSettings"),
+        enablePromptCache: yup.boolean().nullable(),
         isSetTemperature: yup.boolean().nullable(),
         temperature: getTemperatureSchema("openAiSettings"),
     }),
@@ -308,6 +311,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 deploymentName: null,
                 dimensions: null,
                 embeddingsMaxConcurrentBatches: null,
+                enablePromptCache: null,
                 isSetTemperature: false,
                 temperature: null,
             } satisfies Required<FormData["azureOpenAiSettings"]>,
@@ -318,6 +322,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 dimensions: null,
                 endpoint: null,
                 embeddingsMaxConcurrentBatches: null,
+                enablePromptCache: null,
             } satisfies Required<FormData["googleSettings"]>,
             huggingFaceSettings: {
                 apiKey: null,
@@ -344,6 +349,7 @@ function getDefaultValues(initialConnection: AiConnection, isForNewConnection: b
                 projectId: null,
                 dimensions: null,
                 embeddingsMaxConcurrentBatches: null,
+                enablePromptCache: null,
                 isSetTemperature: false,
                 temperature: null,
             } satisfies Required<FormData["openAiSettings"]>,

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
@@ -18,6 +18,7 @@ import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesFiel
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
 import { SelectOption } from "components/common/select/Select";
 import TemperatureField from "./TemperatureField";
+import PromptCacheField from "./PromptCacheField";
 
 export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: boolean }) {
     const { control, trigger } = useFormContext<ConnectionFormData<AiConnection>>();
@@ -35,6 +36,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
         return tasksService.testAiConnectionString(databaseName, "AzureOpenAi", formValues.modelType, {
             ApiKey: formValues.azureOpenAiSettings.apiKey,
             Endpoint: formValues.azureOpenAiSettings.endpoint,
+            EnablePromptCache: formValues.azureOpenAiSettings.enablePromptCache,
             Model: formValues.azureOpenAiSettings.model,
             DeploymentName: formValues.azureOpenAiSettings.deploymentName,
             Dimensions: formValues.azureOpenAiSettings.dimensions,
@@ -153,6 +155,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
                     />
                 </div>
             )}
+            <PromptCacheField baseName="azureOpenAiSettings" />
             <TemperatureField baseName="azureOpenAiSettings" />
             {formValues.modelType === "TextEmbeddings" && (
                 <EmbeddingsMaxConcurrentBatches baseName="azureOpenAiSettings" />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
@@ -18,6 +18,7 @@ import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import RichAlert from "components/common/RichAlert";
 import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesField";
 import assertUnreachable from "components/utils/assertUnreachable";
+import PromptCacheField from "./PromptCacheField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -37,6 +38,7 @@ export default function GoogleSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         return tasksService.testAiConnectionString(databaseName, "Google", formValues.modelType, {
             AiVersion: formValues.googleSettings.aiVersion,
             ApiKey: formValues.googleSettings.apiKey,
+            EnablePromptCache: formValues.googleSettings.enablePromptCache,
             Model: formValues.googleSettings.model,
             Endpoint: formValues.googleSettings.endpoint,
         });
@@ -106,6 +108,7 @@ export default function GoogleSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     options={getModelOptions(formValues.modelType)}
                 />
             </div>
+            <PromptCacheField baseName="googleSettings" />
             <div className="mb-2">
                 <FormLabel>
                     Dimensions <OptionalLabel />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
@@ -18,6 +18,7 @@ import EmbeddingsMaxConcurrentBatches from "./EmbeddingsMaxConcurrentBatchesFiel
 import { SelectOption } from "components/common/select/Select";
 import { useAsyncDebounce } from "components/hooks/useAsyncDebounce";
 import TemperatureField from "./TemperatureField";
+import PromptCacheField from "./PromptCacheField";
 
 type FormData = ConnectionFormData<AiConnection>;
 
@@ -37,6 +38,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
         return tasksService.testAiConnectionString(databaseName, "OpenAi", formValues.modelType, {
             ApiKey: formValues.openAiSettings.apiKey,
             Endpoint: formValues.openAiSettings.endpoint,
+            EnablePromptCache: formValues.openAiSettings.enablePromptCache,
             Model: formValues.openAiSettings.model,
             OrganizationId: formValues.openAiSettings.organizationId,
             ProjectId: formValues.openAiSettings.projectId,
@@ -191,6 +193,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     />
                 </div>
             )}
+            <PromptCacheField baseName="openAiSettings" />
             <TemperatureField baseName="openAiSettings" />
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="openAiSettings" />}
             <div className="d-flex mb-2">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
@@ -1,0 +1,62 @@
+import { FormLabel, FormSelect } from "components/common/Form";
+import { Icon } from "components/common/Icon";
+import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
+import { SelectOption } from "components/common/select/Select";
+import {
+    ConnectionFormData,
+    AiConnection,
+} from "components/pages/database/settings/connectionStrings/connectionStringsTypes";
+import { FieldPath, useFormContext, useWatch } from "react-hook-form";
+
+type FormData = ConnectionFormData<AiConnection>;
+
+interface PromptCacheFieldProps {
+    baseName: Extract<FormData["connectorType"], "azureOpenAiSettings" | "googleSettings" | "openAiSettings">;
+}
+
+export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
+    const { control } = useFormContext<FormData>();
+
+    const modelType = useWatch({ control, name: "modelType" });
+
+    if (modelType !== "Chat") {
+        return null;
+    }
+
+    const fieldName = `${baseName}.enablePromptCache` satisfies FieldPath<FormData>;
+
+    return (
+        <div className="mb-2">
+            <FormLabel>
+                Prompt Cache Key
+                <PopoverWithHoverWrapper
+                    message={
+                        <>
+                            Controls whether RavenDB sends <code>prompt_cache_key</code> with chat completion requests.
+                            <ul className="mb-0">
+                                <li className="mt-1">
+                                    <strong>Default:</strong> use the server&apos;s provider-specific behavior.
+                                </li>
+                                <li className="mt-1">
+                                    <strong>True:</strong> always send the field.
+                                </li>
+                                <li className="mt-1">
+                                    <strong>False:</strong> never send the field.
+                                </li>
+                            </ul>
+                        </>
+                    }
+                >
+                    <Icon icon="info" color="info" margin="ms-1" />
+                </PopoverWithHoverWrapper>
+            </FormLabel>
+            <FormSelect control={control} name={fieldName} options={promptCacheOptions} />
+        </div>
+    );
+}
+
+const promptCacheOptions: SelectOption<boolean>[] = [
+    { label: "Default", value: null },
+    { label: "True", value: true },
+    { label: "False", value: false },
+];

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsFromDto.ts
@@ -381,6 +381,7 @@ export function mapAiConnectionsFromDto(
                     deploymentName: connection.AzureOpenAiSettings?.DeploymentName,
                     dimensions: connection.AzureOpenAiSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.AzureOpenAiSettings?.EmbeddingsMaxConcurrentBatches,
+                    enablePromptCache: connection.AzureOpenAiSettings?.EnablePromptCache ?? null,
                     isSetTemperature: connection.AzureOpenAiSettings?.Temperature != null,
                     temperature: connection.AzureOpenAiSettings?.Temperature ?? null,
                 },
@@ -390,6 +391,7 @@ export function mapAiConnectionsFromDto(
                     model: connection.GoogleSettings?.Model,
                     dimensions: connection.GoogleSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.GoogleSettings?.EmbeddingsMaxConcurrentBatches,
+                    enablePromptCache: connection.GoogleSettings?.EnablePromptCache ?? null,
                 },
                 huggingFaceSettings: {
                     apiKey: connection.HuggingFaceSettings?.ApiKey,
@@ -416,6 +418,7 @@ export function mapAiConnectionsFromDto(
                     projectId: connection.OpenAiSettings?.ProjectId,
                     dimensions: connection.OpenAiSettings?.Dimensions,
                     embeddingsMaxConcurrentBatches: connection.OpenAiSettings?.EmbeddingsMaxConcurrentBatches,
+                    enablePromptCache: connection.OpenAiSettings?.EnablePromptCache ?? null,
                     isSetTemperature: connection.OpenAiSettings?.Temperature != null,
                     temperature: connection.OpenAiSettings?.Temperature ?? null,
                 },

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/store/connectionStringsMapsToDto.ts
@@ -218,6 +218,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       DeploymentName: connection.azureOpenAiSettings.deploymentName,
                       Dimensions: mapDimensionsToDto(connection),
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      EnablePromptCache: connection.azureOpenAiSettings.enablePromptCache,
                       Temperature: mapTemperatureToDto(connection),
                   }
                 : null,
@@ -230,6 +231,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       Dimensions: mapDimensionsToDto(connection),
                       Endpoint: connection.googleSettings.endpoint,
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      EnablePromptCache: connection.googleSettings.enablePromptCache,
                   }
                 : null,
         HuggingFaceSettings:
@@ -269,6 +271,7 @@ export function mapAiConnectionStringToDto(connection: AiConnection): Connection
                       ProjectId: connection.openAiSettings.projectId,
                       Dimensions: mapDimensionsToDto(connection),
                       EmbeddingsMaxConcurrentBatches: mapEmbeddingsMaxConcurrentBatchesToDto(connection),
+                      EnablePromptCache: connection.openAiSettings.enablePromptCache,
                       Temperature: mapTemperatureToDto(connection),
                   }
                 : null,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26268

### Additional description

- Add Studio part for prompt_cache_key
- Remove package-lock.json from Raven.Server

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
