### PR TITLE
RavenDB-15162 Prevent SaveChanges after DocumentStore disposal

### DIFF
--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -150,6 +150,7 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public async Task SaveChangesAsync(CancellationToken token = default(CancellationToken))
         {
+            AssertNotDisposed();
             using (AsyncTaskHolder())
             {
                 if (_asyncDocumentIdGeneration != null)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -150,8 +150,7 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public async Task SaveChangesAsync(CancellationToken token = default(CancellationToken))
         {
-            if (DisableDisposeChecks == false)
-                AssertNotDisposed();
+            AssertNotDisposed();
             using (AsyncTaskHolder())
             {
                 if (_asyncDocumentIdGeneration != null)

--- a/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentSession.cs
@@ -150,7 +150,8 @@ namespace Raven.Client.Documents.Session
         /// <returns></returns>
         public async Task SaveChangesAsync(CancellationToken token = default(CancellationToken))
         {
-            AssertNotDisposed();
+            if (DisableDisposeChecks == false)
+                AssertNotDisposed();
             using (AsyncTaskHolder())
             {
                 if (_asyncDocumentIdGeneration != null)

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,6 +86,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public void SaveChanges()
         {
+            AssertNotDisposed();
             var saveChangesOperation = new BatchOperation(this);
 
             using (var command = saveChangesOperation.CreateRequest())

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,7 +86,8 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public void SaveChanges()
         {
-            AssertNotDisposed();
+            if (DisableDisposeChecks == false)
+                AssertNotDisposed();
             var saveChangesOperation = new BatchOperation(this);
 
             using (var command = saveChangesOperation.CreateRequest())

--- a/src/Raven.Client/Documents/Session/DocumentSession.cs
+++ b/src/Raven.Client/Documents/Session/DocumentSession.cs
@@ -86,8 +86,7 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         public void SaveChanges()
         {
-            if (DisableDisposeChecks == false)
-                AssertNotDisposed();
+            AssertNotDisposed();
             var saveChangesOperation = new BatchOperation(this);
 
             using (var command = saveChangesOperation.CreateRequest())

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -1435,6 +1435,9 @@ more responsive application.
         {
             if (_isDisposed)
                 throw new ObjectDisposedException("session");
+
+            if (_documentStore.WasDisposed)
+                throw new ObjectDisposedException("store", "The document store has already been disposed and cannot be used");
         }
 
         private void Dispose(bool isDisposing)

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -40,6 +40,8 @@ namespace Raven.Client.Documents.Session
     /// </summary>
     public abstract partial class InMemoryDocumentSessionOperations : IDisposable
     {
+        internal static readonly bool DisableDisposeChecks = string.Equals(Environment.GetEnvironmentVariable("RAVEN_DISABLE_DISPOSE_CHECKS"), "true", StringComparison.OrdinalIgnoreCase);
+
         internal long _asyncTasksCounter;
         internal int _maxDocsCountOnCachedRenewSession = 16 * 1024;
         protected readonly RequestExecutor _requestExecutor;
@@ -1436,7 +1438,7 @@ more responsive application.
             if (_isDisposed)
                 throw new ObjectDisposedException("session");
 
-            if (_documentStore.WasDisposed)
+            if (DisableDisposeChecks == false && _documentStore.WasDisposed)
                 throw new ObjectDisposedException("store", "The document store has already been disposed and cannot be used");
         }
 

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -600,6 +600,9 @@ namespace Raven.Client.Http
             SessionInfo sessionInfo = null,
             CancellationToken token = default)
         {
+            if (Disposed)
+                ThrowObjectDisposedException();
+
             var topologyUpdate = _firstTopologyUpdate;
 
             if (topologyUpdate != null && topologyUpdate.Status == TaskStatus.RanToCompletion)
@@ -2057,6 +2060,11 @@ namespace Raven.Client.Http
         internal bool Disposed => _disposeOnceRunner.Disposed;
 
         public static bool HasServerCertificateCustomValidationCallback => _serverCertificateCustomValidationCallback?.Length > 0;
+
+        private static void ThrowObjectDisposedException()
+        {
+            throw new ObjectDisposedException(nameof(RequestExecutor), "The request executor has already been disposed and cannot be used");
+        }
 
         public virtual void Dispose()
         {

--- a/src/Raven.Client/Http/RequestExecutor.cs
+++ b/src/Raven.Client/Http/RequestExecutor.cs
@@ -600,7 +600,7 @@ namespace Raven.Client.Http
             SessionInfo sessionInfo = null,
             CancellationToken token = default)
         {
-            if (Disposed)
+            if (InMemoryDocumentSessionOperations.DisableDisposeChecks == false && Disposed)
                 ThrowObjectDisposedException();
 
             var topologyUpdate = _firstTopologyUpdate;

--- a/test/FastTests/Client/HiLo.cs
+++ b/test/FastTests/Client/HiLo.cs
@@ -529,6 +529,51 @@ namespace FastTests.Client
             }
         }
 
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public void SaveChanges_After_Store_Dispose_Should_Throw()
+        {
+            var name = GetDatabaseName();
+            var store = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseName = _ => name,
+                DeleteDatabaseOnDispose = false,
+                ModifyDocumentStore = s => s.Conventions = new Raven.Client.Documents.Conventions.DocumentConventions { UseOptimisticConcurrency = true }
+            });
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User());
+                session.SaveChanges();
+            }
+
+            // open a session before dispose
+            using (var session = store.OpenSession())
+            {
+                session.Store(new User());
+
+                store.Dispose();
+
+                session.Store(new User());
+                Assert.Throws<ObjectDisposedException>(() => session.SaveChanges());
+            }
+
+            // verify that reopening the store and saving doesn't cause a concurrency conflict from a corrupted HiLo
+            using (var store2 = GetDocumentStore(new Options
+            {
+                RunInMemory = false,
+                ModifyDatabaseName = _ => name,
+                ModifyDocumentStore = s => s.Conventions = new Raven.Client.Documents.Conventions.DocumentConventions { UseOptimisticConcurrency = true }
+            }))
+            {
+                using (var session = store2.OpenSession())
+                {
+                    session.Store(new User());
+                    session.SaveChanges();
+                }
+            }
+        }
+
         private static async Task<long> GetNextIdAsync(AsyncHiLoIdGenerator idGenerator)
         {
             var nextId = await idGenerator.GetNextIdAsync();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-15162

### Additional description

A session opened before `DocumentStore.Dispose()` could still execute `SaveChanges` during or after disposal, racing with the HiLo key return and corrupting the HiLo range. A second store opening the same database would then get conflicting IDs due to optimistic concurrency.

`SaveChanges`/`SaveChangesAsync` now call `AssertNotDisposed()` which checks both the session and the store's `WasDisposed` flag. `RequestExecutor.ExecuteAsync` also checks its own `Disposed` state as a second line of defense.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed