### PR TITLE
RavenDB-26373 Isolate topology updates from ambient trace context

### DIFF
--- a/src/Raven.Client/Http/ClusterRequestExecutor.cs
+++ b/src/Raven.Client/Http/ClusterRequestExecutor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -119,6 +120,11 @@ namespace Raven.Client.Http
 
             if (Disposed)
                 return false;
+
+#if NETCOREAPP3_1_OR_GREATER
+            Activity.Current = null;
+#endif
+
             var lockTaken = await _clusterTopologySemaphore.WaitAsync(parameters.TimeoutInMs).ConfigureAwait(false);
             if (lockTaken == false)
                 return false;

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -501,7 +501,9 @@ namespace Raven.Client.Http
             // maintenance operations and should not appear as child spans of unrelated user traces.
             // Setting Activity.Current = null here is safe: AsyncLocal semantics ensure the caller's
             // Activity is unaffected once this method returns from its await.
+#if NETCOREAPP3_1_OR_GREATER
             Activity.Current = null;
+#endif
 
             //prevent double topology updates if execution takes too much time
             // --> in cases with transient issues

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -497,6 +497,12 @@ namespace Raven.Client.Http
             if (Disposed)
                 return false;
 
+            // Isolate topology updates from any ambient trace — topology updates are background
+            // maintenance operations and should not appear as child spans of unrelated user traces.
+            // Setting Activity.Current = null here is safe: AsyncLocal semantics ensure the caller's
+            // Activity is unaffected once this method returns from its await.
+            Activity.Current = null;
+
             //prevent double topology updates if execution takes too much time
             // --> in cases with transient issues
             var lockTaken = await _updateDatabaseTopologySemaphore.WaitAsync(parameters.TimeoutInMs).ConfigureAwait(false);

--- a/test/FastTests/Client/RequestExecutorTests.cs
+++ b/test/FastTests/Client/RequestExecutorTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -6,6 +8,7 @@ using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Commands;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
 using Raven.Tests.Core.Utils.Entities;
 using Sparrow.Json;
 using Tests.Infrastructure;
@@ -17,6 +20,54 @@ namespace FastTests.Client
     {
         public RequestExecutorTests(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task UpdateTopologyAsync_ClearsAmbientActivity_BeforeTopologyHttpRequest()
+        {
+            using var store = GetDocumentStore();
+            var requestExecutor = store.GetRequestExecutor();
+
+            // Warm up — ensure topology is already populated so TopologyNodes is non-null.
+            using (var session = store.OpenAsyncSession())
+                _ = await session.LoadAsync<object>("warmup/1");
+
+            // Simulate being inside an active user request trace.
+            var parentActivity = new Activity("UserRequest").Start();
+            Activity capturedDuringTopology = null;
+            var topologyRequestObserved = false;
+
+            requestExecutor.OnBeforeRequest += (_, args) =>
+            {
+                if (args.Url.Contains("/topology"))
+                {
+                    topologyRequestObserved = true;
+                    capturedDuringTopology = Activity.Current;
+                }
+            };
+
+            try
+            {
+                var node = requestExecutor.TopologyNodes.First();
+                await requestExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(node)
+                {
+                    TimeoutInMs = 15_000,
+                    DebugTag = "test-trace-isolation",
+                    ForceUpdate = true
+                });
+
+                // After the await, the caller's Activity.Current must be unaffected.
+                // Activity.Current is AsyncLocal<Activity>; mutations inside the async callee
+                // do not propagate back to the caller's execution context.
+                Assert.Same(parentActivity, Activity.Current);
+            }
+            finally
+            {
+                parentActivity.Stop();
+            }
+
+            Assert.True(topologyRequestObserved, "OnBeforeRequest should have fired for the /topology endpoint");
+            Assert.Null(capturedDuringTopology);
         }
 
         [LicenseRequiredTheory]

--- a/test/FastTests/Client/RequestExecutorTests.cs
+++ b/test/FastTests/Client/RequestExecutorTests.cs
@@ -23,6 +23,54 @@ namespace FastTests.Client
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task ClusterUpdateTopologyAsync_ClearsAmbientActivity_BeforeTopologyHttpRequest()
+        {
+            using var store = GetDocumentStore();
+
+            using var clusterExecutor = ClusterRequestExecutor.Create(store.Urls, store.Certificate, store.Conventions);
+
+            // Warm up — ensure cluster topology is populated by executing a command.
+            using (clusterExecutor.ContextPool.AllocateOperationContext(out var ctx))
+            {
+                var cmd = new Raven.Client.ServerWide.Commands.GetClusterTopologyCommand();
+                await clusterExecutor.ExecuteAsync(cmd, ctx);
+            }
+
+            var parentActivity = new Activity("UserRequest").Start();
+            Activity capturedDuringTopology = null;
+            var topologyRequestObserved = false;
+
+            clusterExecutor.OnBeforeRequest += (_, args) =>
+            {
+                if (args.Url.Contains("/cluster/topology"))
+                {
+                    topologyRequestObserved = true;
+                    capturedDuringTopology = Activity.Current;
+                }
+            };
+
+            try
+            {
+                var node = clusterExecutor.TopologyNodes.First();
+                await clusterExecutor.UpdateTopologyAsync(new RequestExecutor.UpdateTopologyParameters(node)
+                {
+                    TimeoutInMs = 15_000,
+                    DebugTag = "test-cluster-trace-isolation",
+                    ForceUpdate = true
+                });
+
+                Assert.Same(parentActivity, Activity.Current);
+            }
+            finally
+            {
+                parentActivity.Stop();
+            }
+
+            Assert.True(topologyRequestObserved, "OnBeforeRequest should have fired for the /cluster/topology endpoint");
+            Assert.Null(capturedDuringTopology);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
         public async Task UpdateTopologyAsync_ClearsAmbientActivity_BeforeTopologyHttpRequest()
         {
             using var store = GetDocumentStore();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26373

### Additional description

Based on #22608. Extends the trace isolation fix to `ClusterRequestExecutor.UpdateTopologyAsync` (which has the same issue) and fixes the netstandard2.0/2.1 build — `Activity.Current` setter is unavailable there, so both call sites need `#if NETCOREAPP3_1_OR_GREATER` guards.

Adds `InternalsVisibleTo` for FastTests on `Raven.Client` so we can directly test `ClusterRequestExecutor`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed