### PR TITLE
Improve tracing by isolating topology updates from ambient trace context

### DIFF
--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -497,6 +497,12 @@ namespace Raven.Client.Http
             if (Disposed)
                 return false;
 
+            // Isolate topology updates from any ambient trace — topology updates are background
+            // maintenance operations and should not appear as child spans of unrelated user traces.
+            // Setting Activity.Current = null here is safe: AsyncLocal semantics ensure the caller's
+            // Activity is unaffected once this method returns from its await.
+            Activity.Current = null;
+
             //prevent double topology updates if execution takes too much time
             // --> in cases with transient issues
             var lockTaken = await _updateDatabaseTopologySemaphore.WaitAsync(parameters.TimeoutInMs).ConfigureAwait(false);

--- a/test/FastTests/Client/RequestExecutorTests.cs
+++ b/test/FastTests/Client/RequestExecutorTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -6,6 +8,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Tests.Infrastructure;
@@ -17,6 +20,54 @@ namespace FastTests.Client
     {
         public RequestExecutorTests(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task UpdateTopologyAsync_ClearsAmbientActivity_BeforeTopologyHttpRequest()
+        {
+            using var store = GetDocumentStore();
+            var requestExecutor = store.GetRequestExecutor();
+
+            // Warm up — ensure topology is already populated so TopologyNodes is non-null.
+            using (var session = store.OpenAsyncSession())
+                _ = await session.LoadAsync<object>("warmup/1");
+
+            // Simulate being inside an active user request trace.
+            var parentActivity = new Activity("UserRequest").Start();
+            Activity capturedDuringTopology = null;
+            var topologyRequestObserved = false;
+
+            requestExecutor.OnBeforeRequest += (_, args) =>
+            {
+                if (args.Url.Contains("/topology"))
+                {
+                    topologyRequestObserved = true;
+                    capturedDuringTopology = Activity.Current;
+                }
+            };
+
+            try
+            {
+                var node = requestExecutor.TopologyNodes.First();
+                await requestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(node)
+                {
+                    TimeoutInMs = 15_000,
+                    DebugTag = "test-trace-isolation",
+                    ForceUpdate = true
+                });
+
+                // After the await, the caller's Activity.Current must be unaffected.
+                // Activity.Current is AsyncLocal<Activity>; mutations inside the async callee
+                // do not propagate back to the caller's execution context.
+                Assert.Same(parentActivity, Activity.Current);
+            }
+            finally
+            {
+                parentActivity.Stop();
+            }
+
+            Assert.True(topologyRequestObserved, "OnBeforeRequest should have fired for the /topology endpoint");
+            Assert.Null(capturedDuringTopology);
         }
 
         [LicenseRequiredTheory]


### PR DESCRIPTION
UpdateTopologyAsync is called from multiple sites: the periodic timer callback, refresh-topology-header handling, retry logic, and initial setup. In every case these are background maintenance operations and should not appear as child spans of whatever user request happens to be in flight at the time.

Setting Activity.Current = null before the first await is sufficient:
- All HTTP work inside the method (including GetDatabaseTopologyCommand) will start with no parent activity, producing independent root spans.
- AsyncLocal semantics guarantee the caller's Activity.Current is unaffected once this method's await returns, so no save/restore is needed.

### Additional description

The current state results in an endless creation of HTTP GET Activities that are periodically created for the life of the process that can be stuck under some unrelated request that triggered a topology update (like the first request for the process) resulting in a single gigantic trace. 

This is visible while exporting traces from a process using RavenDB that includes HttpClient Activities.

Example 6d long trace that is a string of topology update calls under the trace of a normal request:

<img width="1476" height="179" alt="image" src="https://github.com/user-attachments/assets/1823d719-a0ab-404f-bf90-d201ed305018" />


### Type of change

- [X] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [X] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [X] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [X] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [X] No documentation update is needed 

### Testing by Contributor

- [X] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [X] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [X] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [X] No UI work is needed
