### PR TITLE
RavenDB-25378 fix IO stats on threads view

### DIFF
--- a/src/Raven.Server/Dashboard/ThreadsInfo.cs
+++ b/src/Raven.Server/Dashboard/ThreadsInfo.cs
@@ -75,20 +75,20 @@ namespace Raven.Server.Dashboard
         public double? IoSyscallsPerSecLast { get; set; }
         // Last measured throughput in KB/s based on read_bytes+write_bytes delta
         public double? ThroughputKbPerSecLast { get; set; }
-        // Total number of I/O operations since metering started
-        public long? IoSyscallsTotal { get; set; }
-        // Total data volume in KB since metering started
-        public double? ThroughputKbTotal { get; set; }
 
         // Split read/write metrics
         public double? ReadIoSyscallsPerSecLast { get; set; }
         public double? WriteIoSyscallsPerSecLast { get; set; }
         public double? ReadThroughputKbPerSecLast { get; set; }
         public double? WriteThroughputKbPerSecLast { get; set; }
-        public long? ReadIoSyscallsTotal { get; set; }
-        public long? WriteIoSyscallsTotal { get; set; }
-        public double? ReadThroughputKbTotal { get; set; }
-        public double? WriteThroughputKbTotal { get; set; }
+
+        // Raw cumulative values from /proc/self/task/{tid}/io
+        // These are monotonically increasing counters for the lifetime of each thread.
+        // The client uses these to compute totals as (current - initial_snapshot).
+        public long? Syscr { get; set; }
+        public long? Syscw { get; set; }
+        public long? ReadBytes { get; set; }
+        public long? WriteBytes { get; set; }
 
         public DynamicJsonValue ToJson()
         {
@@ -96,16 +96,14 @@ namespace Raven.Server.Dashboard
             {
                 [nameof(IoSyscallsPerSecLast)] = IoSyscallsPerSecLast,
                 [nameof(ThroughputKbPerSecLast)] = ThroughputKbPerSecLast,
-                [nameof(IoSyscallsTotal)] = IoSyscallsTotal,
-                [nameof(ThroughputKbTotal)] = ThroughputKbTotal,
                 [nameof(ReadIoSyscallsPerSecLast)] = ReadIoSyscallsPerSecLast,
                 [nameof(WriteIoSyscallsPerSecLast)] = WriteIoSyscallsPerSecLast,
                 [nameof(ReadThroughputKbPerSecLast)] = ReadThroughputKbPerSecLast,
                 [nameof(WriteThroughputKbPerSecLast)] = WriteThroughputKbPerSecLast,
-                [nameof(ReadIoSyscallsTotal)] = ReadIoSyscallsTotal,
-                [nameof(WriteIoSyscallsTotal)] = WriteIoSyscallsTotal,
-                [nameof(ReadThroughputKbTotal)] = ReadThroughputKbTotal,
-                [nameof(WriteThroughputKbTotal)] = WriteThroughputKbTotal
+                [nameof(Syscr)] = Syscr,
+                [nameof(Syscw)] = Syscw,
+                [nameof(ReadBytes)] = ReadBytes,
+                [nameof(WriteBytes)] = WriteBytes
             };
         }
     }

--- a/src/Raven.Server/Utils/ThreadIoStatsReader.cs
+++ b/src/Raven.Server/Utils/ThreadIoStatsReader.cs
@@ -21,18 +21,18 @@ namespace Raven.Server.Utils
         {
             public double IoSyscallsPerSecLast;
             public double KbPerSecLast;
-            public long IoSyscallsTotal;
-            public double KbTotal;
 
             // Split metrics when available
             public double? ReadIoSyscallsPerSecLast;
             public double? WriteIoSyscallsPerSecLast;
             public double? ReadKbPerSecLast;
             public double? WriteKbPerSecLast;
-            public long? ReadSyscallsTotal;
-            public long? WriteSyscallsTotal;
-            public double? ReadKbTotal;
-            public double? WriteKbTotal;
+
+            // Raw cumulative values from /proc
+            public long Syscr;
+            public long Syscw;
+            public long ReadBytes;
+            public long WriteBytes;
         }
 
         private ThreadIoStatsReader()
@@ -215,37 +215,30 @@ namespace Raven.Server.Utils
                         var readKbPerSec = dReadBytes / Kb / elapsed;
                         var writeKbPerSec = dWriteBytes / Kb / elapsed;
 
-                        var opsTotal = syscr + syscw;
-                        var kbTotal = (readBytes + writeBytes) / Kb;
-
                         _stats.AddOrUpdate(tid, new Stats
                         {
                             IoSyscallsPerSecLast = readOpsPerSec + writeOpsPerSec,
                             KbPerSecLast = readKbPerSec + writeKbPerSec,
-                            IoSyscallsTotal = opsTotal,
-                            KbTotal = kbTotal,
                             ReadIoSyscallsPerSecLast = readOpsPerSec,
                             WriteIoSyscallsPerSecLast = writeOpsPerSec,
                             ReadKbPerSecLast = readKbPerSec,
                             WriteKbPerSecLast = writeKbPerSec,
-                            ReadSyscallsTotal = syscr,
-                            WriteSyscallsTotal = syscw,
-                            ReadKbTotal = readBytes / Kb,
-                            WriteKbTotal = writeBytes / Kb
+                            Syscr = syscr,
+                            Syscw = syscw,
+                            ReadBytes = readBytes,
+                            WriteBytes = writeBytes
                         }, (kk, s) =>
                         {
                             s.IoSyscallsPerSecLast = readOpsPerSec + writeOpsPerSec;
                             s.KbPerSecLast = readKbPerSec + writeKbPerSec;
-                            s.IoSyscallsTotal = opsTotal;
-                            s.KbTotal = kbTotal;
                             s.ReadIoSyscallsPerSecLast = readOpsPerSec;
                             s.WriteIoSyscallsPerSecLast = writeOpsPerSec;
                             s.ReadKbPerSecLast = readKbPerSec;
                             s.WriteKbPerSecLast = writeKbPerSec;
-                            s.ReadSyscallsTotal = syscr;
-                            s.WriteSyscallsTotal = syscw;
-                            s.ReadKbTotal = readBytes / Kb;
-                            s.WriteKbTotal = writeBytes / Kb;
+                            s.Syscr = syscr;
+                            s.Syscw = syscw;
+                            s.ReadBytes = readBytes;
+                            s.WriteBytes = writeBytes;
                             return s;
                         });
 

--- a/src/Raven.Server/Utils/ThreadsUsage.cs
+++ b/src/Raven.Server/Utils/ThreadsUsage.cs
@@ -152,17 +152,16 @@ namespace Raven.Server.Utils
                                         {
                                             IoSyscallsPerSecLast = io.IoSyscallsPerSecLast,
                                             ThroughputKbPerSecLast = io.KbPerSecLast,
-                                            IoSyscallsTotal = io.IoSyscallsTotal,
-                                            ThroughputKbTotal = io.KbTotal,
 
                                             ReadIoSyscallsPerSecLast = io.ReadIoSyscallsPerSecLast,
                                             WriteIoSyscallsPerSecLast = io.WriteIoSyscallsPerSecLast,
                                             ReadThroughputKbPerSecLast = io.ReadKbPerSecLast,
                                             WriteThroughputKbPerSecLast = io.WriteKbPerSecLast,
-                                            ReadIoSyscallsTotal = io.ReadSyscallsTotal,
-                                            WriteIoSyscallsTotal = io.WriteSyscallsTotal,
-                                            ReadThroughputKbTotal = io.ReadKbTotal,
-                                            WriteThroughputKbTotal = io.WriteKbTotal
+
+                                            Syscr = io.Syscr,
+                                            Syscw = io.Syscw,
+                                            ReadBytes = io.ReadBytes,
+                                            WriteBytes = io.WriteBytes
                                         };
                                     }
                                 }

--- a/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
+++ b/src/Raven.Studio/typescript/viewmodels/manage/debugAdvancedThreadsRuntime.ts
@@ -13,7 +13,26 @@ import eventsCollector = require("common/eventsCollector");
 import awesomeMultiselect = require("common/awesomeMultiselect");
 
 type Unit = "" | "%" | "B" | "KB" | "KB/s";
-type ThreadInfo = Raven.Server.Dashboard.ThreadInfo;
+
+interface IoStatsWithTotals extends Raven.Server.Dashboard.IoStats {
+    IoSyscallsTotal?: number;
+    ReadIoSyscallsTotal?: number;
+    WriteIoSyscallsTotal?: number;
+    ThroughputKbTotal?: number;
+    ReadThroughputKbTotal?: number;
+    WriteThroughputKbTotal?: number;
+}
+
+interface ThreadInfo extends Omit<Raven.Server.Dashboard.ThreadInfo, "IoStats"> {
+    IoStats?: IoStatsWithTotals;
+}
+
+interface IoSnapshot {
+    syscr: number;
+    syscw: number;
+    readBytes: number;
+    writeBytes: number;
+}
 
 class debugAdvancedThreadsRuntime extends viewModelBase {
     view = require("views/manage/debugAdvancedThreadsRuntime.html");
@@ -35,6 +54,10 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
     isPause = ko.observable<boolean>(false);
     
     filter = ko.observable<string>();
+    
+    showTotalsSinceThreadCreation = ko.observable<boolean>(false);
+    
+    private initialSnapshots = new Map<string, IoSnapshot>();
 
     allColumnHeaders = [
         "Stack",
@@ -92,6 +115,7 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         
         this.filter.throttle(300).subscribe(() => this.filterEntries());
         this.visibleColumnHeaders.subscribe(() => this.filterEntries(true));
+        this.showTotalsSinceThreadCreation.subscribe(() => this.filterEntries(true));
     }
     
     attached() {
@@ -179,6 +203,10 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
         grid.init(fetcher, () => {
                 type ColumnHeader = (typeof this.allColumnHeaders)[number];
 
+                const totalsSuffix = this.showTotalsSinceThreadCreation()
+                    ? "aggregated since thread creation"
+                    : "aggregated since this view was open";
+
                 const columns = [
                     new actionColumn<ThreadInfo>(grid, (x) => this.showStackTrace(x), "Stack" satisfies ColumnHeader, () => `<i title="Click to view Stack Trace" class="icon-thread-stack-trace"></i>`, "55px"),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => x.Name, "Name", "20%", {
@@ -213,27 +241,27 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.IoSyscallsTotal, 0), "Total IO SysCalls", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.IoSyscallsTotal),
-                        headerTitle: "Total IO SysCalls aggregated since this view was open",
+                        headerTitle: `Total IO SysCalls ${totalsSuffix}`,
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadIoSyscallsTotal, 0), "Total IO SysCalls Read", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.ReadIoSyscallsTotal),
-                        headerTitle: "Total IO SysCalls Read aggregated since this view was open",
+                        headerTitle: `Total IO SysCalls Read ${totalsSuffix}`,
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteIoSyscallsTotal, 0), "Total IO SysCalls Write", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.WriteIoSyscallsTotal),
-                        headerTitle: "Total IO SysCalls aggregated since this view was open",
+                        headerTitle: `Total IO SysCalls Write ${totalsSuffix}`,
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ThroughputKbTotal, 2, "KB"), "Total IO Throughput", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.ThroughputKbTotal),
-                        headerTitle: "Total IO Throughput aggregated since this view was open",
+                        headerTitle: `Total IO Throughput ${totalsSuffix}`,
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.ReadThroughputKbTotal, 2, "KB"), "Total IO Throughput Read", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.ReadThroughputKbTotal),
-                        headerTitle: "Total IO Throughput Read aggregated since this view was open",
+                        headerTitle: `Total IO Throughput Read ${totalsSuffix}`,
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => this.getStringValue(x.IoStats?.WriteThroughputKbTotal, 2, "KB"), "Total IO Throughput Write", "7%", {
                         sortable: x => this.getSortableValue(x.IoStats?.WriteThroughputKbTotal),
-                        headerTitle: "Total IO Throughput Write aggregated since this view was open",
+                        headerTitle: `Total IO Throughput Write ${totalsSuffix}`,
                     }),
                     new textColumn<ThreadInfo, ColumnHeader>(grid, x => generalUtils.formatTimeSpan(x.Duration, false), "Total CPU Time", "7%", {
                         sortable: x => this.getSortableValue(x.Duration),
@@ -280,12 +308,54 @@ class debugAdvancedThreadsRuntime extends viewModelBase {
     connectWebSocket() {
         eventsCollector.default.reportEvent("threads-info", "connect");
 
+        this.initialSnapshots.clear();
+
         const ws = new threadsInfoWebSocketClient(data => this.onData(data));
         this.liveClient(ws);
     }
     
     private onData(data: Raven.Server.Dashboard.ThreadsInfo) {
-        this.allData(data.List);
+        const KB = 1024;
+        const threads = data.List as ThreadInfo[];
+        const sinceCreation = this.showTotalsSinceThreadCreation();
+
+        for (const thread of threads) {
+            if (thread.IoStats && thread.IoStats.Syscr != null) {
+                const snapshotKey = thread.Id + "_" + thread.StartingTime;
+                const current: IoSnapshot = {
+                    syscr: thread.IoStats.Syscr,
+                    syscw: thread.IoStats.Syscw,
+                    readBytes: thread.IoStats.ReadBytes,
+                    writeBytes: thread.IoStats.WriteBytes
+                };
+
+                if (!this.initialSnapshots.has(snapshotKey)) {
+                    this.initialSnapshots.set(snapshotKey, { ...current });
+                }
+
+                if (sinceCreation) {
+                    // Use raw cumulative values (total since thread creation)
+                    thread.IoStats.IoSyscallsTotal = current.syscr + current.syscw;
+                    thread.IoStats.ThroughputKbTotal = (current.readBytes + current.writeBytes) / KB;
+                    thread.IoStats.ReadIoSyscallsTotal = current.syscr;
+                    thread.IoStats.WriteIoSyscallsTotal = current.syscw;
+                    thread.IoStats.ReadThroughputKbTotal = current.readBytes / KB;
+                    thread.IoStats.WriteThroughputKbTotal = current.writeBytes / KB;
+                } else {
+                    // Use snapshot deltas (total since monitoring started)
+                    const initial = this.initialSnapshots.get(snapshotKey);
+
+                    thread.IoStats.IoSyscallsTotal = (current.syscr - initial.syscr) + (current.syscw - initial.syscw);
+                    thread.IoStats.ThroughputKbTotal = ((current.readBytes - initial.readBytes) + (current.writeBytes - initial.writeBytes)) / KB;
+                    thread.IoStats.ReadIoSyscallsTotal = current.syscr - initial.syscr;
+                    thread.IoStats.WriteIoSyscallsTotal = current.syscw - initial.syscw;
+                    thread.IoStats.ReadThroughputKbTotal = (current.readBytes - initial.readBytes) / KB;
+                    thread.IoStats.WriteThroughputKbTotal = (current.writeBytes - initial.writeBytes) / KB;
+                }
+            }
+        }
+
+        this.allData(threads);
         this.machineCpuUsage(data.CpuUsage);
         this.serverCpuUsage(data.ProcessCpuUsage);
         this.dedicatedThreadsCount(data.DedicatedThreadsCount);

--- a/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedThreadsRuntime.html
+++ b/src/Raven.Studio/wwwroot/App/views/manage/debugAdvancedThreadsRuntime.html
@@ -15,6 +15,14 @@
                 <div>
                     <input class="form-control" placeholder="Filter (Name, Thread Id)" data-bind="textInput: filter" />
                 </div>
+                <div>
+                    <div class="toggle">
+                        <input id="io-totals-since-creation" class="styled" type="checkbox" data-bind="checked: showTotalsSinceThreadCreation">
+                        <label for="io-totals-since-creation" class="properties-label" title="When enabled, IO totals show cumulative values since thread creation. When disabled, totals are relative to when monitoring started.">
+                            IO totals since thread creation
+                        </label>
+                    </div>
+                </div>
                 <div class="btn-group">
                     <select
                         id="visibleColumnsSelector"


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25378

### Additional description

This PR moves the Total IOPS and Total Throughput aggregation from the server-side to the client-side for the Threads Runtime debug view.

**Server-side changes:**
- Removed the computed `IoSyscallsTotal`, `ThroughputKbTotal`, and split total fields from `IoStats` and `Stats`.
- Added raw cumulative fields (`Syscr`, `Syscw`, `ReadBytes`, `WriteBytes`) sourced directly from `/proc/self/task/{tid}/io` to `IoStats` and `Stats`.
- `ThreadIoStatsReader` and `ThreadsUsage` now populate these raw counters instead of computing derived totals.

**Client-side changes (`debugAdvancedThreadsRuntime.ts`):**
- On WebSocket connect, an initial snapshot of raw counters is captured per thread (`initialSnapshots` map).
- On every data update, totals are computed as `current - initial` (snapshot-based subtraction), giving accurate totals relative to when monitoring started.
- This avoids accumulation drift caused by rate-based summation on the server.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.
  - Linux only (relies on `/proc/self/task/{tid}/io`)
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
