### PR TITLE
RavenDB-22191 Add implicit bool conversion to DynamicNullObject

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/DynamicNullObject.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicNullObject.cs
@@ -43,6 +43,14 @@ namespace Raven.Server.Documents.Indexes.Static
                 case ExpressionType.NotEqual:
                     result = arg != null && arg is DynamicNullObject == false;
                     break;
+                case ExpressionType.Or:
+                    result = arg switch
+                    {
+                        DynamicNullObject => false,
+                        bool b => b,
+                        _ => true
+                    };
+                    break;
                 default:
                     result = Null;
                     break;
@@ -131,11 +139,17 @@ namespace Raven.Server.Documents.Indexes.Static
 
         public static dynamic operator &(DynamicNullObject left, object right)
         {
+            if (right is bool or DynamicNullObject)
+                return false;
             return left;
         }
 
         public static dynamic operator |(DynamicNullObject left, object right)
         {
+            if (right is bool b)
+                return b;
+            if (right is DynamicNullObject)
+                return false;
             return left;
         }
 

--- a/src/Raven.Server/Documents/Indexes/Static/DynamicNullObject.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/DynamicNullObject.cs
@@ -261,6 +261,11 @@ namespace Raven.Server.Documents.Indexes.Static
             return null;
         }
 
+        public static implicit operator bool(DynamicNullObject o)
+        {
+            return false;
+        }
+
         public override bool Equals(object obj)
         {
             return obj == null || obj is DynamicNullObject;

--- a/test/SlowTests/Issues/RavenDB_22191.cs
+++ b/test/SlowTests/Issues/RavenDB_22191.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_22191 : RavenTestBase
+    {
+        public RavenDB_22191(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Company { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void BooleanOperatorsWithDynamicNullObjectShouldWork()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "Users/ByIsActive",
+                    Maps =
+                    {
+                        @"from doc in docs.Users
+                          let loadedActive = (LoadDocument(doc.Company, ""Companies"")).IsActive
+                          select new {
+                              IsActive1 = loadedActive && true,
+                              IsActive2 = loadedActive && false,
+                              IsActive3 = loadedActive || true,
+                              IsActive4 = loadedActive || false,
+                              IsActive5 = false || loadedActive,
+                              IsActive6 = true && loadedActive
+                          }"
+                    }
+                }));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new User(), "users/1-A");
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Users/ByIsActive" }));
+                Assert.Empty(errors[0].Errors);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_22191.cs
+++ b/test/SlowTests/Issues/RavenDB_22191.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
@@ -20,14 +19,31 @@ namespace SlowTests.Issues
             public string Company { get; set; }
         }
 
+        private class Result
+        {
+            public bool IsActive1 { get; set; }
+            public bool IsActive2 { get; set; }
+            public bool IsActive3 { get; set; }
+            public bool IsActive4 { get; set; }
+            public bool IsActive5 { get; set; }
+            public bool IsActive6 { get; set; }
+            public bool IsActive7 { get; set; }
+            public bool IsActive8 { get; set; }
+            public bool IsActive9 { get; set; }
+        }
+
         [RavenFact(RavenTestCategory.Indexes)]
         public void BooleanOperatorsWithDynamicNullObjectShouldWork()
         {
             using (var store = GetDocumentStore())
             {
+                const string indexName = "Users/ByIsActive";
+
+                var storedField = new IndexFieldOptions { Storage = FieldStorage.Yes };
+
                 store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
                 {
-                    Name = "Users/ByIsActive",
+                    Name = indexName,
                     Maps =
                     {
                         @"from doc in docs.Users
@@ -38,8 +54,23 @@ namespace SlowTests.Issues
                               IsActive3 = loadedActive || true,
                               IsActive4 = loadedActive || false,
                               IsActive5 = false || loadedActive,
-                              IsActive6 = true && loadedActive
+                              IsActive6 = true && loadedActive,
+                              IsActive7 = loadedActive | true,
+                              IsActive8 = loadedActive || ""hello"",
+                              IsActive9 = loadedActive || loadedActive
                           }"
+                    },
+                    Fields =
+                    {
+                        [nameof(Result.IsActive1)] = storedField,
+                        [nameof(Result.IsActive2)] = storedField,
+                        [nameof(Result.IsActive3)] = storedField,
+                        [nameof(Result.IsActive4)] = storedField,
+                        [nameof(Result.IsActive5)] = storedField,
+                        [nameof(Result.IsActive6)] = storedField,
+                        [nameof(Result.IsActive7)] = storedField,
+                        [nameof(Result.IsActive8)] = storedField,
+                        [nameof(Result.IsActive9)] = storedField
                     }
                 }));
 
@@ -51,8 +82,25 @@ namespace SlowTests.Issues
 
                 Indexes.WaitForIndexing(store);
 
-                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Users/ByIsActive" }));
+                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { indexName }));
                 Assert.Empty(errors[0].Errors);
+
+                using (var session = store.OpenSession())
+                {
+                    var result = session.Advanced.RawQuery<Result>(
+                            $"from index '{indexName}' select IsActive1, IsActive2, IsActive3, IsActive4, IsActive5, IsActive6, IsActive7, IsActive8, IsActive9")
+                        .Single();
+
+                    Assert.False(result.IsActive1, "loadedActive && true");
+                    Assert.False(result.IsActive2, "loadedActive && false");
+                    Assert.True(result.IsActive3, "loadedActive || true");
+                    Assert.False(result.IsActive4, "loadedActive || false");
+                    Assert.False(result.IsActive5, "false || loadedActive");
+                    Assert.False(result.IsActive6, "true && loadedActive");
+                    Assert.True(result.IsActive7, "loadedActive | true");
+                    Assert.True(result.IsActive8, "loadedActive || \"hello\"");
+                    Assert.False(result.IsActive9, "loadedActive || loadedActive");
+                }
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22191

### Additional description

Added `implicit operator bool` returning `false`, consistent with the existing `operator true`/`operator false` semantics (null is falsy).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
