### PR TITLE
RavenDB-24400 Cluster Debug view - an empty space in the `Role / Phas…

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.tsx
@@ -151,6 +151,24 @@ export default function ClusterDebugSummary(props: ClusterDebugSummaryProps) {
                             </PopoverWithHoverWrapper>
                         </th>
                         {nodes.map((node) => {
+                             if (node.status === "failure") {
+                                return (
+                                    <td
+                                        rowSpan={hasAnyCriticalError ? 9 : 8}
+                                        className="align-content-center"
+                                        key={node.nodeTag}
+                                    >
+                                        <EmptySet color="danger" icon="warning">
+                                            <span>Unable to connect</span>
+                                            <br />
+                                            <small className="text-muted">
+                                                There was connection issue with{" "}
+                                                <Icon icon="node" addon="warning" margin="ms-1 me-1" /> {node.nodeTag}
+                                            </small>
+                                        </EmptySet>
+                                    </td>
+                                );
+                            }
                             return (
                                 <ConditionalRender node={node} key={node.nodeTag}>
                                     {() => {
@@ -188,24 +206,6 @@ export default function ClusterDebugSummary(props: ClusterDebugSummaryProps) {
                             </PopoverWithHoverWrapper>
                         </th>
                         {nodes.map((node) => {
-                            if (node.status === "failure") {
-                                return (
-                                    <td
-                                        rowSpan={hasAnyCriticalError ? 9 : 8}
-                                        className="align-content-center"
-                                        key={node.nodeTag}
-                                    >
-                                        <EmptySet color="danger" icon="warning">
-                                            <span>Unable to connect</span>
-                                            <br />
-                                            <small className="text-muted">
-                                                There was connection issue with{" "}
-                                                <Icon icon="node" addon="warning" margin="ms-1 me-1" /> {node.nodeTag}
-                                            </small>
-                                        </EmptySet>
-                                    </td>
-                                );
-                            }
 
                             return (
                                 <ConditionalRender node={node} key={node.nodeTag}>

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/advanced/clusterDebug/partials/ClusterDebugSummary.tsx
@@ -151,7 +151,7 @@ export default function ClusterDebugSummary(props: ClusterDebugSummaryProps) {
                             </PopoverWithHoverWrapper>
                         </th>
                         {nodes.map((node) => {
-                             if (node.status === "failure") {
+                            if (node.status === "failure") {
                                 return (
                                     <td
                                         rowSpan={hasAnyCriticalError ? 9 : 8}
@@ -206,7 +206,6 @@ export default function ClusterDebugSummary(props: ClusterDebugSummaryProps) {
                             </PopoverWithHoverWrapper>
                         </th>
                         {nodes.map((node) => {
-
                             return (
                                 <ConditionalRender node={node} key={node.nodeTag}>
                                     {() => (


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24400

### Additional description

Fixed empty space in the table for unavailable node. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
