### PR TITLE
RavenDB-17867 Prevent server crash from recursive Additional Sources

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -330,6 +330,7 @@ namespace Raven.Server.Documents.Indexes.Static
             );
 
             var rewriter = new MethodDynamicParametersRewriter();
+            var recursionGuard = new RecursionGuardRewriter();
             result.SyntaxTrees = new List<SyntaxTree>();
 
             foreach (var kvp in syntaxTrees) //now do the rewrites
@@ -339,7 +340,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 rewriter.SemanticModel = tempCompilation.GetSemanticModel(tree);
 
-                var rewritten = rewriter.Visit(tree.GetRoot()).NormalizeWhitespace();
+                var rewritten = rewriter.Visit(tree.GetRoot());
+                rewritten = recursionGuard.Visit(rewritten).NormalizeWhitespace();
 
                 SyntaxTree syntaxTree;
 

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/RecursionGuardRewriter.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/RecursionGuardRewriter.cs
@@ -1,0 +1,150 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters
+{
+    public sealed class RecursionGuardRewriter : CSharpSyntaxRewriter
+    {
+        private static readonly StatementSyntax EnsureSufficientExecutionStackStatement =
+            SyntaxFactory.ParseStatement("System.Runtime.CompilerServices.RuntimeHelpers.EnsureSufficientExecutionStack();\n");
+
+        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                IsVoidReturnType(node.ReturnType),
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
+        {
+            node = (LocalFunctionStatementSyntax)base.VisitLocalFunctionStatement(node);
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                IsVoidReturnType(node.ReturnType),
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            node = (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node);
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                isVoidReturning: true,
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitDestructorDeclaration(DestructorDeclarationSyntax node)
+        {
+            node = (DestructorDeclarationSyntax)base.VisitDestructorDeclaration(node);
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                isVoidReturning: true,
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitOperatorDeclaration(OperatorDeclarationSyntax node)
+        {
+            node = (OperatorDeclarationSyntax)base.VisitOperatorDeclaration(node);
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                isVoidReturning: false,
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+        {
+            node = (ConversionOperatorDeclarationSyntax)base.VisitConversionOperatorDeclaration(node);
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                isVoidReturning: false,
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
+        {
+            node = (AccessorDeclarationSyntax)base.VisitAccessorDeclaration(node);
+            bool isVoid = node.Kind() != SyntaxKind.GetAccessorDeclaration;
+            return GuardMethodBody(node, node.Body, node.ExpressionBody,
+                isVoid,
+                (n, b) => n.WithBody(b).WithExpressionBody(null).WithSemicolonToken(default),
+                (n, b) => n.WithBody(b));
+        }
+
+        public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            node = (PropertyDeclarationSyntax)base.VisitPropertyDeclaration(node);
+
+            if (node.ExpressionBody == null)
+                return node;
+
+            var getter = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithBody(SyntaxFactory.Block(
+                    EnsureSufficientExecutionStackStatement,
+                    ConvertExpressionToStatement(node.ExpressionBody.Expression, isVoidReturning: false)));
+
+            return node
+                .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(getter)))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default);
+        }
+
+        public override SyntaxNode VisitIndexerDeclaration(IndexerDeclarationSyntax node)
+        {
+            node = (IndexerDeclarationSyntax)base.VisitIndexerDeclaration(node);
+
+            if (node.ExpressionBody == null)
+                return node;
+
+            var getter = SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                .WithBody(SyntaxFactory.Block(
+                    EnsureSufficientExecutionStackStatement,
+                    ConvertExpressionToStatement(node.ExpressionBody.Expression, isVoidReturning: false)));
+
+            return node
+                .WithAccessorList(SyntaxFactory.AccessorList(SyntaxFactory.SingletonList(getter)))
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default);
+        }
+
+        private static T GuardMethodBody<T>(T node, BlockSyntax body, ArrowExpressionClauseSyntax expressionBody,
+            bool isVoidReturning,
+            System.Func<T, BlockSyntax, T> withExpressionBodyReplacement,
+            System.Func<T, BlockSyntax, T> withBodyReplacement) where T : SyntaxNode
+        {
+            if (body != null)
+            {
+                return withBodyReplacement(node,
+                    body.WithStatements(
+                        body.Statements.Insert(0, EnsureSufficientExecutionStackStatement)));
+            }
+
+            if (expressionBody != null)
+            {
+                var block = SyntaxFactory.Block(EnsureSufficientExecutionStackStatement,
+                    ConvertExpressionToStatement(expressionBody.Expression, isVoidReturning));
+                return withExpressionBodyReplacement(node, block);
+            }
+
+            return node;
+        }
+
+        private static StatementSyntax ConvertExpressionToStatement(ExpressionSyntax expression, bool isVoidReturning)
+        {
+            if (expression is ThrowExpressionSyntax throwExpression)
+                return SyntaxFactory.ThrowStatement(throwExpression.Expression);
+
+            if (isVoidReturning)
+                return SyntaxFactory.ExpressionStatement(expression);
+
+            return SyntaxFactory.ReturnStatement(expression);
+        }
+
+        private static bool IsVoidReturnType(TypeSyntax returnType)
+        {
+            return returnType is PredefinedTypeSyntax predefined && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-17867.cs
+++ b/test/SlowTests/Issues/RavenDB-17867.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Documents.Operations.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_17867 : RavenTestBase
+    {
+        public RavenDB_17867(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Recursion_In_Additional_Sources_Should_Not_Crash_The_Server()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "Companies/WithRecursion",
+                    Maps =
+                    {
+                        @"from company in docs.Companies
+                          select new
+                          {
+                              company.Name,
+                              Test = PeopleUtil.CalculatePersonEmail(company.Name)
+                          }"
+                    },
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["PeopleUtil"] = @"
+public static class PeopleUtil
+{
+    public static string CalculatePersonEmail(string name)
+    {
+        return CalculatePersonEmail(name);
+    }
+}"
+                    }
+                }));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "HR" });
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store, allowErrors: true);
+
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithRecursion"));
+
+                Assert.True(indexStats.MapErrors > 0, "Expected map errors from recursive additional source");
+                Assert.Equal(0, indexStats.MapSuccesses);
+
+                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Companies/WithRecursion" }));
+                Assert.True(errors[0].Errors.Length > 0, "Expected index errors to be recorded");
+                Assert.True(errors[0].Errors.Any(e => e.Error.Contains("InsufficientExecutionStackException")),
+                    "Expected at least one error to contain InsufficientExecutionStackException");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Recursion_In_Expression_Bodied_Additional_Sources_Should_Not_Crash_The_Server()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "Companies/WithExpressionBodyRecursion",
+                    Maps =
+                    {
+                        @"from company in docs.Companies
+                          select new
+                          {
+                              company.Name,
+                              Depth = TreeUtil.GetDepth(company.Name)
+                          }"
+                    },
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["TreeUtil"] = @"
+public static class TreeUtil
+{
+    public static int GetDepth(string name) => 1 + GetDepth(name);
+}"
+                    }
+                }));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "HR" });
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store, allowErrors: true);
+
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithExpressionBodyRecursion"));
+
+                Assert.True(indexStats.MapErrors > 0, "Expected map errors from recursive expression-bodied additional source");
+                Assert.Equal(0, indexStats.MapSuccesses);
+
+                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Companies/WithExpressionBodyRecursion" }));
+                Assert.True(errors[0].Errors.Length > 0, "Expected index errors to be recorded");
+                Assert.True(errors[0].Errors.Any(e => e.Error.Contains("InsufficientExecutionStackException")),
+                    "Expected at least one error to contain InsufficientExecutionStackException");
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Recursion_In_Local_Function_Additional_Sources_Should_Not_Crash_The_Server()
+        {
+            using (var store = GetDocumentStore())
+            {
+                store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+                {
+                    Name = "Companies/WithLocalFunctionRecursion",
+                    Maps =
+                    {
+                        @"from company in docs.Companies
+                          select new
+                          {
+                              company.Name,
+                              Test = Helper.Process(company.Name)
+                          }"
+                    },
+                    AdditionalSources = new Dictionary<string, string>
+                    {
+                        ["Helper"] = @"
+public static class Helper
+{
+    public static string Process(string name)
+    {
+        string Inner(string n) { return Inner(n); }
+        return Inner(name);
+    }
+}"
+                    }
+                }));
+
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Company { Name = "HR" });
+                    session.SaveChanges();
+                }
+
+                Indexes.WaitForIndexing(store, allowErrors: true);
+
+                var indexStats = store.Maintenance.Send(new GetIndexStatisticsOperation("Companies/WithLocalFunctionRecursion"));
+
+                Assert.True(indexStats.MapErrors > 0, "Expected map errors from recursive local function in additional source");
+                Assert.Equal(0, indexStats.MapSuccesses);
+
+                var errors = store.Maintenance.Send(new GetIndexErrorsOperation(new[] { "Companies/WithLocalFunctionRecursion" }));
+                Assert.True(errors[0].Errors.Length > 0, "Expected index errors to be recorded");
+                Assert.True(errors[0].Errors.Any(e => e.Error.Contains("InsufficientExecutionStackException")),
+                    "Expected at least one error to contain InsufficientExecutionStackException");
+            }
+        }
+
+        private class Company
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-17867

### Additional description

Infinite recursion in user-provided Additional Sources for C# indexes causes a `StackOverflowException` that crashes the entire server process. This adds a Roslyn `CSharpSyntaxRewriter` that injects `RuntimeHelpers.EnsureSufficientExecutionStack()` at the top of every method body (block and expression-bodied) and local function in Additional Sources during index compilation. This converts the unrecoverable crash into a catchable `InsufficientExecutionStackException`, which the existing indexing error pipeline handles gracefully as a per-document map error.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed