### PR TITLE
RavenDB-26328 Expanding one of the agent tools cause Unsaved changes

### DIFF
--- a/src/Raven.Studio/typescript/components/common/Form.tsx
+++ b/src/Raven.Studio/typescript/components/common/Form.tsx
@@ -1007,3 +1007,29 @@ export function useErrorMessage<TFieldValues extends FieldValues>({
         message: error?.message,
     };
 }
+
+export function hasRelevantDirtyFields(dirtyFields: unknown, ignoredFieldNames: string[]): boolean {
+    if (!dirtyFields) {
+        return false;
+    }
+
+    if (dirtyFields === true) {
+        return true;
+    }
+
+    if (Array.isArray(dirtyFields)) {
+        return dirtyFields.some((field) => hasRelevantDirtyFields(field, ignoredFieldNames));
+    }
+
+    if (typeof dirtyFields === "object") {
+        return Object.entries(dirtyFields).some(([key, value]) => {
+            if (ignoredFieldNames.includes(key)) {
+                return false;
+            }
+
+            return hasRelevantDirtyFields(value, ignoredFieldNames);
+        });
+    }
+
+    return false;
+}

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/edit/hooks/useEditAiAgent.ts
@@ -18,6 +18,7 @@ import {
     testAiAgentYupResolver,
 } from "../utils/editAiAgentValidation";
 import router from "plugins/router";
+import { hasRelevantDirtyFields } from "components/common/Form";
 
 interface QueryParams {
     id: string;
@@ -92,7 +93,8 @@ export default function useEditAiAgent(queryParams: QueryParams) {
         );
     };
 
-    const { setIsDirty } = useDirtyFlag(editForm.formState.isDirty);
+    const hasRelevantDirty = hasRelevantDirtyFields(editForm.formState.dirtyFields, ["isEditing"]);
+    const { setIsDirty } = useDirtyFlag(hasRelevantDirty);
 
     const reloadEditForm = async () => {
         const result = await asyncGetEditDefaultValues.execute();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26328/Expanding-one-of-the-agent-tools-cause-Unsaved-changes

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
