### PR TITLE
RavenDB-26370 - Allow `Raven-` prefixed metadata keys to be stored in documents outside of legacy import context

### DIFF
--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -32,7 +32,7 @@ namespace Raven.Server.Documents
         public BlittableMetadataModifier(JsonOperationContext context, bool legacyImport, bool readLegacyEtag, DatabaseItemType operateOnTypes)
         {
             _ctx = context;
-            ReadFirstEtagOfLegacyRevision = legacyImport;
+            HandleLegacyProperties = legacyImport;
             ReadLegacyEtag = readLegacyEtag;
             OperateOnTypes = operateOnTypes;
         }
@@ -45,7 +45,8 @@ namespace Raven.Server.Documents
 
         // Change vector is null when importing from v3.5.
         // We'll generate a new change vector in this format: "RV:{revisionsCount}-{firstEtagOfLegacyRevision}"
-        public bool ReadFirstEtagOfLegacyRevision;
+        // Also skips all legacy v3 metadata properties instead of renaming/processing them.
+        public bool HandleLegacyProperties;
 
         public bool ReadLegacyEtag;
         public DatabaseItemType OperateOnTypes;
@@ -328,7 +329,7 @@ namespace Raven.Server.Documents
                         return true;
                     }
 
-                    if (ReadFirstEtagOfLegacyRevision &&
+                    if (HandleLegacyProperties &&
                         (NonPersistentFlags & NonPersistentDocumentFlags.LegacyRevision) == NonPersistentDocumentFlags.LegacyRevision)
                     {
                         if (FirstEtagOfLegacyRevision == null)
@@ -452,7 +453,7 @@ namespace Raven.Server.Documents
                     return true;
 
                 case 13: //Last-Modified
-                    if ("Last-Modified"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Last-Modified"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -502,7 +503,7 @@ namespace Raven.Server.Documents
                     return true;
 
                 case 15: //Raven-Read-Only
-                    if ("Raven-Read-Only"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-Read-Only"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -511,7 +512,7 @@ namespace Raven.Server.Documents
                     goto case -1;
 
                 case 17: //Raven-Entity-Name --> @collection
-                    if ("Raven-Entity-Name"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-Entity-Name"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -525,7 +526,7 @@ namespace Raven.Server.Documents
 
                 case 19: //Raven-Last-Modified or Raven-Delete-Marker
 
-                    if ("Raven-"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -564,7 +565,7 @@ namespace Raven.Server.Documents
                     break;
 
                 case 21: //Raven-Expiration-Date
-                    if ("Raven-Expiration-Date"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-Expiration-Date"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -577,7 +578,7 @@ namespace Raven.Server.Documents
                     return true;
 
                 case 23: //Raven-Document-Revision
-                    if ("Raven-Document-Revision"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-Document-Revision"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -585,7 +586,7 @@ namespace Raven.Server.Documents
 
                     goto case -1;
                 case 24: //Raven-Replication-Source
-                    if ("Raven-Replication-Source"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-Replication-Source"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -593,6 +594,12 @@ namespace Raven.Server.Documents
 
                     goto case -1;
                 case 25: //Raven-Replication-Version OR Raven-Replication-History
+
+                    if (HandleLegacyProperties == false)
+                    {
+                        aboutToReadPropertyName = true;
+                        return true;
+                    }
 
                     var lastByte = state.StringBuffer[24];
                     if (lastByte != (byte)'n' && lastByte != (byte)'y')
@@ -627,7 +634,7 @@ namespace Raven.Server.Documents
 
                 case 29: //Non-Authoritative-Information
 
-                    if ("Non-Authoritative-Information"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Non-Authoritative-Information"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;
@@ -636,6 +643,12 @@ namespace Raven.Server.Documents
                     goto case -1;
 
                 case 30: //Raven-Document-Parent-Revision OR Raven-Document-Revision-Status
+
+                    if (HandleLegacyProperties == false)
+                    {
+                        aboutToReadPropertyName = true;
+                        return true;
+                    }
 
                     if ("Raven-Document-Parent-Revision"u8.IsEqualConstant(state.StringBuffer) == false &&
                         "Raven-Document-Revision-Status"u8.IsEqualConstant(state.StringBuffer) == false)
@@ -673,7 +686,7 @@ namespace Raven.Server.Documents
                     break;
 
                 case 32: //Raven-Replication-Merged-History
-                    if ("Raven-Replication-Merged-History"u8.IsEqualConstant(state.StringBuffer) == false)
+                    if (HandleLegacyProperties == false || "Raven-Replication-Merged-History"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;
                         return true;

--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -608,7 +608,7 @@ namespace Raven.Server.Documents
                         return true;
                     }
 
-                    if ("Raven-Replication-Version"u8.IsEqualConstant(state.StringBuffer) == false ||
+                    if ("Raven-Replication-Version"u8.IsEqualConstant(state.StringBuffer) == false &&
                         "Raven-Replication-History"u8.IsEqualConstant(state.StringBuffer) == false)
                     {
                         aboutToReadPropertyName = true;

--- a/src/Raven.Server/Documents/BlittableMetadataModifier.cs
+++ b/src/Raven.Server/Documents/BlittableMetadataModifier.cs
@@ -45,7 +45,9 @@ namespace Raven.Server.Documents
 
         // Change vector is null when importing from v3.5.
         // We'll generate a new change vector in this format: "RV:{revisionsCount}-{firstEtagOfLegacyRevision}"
-        // Also skips all legacy v3 metadata properties instead of renaming/processing them.
+        // Legacy import handling does not preserve legacy v3 metadata properties as-is.
+        // Selected legacy properties are still recognized and may be mapped to current metadata fields
+        // or read to populate internal flags/state needed during import.
         public bool HandleLegacyProperties;
 
         public bool ReadLegacyEtag;

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
@@ -61,7 +61,9 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     "Raven-Replication-Merged-History": "true",
                     "Non-Authoritative-Information": "false",
                     "Raven-Document-Parent-Revision": "0",
-                    "Raven-Document-Revision-Status": "Current"
+                    "Raven-Document-Revision-Status": "Current",
+                    "Raven-Replication-Version": "1",
+                    "Raven-Replication-History": []
                 }
             }
             """;
@@ -104,6 +106,8 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                 Assert.False(metadata.TryGet("Raven-Document-Parent-Revision", out string _), "Raven-Document-Parent-Revision should be stripped");
                 Assert.False(metadata.TryGet("Raven-Document-Revision-Status", out string _), "Raven-Document-Revision-Status should be stripped");
                 Assert.False(metadata.TryGet("Raven-Replication-Merged-History", out string _), "Raven-Replication-Merged-History should be stripped");
+                Assert.False(metadata.TryGet("Raven-Replication-Version", out string _), "Raven-Replication-Version should be stripped");
+                Assert.False(metadata.TryGet("Raven-Replication-History", out BlittableJsonReaderArray _), "Raven-Replication-History should be stripped");
 
                 Assert.True(metadata.TryGet("@collection", out string _));
                 Assert.True(metadata.TryGet("@expires", out DateTime _));
@@ -131,7 +135,9 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     "Raven-Replication-Merged-History": "true",
                     "Non-Authoritative-Information": "false",
                     "Raven-Document-Parent-Revision": "0",
-                    "Raven-Document-Revision-Status": "Current"
+                    "Raven-Document-Revision-Status": "Current",
+                    "Raven-Replication-Version": "1",
+                    "Raven-Replication-History": []
                 }
             }
             """;
@@ -174,6 +180,8 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                 Assert.True(metadata.TryGet("Raven-Document-Parent-Revision", out string _));
                 Assert.True(metadata.TryGet("Raven-Document-Revision-Status", out string _));
                 Assert.True(metadata.TryGet("Raven-Replication-Merged-History", out string _));
+                Assert.True(metadata.TryGet("Raven-Replication-Version", out string _));
+                Assert.True(metadata.TryGet("Raven-Replication-History", out BlittableJsonReaderArray _));
 
                 Assert.False(metadata.TryGet("@collection", out string _));
                 Assert.False(metadata.TryGet("@expires", out DateTime _));

--- a/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
+++ b/test/FastTests/Blittable/BlittableJsonWriterTests/BlittableMetadataModifierTest.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
+using Raven.Client.Documents.Smuggler;
 using Raven.Server.Documents;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -37,6 +39,144 @@ namespace FastTests.Blittable.BlittableJsonWriterTests
                     }
 
                 Assert.NotNull(modifier.Id.EscapePositions);
+            }
+        }
+
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void ShouldSkipAllLegacyMetadataPropertiesForLegacyImport()
+        {
+            const string json = """
+            {
+                "@metadata": {
+                    "@id": "orders/1",
+                    "Last-Modified": "2024-01-01T00:00:00.0000000",
+                    "Raven-Read-Only": "true",
+                    "Raven-Entity-Name": "Orders",
+                    "Raven-Last-Modified": "2024-01-01T00:00:00.0000000",
+                    "Raven-Delete-Marker": false,
+                    "Raven-Expiration-Date": "2099-01-01T00:00:00.0000000",
+                    "Raven-Document-Revision": "1",
+                    "Raven-Replication-Source": "some-source",
+                    "Raven-Replication-Merged-History": "true",
+                    "Non-Authoritative-Information": "false",
+                    "Raven-Document-Parent-Revision": "0",
+                    "Raven-Document-Revision-Status": "Current"
+                }
+            }
+            """;
+
+            using var ctx = JsonOperationContext.ShortTermSingleUse();
+
+            var buffer = Encoding.UTF8.GetBytes(json);
+            var state = new JsonParserState();
+
+            var modifier = new BlittableMetadataModifier(ctx, legacyImport: true, readLegacyEtag: false, operateOnTypes: DatabaseItemType.Documents);
+
+            BlittableJsonReaderObject result;
+            using (var parser = new UnmanagedJsonParser(ctx, state, "test"))
+            {
+                fixed (byte* pBuffer = buffer)
+                {
+                    parser.SetBuffer(pBuffer, buffer.Length);
+                    using var builder = new BlittableJsonDocumentBuilder(ctx, BlittableJsonDocumentBuilder.UsageMode.None, "test", parser, state, null, modifier);
+                    builder.ReadObjectDocument();
+                    builder.Read();
+                    builder.FinalizeDocument();
+                    result = builder.CreateReader();
+                }
+            }
+
+            using (result)
+            {
+                Assert.True(result.TryGet("@metadata", out BlittableJsonReaderObject metadata));
+                Assert.NotNull(metadata);
+
+                Assert.False(metadata.TryGet("Last-Modified", out object _), "Last-Modified should be stripped");
+                Assert.False(metadata.TryGet("Raven-Read-Only", out string _), "Raven-Read-Only should be stripped");
+                Assert.False(metadata.TryGet("Raven-Entity-Name", out string _), "Raven-Entity-Name should be stripped");
+                Assert.False(metadata.TryGet("Raven-Last-Modified", out string _), "Raven-Last-Modified should be stripped");
+                Assert.False(metadata.TryGet("Raven-Delete-Marker", out bool _), "Raven-Delete-Marker should be stripped");
+                Assert.False(metadata.TryGet("Raven-Expiration-Date", out DateTime _), "Raven-Expiration-Date should be stripped");
+                Assert.False(metadata.TryGet("Raven-Document-Revision", out string _), "Raven-Document-Revision should be stripped");
+                Assert.False(metadata.TryGet("Raven-Replication-Source", out string _), "Raven-Replication-Source should be stripped");
+                Assert.False(metadata.TryGet("Non-Authoritative-Information", out string _), "Non-Authoritative-Information should be stripped");
+                Assert.False(metadata.TryGet("Raven-Document-Parent-Revision", out string _), "Raven-Document-Parent-Revision should be stripped");
+                Assert.False(metadata.TryGet("Raven-Document-Revision-Status", out string _), "Raven-Document-Revision-Status should be stripped");
+                Assert.False(metadata.TryGet("Raven-Replication-Merged-History", out string _), "Raven-Replication-Merged-History should be stripped");
+
+                Assert.True(metadata.TryGet("@collection", out string _));
+                Assert.True(metadata.TryGet("@expires", out DateTime _));
+
+                // @id should still be parsed
+                Assert.Equal("orders/1", modifier.Id.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Core)]
+        public void ShouldKeepAllLegacyMetadataProperties()
+        {
+            const string json = """
+            {
+                "@metadata": {
+                    "@id": "orders/1",
+                    "Last-Modified": "2024-01-01T00:00:00.0000000",
+                    "Raven-Read-Only": "true",
+                    "Raven-Entity-Name": "Orders",
+                    "Raven-Last-Modified": "2024-01-01T00:00:00.0000000",
+                    "Raven-Delete-Marker": false,
+                    "Raven-Expiration-Date": "2099-01-01T00:00:00.0000000",
+                    "Raven-Document-Revision": "1",
+                    "Raven-Replication-Source": "some-source",
+                    "Raven-Replication-Merged-History": "true",
+                    "Non-Authoritative-Information": "false",
+                    "Raven-Document-Parent-Revision": "0",
+                    "Raven-Document-Revision-Status": "Current"
+                }
+            }
+            """;
+
+            using var ctx = JsonOperationContext.ShortTermSingleUse();
+
+            var buffer = Encoding.UTF8.GetBytes(json);
+            var state = new JsonParserState();
+
+            var modifier = new BlittableMetadataModifier(ctx, legacyImport: false, readLegacyEtag: false, operateOnTypes: DatabaseItemType.Documents);
+
+            BlittableJsonReaderObject result;
+            using (var parser = new UnmanagedJsonParser(ctx, state, "test"))
+            {
+                fixed (byte* pBuffer = buffer)
+                {
+                    parser.SetBuffer(pBuffer, buffer.Length);
+                    using var builder = new BlittableJsonDocumentBuilder(ctx, BlittableJsonDocumentBuilder.UsageMode.None, "test", parser, state, null, modifier);
+                    builder.ReadObjectDocument();
+                    builder.Read();
+                    builder.FinalizeDocument();
+                    result = builder.CreateReader();
+                }
+            }
+
+            using (result)
+            {
+                Assert.True(result.TryGet("@metadata", out BlittableJsonReaderObject metadata));
+                Assert.NotNull(metadata);
+
+                Assert.True(metadata.TryGet("Last-Modified", out object _));
+                Assert.True(metadata.TryGet("Raven-Read-Only", out string _));
+                Assert.True(metadata.TryGet("Raven-Entity-Name", out string _));
+                Assert.True(metadata.TryGet("Raven-Last-Modified", out string _));
+                Assert.True(metadata.TryGet("Raven-Delete-Marker", out bool _));
+                Assert.True(metadata.TryGet("Raven-Expiration-Date", out DateTime _));
+                Assert.True(metadata.TryGet("Raven-Document-Revision", out string _));
+                Assert.True(metadata.TryGet("Raven-Replication-Source", out string _));
+                Assert.True(metadata.TryGet("Non-Authoritative-Information", out string _));
+                Assert.True(metadata.TryGet("Raven-Document-Parent-Revision", out string _));
+                Assert.True(metadata.TryGet("Raven-Document-Revision-Status", out string _));
+                Assert.True(metadata.TryGet("Raven-Replication-Merged-History", out string _));
+
+                Assert.False(metadata.TryGet("@collection", out string _));
+                Assert.False(metadata.TryGet("@expires", out DateTime _));
             }
         }
     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26370/Metadata-silently-removed-when-using-names-such-as-Raven-Document-Revision-and

### Additional description

`BlittableMetadataModifier` previously treated legacy v3-era metadata properties inconsistently: some were silently dropped, some were renamed (`Raven-Entity-Name` → `@collection`, `Raven-Expiration-Date` → `@expires`), and some were read to populate internal state (`Raven-Last-Modified`, `Raven-Delete-Marker`, `Raven-Document-Revision-Status`).

When performing a legacy import or legacy replication, none of these properties should survive into the stored document metadata.
For standard document saves, however, these properties must be preserved as-is.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
