### PR TITLE
RavenDB-21909 Informative error for non-RavenDB URL in DocumentStore

### DIFF
--- a/src/Raven.Client/ServerWide/Commands/GetClusterTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetClusterTopologyCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Sparrow.Json;
@@ -36,6 +37,18 @@ namespace Raven.Client.ServerWide.Commands
                 return;
 
             Result = JsonDeserializationClient.ClusterTopology(response);
+        }
+
+        public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
+        {
+            var result = await TopologyCommandHelper.ParseTopologyResponseAsync(context, response, url, "cluster/topology").ConfigureAwait(false);
+
+            SetResponse(context, result, fromCache: false);
+
+            if (Result?.Topology == null)
+                TopologyCommandHelper.ThrowUnexpectedTopologyResponse(url, result);
+
+            return ResponseDisposeHandling.Automatic;
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Client/ServerWide/Commands/GetClusterTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetClusterTopologyCommand.cs
@@ -43,6 +43,9 @@ namespace Raven.Client.ServerWide.Commands
         {
             var result = await TopologyCommandHelper.ParseTopologyResponseAsync(context, response, url, "cluster/topology").ConfigureAwait(false);
 
+            if (cache != null && CanCache)
+                CacheResponse(cache, url, response, result);
+
             SetResponse(context, result, fromCache: false);
 
             if (Result?.Topology == null)

--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Raven.Client.Http;
 using Raven.Client.Json.Serialization;
 using Sparrow.Json;
@@ -69,6 +70,18 @@ namespace Raven.Client.ServerWide.Commands
                 return;
 
             Result = JsonDeserializationClient.Topology(response);
+        }
+
+        public override async Task<ResponseDisposeHandling> ProcessResponse(JsonOperationContext context, HttpCache cache, HttpResponseMessage response, string url)
+        {
+            var result = await TopologyCommandHelper.ParseTopologyResponseAsync(context, response, url, "database/topology").ConfigureAwait(false);
+
+            SetResponse(context, result, fromCache: false);
+
+            if (Result?.Nodes == null)
+                TopologyCommandHelper.ThrowUnexpectedTopologyResponse(url, result);
+
+            return ResponseDisposeHandling.Automatic;
         }
 
         public override bool IsReadRequest => true;

--- a/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
+++ b/src/Raven.Client/ServerWide/Commands/GetDatabaseTopologyCommand.cs
@@ -76,6 +76,9 @@ namespace Raven.Client.ServerWide.Commands
         {
             var result = await TopologyCommandHelper.ParseTopologyResponseAsync(context, response, url, "database/topology").ConfigureAwait(false);
 
+            if (cache != null && CanCache)
+                CacheResponse(cache, url, response, result);
+
             SetResponse(context, result, fromCache: false);
 
             if (Result?.Nodes == null)

--- a/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
+++ b/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
@@ -36,8 +36,6 @@ namespace Raven.Client.ServerWide.Commands
                     catch (Exception e)
                     {
                         string body = GetLastReadBytes(buffer);
-                        if (body.Length == 0)
-                            body = await FetchResponseBodyForError(url).ConfigureAwait(false);
 
                         throw new InvalidOperationException(
                             $"Failed to parse the topology response from '{url}'. " +
@@ -62,25 +60,5 @@ namespace Raven.Client.ServerWide.Commands
             return Encoding.UTF8.GetString(buffer.Address, buffer.Valid);
         }
 
-        private static async Task<string> FetchResponseBodyForError(string url)
-        {
-            try
-            {
-                using var client = new HttpClient();
-                var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
-#if NETSTANDARD2_0
-                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#else
-                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-#endif
-                var buf = new byte[4096];
-                var read = await responseStream.ReadAsync(buf, 0, buf.Length).ConfigureAwait(false);
-                return Encoding.UTF8.GetString(buf, 0, read);
-            }
-            catch
-            {
-                return "(could not read response body)";
-            }
-        }
     }
 }

--- a/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
+++ b/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -16,9 +15,6 @@ namespace Raven.Client.ServerWide.Commands
         public static async Task<BlittableJsonReaderObject> ParseTopologyResponseAsync(
             JsonOperationContext context, HttpResponseMessage response, string url, string debugTag)
         {
-            if (response.StatusCode == HttpStatusCode.NoContent)
-                return null;
-
 #if NETSTANDARD2_0
             using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
 #else

--- a/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
+++ b/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.ServerWide.Commands
+{
+    internal static class TopologyCommandHelper
+    {
+        private const int MaxTopologyResponseSize = 1024 * 1024; // 1 MB is crazy high limit for topology response
+
+        public static async Task<BlittableJsonReaderObject> ParseTopologyResponseAsync(
+            JsonOperationContext context, HttpResponseMessage response, string url, string debugTag)
+        {
+            if (response.StatusCode == HttpStatusCode.NoContent)
+                return null;
+
+#if NETSTANDARD2_0
+            using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
+#else
+            await using (var responseStream = await response.Content.ReadAsStreamWithZstdSupportAsync().ConfigureAwait(false))
+#endif
+            await using (var stream = new StreamWithTimeout(responseStream))
+            {
+                using (context.GetMemoryBuffer(out var buffer))
+                {
+                    try
+                    {
+                        return await context.ParseToMemoryAsync(stream, debugTag,
+                            BlittableJsonDocumentBuilder.UsageMode.None, buffer, maxSize: MaxTopologyResponseSize).ConfigureAwait(false);
+                    }
+                    catch (Exception e)
+                    {
+                        string body = GetLastReadBytes(buffer);
+                        if (body.Length == 0)
+                            body = await FetchResponseBodyForError(url).ConfigureAwait(false);
+
+                        throw new InvalidOperationException(
+                            $"Failed to parse the topology response from '{url}'. " +
+                            $"This may indicate that the URL does not point to a RavenDB server. Response: {body}", e);
+                    }
+                }
+            }
+        }
+
+        public static void ThrowUnexpectedTopologyResponse(string url, BlittableJsonReaderObject json)
+        {
+            throw new InvalidOperationException(
+                $"Received an unexpected topology response from '{url}'. " +
+                $"This may indicate that the URL does not point to a RavenDB server. Response: {json}");
+        }
+
+        private static unsafe string GetLastReadBytes(JsonOperationContext.MemoryBuffer buffer)
+        {
+            if (buffer.Valid == 0)
+                return string.Empty;
+
+            return Encoding.UTF8.GetString(buffer.Address, buffer.Valid);
+        }
+
+        private static async Task<string> FetchResponseBodyForError(string url)
+        {
+            try
+            {
+                using var client = new HttpClient();
+                var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+#if NETSTANDARD2_0
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+                var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+                var buf = new byte[4096];
+                var read = await responseStream.ReadAsync(buf, 0, buf.Length).ConfigureAwait(false);
+                return Encoding.UTF8.GetString(buf, 0, read);
+            }
+            catch
+            {
+                return "(could not read response body)";
+            }
+        }
+    }
+}

--- a/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
+++ b/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
@@ -48,12 +48,18 @@ namespace Raven.Client.ServerWide.Commands
                 $"This may indicate that the URL does not point to a RavenDB server. Response: {json}");
         }
 
+        private const int MaxErrorBodySize = 4096;
+
         private static unsafe string GetLastReadBytes(JsonOperationContext.MemoryBuffer buffer)
         {
             if (buffer.Valid == 0)
                 return string.Empty;
 
-            return Encoding.UTF8.GetString(buffer.Address, buffer.Valid);
+            int size = Math.Min(buffer.Valid, MaxErrorBodySize);
+            var text = Encoding.UTF8.GetString(buffer.Address, size);
+            if (buffer.Valid > MaxErrorBodySize)
+                text += "... (truncated)";
+            return text;
         }
 
     }

--- a/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
+++ b/src/Raven.Client/ServerWide/Commands/TopologyCommandHelper.cs
@@ -1,9 +1,12 @@
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Raven.Client.Http;
 using Raven.Client.Util;
+using Sparrow;
+using Sparrow.Exceptions;
 using Sparrow.Json;
 
 namespace Raven.Client.ServerWide.Commands
@@ -29,7 +32,13 @@ namespace Raven.Client.ServerWide.Commands
                         return await context.ParseToMemoryAsync(stream, debugTag,
                             BlittableJsonDocumentBuilder.UsageMode.None, buffer, maxSize: MaxTopologyResponseSize).ConfigureAwait(false);
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (e.InnerException is null && // only catch exceptions that are directly thrown by the parsing code
+                                              e is InvalidDataException   // and only those that are raised directly by the parsing code, not by the HTTP layer or other code
+                                                or InvalidStartOfObjectException 
+                                                or FormatException 
+                                                or EndOfStreamException 
+                                                or ArgumentException 
+                                                or InvalidOperationException)
                     {
                         string body = GetLastReadBytes(buffer);
 
@@ -48,16 +57,14 @@ namespace Raven.Client.ServerWide.Commands
                 $"This may indicate that the URL does not point to a RavenDB server. Response: {json}");
         }
 
-        private const int MaxErrorBodySize = 4096;
-
         private static unsafe string GetLastReadBytes(JsonOperationContext.MemoryBuffer buffer)
         {
             if (buffer.Valid == 0)
                 return string.Empty;
 
-            int size = Math.Min(buffer.Valid, MaxErrorBodySize);
+            int size = Math.Min(buffer.Valid, PeepingTomStream.BufferWindowSize);
             var text = Encoding.UTF8.GetString(buffer.Address, size);
-            if (buffer.Valid > MaxErrorBodySize)
+            if (buffer.Valid > PeepingTomStream.BufferWindowSize)
                 text += "... (truncated)";
             return text;
         }

--- a/test/SlowTests/Issues/RavenDB_21909.cs
+++ b/test/SlowTests/Issues/RavenDB_21909.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
             listener.Prefixes.Add(prefix);
             listener.Start();
 
-            _ = Task.Run(async () =>
+            var listenerTask = Task.Run(async () =>
             {
                 while (listener.IsListening)
                 {
@@ -40,6 +40,10 @@ namespace SlowTests.Issues
                         ctx.Response.Close();
                     }
                     catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (HttpListenerException)
                     {
                         break;
                     }
@@ -66,6 +70,7 @@ namespace SlowTests.Issues
             }
 
             listener.Stop();
+            await listenerTask;
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
@@ -77,7 +82,7 @@ namespace SlowTests.Issues
             listener.Prefixes.Add(prefix);
             listener.Start();
 
-            _ = Task.Run(async () =>
+            var listenerTask = Task.Run(async () =>
             {
                 while (listener.IsListening)
                 {
@@ -91,6 +96,10 @@ namespace SlowTests.Issues
                         ctx.Response.Close();
                     }
                     catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (HttpListenerException)
                     {
                         break;
                     }
@@ -117,6 +126,7 @@ namespace SlowTests.Issues
             }
 
             listener.Stop();
+            await listenerTask;
         }
 
         private static int GetAvailablePort()

--- a/test/SlowTests/Issues/RavenDB_21909.cs
+++ b/test/SlowTests/Issues/RavenDB_21909.cs
@@ -26,7 +26,7 @@ namespace SlowTests.Issues
             listener.Prefixes.Add(prefix);
             listener.Start();
 
-            var listenerTask = Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 while (listener.IsListening)
                 {
@@ -77,7 +77,7 @@ namespace SlowTests.Issues
             listener.Prefixes.Add(prefix);
             listener.Start();
 
-            var listenerTask = Task.Run(async () =>
+            _ = Task.Run(async () =>
             {
                 while (listener.IsListening)
                 {

--- a/test/SlowTests/Issues/RavenDB_21909.cs
+++ b/test/SlowTests/Issues/RavenDB_21909.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.ServerWide.Operations;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_21909 : RavenTestBase
+    {
+        public RavenDB_21909(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task Should_Throw_Informative_Error_When_Using_Non_RavenDB_Url()
+        {
+            using var listener = new HttpListener();
+            var port = GetAvailablePort();
+            var prefix = $"http://127.0.0.1:{port}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+
+            var listenerTask = Task.Run(async () =>
+            {
+                while (listener.IsListening)
+                {
+                    try
+                    {
+                        var ctx = await listener.GetContextAsync();
+                        var response = Encoding.UTF8.GetBytes("<html><body>Cats are cute</body></html>");
+                        ctx.Response.ContentType = "text/html";
+                        ctx.Response.ContentLength64 = response.Length;
+                        await ctx.Response.OutputStream.WriteAsync(response, 0, response.Length);
+                        ctx.Response.Close();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                }
+            });
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { prefix.TrimEnd('/') },
+                Database = "test"
+            })
+            {
+                store.Initialize();
+
+                var e = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                {
+                    await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                });
+
+                // Should not be NullReferenceException
+                Assert.DoesNotContain("NullReferenceException", e.ToString());
+                // Should mention that the URL may not point to a RavenDB server
+                Assert.Contains("Cats are cute", e.ToString());
+            }
+
+            listener.Stop();
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task Should_Throw_Informative_Error_When_Server_Returns_Unrelated_Json()
+        {
+            using var listener = new HttpListener();
+            var port = GetAvailablePort();
+            var prefix = $"http://127.0.0.1:{port}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+
+            var listenerTask = Task.Run(async () =>
+            {
+                while (listener.IsListening)
+                {
+                    try
+                    {
+                        var ctx = await listener.GetContextAsync();
+                        var response = Encoding.UTF8.GetBytes("{\"status\":\"ok\",\"service\":\"some-other-api\",\"version\":\"2.0\"}");
+                        ctx.Response.ContentType = "application/json";
+                        ctx.Response.ContentLength64 = response.Length;
+                        await ctx.Response.OutputStream.WriteAsync(response, 0, response.Length);
+                        ctx.Response.Close();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                }
+            });
+
+            using (var store = new DocumentStore
+            {
+                Urls = new[] { prefix.TrimEnd('/') },
+                Database = "test"
+            })
+            {
+                store.Initialize();
+
+                var e = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                {
+                    await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                });
+
+                // Should not be NullReferenceException
+                Assert.DoesNotContain("NullReferenceException", e.ToString());
+                // Should contain the JSON response body from the server
+                Assert.Contains("some-other-api", e.ToString());
+            }
+
+            listener.Stop();
+        }
+
+        private static int GetAvailablePort()
+        {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_21909.cs
+++ b/test/SlowTests/Issues/RavenDB_21909.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using FastTests;
@@ -20,39 +22,11 @@ namespace SlowTests.Issues
         [RavenFact(RavenTestCategory.ClientApi)]
         public async Task Should_Throw_Informative_Error_When_Using_Non_RavenDB_Url()
         {
-            using var listener = new HttpListener();
-            var port = GetAvailablePort();
-            var prefix = $"http://127.0.0.1:{port}/";
-            listener.Prefixes.Add(prefix);
-            listener.Start();
-
-            var listenerTask = Task.Run(async () =>
-            {
-                while (listener.IsListening)
-                {
-                    try
-                    {
-                        var ctx = await listener.GetContextAsync();
-                        var response = Encoding.UTF8.GetBytes("<html><body>Cats are cute</body></html>");
-                        ctx.Response.ContentType = "text/html";
-                        ctx.Response.ContentLength64 = response.Length;
-                        await ctx.Response.OutputStream.WriteAsync(response, 0, response.Length);
-                        ctx.Response.Close();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        break;
-                    }
-                    catch (HttpListenerException)
-                    {
-                        break;
-                    }
-                }
-            });
+            await using var server = new FakeHttpServer("<html><body>Cats are cute</body></html>", "text/html");
 
             using (var store = new DocumentStore
             {
-                Urls = new[] { prefix.TrimEnd('/') },
+                Urls = new[] { server.Url },
                 Database = "test"
             })
             {
@@ -63,52 +37,21 @@ namespace SlowTests.Issues
                     await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 });
 
-                // Should not be NullReferenceException
                 Assert.DoesNotContain("NullReferenceException", e.ToString());
-                // Should mention that the URL may not point to a RavenDB server
+                // Should include the actual response body and indicate it's not a RavenDB server
+                Assert.Contains("does not point to a RavenDB server", e.ToString());
                 Assert.Contains("Cats are cute", e.ToString());
             }
-
-            listener.Stop();
-            await listenerTask;
         }
 
         [RavenFact(RavenTestCategory.ClientApi)]
         public async Task Should_Throw_Informative_Error_When_Server_Returns_Unrelated_Json()
         {
-            using var listener = new HttpListener();
-            var port = GetAvailablePort();
-            var prefix = $"http://127.0.0.1:{port}/";
-            listener.Prefixes.Add(prefix);
-            listener.Start();
-
-            var listenerTask = Task.Run(async () =>
-            {
-                while (listener.IsListening)
-                {
-                    try
-                    {
-                        var ctx = await listener.GetContextAsync();
-                        var response = Encoding.UTF8.GetBytes("{\"status\":\"ok\",\"service\":\"some-other-api\",\"version\":\"2.0\"}");
-                        ctx.Response.ContentType = "application/json";
-                        ctx.Response.ContentLength64 = response.Length;
-                        await ctx.Response.OutputStream.WriteAsync(response, 0, response.Length);
-                        ctx.Response.Close();
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        break;
-                    }
-                    catch (HttpListenerException)
-                    {
-                        break;
-                    }
-                }
-            });
+            await using var server = new FakeHttpServer("{\"status\":\"ok\",\"service\":\"some-other-api\",\"version\":\"2.0\"}", "application/json");
 
             using (var store = new DocumentStore
             {
-                Urls = new[] { prefix.TrimEnd('/') },
+                Urls = new[] { server.Url },
                 Database = "test"
             })
             {
@@ -119,23 +62,77 @@ namespace SlowTests.Issues
                     await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
                 });
 
-                // Should not be NullReferenceException
                 Assert.DoesNotContain("NullReferenceException", e.ToString());
-                // Should contain the JSON response body from the server
+                // Should include the actual response body and indicate it's not a RavenDB server
+                Assert.Contains("does not point to a RavenDB server", e.ToString());
                 Assert.Contains("some-other-api", e.ToString());
             }
-
-            listener.Stop();
-            await listenerTask;
         }
 
-        private static int GetAvailablePort()
+        private sealed class FakeHttpServer : IAsyncDisposable
         {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            private readonly TcpListener _listener;
+            private readonly Task _acceptLoop;
+            private readonly string _body;
+            private readonly string _contentType;
+            private volatile bool _stopped;
+
+            public string Url { get; }
+
+            public FakeHttpServer(string body, string contentType)
+            {
+                _body = body;
+                _contentType = contentType;
+                _listener = new TcpListener(IPAddress.Loopback, 0);
+                _listener.Start();
+                var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+                Url = $"http://127.0.0.1:{port}";
+                _acceptLoop = Task.Run(AcceptLoopAsync);
+            }
+
+            private async Task AcceptLoopAsync()
+            {
+                while (_stopped == false)
+                {
+                    TcpClient client;
+                    try
+                    {
+                        client = await _listener.AcceptTcpClientAsync();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (SocketException)
+                    {
+                        break;
+                    }
+
+                    using (client)
+                    await using (var stream = client.GetStream())
+                    using (var reader = new StreamReader(stream, Encoding.ASCII, false, 1024, leaveOpen: true))
+                    {
+                        // read until empty line (end of HTTP headers)
+                        string line;
+                        while ((line = await reader.ReadLineAsync()) != null && line.Length > 0)
+                        {
+                        }
+
+                        var bodyBytes = Encoding.UTF8.GetBytes(_body);
+                        var responseHeader = $"HTTP/1.1 200 OK\r\nContent-Type: {_contentType}\r\nContent-Length: {bodyBytes.Length}\r\nConnection: close\r\n\r\n";
+                        var headerBytes = Encoding.ASCII.GetBytes(responseHeader);
+                        await stream.WriteAsync(headerBytes, 0, headerBytes.Length);
+                        await stream.WriteAsync(bodyBytes, 0, bodyBytes.Length);
+                    }
+                }
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                _stopped = true;
+                _listener.Stop();
+                await _acceptLoop;
+            }
         }
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-21909

### Additional description

When a non-RavenDB URL (e.g. google.com) is used in the DocumentStore, the topology fetch fails with a NullReferenceException because the response can't be parsed as a valid topology.

Now both topology commands override `ProcessResponse` to detect non-JSON or unexpected JSON responses. On parse failure a fragment of the actual response is included in the error message. Response size is capped at 1MB via `ParseToMemoryAsync` maxSize to prevent unbounded reads.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed