### PR TITLE
RavenDB-26365 Replace coin-flip level assignment

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -557,14 +557,25 @@ public partial class Hnsw
             
             private int GetLevelForNewNode(int maxLevel)
             {
-                int level = 0;
-                while ((parent.Random.Next() & 1) == 0 && // 50% chance 
-                       level < maxLevel)
-                {
-                    level++;
-                }
-
-                return level;
+                // Use the level assignment formula from the original HNSW paper.
+                // Most nodes stay at level 0 where they form a dense, detailed graph
+                // that captures fine-grained neighborhood relationships. Only a few
+                // nodes get promoted to upper levels, which act as sparse long-range
+                // shortcuts. During search, the algorithm quickly descends through
+                // these thin upper layers to find a good entry region, then switches
+                // to the dense level 0 to refine the actual nearest neighbors.
+                // If promotion were too aggressive (e.g. a 50% coin flip), half the
+                // nodes would reach level 1, a quarter level 2, and so on. The upper
+                // layers would become crowded with nodes and edges, making insertion
+                // and search spend most of their time navigating dense upper levels
+                // instead of quickly skipping down to where the real work happens.
+                int m = _searchState.Options.NumberOfEdges;
+                double mL = 1.0 / Math.Log(m);
+                double r = parent.Random.NextDouble();
+                // Avoid log(0)
+                if (r == 0.0) r = double.Epsilon;
+                int level = (int)(-Math.Log(r) * mL);
+                return Math.Min(level, maxLevel);
             }
 
             /// <summary>


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26365

### Additional description

  Replace the coin-flip loop in `GetLevelForNewNode()` with the standard HNSW exponential decay formula. 10 lines changed in `Hnsw.Parallel.cs`.

  mL = 1 / ln(M)
  level = floor(-ln(uniform()) × mL)

  This concentrates edges at level 0 where they matter, using upper levels only as sparse long-range shortcuts as originally intended by the HNSW paper.

  ## Results

  | M | Metric | Coin-Flip | Standard HNSW | Delta |
  |---|--------|-----------|---------------|-------|
  | 8 | Insert time | 1,642 ms | 1,153 ms | **-30%** |
  | 8 | Insert (vec/s) | 6,091 | 8,672 | **+42%** |
  | 8 | Recall@10 | 54.5% | 54.6% | — |
  | 8 | Query QPS | 842 | 1,410 | **+67%** |
  | 16 | Insert time | 1,562 ms | 889 ms | **-43%** |
  | 16 | Insert (vec/s) | 6,402 | 11,251 | **+76%** |
  | 16 | Recall@10 | 54.8% | 54.8% | — |
  | 16 | Query QPS | 1,009 | 1,357 | **+34%** |

  N=10,000 D=16 efConstruction=64, 3 iterations averaged.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
