### PR TITLE
RavenDB-26036 Fix journal removal logic in UpdateJournalStateUnderWriteTransactionLock by updating HasAdditionalTransactionsToFlush to account for peeked but unconsumed records, ensuring correct journal retention

### DIFF
--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -1671,7 +1671,10 @@ namespace Voron
         // We create a single thread-safe persistent dictionary locator with enough state to deal with almost any scenario.
         internal PersistentDictionaryLocator DictionaryLocator { get; } = new PersistentDictionaryLocator(1024);
         public bool IsFlushInProgress => Journal.Applicator.FlushInProgress != 0;
-        public bool HasAdditionalTransactionsToFlush => _transactionsToFlush.IsEmpty is false;
+
+        // Must check both the queue and _lastPeekedRecord, since TryPeekNextRecordToFlush
+        // may dequeue a record into _lastPeekedRecord without consuming it
+        public bool HasAdditionalTransactionsToFlush => _transactionsToFlush.IsEmpty is false || _lastPeekedRecord is not null;
 
         public PersistentDictionary CreateEncodingDictionary(Page dictionaryPage)
         {

--- a/test/SlowTests/Voron/Issues/RavenDB_26036.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26036.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Linq;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_26036 : StorageTest
+{
+    public RavenDB_26036(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        base.Configure(options);
+
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+        options.MaxLogFileSize = 10 * Constants.Storage.PageSize;
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void Must_not_remove_journal_referenced_by_peeked_record_during_flush()
+    {
+        var bytes = new byte[Constants.Storage.PageSize / 2];
+        var random = new Random(42);
+        random.NextBytes(bytes);
+
+        for (int i = 0; i < 5; i++)
+        {
+            using (var tx = Env.WriteTransaction())
+            {
+                var tree = tx.CreateTree("test");
+                tree.Add($"items/{i}", new MemoryStream(bytes));
+                tx.Commit();
+            }
+        }
+
+        using (var tx = Env.WriteTransaction())
+        {
+            var tree = tx.CreateTree("test");
+
+            var bigBytes = new byte[Constants.Storage.PageSize * 2];
+            random.NextBytes(bigBytes);
+
+            tree.Add("items/big", new MemoryStream(bigBytes));
+            tx.Commit(); // this is going to fill up the first journal file completely
+        }
+
+        Assert.True(Env.Journal.Files.Count == 1,$"Expected exactly 1 journal file after writes, got {Env.Journal.Files.Count}");
+
+
+        Assert.True(Env.Journal.Files.First().DoneWriting.IsRaised(), "Expected the journal file to have DoneWriting raised - meaning that there is exactly 0 pages available to write there");
+
+        // Open a read transaction. Its ID = latest committed tx ID.
+        // This constrains uptoTxIdExclusive during flush, causing the LAST record
+        // in the queue to be peeked (txId >= uptoTxIdExclusive) rather than consumed.
+        using (Env.ReadTransaction())
+        {
+            // Flush #1: Consumes records up to readTx.Id - 1, peeks the last record.
+            // Without the fix: else branch in UpdateJournalStateUnderWriteTransactionLock removes it from _files.
+            Env.FlushLogToDataFile();
+        }
+
+        // Read tx is disposed. uptoTxIdExclusive advances.
+        // Flush #2: Consumes the previously peeked record (FlushedToJournal=X).
+        // Without the fix: journal X was removed by Flush #1 -> "Unable to find journal file 0"
+        Env.FlushLogToDataFile();
+    }
+}


### PR DESCRIPTION


### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26036

### Additional description

The problematic case was:

`HasAdditionalTransactionsToFlush` only checked `_transactionsToFlush.IsEmpty` but missed `_lastPeekedRecord` (a record dequeued by `TryPeekNextRecordToFlush` but not consumed because `TransactionId >= uptoTxIdExclusive`.

 When the queue was empty but `_lastPeekedRecord` was non-null, the else branch aggressively removed all `DoneWriting` journals here:

https://github.com/ravendb/ravendb/blob/7ce9d386a2ed8e97bdfd6dadb614c4bb749aed82/src/Voron/Impl/Journal/WriteAheadJournal.cs#L1028-L1040

Also including journals that were still referenced by the peeked record. The next flush consumed that record and crashed with:

```
System.InvalidOperationException: Unable to find journal file 1 in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\test\SlowTests\bin\Debug\net10.0\Temp\ravendb-9800-58059-data.pager-aa22796d-b6c7-47b0-9a00-e76148bb176a
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.UpdateJournalStateUnderWriteTransactionLock(LowLevelTransaction txw, List`1 bufferOfPageFromScratchBuffersToFree, EnvironmentStateRecord flushedRecord) in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 1015
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.<>c__DisplayClass43_0.<ApplyJournalStateAfterFlush>b__0(LowLevelTransaction txw) in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 909
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.OnTransactionCommitted(LowLevelTransaction tx) in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 698
   at Voron.Impl.LowLevelTransaction.CommitStage1_CompleteTransaction() in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\LowLevelTransaction.cs:line 1241
   at Voron.Impl.LowLevelTransaction.Commit() in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\LowLevelTransaction.cs:line 1014
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.WaitForJournalStateToBeUpdated(CancellationToken token, TransactionPersistentContext transactionPersistentContext, Action`1 currentAction, ByteStringContext byteStringContext) in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 994
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.ApplyJournalStateAfterFlush(CancellationToken token, List`1 bufferOfPageFromScratchBuffersToFree, EnvironmentStateRecord record, State dataPagerState, ByteStringContext byteStringContext) in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 903
   at Voron.Impl.Journal.WriteAheadJournal.JournalApplicator.ApplyLogsToDataFile(CancellationToken token, TimeSpan timeToWait) in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\Impl\Journal\WriteAheadJournal.cs:line 860
   at Voron.StorageEnvironment.BackgroundFlushWritesToDataFile() in c:\Jenkins\workspace\Testsv80_Winx64_Debug\s\src\Voron\StorageEnvironment.cs:line 1457
   ```

The PR which introduced `_lastPeekedRecord` is https://github.com/ravendb/ravendb/pull/22231

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
