### PR TITLE
RavenDB-25485 Fix AI Agent Handle not working when returning a list

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -1,4 +1,5 @@
 ﻿using Raven.Client.Extensions;
+using Newtonsoft.Json;
 using Sparrow.Json.Sync;
 using System;
 using System.Collections.Generic;
@@ -28,6 +29,8 @@ internal class AiConversation : IAiConversationOperations
     private readonly List<ContentPart> _promptParts = [];
     private string _changeVector;
     private readonly List<ICommandData> _attachmentsCommands = new();
+    private StringBuilder _jsonBuffer;
+    private StringWriter _jsonWriter;
     
     public string ChangeVector => _changeVector;
 
@@ -106,12 +109,7 @@ internal class AiConversation : IAiConversationOperations
             return;
         }
 
-        using (_aiOperations.AllocateOperationContext(out var context))
-        {
-            var jsonSerializer = _aiOperations._store.Conventions.Serialization.DefaultConverter;
-            var json = jsonSerializer.ToBlittable(actionResponse, context);
-            AddArtificialActionWithResponse(toolId, json.ToString());
-        }
+        AddArtificialActionWithResponse(toolId, SerializeToJson(actionResponse));
     }
 
     public void AddActionResponse<TResponse>(string toolId, TResponse actionResponse) where TResponse : class
@@ -126,12 +124,7 @@ internal class AiConversation : IAiConversationOperations
             return;
         }
 
-        using (_aiOperations.AllocateOperationContext(out var context))
-        {
-            var jsonSerializer = _aiOperations._store.Conventions.Serialization.DefaultConverter;
-            var json = jsonSerializer.ToBlittable(actionResponse, context);
-            AddActionResponse(toolId, json.ToString());
-        }
+        AddActionResponse(toolId, SerializeToJson(actionResponse));
     }
 
     public void AddActionResponse(string toolId, string actionResponse)
@@ -330,6 +323,16 @@ internal class AiConversation : IAiConversationOperations
             _artificialActions.Clear();
             _attachmentsCommands.Clear();
         }
+    }
+
+    private string SerializeToJson(object value)
+    {
+        _jsonBuffer ??= new StringBuilder();
+        _jsonWriter ??= new StringWriter(_jsonBuffer);
+        _jsonBuffer.Clear();
+        var serializer = (JsonSerializer)_aiOperations._store.Conventions.Serialization.CreateSerializer();
+        serializer.Serialize(_jsonWriter, value);
+        return _jsonBuffer.ToString();
     }
 
     internal class AiActionContext<TActionParametersSchema>

--- a/src/Raven.Server/Documents/AI/Settings/AzureOpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/AzureOpenAiChatCompletionClientSettings.cs
@@ -9,7 +9,7 @@ namespace Raven.Server.Documents.AI.Settings;
 
 internal class AzureOpenAiChatCompletionClientSettings : AbstractOpenAiChatCompletionClientSettings
 {
-    private readonly AzureOpenAiSettings _settings;
+    private new readonly AzureOpenAiSettings _settings;
 
     private const string ApiVersion = "2024-10-21";
 

--- a/src/Raven.Server/Documents/AI/Settings/OpenAiChatCompletionClientSettings.cs
+++ b/src/Raven.Server/Documents/AI/Settings/OpenAiChatCompletionClientSettings.cs
@@ -10,7 +10,7 @@ namespace Raven.Server.Documents.AI.Settings;
 
 internal class OpenAiChatCompletionClientSettings : AbstractOpenAiChatCompletionClientSettings
 {
-    private readonly OpenAiSettings _settings;
+    private new readonly OpenAiSettings _settings;
     public OpenAiChatCompletionClientSettings(OpenAiSettings settings) 
         : base(settings)
     {

--- a/test/FastTests/Issues/RavenDB-25485.cs
+++ b/test/FastTests/Issues/RavenDB-25485.cs
@@ -18,7 +18,7 @@ public class RavenDB_25485 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void HandleShouldWorkWhenReturningAList()
+    public void AddActionResponseShouldWorkWhenReturningAList()
     {
         using var store = GetDocumentStore();
 
@@ -34,7 +34,7 @@ public class RavenDB_25485 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void HandleShouldWorkWhenReturningAnArray()
+    public void AddActionResponseShouldWorkWhenReturningAnArray()
     {
         using var store = GetDocumentStore();
 
@@ -50,7 +50,7 @@ public class RavenDB_25485 : RavenTestBase
     }
 
     [RavenFact(RavenTestCategory.Ai)]
-    public void HandleShouldWorkWhenReturningAnEmptyList()
+    public void AddActionResponseShouldWorkWhenReturningAnEmptyList()
     {
         using var store = GetDocumentStore();
 

--- a/test/FastTests/Issues/RavenDB-25485.cs
+++ b/test/FastTests/Issues/RavenDB-25485.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -31,6 +34,13 @@ public class RavenDB_25485 : RavenTestBase
         };
 
         chat.AddActionResponse("tool-1", list);
+
+        var result = JArray.Parse(GetActionResponseContent(chat, "tool-1"));
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Widget", result[0]["Name"].Value<string>());
+        Assert.Equal(9.99m, result[0]["Price"].Value<decimal>());
+        Assert.Equal("Gadget", result[1]["Name"].Value<string>());
+        Assert.Equal(19.99m, result[1]["Price"].Value<decimal>());
     }
 
     [RavenFact(RavenTestCategory.Ai)]
@@ -47,6 +57,13 @@ public class RavenDB_25485 : RavenTestBase
         };
 
         chat.AddActionResponse("tool-1", array);
+
+        var result = JArray.Parse(GetActionResponseContent(chat, "tool-1"));
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Widget", result[0]["Name"].Value<string>());
+        Assert.Equal(9.99m, result[0]["Price"].Value<decimal>());
+        Assert.Equal("Gadget", result[1]["Name"].Value<string>());
+        Assert.Equal(19.99m, result[1]["Price"].Value<decimal>());
     }
 
     [RavenFact(RavenTestCategory.Ai)]
@@ -57,5 +74,15 @@ public class RavenDB_25485 : RavenTestBase
         var chat = store.AI.Conversation("agents/test", "chats/123", new AiConversationCreationOptions());
 
         chat.AddActionResponse("tool-1", new List<ProductInfo>());
+
+        var result = JArray.Parse(GetActionResponseContent(chat, "tool-1"));
+        Assert.Equal(0, result.Count);
+    }
+
+    private static string GetActionResponseContent(IAiConversationOperations chat, string toolId)
+    {
+        var field = chat.GetType().GetField("_actionResponses", BindingFlags.NonPublic | BindingFlags.Instance);
+        var responses = (Dictionary<string, AiAgentActionResponse>)field.GetValue(chat);
+        return responses[toolId].Content;
     }
 }

--- a/test/FastTests/Issues/RavenDB-25485.cs
+++ b/test/FastTests/Issues/RavenDB-25485.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using Raven.Client.Documents.AI;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Issues;
+
+public class RavenDB_25485 : RavenTestBase
+{
+    public RavenDB_25485(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    private class ProductInfo
+    {
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public void HandleShouldWorkWhenReturningAList()
+    {
+        using var store = GetDocumentStore();
+
+        var chat = store.AI.Conversation("agents/test", "chats/123", new AiConversationCreationOptions());
+
+        var list = new List<ProductInfo>
+        {
+            new() { Name = "Widget", Price = 9.99m },
+            new() { Name = "Gadget", Price = 19.99m }
+        };
+
+        chat.AddActionResponse("tool-1", list);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public void HandleShouldWorkWhenReturningAnArray()
+    {
+        using var store = GetDocumentStore();
+
+        var chat = store.AI.Conversation("agents/test", "chats/123", new AiConversationCreationOptions());
+
+        var array = new[]
+        {
+            new ProductInfo { Name = "Widget", Price = 9.99m },
+            new ProductInfo { Name = "Gadget", Price = 19.99m }
+        };
+
+        chat.AddActionResponse("tool-1", array);
+    }
+
+    [RavenFact(RavenTestCategory.Ai)]
+    public void HandleShouldWorkWhenReturningAnEmptyList()
+    {
+        using var store = GetDocumentStore();
+
+        var chat = store.AI.Conversation("agents/test", "chats/123", new AiConversationCreationOptions());
+
+        chat.AddActionResponse("tool-1", new List<ProductInfo>());
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentClientApiHandleActionCalls.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FastTests;
 using Raven.Client.Documents.AI;
@@ -201,6 +202,49 @@ Deviation from these rules is not allowed.");
             string.Empty);
         chat2.SetUserPrompt("hi");
         await Assert.ThrowsAsync<ConcurrencyException>(() => chat2.RunAsync<Sample>());
+    }
+
+    private class OrderResult
+    {
+        public string ProductName { get; set; }
+        public int Quantity { get; set; }
+    }
+
+    [RavenTheory(RavenTestCategory.Ai)]
+    [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task CanHandleAsyncToolCallReturningList(Options options, GenAiConfiguration config)
+    {
+        using var store = GetDocumentStore(options);
+
+        await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+        var agent = BuildAgent(config.ConnectionStringName);
+        var r = await store.AI.CreateAgentAsync(agent, new Sample
+        {
+            Answer = "the answer"
+        });
+        var chat = store.AI.Conversation(
+            r.Identifier,
+            "chats/123",
+            new AiConversationCreationOptions().AddParameter("company", "companies/90-A"));
+
+        var recentOrderCalled = false;
+        chat.Handle(RecentOrder, async (object _) =>
+        {
+            await Task.Delay(10);
+            recentOrderCalled = true;
+            return new List<OrderResult>
+            {
+                new() { ProductName = "Widget", Quantity = 2 },
+                new() { ProductName = "Gadget", Quantity = 1 }
+            };
+        });
+
+        chat.SetUserPrompt("fetch my recent orders");
+        var run = await chat.RunAsync<Sample>();
+        Assert.Equal(AiConversationResult.Done, run.Status);
+        Assert.NotNull(run.Answer.Answer);
+        Assert.True(recentOrderCalled);
     }
 
     internal static AiAgentConfiguration BuildAgent(string connection)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25485

### Additional description

`AddActionResponse<TResponse>` used `ToBlittable()` which internally uses `BlittableJsonWriter` — it only supports root-level JSON objects. When a Handle callback returns a collection (`List<T>`, arrays), Newtonsoft serializes it as a JSON array, causing the writer's state machine to throw `InvalidOperationException`.

Fix: use the Newtonsoft serializer directly to a cached `StringWriter`/`StringBuilder`, which handles any type correctly. Applied to both `AddActionResponse` and `AddArtificialActionWithResponse`.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed