### PR TITLE
RavenDB-23037 Add System.Text.Json as alternative client serialization provider

### DIFF
--- a/bench/Micro.Benchmark/Benchmarks/JsonSerialization.cs
+++ b/bench/Micro.Benchmark/Benchmarks/JsonSerialization.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Json.Serialization;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Raven.Client.Json.Serialization.SystemTextJson;
+using Sparrow.Json;
+
+namespace Micro.Benchmark.Benchmarks
+{
+    [MemoryDiagnoser]
+    [Config(typeof(Config))]
+    public class JsonSerialization
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(Job.ShortRun);
+            }
+        }
+
+        private DocumentConventions _newtonsoftConventions;
+        private DocumentConventions _stjConventions;
+        private JsonOperationContext _context;
+
+        private SmallEntity _smallEntity;
+        private MediumEntity _mediumEntity;
+        private LargeEntity _largeEntity;
+
+        private BlittableJsonReaderObject _smallBlittable;
+        private BlittableJsonReaderObject _mediumBlittable;
+        private BlittableJsonReaderObject _largeBlittable;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _newtonsoftConventions = new DocumentConventions
+            {
+                Serialization = new NewtonsoftJsonSerializationConventions()
+            };
+
+            _stjConventions = new DocumentConventions
+            {
+                Serialization = new SystemTextJsonSerializationConventions()
+            };
+
+            _context = JsonOperationContext.ShortTermSingleUse();
+
+            _smallEntity = new SmallEntity
+            {
+                Name = "Test User",
+                Age = 42,
+                IsActive = true,
+                CreatedAt = new DateTime(2026, 4, 11, 12, 0, 0, DateTimeKind.Utc),
+                Score = 98.6
+            };
+
+            _mediumEntity = new MediumEntity
+            {
+                Id = "orders/1",
+                CustomerName = "John Doe",
+                Email = "john@example.com",
+                OrderDate = new DateTime(2026, 4, 11, 12, 0, 0, DateTimeKind.Utc),
+                ShippingDate = new DateTimeOffset(2026, 4, 15, 12, 0, 0, TimeSpan.Zero),
+                Total = 1234.56m,
+                Tax = 123.46m,
+                Discount = 50.00m,
+                IsShipped = false,
+                Notes = "Please deliver before noon",
+                ShippingAddress = new Address
+                {
+                    Street = "123 Main St",
+                    City = "Springfield",
+                    State = "IL",
+                    ZipCode = "62701",
+                    Country = "US"
+                },
+                Tags = new List<string> { "priority", "fragile", "gift-wrap" }
+            };
+
+            _largeEntity = new LargeEntity
+            {
+                Id = "reports/1",
+                Title = "Annual Sales Report",
+                GeneratedAt = new DateTime(2026, 4, 11, 12, 0, 0, DateTimeKind.Utc),
+                Items = new List<ReportItem>()
+            };
+            for (int i = 0; i < 100; i++)
+            {
+                _largeEntity.Items.Add(new ReportItem
+                {
+                    ProductName = $"Product {i}",
+                    Quantity = i * 10,
+                    UnitPrice = 9.99m + i,
+                    TotalPrice = (9.99m + i) * (i * 10),
+                    Category = i % 5 == 0 ? "Electronics" : i % 3 == 0 ? "Clothing" : "Food"
+                });
+            }
+
+            // Pre-create blittable documents for deserialization benchmarks using Newtonsoft
+            var converter = _newtonsoftConventions.Serialization.DefaultConverter;
+            _smallBlittable = converter.ToBlittable(_smallEntity, _context);
+            _mediumBlittable = converter.ToBlittable(_mediumEntity, _context);
+            _largeBlittable = converter.ToBlittable(_largeEntity, _context);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _context?.Dispose();
+        }
+
+        // === SERIALIZATION (Entity → Blittable) ===
+
+        [Benchmark(Description = "Newtonsoft Serialize Small")]
+        public BlittableJsonReaderObject Newtonsoft_Serialize_Small()
+        {
+            return _newtonsoftConventions.Serialization.DefaultConverter.ToBlittable(_smallEntity, _context);
+        }
+
+        [Benchmark(Description = "STJ Serialize Small")]
+        public BlittableJsonReaderObject STJ_Serialize_Small()
+        {
+            return _stjConventions.Serialization.DefaultConverter.ToBlittable(_smallEntity, _context);
+        }
+
+        [Benchmark(Description = "Newtonsoft Serialize Medium")]
+        public BlittableJsonReaderObject Newtonsoft_Serialize_Medium()
+        {
+            return _newtonsoftConventions.Serialization.DefaultConverter.ToBlittable(_mediumEntity, _context);
+        }
+
+        [Benchmark(Description = "STJ Serialize Medium")]
+        public BlittableJsonReaderObject STJ_Serialize_Medium()
+        {
+            return _stjConventions.Serialization.DefaultConverter.ToBlittable(_mediumEntity, _context);
+        }
+
+        [Benchmark(Description = "Newtonsoft Serialize Large")]
+        public BlittableJsonReaderObject Newtonsoft_Serialize_Large()
+        {
+            return _newtonsoftConventions.Serialization.DefaultConverter.ToBlittable(_largeEntity, _context);
+        }
+
+        [Benchmark(Description = "STJ Serialize Large")]
+        public BlittableJsonReaderObject STJ_Serialize_Large()
+        {
+            return _stjConventions.Serialization.DefaultConverter.ToBlittable(_largeEntity, _context);
+        }
+
+        // === DESERIALIZATION (Blittable → Entity) ===
+
+        [Benchmark(Description = "Newtonsoft Deserialize Small")]
+        public SmallEntity Newtonsoft_Deserialize_Small()
+        {
+            return _newtonsoftConventions.Serialization.DeserializeEntityFromBlittable<SmallEntity>(_smallBlittable);
+        }
+
+        [Benchmark(Description = "STJ Deserialize Small")]
+        public SmallEntity STJ_Deserialize_Small()
+        {
+            return _stjConventions.Serialization.DeserializeEntityFromBlittable<SmallEntity>(_smallBlittable);
+        }
+
+        [Benchmark(Description = "Newtonsoft Deserialize Medium")]
+        public MediumEntity Newtonsoft_Deserialize_Medium()
+        {
+            return _newtonsoftConventions.Serialization.DeserializeEntityFromBlittable<MediumEntity>(_mediumBlittable);
+        }
+
+        [Benchmark(Description = "STJ Deserialize Medium")]
+        public MediumEntity STJ_Deserialize_Medium()
+        {
+            return _stjConventions.Serialization.DeserializeEntityFromBlittable<MediumEntity>(_mediumBlittable);
+        }
+
+        [Benchmark(Description = "Newtonsoft Deserialize Large")]
+        public LargeEntity Newtonsoft_Deserialize_Large()
+        {
+            return _newtonsoftConventions.Serialization.DeserializeEntityFromBlittable<LargeEntity>(_largeBlittable);
+        }
+
+        [Benchmark(Description = "STJ Deserialize Large")]
+        public LargeEntity STJ_Deserialize_Large()
+        {
+            return _stjConventions.Serialization.DeserializeEntityFromBlittable<LargeEntity>(_largeBlittable);
+        }
+
+        // === Entity Classes ===
+
+        public class SmallEntity
+        {
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public bool IsActive { get; set; }
+            public DateTime CreatedAt { get; set; }
+            public double Score { get; set; }
+        }
+
+        public class MediumEntity
+        {
+            public string Id { get; set; }
+            public string CustomerName { get; set; }
+            public string Email { get; set; }
+            public DateTime OrderDate { get; set; }
+            public DateTimeOffset ShippingDate { get; set; }
+            public decimal Total { get; set; }
+            public decimal Tax { get; set; }
+            public decimal Discount { get; set; }
+            public bool IsShipped { get; set; }
+            public string Notes { get; set; }
+            public Address ShippingAddress { get; set; }
+            public List<string> Tags { get; set; }
+        }
+
+        public class Address
+        {
+            public string Street { get; set; }
+            public string City { get; set; }
+            public string State { get; set; }
+            public string ZipCode { get; set; }
+            public string Country { get; set; }
+        }
+
+        public class LargeEntity
+        {
+            public string Id { get; set; }
+            public string Title { get; set; }
+            public DateTime GeneratedAt { get; set; }
+            public List<ReportItem> Items { get; set; }
+        }
+
+        public class ReportItem
+        {
+            public string ProductName { get; set; }
+            public int Quantity { get; set; }
+            public decimal UnitPrice { get; set; }
+            public decimal TotalPrice { get; set; }
+            public string Category { get; set; }
+        }
+    }
+}

--- a/bench/Micro.Benchmark/Benchmarks/JsonSerializationProfile.cs
+++ b/bench/Micro.Benchmark/Benchmarks/JsonSerializationProfile.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Diagnostics;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Json.Serialization.SystemTextJson;
+using Sparrow.Json;
+
+namespace Micro.Benchmark.Benchmarks
+{
+    public static class JsonSerializationProfile
+    {
+        public static void Run()
+        {
+            var conventions = new DocumentConventions
+            {
+                Serialization = new SystemTextJsonSerializationConventions()
+            };
+
+            var converter = conventions.Serialization.DefaultConverter;
+
+            using var context = JsonOperationContext.ShortTermSingleUse();
+
+            var entity = new SmallEntity
+            {
+                Name = "Test User",
+                Age = 42,
+                IsActive = true,
+                CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Score = 98.6
+            };
+
+            int iterations = 200_000;
+
+            // Warmup
+            for (int i = 0; i < 1000; i++)
+            {
+                using var blittable = converter.ToBlittable(entity, context);
+            }
+
+            Console.WriteLine($"Starting {iterations} serialize iterations...");
+
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < iterations; i++)
+            {
+                using var blittable = converter.ToBlittable(entity, context);
+            }
+            sw.Stop();
+            Console.WriteLine($"{iterations} iterations: {sw.ElapsedMilliseconds}ms ({sw.ElapsedMilliseconds * 1000.0 / iterations:F2} us/op)");
+        }
+
+        public class SmallEntity
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public bool IsActive { get; set; }
+            public DateTime CreatedAt { get; set; }
+            public double Score { get; set; }
+        }
+    }
+}

--- a/bench/Micro.Benchmark/Micro.Benchmark.csproj
+++ b/bench/Micro.Benchmark/Micro.Benchmark.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sparrow.Server\Sparrow.Server.csproj" />
     <ProjectReference Include="..\..\src\Voron\Voron.csproj" />
+    <ProjectReference Include="..\..\src\Raven.Client\Raven.Client.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsAnyOS)' == 'true' OR '$(IsWindows64)' == 'true'">
     <None Include="..\..\libs\librvnpal\librvnpal.win.x64.dll" Link="librvnpal.win.x64.dll">

--- a/bench/Micro.Benchmark/Program.cs
+++ b/bench/Micro.Benchmark/Program.cs
@@ -25,6 +25,12 @@ namespace Micro.Benchmark
             Console.WriteLine($"{nameof(AvxVnni)} support: {AvxVnni.IsSupported}");
             Console.WriteLine($"{nameof(Vector512)} support: {Vector512.IsHardwareAccelerated}");
 
+            if (args.Length > 0 && args[0] == "--profile-json")
+            {
+                Benchmarks.JsonSerializationProfile.Run();
+                return;
+            }
+
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }

--- a/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
+++ b/src/Raven.Client/Documents/BulkInsert/BulkInsertOperation.cs
@@ -21,6 +21,7 @@ using Raven.Client.Exceptions.Documents.BulkInsert;
 using Raven.Client.Http;
 using Raven.Client.Json;
 using Raven.Client.Json.Serialization;
+using Raven.Client.Json.Serialization.SystemTextJson;
 using Raven.Client.Util;
 using Sparrow;
 using Sparrow.Json;
@@ -411,8 +412,16 @@ namespace Raven.Client.Documents.BulkInsert
 
                 if (_customEntitySerializer == null || _customEntitySerializer(entity, metadata, _writer.StreamWriter) == false)
                 {
-                    using (var json = _conventions.Serialization.DefaultConverter.ToBlittable(entity, metadata, _context, _defaultSerializer))
-                        await json.WriteJsonToAsync(_writer.StreamWriter.BaseStream, _token).ConfigureAwait(false);
+                    if (_conventions.Serialization is SystemTextJsonSerializationConventions stjConventions)
+                    {
+                        // Fast path: write entity + metadata directly to stream as UTF-8, bypassing blittable
+                        stjConventions.WriteEntityToStream(_writer.StreamWriter.BaseStream, entity, metadata, _defaultSerializer);
+                    }
+                    else
+                    {
+                        using (var json = _conventions.Serialization.DefaultConverter.ToBlittable(entity, metadata, _context, _defaultSerializer))
+                            await json.WriteJsonToAsync(_writer.StreamWriter.BaseStream, _token).ConfigureAwait(false);
+                    }
                 }
 
                 _writer.Write('}');

--- a/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
+++ b/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
@@ -17,12 +17,8 @@ namespace Raven.Client.Documents.Identity
         private readonly Func<object, Task<string>> _generateIdAsync;
 
         // Cache backing field lookup for read-only identity properties (records, init-only).
-        // Key: (entityType, identityPropertyName). Value: FieldInfo or null (positive cache).
+        // Key: (entityType, identityPropertyName). Value: FieldInfo, or null meaning "looked up, not found".
         private static readonly ConcurrentDictionary<(Type, string), FieldInfo> _backingFieldCache = new();
-
-        // Negative cache: tracks (entityType, identityPropertyName) pairs where no backing field exists,
-        // so we don't repeat the reflection search on every call.
-        private static readonly System.Collections.Generic.HashSet<(Type, string)> _backingFieldNotFound = new();
 
         public GenerateEntityIdOnTheClient(DocumentConventions conventions, Func<object, Task<string>> generateIdAsync)
         {
@@ -181,31 +177,12 @@ namespace Raven.Client.Documents.Identity
             else
             {
                 var key = (entityType, identityProperty.Name);
-                if (_backingFieldCache.TryGetValue(key, out var fieldInfo) == false)
+                var fieldInfo = _backingFieldCache.GetOrAdd(key, static k =>
                 {
-                    // Check negative cache before doing the expensive reflection search
-                    lock (_backingFieldNotFound)
-                    {
-                        if (_backingFieldNotFound.Contains(key))
-                            return;
-                    }
-
                     const BindingFlags privateInstanceField = BindingFlags.Instance | BindingFlags.NonPublic;
-                    fieldInfo = entityType.GetField("<" + identityProperty.Name + ">i__Field", privateInstanceField) ??
-                                entityType.GetField("<" + identityProperty.Name + ">k__BackingField", privateInstanceField);
-
-                    if (fieldInfo != null)
-                    {
-                        _backingFieldCache.TryAdd(key, fieldInfo);
-                    }
-                    else
-                    {
-                        lock (_backingFieldNotFound)
-                        {
-                            _backingFieldNotFound.Add(key);
-                        }
-                    }
-                }
+                    return k.Item1.GetField("<" + k.Item2 + ">i__Field", privateInstanceField) ??
+                           k.Item1.GetField("<" + k.Item2 + ">k__BackingField", privateInstanceField);
+                });
 
                 if (fieldInfo == null)
                     return;

--- a/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
+++ b/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
@@ -176,12 +176,16 @@ namespace Raven.Client.Documents.Identity
             }
             else
             {
-                var fieldInfo = _backingFieldCache.GetOrAdd((entityType, identityProperty.Name), static key =>
+                var key = (entityType, identityProperty.Name);
+                if (_backingFieldCache.TryGetValue(key, out var fieldInfo) == false)
                 {
                     const BindingFlags privateInstanceField = BindingFlags.Instance | BindingFlags.NonPublic;
-                    return key.Item1.GetField("<" + key.Item2 + ">i__Field", privateInstanceField) ??
-                           key.Item1.GetField("<" + key.Item2 + ">k__BackingField", privateInstanceField);
-                });
+                    fieldInfo = entityType.GetField("<" + identityProperty.Name + ">i__Field", privateInstanceField) ??
+                                entityType.GetField("<" + identityProperty.Name + ">k__BackingField", privateInstanceField);
+
+                    if (fieldInfo != null)
+                        _backingFieldCache.TryAdd(key, fieldInfo);
+                }
 
                 if (fieldInfo == null)
                     return;

--- a/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
+++ b/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
@@ -17,8 +17,12 @@ namespace Raven.Client.Documents.Identity
         private readonly Func<object, Task<string>> _generateIdAsync;
 
         // Cache backing field lookup for read-only identity properties (records, init-only).
-        // Key: (entityType, identityPropertyName). Value: FieldInfo or null.
+        // Key: (entityType, identityPropertyName). Value: FieldInfo or null (positive cache).
         private static readonly ConcurrentDictionary<(Type, string), FieldInfo> _backingFieldCache = new();
+
+        // Negative cache: tracks (entityType, identityPropertyName) pairs where no backing field exists,
+        // so we don't repeat the reflection search on every call.
+        private static readonly System.Collections.Generic.HashSet<(Type, string)> _backingFieldNotFound = new();
 
         public GenerateEntityIdOnTheClient(DocumentConventions conventions, Func<object, Task<string>> generateIdAsync)
         {
@@ -179,12 +183,28 @@ namespace Raven.Client.Documents.Identity
                 var key = (entityType, identityProperty.Name);
                 if (_backingFieldCache.TryGetValue(key, out var fieldInfo) == false)
                 {
+                    // Check negative cache before doing the expensive reflection search
+                    lock (_backingFieldNotFound)
+                    {
+                        if (_backingFieldNotFound.Contains(key))
+                            return;
+                    }
+
                     const BindingFlags privateInstanceField = BindingFlags.Instance | BindingFlags.NonPublic;
                     fieldInfo = entityType.GetField("<" + identityProperty.Name + ">i__Field", privateInstanceField) ??
                                 entityType.GetField("<" + identityProperty.Name + ">k__BackingField", privateInstanceField);
 
                     if (fieldInfo != null)
+                    {
                         _backingFieldCache.TryAdd(key, fieldInfo);
+                    }
+                    else
+                    {
+                        lock (_backingFieldNotFound)
+                        {
+                            _backingFieldNotFound.Add(key);
+                        }
+                    }
                 }
 
                 if (fieldInfo == null)

--- a/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
+++ b/src/Raven.Client/Documents/Identity/GenerateEntityIdOnTheClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Dynamic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -14,6 +15,10 @@ namespace Raven.Client.Documents.Identity
         private readonly DocumentConventions _conventions;
         private readonly Func<object, string> _generateId;
         private readonly Func<object, Task<string>> _generateIdAsync;
+
+        // Cache backing field lookup for read-only identity properties (records, init-only).
+        // Key: (entityType, identityPropertyName). Value: FieldInfo or null.
+        private static readonly ConcurrentDictionary<(Type, string), FieldInfo> _backingFieldCache = new();
 
         public GenerateEntityIdOnTheClient(DocumentConventions conventions, Func<object, Task<string>> generateIdAsync)
         {
@@ -171,9 +176,12 @@ namespace Raven.Client.Documents.Identity
             }
             else
             {
-                const BindingFlags privateInstanceField = BindingFlags.Instance | BindingFlags.NonPublic;
-                var fieldInfo = entityType.GetField("<" + identityProperty.Name + ">i__Field", privateInstanceField) ??
-                                entityType.GetField("<" + identityProperty.Name + ">k__BackingField", privateInstanceField);
+                var fieldInfo = _backingFieldCache.GetOrAdd((entityType, identityProperty.Name), static key =>
+                {
+                    const BindingFlags privateInstanceField = BindingFlags.Instance | BindingFlags.NonPublic;
+                    return key.Item1.GetField("<" + key.Item2 + ">i__Field", privateInstanceField) ??
+                           key.Item1.GetField("<" + key.Item2 + ">k__BackingField", privateInstanceField);
+                });
 
                 if (fieldInfo == null)
                     return;

--- a/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
+++ b/src/Raven.Client/Documents/Indexes/ExpressionStringBuilder.cs
@@ -5,13 +5,12 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 using System.Text;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json;
 using Raven.Client.Documents.Attachments;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Extensions;
+using Raven.Client.Json;
 using Raven.Client.Util;
 
 namespace Raven.Client.Documents.Indexes
@@ -273,28 +272,12 @@ namespace Raven.Client.Documents.Indexes
             if (propName != null)
                 return propName;
 
-            foreach (var customAttribute in memberInfo.GetCustomAttributes(inherit: true))
+            propName = JsonPropertyNameResolver.GetJsonPropertyName(memberInfo);
+            if (propName != null)
             {
-                var customAttributeType = customAttribute.GetType();
-                if (typeof(JsonPropertyAttribute).Namespace != customAttributeType.Namespace)
-                    continue;
-
-                switch (customAttributeType.Name)
-                {
-                    case nameof(JsonPropertyAttribute):
-                        propName = ((dynamic)customAttribute).PropertyName;
-                        break;
-                    case nameof(DataMemberAttribute):
-                        propName = ((dynamic)customAttribute).Name;
-                        break;
-                    default:
-                        continue;
-                }
-
                 if (KeywordsInCSharp.Contains(propName))
                     return '@' + propName;
-                if (propName != null)
-                    return propName;
+                return propName;
             }
 
             return _conventions.GetConvertedPropertyNameFor(memberInfo);

--- a/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
+++ b/src/Raven.Client/Documents/Linq/LinqPathProvider.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Json;
 using Raven.Client.Documents.Queries;
 using Raven.Client.Documents.Queries.TimeSeries;
 using Raven.Client.Documents.Session;
@@ -254,31 +254,10 @@ namespace Raven.Client.Documents.Linq
 
         public static string HandlePropertyRenames(MemberInfo member, string name)
         {
-            var jsonPropAttributes = member.GetCustomAttributes(false)
-                                                     .OfType<JsonPropertyAttribute>()
-                                                     .ToArray();
+            string propertyName = JsonPropertyNameResolver.GetJsonPropertyName(member);
+            if (string.IsNullOrEmpty(propertyName) == false)
+                return name.Substring(0, name.Length - member.Name.Length) + propertyName;
 
-            if (jsonPropAttributes.Length != 0)
-            {
-                string propertyName = jsonPropAttributes[0].PropertyName;
-                if (string.IsNullOrEmpty(propertyName) == false)
-                {
-                    return name.Substring(0, name.Length - member.Name.Length) + propertyName;
-                }
-            }
-
-            var dataMemberAttributes = member.GetCustomAttributes(false)
-                                                       .OfType<DataMemberAttribute>()
-                                                       .ToArray();
-
-            if (dataMemberAttributes.Length != 0)
-            {
-                string propertyName = ((dynamic)dataMemberAttributes[0]).Name;
-                if (string.IsNullOrEmpty(propertyName) == false)
-                {
-                    return name.Substring(0, name.Length - member.Name.Length) + propertyName;
-                }
-            }
             return name;
         }
 

--- a/src/Raven.Client/Json/JsonPropertyNameResolver.cs
+++ b/src/Raven.Client/Json/JsonPropertyNameResolver.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Raven.Client.Json
+{
+    internal static class JsonPropertyNameResolver
+    {
+        /// <summary>
+        /// Gets the JSON property name for a member by checking:
+        /// 1. Newtonsoft.Json.JsonPropertyAttribute.PropertyName (by namespace, to avoid hard dependency)
+        /// 2. System.Text.Json.Serialization.JsonPropertyNameAttribute.Name
+        /// 3. System.Runtime.Serialization.DataMemberAttribute.Name
+        /// Returns null if no custom name is found.
+        /// </summary>
+        public static string GetJsonPropertyName(MemberInfo member)
+        {
+            foreach (var attr in member.GetCustomAttributes(false))
+            {
+                var attrType = attr.GetType();
+
+                // Check Newtonsoft.Json.JsonPropertyAttribute by namespace (avoid hard coupling)
+                if (attrType.Namespace == "Newtonsoft.Json" && attrType.Name == "JsonPropertyAttribute")
+                {
+                    var propertyName = ((dynamic)attr).PropertyName as string;
+                    if (propertyName != null)
+                        return propertyName;
+                }
+
+                // Check System.Text.Json.Serialization.JsonPropertyNameAttribute (by namespace, to avoid hard coupling with older TFMs)
+                if (attrType.Namespace == "System.Text.Json.Serialization" && attrType.Name == "JsonPropertyNameAttribute")
+                {
+                    var name = ((dynamic)attr).Name as string;
+                    if (name != null)
+                        return name;
+                }
+
+                // Check DataMemberAttribute
+                if (attr is DataMemberAttribute dataMember && dataMember.Name != null)
+                    return dataMember.Name;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Raven.Client/Json/JsonPropertyNameResolver.cs
+++ b/src/Raven.Client/Json/JsonPropertyNameResolver.cs
@@ -7,6 +7,7 @@ namespace Raven.Client.Json
     internal static class JsonPropertyNameResolver
     {
         // MemberInfo is immutable — attributes never change. Cache the resolved name per member.
+        // Empty string sentinel means "no custom name found" (ConcurrentDictionary can't store null)
         private static readonly ConcurrentDictionary<MemberInfo, string> _cache = new();
 
         /// <summary>
@@ -18,7 +19,8 @@ namespace Raven.Client.Json
         /// </summary>
         public static string GetJsonPropertyName(MemberInfo member)
         {
-            return _cache.GetOrAdd(member, ResolveJsonPropertyName);
+            var result = _cache.GetOrAdd(member, ResolveJsonPropertyName);
+            return result.Length == 0 ? null : result;
         }
 
         private static string ResolveJsonPropertyName(MemberInfo member)
@@ -47,7 +49,7 @@ namespace Raven.Client.Json
                 if (attr is DataMemberAttribute dataMember && dataMember.Name != null)
                     return dataMember.Name;
             }
-            return null;
+            return string.Empty; // sentinel for "no custom name"
         }
     }
 }

--- a/src/Raven.Client/Json/JsonPropertyNameResolver.cs
+++ b/src/Raven.Client/Json/JsonPropertyNameResolver.cs
@@ -23,7 +23,7 @@ namespace Raven.Client.Json
 
         private static string ResolveJsonPropertyName(MemberInfo member)
         {
-            foreach (var attr in member.GetCustomAttributes(false))
+            foreach (var attr in member.GetCustomAttributes(true))
             {
                 var attrType = attr.GetType();
 

--- a/src/Raven.Client/Json/JsonPropertyNameResolver.cs
+++ b/src/Raven.Client/Json/JsonPropertyNameResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.Serialization;
 
@@ -5,6 +6,9 @@ namespace Raven.Client.Json
 {
     internal static class JsonPropertyNameResolver
     {
+        // MemberInfo is immutable — attributes never change. Cache the resolved name per member.
+        private static readonly ConcurrentDictionary<MemberInfo, string> _cache = new();
+
         /// <summary>
         /// Gets the JSON property name for a member by checking:
         /// 1. Newtonsoft.Json.JsonPropertyAttribute.PropertyName (by namespace, to avoid hard dependency)
@@ -13,6 +17,11 @@ namespace Raven.Client.Json
         /// Returns null if no custom name is found.
         /// </summary>
         public static string GetJsonPropertyName(MemberInfo member)
+        {
+            return _cache.GetOrAdd(member, ResolveJsonPropertyName);
+        }
+
+        private static string ResolveJsonPropertyName(MemberInfo member)
         {
             foreach (var attr in member.GetCustomAttributes(false))
             {

--- a/src/Raven.Client/Json/Serialization/BlittableJsonConverterHelper.cs
+++ b/src/Raven.Client/Json/Serialization/BlittableJsonConverterHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -139,11 +140,20 @@ namespace Raven.Client.Json.Serialization
             return typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition());
         }
 
+        // Cache: (rootType, propertyName) → property/field Type.
+        // Types are immutable, so the mapping never changes.
+        private static readonly ConcurrentDictionary<(Type, string), Type> _propertyTypeCache = new();
+
         internal static Type GetPropertyType(string propertyName, Type rootType)
         {
             if (rootType == null)
                 return null;
 
+            return _propertyTypeCache.GetOrAdd((rootType, propertyName), static key => ResolvePropertyType(key.Item2, key.Item1));
+        }
+
+        private static Type ResolvePropertyType(string propertyName, Type rootType)
+        {
             MemberInfo memberInfo = null;
             try
             {

--- a/src/Raven.Client/Json/Serialization/BlittableJsonConverterHelper.cs
+++ b/src/Raven.Client/Json/Serialization/BlittableJsonConverterHelper.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Util;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Json.Serialization
+{
+    internal static class BlittableJsonConverterHelper
+    {
+        internal static bool TryRemoveIdentityProperty(BlittableJsonReaderObject document, Type entityType, DocumentConventions conventions, bool isDynamicObject)
+        {
+            var identityProperty = conventions.GetIdentityProperty(entityType);
+            if (identityProperty == null)
+            {
+                if (conventions.AddIdFieldToDynamicObjects && isDynamicObject)
+                {
+                    if (document.Modifications == null)
+                        document.Modifications = new DynamicJsonValue(document);
+
+                    document.Modifications.Remove("Id");
+                    return true;
+                }
+
+                return false;
+            }
+
+            if (document.Modifications == null)
+                document.Modifications = new DynamicJsonValue(document);
+
+            document.Modifications.Remove(conventions.GetConvertedPropertyNameFor(identityProperty));
+            return true;
+        }
+
+        internal static bool TrySimplifyJson(BlittableJsonReaderObject document, Type rootType, Func<Type, bool> shouldSkipSimplification)
+        {
+            var simplified = false;
+            foreach (var propertyName in document.GetPropertyNames())
+            {
+                var propertyType = GetPropertyType(propertyName, rootType);
+                if (propertyType != null && shouldSkipSimplification(propertyType))
+                {
+                    // don't simplify the property if the caller indicates it should be skipped
+                    continue;
+                }
+
+                var propertyValue = document[propertyName];
+
+                if (propertyValue is BlittableJsonReaderArray propertyArray)
+                {
+                    simplified |= TrySimplifyJson(propertyArray, propertyType, shouldSkipSimplification);
+                    continue;
+                }
+
+                var propertyObject = propertyValue as BlittableJsonReaderObject;
+                if (propertyObject == null)
+                    continue;
+
+                if (propertyObject.TryGet(Constants.Json.Fields.Type, out string type) == false)
+                {
+                    simplified |= TrySimplifyJson(propertyObject, propertyType, shouldSkipSimplification);
+                    continue;
+                }
+
+                if (ShouldSimplifyJsonBasedOnType(type) == false)
+                    continue;
+
+                simplified = true;
+
+                if (document.Modifications == null)
+                    document.Modifications = new DynamicJsonValue(document);
+
+                if (propertyObject.TryGet(Constants.Json.Fields.Values, out BlittableJsonReaderArray values) == false)
+                {
+                    if (propertyObject.Modifications == null)
+                        propertyObject.Modifications = new DynamicJsonValue(propertyObject);
+
+                    propertyObject.Modifications.Remove(Constants.Json.Fields.Type);
+                    continue;
+                }
+
+                document.Modifications[propertyName] = values;
+
+                simplified |= TrySimplifyJson(values, propertyType, shouldSkipSimplification);
+            }
+
+            return simplified;
+        }
+
+        internal static bool TrySimplifyJson(BlittableJsonReaderArray array, Type rootType, Func<Type, bool> shouldSkipSimplification)
+        {
+            var itemType = GetItemType();
+
+            var simplified = false;
+            foreach (var item in array)
+            {
+                var itemObject = item as BlittableJsonReaderObject;
+                if (itemObject == null)
+                    continue;
+
+                simplified |= TrySimplifyJson(itemObject, itemType, shouldSkipSimplification);
+            }
+
+            return simplified;
+
+            Type GetItemType()
+            {
+                if (rootType == null)
+                    return null;
+
+                if (rootType.IsArray)
+                    return rootType.GetElementType();
+
+                var enumerableInterface = rootType.GetInterface(typeof(IEnumerable<>).Name);
+                if (enumerableInterface == null)
+                    return null;
+
+                return enumerableInterface.GenericTypeArguments[0];
+            }
+        }
+
+        internal static bool ShouldSimplifyJsonBasedOnType(string typeValue)
+        {
+            var type = Type.GetType(typeValue);
+
+            if (type == null)
+                return false;
+
+            if (type.IsArray)
+                return true;
+
+            if (type.GetGenericArguments().Length == 0)
+                return type == typeof(Enumerable);
+
+            return typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition());
+        }
+
+        internal static Type GetPropertyType(string propertyName, Type rootType)
+        {
+            if (rootType == null)
+                return null;
+
+            MemberInfo memberInfo = null;
+            try
+            {
+                memberInfo = ReflectionUtil.GetPropertyOrFieldFor(rootType, BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, propertyName);
+            }
+            catch (AmbiguousMatchException)
+            {
+                var memberInfos = ReflectionUtil.GetPropertiesAndFieldsFor(rootType, BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic)
+                    .Where(x => x.Name == propertyName)
+                    .ToList();
+
+                while (typeof(object) != rootType)
+                {
+                    memberInfo = memberInfos.FirstOrDefault(x => x.DeclaringType == rootType);
+                    if (memberInfo != null)
+                        break;
+
+                    if (rootType.BaseType == null)
+                        break;
+
+                    rootType = rootType.BaseType;
+                }
+            }
+
+            switch (memberInfo)
+            {
+                case PropertyInfo pi:
+                    return pi.PropertyType;
+                case FieldInfo fi:
+                    return fi.FieldType;
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs
@@ -1,15 +1,9 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using System.Dynamic;
-using System.Linq;
-using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Raven.Client.Documents.Conventions;
-using Raven.Client.Util;
 using Sparrow.Json;
-using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
 {
@@ -103,8 +97,8 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                 //This is to handle the case when user defined it's own contract resolver
                 //or we are serializing dynamic object
 
-                var changes = removeIdentityProperty && TryRemoveIdentityProperty(reader, type, conventions, isDynamicObject);
-                changes |= TrySimplifyJson(reader, type);
+                var changes = removeIdentityProperty && BlittableJsonConverterHelper.TryRemoveIdentityProperty(reader, type, conventions, isDynamicObject);
+                changes |= BlittableJsonConverterHelper.TrySimplifyJson(reader, type, ShouldSkipSimplification);
 
                 if (changes)
                 {
@@ -118,171 +112,9 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
             return reader;
         }
 
-        private static bool TryRemoveIdentityProperty(BlittableJsonReaderObject document, Type entityType, DocumentConventions conventions, bool isDynamicObject)
+        private static bool ShouldSkipSimplification(Type propertyType)
         {
-            var identityProperty = conventions.GetIdentityProperty(entityType);
-            if (identityProperty == null)
-            {
-                if (conventions.AddIdFieldToDynamicObjects && isDynamicObject)
-                {
-                    if (document.Modifications == null)
-                        document.Modifications = new DynamicJsonValue(document);
-
-                    document.Modifications.Remove("Id");
-                    return true;
-                }
-
-                return false;
-            }
-
-            if (document.Modifications == null)
-                document.Modifications = new DynamicJsonValue(document);
-
-            document.Modifications.Remove(conventions.GetConvertedPropertyNameFor(identityProperty));
-            return true;
-        }
-
-        private static bool TrySimplifyJson(BlittableJsonReaderObject document, Type rootType)
-        {
-            var simplified = false;
-            foreach (var propertyName in document.GetPropertyNames())
-            {
-                var propertyType = GetPropertyType(propertyName, rootType);
-                if (propertyType == typeof(JObject) || propertyType == typeof(JArray) || propertyType == typeof(JValue))
-                {
-                    // don't simplify the property if it's a JObject
-                    continue;
-                }
-
-                var propertyValue = document[propertyName];
-
-                if (propertyValue is BlittableJsonReaderArray propertyArray)
-                {
-                    simplified |= TrySimplifyJson(propertyArray, propertyType);
-                    continue;
-                }
-
-                var propertyObject = propertyValue as BlittableJsonReaderObject;
-                if (propertyObject == null)
-                    continue;
-
-                if (propertyObject.TryGet(Constants.Json.Fields.Type, out string type) == false)
-                {
-                    simplified |= TrySimplifyJson(propertyObject, propertyType);
-                    continue;
-                }
-
-                if (ShouldSimplifyJsonBasedOnType(type) == false)
-                    continue;
-
-                simplified = true;
-
-                if (document.Modifications == null)
-                    document.Modifications = new DynamicJsonValue(document);
-
-                if (propertyObject.TryGet(Constants.Json.Fields.Values, out BlittableJsonReaderArray values) == false)
-                {
-                    if (propertyObject.Modifications == null)
-                        propertyObject.Modifications = new DynamicJsonValue(propertyObject);
-
-                    propertyObject.Modifications.Remove(Constants.Json.Fields.Type);
-                    continue;
-                }
-
-                document.Modifications[propertyName] = values;
-
-                simplified |= TrySimplifyJson(values, propertyType);
-            }
-
-            return simplified;
-        }
-
-        private static bool TrySimplifyJson(BlittableJsonReaderArray array, Type rootType)
-        {
-            var itemType = GetItemType();
-
-            var simplified = false;
-            foreach (var item in array)
-            {
-                var itemObject = item as BlittableJsonReaderObject;
-                if (itemObject == null)
-                    continue;
-
-                simplified |= TrySimplifyJson(itemObject, itemType);
-            }
-
-            return simplified;
-
-            Type GetItemType()
-            {
-                if (rootType == null)
-                    return null;
-
-                if (rootType.IsArray)
-                    return rootType.GetElementType();
-
-                var enumerableInterface = rootType.GetInterface(typeof(IEnumerable<>).Name);
-                if (enumerableInterface == null)
-                    return null;
-
-                return enumerableInterface.GenericTypeArguments[0];
-            }
-        }
-
-        private static bool ShouldSimplifyJsonBasedOnType(string typeValue)
-        {
-            var type = Type.GetType(typeValue);
-
-            if (type == null)
-                return false;
-
-            if (type.IsArray)
-                return true;
-
-            if (type.GetGenericArguments().Length == 0)
-                return type == typeof(Enumerable);
-
-            return typeof(IEnumerable).IsAssignableFrom(type.GetGenericTypeDefinition());
-        }
-
-        internal static Type GetPropertyType(string propertyName, Type rootType)
-        {
-            if (rootType == null)
-                return null;
-
-            MemberInfo memberInfo = null;
-            try
-            {
-                memberInfo = ReflectionUtil.GetPropertyOrFieldFor(rootType, BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic, propertyName);
-            }
-            catch (AmbiguousMatchException)
-            {
-                var memberInfos = ReflectionUtil.GetPropertiesAndFieldsFor(rootType, BindingFlags.Public | BindingFlags.Instance | BindingFlags.NonPublic)
-                    .Where(x => x.Name == propertyName)
-                    .ToList();
-
-                while (typeof(object) != rootType)
-                {
-                    memberInfo = memberInfos.FirstOrDefault(x => x.DeclaringType == rootType);
-                    if (memberInfo != null)
-                        break;
-
-                    if (rootType.BaseType == null)
-                        break;
-
-                    rootType = rootType.BaseType;
-                }
-            }
-
-            switch (memberInfo)
-            {
-                case PropertyInfo pi:
-                    return pi.PropertyType;
-                case FieldInfo fi:
-                    return fi.FieldType;
-                default:
-                    return null;
-            }
+            return propertyType == typeof(JObject) || propertyType == typeof(JArray) || propertyType == typeof(JValue);
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs
+++ b/src/Raven.Client/Json/Serialization/NewtonsoftJson/Internal/BlittableJsonConverterBase.cs
@@ -44,10 +44,6 @@ namespace Raven.Client.Json.Serialization.NewtonsoftJson.Internal
                     serializer.Populate(reader, entity);
                 }
             }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"Could not populate entity.", ex);
-            }
             finally
             {
                 serializer.ObjectCreationHandling = old;

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverter.cs
@@ -61,6 +61,11 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             if (entity is BlittableJsonReaderObject bjro)
                 return bjro;
 
+            // Fast path: serialize entity → UTF-8 → ParseBuffer → blittable directly.
+            // No identity removal needed, no metadata, no token walk.
+            if (jsonSerializer is SystemTextJsonJsonSerializer stjSerializer)
+                return stjSerializer.SerializeToBlittable(entity, entity.GetType(), context);
+
             using (var writer = new SystemTextJsonBlittableWriter(context, documentInfo: null))
                 return ToBlittableInternal(entity, Conventions.Conventions, context, jsonSerializer, writer, removeIdentityProperty: false);
         }
@@ -78,6 +83,10 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
         {
             if (entity is BlittableJsonReaderObject bjro)
                 return bjro;
+
+            // Fast path: serialize entity + metadata → UTF-8 → ParseBuffer → blittable directly.
+            if (jsonSerializer is SystemTextJsonJsonSerializer stjSerializer)
+                return stjSerializer.SerializeToBlittableWithMetadata(entity, entity.GetType(), metadata, context);
 
             using (var writer = new SystemTextJsonBlittableWriter(context, new DocumentInfo { MetadataInstance = metadata }))
                 return ToBlittableInternal(entity, Conventions.Conventions, context, jsonSerializer, writer);

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverter.cs
@@ -1,0 +1,86 @@
+using System;
+using Raven.Client.Documents.Session;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class BlittableJsonConverter : BlittableJsonConverterBase, IBlittableJsonConverter
+    {
+        public BlittableJsonConverter(ISerializationConventions conventions)
+            : base(conventions)
+        {
+        }
+
+        public T FromBlittable<T>(BlittableJsonReaderObject json, string id)
+        {
+            return (T)FromBlittable(typeof(T), json, id);
+        }
+
+        public object FromBlittable(Type type, BlittableJsonReaderObject json, string id)
+        {
+            try
+            {
+                var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
+                var entity = defaultValue;
+
+                var documentTypeAsString = Conventions.Conventions.GetClrType(id, json);
+                if (documentTypeAsString != null)
+                {
+                    var documentType = Conventions.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
+                    if (documentType != null && type.IsAssignableFrom(documentType))
+                    {
+                        entity = Conventions.DeserializeEntityFromBlittable(documentType, json);
+                    }
+                }
+
+                if (Equals(entity, defaultValue))
+                {
+                    entity = Conventions.DeserializeEntityFromBlittable(type, json);
+                }
+
+                return entity;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Could not convert document {id} to entity of type {type}",
+                    ex);
+            }
+        }
+
+        public BlittableJsonReaderObject ToBlittable(object entity, JsonOperationContext context)
+        {
+            if (entity is BlittableJsonReaderObject bjro)
+                return bjro;
+
+            var jsonSerializer = Conventions.CreateSerializer();
+            return ToBlittable(entity, context, jsonSerializer);
+        }
+
+        public BlittableJsonReaderObject ToBlittable(object entity, JsonOperationContext context, IJsonSerializer jsonSerializer)
+        {
+            if (entity is BlittableJsonReaderObject bjro)
+                return bjro;
+
+            using (var writer = new SystemTextJsonBlittableWriter(context, documentInfo: null))
+                return ToBlittableInternal(entity, Conventions.Conventions, context, jsonSerializer, writer, removeIdentityProperty: false);
+        }
+
+        public BlittableJsonReaderObject ToBlittable(object entity, IMetadataDictionary metadata, JsonOperationContext context)
+        {
+            if (entity is BlittableJsonReaderObject bjro)
+                return bjro;
+
+            var jsonSerializer = Conventions.CreateSerializer();
+            return ToBlittable(entity, metadata, context, jsonSerializer);
+        }
+
+        public BlittableJsonReaderObject ToBlittable(object entity, IMetadataDictionary metadata, JsonOperationContext context, IJsonSerializer jsonSerializer)
+        {
+            if (entity is BlittableJsonReaderObject bjro)
+                return bjro;
+
+            using (var writer = new SystemTextJsonBlittableWriter(context, new DocumentInfo { MetadataInstance = metadata }))
+                return ToBlittableInternal(entity, Conventions.Conventions, context, jsonSerializer, writer);
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterBase.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterBase.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Dynamic;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Raven.Client.Documents.Conventions;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal abstract class BlittableJsonConverterBase : IBlittableJsonConverterBase
+    {
+        protected readonly ISerializationConventions Conventions;
+
+        protected BlittableJsonConverterBase(ISerializationConventions conventions)
+        {
+            Conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+        }
+
+        public void PopulateEntity(object entity, BlittableJsonReaderObject json)
+        {
+            var jsonSerializer = Conventions.CreateSerializer();
+            PopulateEntity(entity, json, jsonSerializer);
+        }
+
+        public void PopulateEntity(object entity, BlittableJsonReaderObject json, IJsonSerializer jsonSerializer)
+        {
+            if (entity == null)
+                throw new ArgumentNullException(nameof(entity));
+            if (json == null)
+                throw new ArgumentNullException(nameof(json));
+            if (jsonSerializer == null)
+                throw new ArgumentNullException(nameof(jsonSerializer));
+
+            // STJ has no Populate() equivalent. Deserialize to a new instance and copy properties.
+            using (var reader = new SystemTextJsonBlittableReader())
+            {
+                reader.Initialize(json);
+                var type = entity.GetType();
+                var serializer = (SystemTextJsonJsonSerializer)jsonSerializer;
+                object newInstance = JsonSerializer.Deserialize(reader.GetUtf8Json(), type, serializer.Options);
+
+                if (newInstance == null)
+                    return;
+
+                CopyProperties(newInstance, entity, type);
+            }
+        }
+
+        private static void CopyProperties(object source, object target, Type type)
+        {
+            for (Type currentType = type; currentType != null && currentType != typeof(object); currentType = currentType.BaseType)
+            {
+                PropertyInfo[] properties = currentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                for (int i = 0; i < properties.Length; i++)
+                {
+                    PropertyInfo property = properties[i];
+                    if (property.CanRead == false || property.CanWrite == false)
+                        continue;
+
+                    if (property.GetIndexParameters().Length > 0)
+                        continue;
+
+                    object value = property.GetValue(source);
+                    property.SetValue(target, value);
+                }
+
+                FieldInfo[] fields = currentType.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                for (int i = 0; i < fields.Length; i++)
+                {
+                    FieldInfo field = fields[i];
+                    object value = field.GetValue(source);
+                    field.SetValue(target, value);
+                }
+            }
+        }
+
+        protected static BlittableJsonReaderObject ToBlittableInternal(
+            object entity,
+            DocumentConventions conventions,
+            JsonOperationContext context,
+            IJsonSerializer serializer,
+            IJsonWriter writer,
+            bool removeIdentityProperty = true)
+        {
+            var type = entity.GetType();
+            var isDynamicObject = entity is IDynamicMetaObjectProvider;
+            var hasIdentityProperty = conventions.GetIdentityProperty(type) != null;
+            var useResolver = isDynamicObject == false;
+
+            if (useResolver)
+            {
+                RavenJsonTypeInfoResolver.RootEntity = removeIdentityProperty && hasIdentityProperty ? entity : null;
+                RavenJsonTypeInfoResolver.RemovedIdentityProperty = false;
+
+                try
+                {
+                    serializer.Serialize(writer, entity);
+                }
+                finally
+                {
+                    RavenJsonTypeInfoResolver.RootEntity = null;
+                }
+            }
+            else
+            {
+                serializer.Serialize(writer, entity);
+            }
+
+            writer.FinalizeDocument();
+
+            var reader = writer.CreateReader();
+
+            if (useResolver == false || hasIdentityProperty && RavenJsonTypeInfoResolver.RemovedIdentityProperty == false)
+            {
+                var changes = removeIdentityProperty && BlittableJsonConverterHelper.TryRemoveIdentityProperty(reader, type, conventions, isDynamicObject);
+                changes |= BlittableJsonConverterHelper.TrySimplifyJson(reader, type, ShouldSkipSimplification);
+
+                if (changes)
+                {
+                    using (var old = reader)
+                    {
+                        reader = context.ReadObject(reader, "convert/entityToBlittable");
+                    }
+                }
+            }
+
+            return reader;
+        }
+
+        private static bool ShouldSkipSimplification(Type propertyType)
+        {
+            return propertyType == typeof(JsonElement) || propertyType == typeof(JsonNode) ||
+                   propertyType == typeof(JsonObject) || propertyType == typeof(JsonArray) ||
+                   propertyType == typeof(JsonValue);
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterBase.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterBase.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -43,12 +46,31 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 if (newInstance == null)
                     return;
 
-                CopyProperties(newInstance, entity, type);
+                GetCompiledCopier(type)(newInstance, entity);
             }
         }
 
-        private static void CopyProperties(object source, object target, Type type)
+        private static readonly ConcurrentDictionary<Type, Action<object, object>> _copiers = new();
+
+        private static Action<object, object> GetCompiledCopier(Type type)
         {
+            return _copiers.GetOrAdd(type, CompileCopier);
+        }
+
+        private static Action<object, object> CompileCopier(Type type)
+        {
+            var sourceParam = Expression.Parameter(typeof(object), "source");
+            var targetParam = Expression.Parameter(typeof(object), "target");
+
+            var sourceTyped = Expression.Variable(type, "s");
+            var targetTyped = Expression.Variable(type, "t");
+
+            var body = new List<Expression>
+            {
+                Expression.Assign(sourceTyped, Expression.Convert(sourceParam, type)),
+                Expression.Assign(targetTyped, Expression.Convert(targetParam, type))
+            };
+
             for (Type currentType = type; currentType != null && currentType != typeof(object); currentType = currentType.BaseType)
             {
                 PropertyInfo[] properties = currentType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
@@ -57,22 +79,29 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                     PropertyInfo property = properties[i];
                     if (property.CanRead == false || property.CanWrite == false)
                         continue;
-
                     if (property.GetIndexParameters().Length > 0)
                         continue;
 
-                    object value = property.GetValue(source);
-                    property.SetValue(target, value);
+                    // t.Prop = s.Prop
+                    body.Add(Expression.Assign(
+                        Expression.Property(targetTyped, property),
+                        Expression.Property(sourceTyped, property)));
                 }
 
                 FieldInfo[] fields = currentType.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
                 for (int i = 0; i < fields.Length; i++)
                 {
                     FieldInfo field = fields[i];
-                    object value = field.GetValue(source);
-                    field.SetValue(target, value);
+
+                    // t.Field = s.Field
+                    body.Add(Expression.Assign(
+                        Expression.Field(targetTyped, field),
+                        Expression.Field(sourceTyped, field)));
                 }
             }
+
+            var block = Expression.Block(new[] { sourceTyped, targetTyped }, body);
+            return Expression.Lambda<Action<object, object>>(block, sourceParam, targetParam).Compile();
         }
 
         protected static BlittableJsonReaderObject ToBlittableInternal(

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterBase.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterBase.cs
@@ -41,7 +41,15 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 reader.Initialize(json);
                 var type = entity.GetType();
                 var serializer = (SystemTextJsonJsonSerializer)jsonSerializer;
-                object newInstance = JsonSerializer.Deserialize(reader.GetUtf8Json(), type, serializer.Options);
+                object newInstance;
+                try
+                {
+                    newInstance = JsonSerializer.Deserialize(reader.GetUtf8Json(), type, serializer.Options);
+                }
+                finally
+                {
+                    reader.ReturnMemory();
+                }
 
                 if (newInstance == null)
                     return;

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterWithMissingProperties.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/BlittableJsonConverterWithMissingProperties.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Raven.Client.Util;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal;
+
+internal abstract class BlittableJsonConverterWithMissingProperties : BlittableJsonConverterBase
+{
+    public Dictionary<object, Dictionary<object, object>> MissingProperties { get; set; }
+
+    protected BlittableJsonConverterWithMissingProperties(ISerializationConventions conventions) : base(conventions)
+    {
+    }
+
+    protected void RegisterMissingProperties(object o, string id, object value)
+    {
+        if (Conventions.Conventions.PreserveDocumentPropertiesNotFoundOnModel == false ||
+            id == Constants.Documents.Metadata.Key)
+            return;
+
+        MissingProperties ??= new Dictionary<object, Dictionary<object, object>>(ObjectReferenceEqualityComparer<object>.Default);
+
+        if (MissingProperties.TryGetValue(o, out var dictionary) == false)
+        {
+            MissingProperties[o] = dictionary = new Dictionary<object, object>();
+        }
+
+        dictionary[id] = value;
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/ContextMemoryBufferWriter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/ContextMemoryBufferWriter.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    /// <summary>
+    /// An IBufferWriter backed by JsonOperationContext arena memory.
+    /// Avoids managed byte[] allocations entirely - all memory comes from the context's
+    /// native arena allocator and is freed when the context is reset/disposed.
+    /// </summary>
+    internal sealed unsafe class ContextMemoryBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        private readonly JsonOperationContext _context;
+        private AllocatedMemoryData _allocation;
+        private int _position;
+
+        public ContextMemoryBufferWriter(JsonOperationContext context, int initialSize = 4096)
+        {
+            _context = context;
+            _allocation = context.GetMemory(initialSize);
+            _position = 0;
+        }
+
+        public ReadOnlySpan<byte> WrittenSpan => new ReadOnlySpan<byte>(_allocation.Address, _position);
+
+        public int WrittenCount => _position;
+
+        public void Advance(int count)
+        {
+            _position += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _allocation.AsMemory().Slice(_position);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return new Span<byte>(_allocation.Address + _position, _allocation.SizeInBytes - _position);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureCapacity(int sizeHint)
+        {
+            if (sizeHint <= 0)
+                sizeHint = 1;
+
+            int remaining = _allocation.SizeInBytes - _position;
+            if (remaining >= sizeHint)
+                return;
+
+            Grow(sizeHint);
+        }
+
+        private void Grow(int sizeHint)
+        {
+            int needed = _position + sizeHint;
+            int increase = needed - _allocation.SizeInBytes;
+
+            // Try to grow in-place first (just bumps the arena pointer, no copy)
+            if (_context.GrowAllocation(_allocation, increase))
+                return;
+
+            // Can't grow in-place - allocate new, copy, return old
+            int newSize = Math.Max(_allocation.SizeInBytes * 2, needed);
+            var newAllocation = _context.GetMemory(newSize);
+            Buffer.MemoryCopy(_allocation.Address, newAllocation.Address, newAllocation.SizeInBytes, _position);
+            _context.ReturnMemory(_allocation);
+            _allocation = newAllocation;
+        }
+
+        /// <summary>
+        /// Return native memory to the context immediately.
+        /// Call after the written bytes have been consumed.
+        /// </summary>
+        public void ReturnMemory()
+        {
+            if (_allocation != null)
+            {
+                _context.ReturnMemory(_allocation);
+                _allocation = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            ReturnMemory();
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/DateOnlyConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/DateOnlyConverter.cs
@@ -1,0 +1,112 @@
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    // ISO 8601 standard
+    // More info available at: https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
+    internal sealed class DateOnlyConverter : JsonConverterFactory
+    {
+        public static readonly DateOnlyConverter Instance = new();
+
+        private DateOnlyConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(DateOnly) || typeToConvert == typeof(DateOnly?);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (typeToConvert == typeof(DateOnly))
+                return DateOnlyConverterInner.Instance;
+
+            return NullableDateOnlyConverter.Instance;
+        }
+
+        private sealed class DateOnlyConverterInner : JsonConverter<DateOnly>
+        {
+            public static readonly DateOnlyConverterInner Instance = new();
+
+            public override unsafe DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidOperationException("Expected string, Got " + reader.TokenType);
+
+                string value = reader.GetString();
+
+                fixed (char* buffer = value.AsSpan())
+                {
+                    if (LazyStringParser.TryParseDateOnly(buffer, value.Length, out DateOnly dateOnly) == false)
+                    {
+                        if (LazyStringParser.TryParseDateTime(buffer, value.Length, out DateTime dt, out _, true) is LazyStringParser.Result.Failed
+                            or LazyStringParser.Result.DateTimeOffset)
+                        {
+                            throw new InvalidOperationException("Expected DateOnly, Got " + value);
+                        }
+
+                        return DateOnly.FromDateTime(dt);
+                    }
+
+                    return dateOnly;
+                }
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString(DefaultFormat.DateOnlyFormatToWrite, CultureInfo.InvariantCulture));
+            }
+        }
+
+        private sealed class NullableDateOnlyConverter : JsonConverter<DateOnly?>
+        {
+            public static readonly NullableDateOnlyConverter Instance = new();
+
+            public override unsafe DateOnly? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidOperationException("Expected string, Got " + reader.TokenType);
+
+                string value = reader.GetString();
+
+                fixed (char* buffer = value.AsSpan())
+                {
+                    if (LazyStringParser.TryParseDateOnly(buffer, value.Length, out DateOnly dateOnly) == false)
+                    {
+                        if (LazyStringParser.TryParseDateTime(buffer, value.Length, out DateTime dt, out _, true) is LazyStringParser.Result.Failed
+                            or LazyStringParser.Result.DateTimeOffset)
+                        {
+                            throw new InvalidOperationException("Expected DateOnly, Got " + value);
+                        }
+
+                        return DateOnly.FromDateTime(dt);
+                    }
+
+                    return dateOnly;
+                }
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateOnly? value, JsonSerializerOptions options)
+            {
+                if (value == null)
+                {
+                    writer.WriteNullValue();
+                    return;
+                }
+
+                writer.WriteStringValue(value.Value.ToString(DefaultFormat.DateOnlyFormatToWrite, CultureInfo.InvariantCulture));
+            }
+        }
+    }
+}
+#endif

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/DateTimeISO8601Converter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/DateTimeISO8601Converter.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow;
+using Sparrow.Extensions;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class DateTimeISO8601Converter : JsonConverterFactory
+    {
+        public static readonly DateTimeISO8601Converter Instance = new();
+
+        private DateTimeISO8601Converter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(DateTime)
+                || typeToConvert == typeof(DateTime?)
+                || typeToConvert == typeof(DateTimeOffset)
+                || typeToConvert == typeof(DateTimeOffset?);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (typeToConvert == typeof(DateTime))
+                return DateTimeConverterInner.Instance;
+            if (typeToConvert == typeof(DateTime?))
+                return NullableDateTimeConverterInner.Instance;
+            if (typeToConvert == typeof(DateTimeOffset))
+                return DateTimeOffsetConverterInner.Instance;
+            return NullableDateTimeOffsetConverterInner.Instance;
+        }
+
+        private sealed class DateTimeConverterInner : JsonConverter<DateTime>
+        {
+            public static readonly DateTimeConverterInner Instance = new();
+
+            public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                string s = reader.GetString();
+                if (s != null)
+                {
+                    if (DateTime.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime time))
+                    {
+                        if (s.EndsWith("+00:00"))
+                            return time.ToUniversalTime();
+                        return time;
+                    }
+
+                    DateTime lucene = LuceneDateTimeConverter.TryParseLucene(s, isOffset: false);
+                    if (lucene != default)
+                        return DateTime.SpecifyKind(lucene, DateTimeKind.Local);
+                }
+
+                return default;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            {
+                if (value.Kind == DateTimeKind.Unspecified)
+                    value = DateTime.SpecifyKind(value, DateTimeKind.Local);
+                writer.WriteStringValue(value.GetDefaultRavenFormat());
+            }
+        }
+
+        private sealed class NullableDateTimeConverterInner : JsonConverter<DateTime?>
+        {
+            public static readonly NullableDateTimeConverterInner Instance = new();
+
+            public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                string s = reader.GetString();
+                if (s != null)
+                {
+                    if (DateTime.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime time))
+                    {
+                        if (s.EndsWith("+00:00"))
+                            return time.ToUniversalTime();
+                        return time;
+                    }
+
+                    DateTime lucene = LuceneDateTimeConverter.TryParseLucene(s, isOffset: false);
+                    if (lucene != default)
+                        return DateTime.SpecifyKind(lucene, DateTimeKind.Local);
+                }
+
+                return null;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+            {
+                if (value == null)
+                {
+                    writer.WriteNullValue();
+                    return;
+                }
+
+                DateTime dt = value.Value;
+                if (dt.Kind == DateTimeKind.Unspecified)
+                    dt = DateTime.SpecifyKind(dt, DateTimeKind.Local);
+                writer.WriteStringValue(dt.GetDefaultRavenFormat());
+            }
+        }
+
+        private sealed class DateTimeOffsetConverterInner : JsonConverter<DateTimeOffset>
+        {
+            public static readonly DateTimeOffsetConverterInner Instance = new();
+
+            public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                string s = reader.GetString();
+                if (s != null)
+                {
+                    if (DateTimeOffset.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset time))
+                        return time;
+
+                    DateTime lucene = LuceneDateTimeConverter.TryParseLucene(s, isOffset: true);
+                    if (lucene != default)
+                        return new DateTimeOffset(lucene, DateTimeOffset.Now.Offset);
+                }
+
+                return default;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite, CultureInfo.InvariantCulture));
+            }
+        }
+
+        private sealed class NullableDateTimeOffsetConverterInner : JsonConverter<DateTimeOffset?>
+        {
+            public static readonly NullableDateTimeOffsetConverterInner Instance = new();
+
+            public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                string s = reader.GetString();
+                if (s != null)
+                {
+                    if (DateTimeOffset.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset time))
+                        return time;
+
+                    DateTime lucene = LuceneDateTimeConverter.TryParseLucene(s, isOffset: true);
+                    if (lucene != default)
+                        return new DateTimeOffset(lucene, DateTimeOffset.Now.Offset);
+                }
+
+                return null;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options)
+            {
+                if (value == null)
+                {
+                    writer.WriteNullValue();
+                    return;
+                }
+
+                writer.WriteStringValue(value.Value.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite, CultureInfo.InvariantCulture));
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/DictionaryDateTimeKeysConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/DictionaryDateTimeKeysConverter.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow;
+using Sparrow.Extensions;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class DictionaryDateTimeKeysConverter : JsonConverterFactory
+    {
+        public static readonly DictionaryDateTimeKeysConverter Instance = new();
+
+        private DictionaryDateTimeKeysConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (typeToConvert.IsGenericType == false)
+                return false;
+
+            Type genericDef = typeToConvert.GetGenericTypeDefinition();
+            if (genericDef != typeof(Dictionary<,>) && genericDef != typeof(IDictionary<,>))
+                return false;
+
+            Type keyType = typeToConvert.GetGenericArguments()[0];
+            return keyType == typeof(DateTime)
+                || keyType == typeof(DateTime?)
+                || keyType == typeof(DateTimeOffset)
+                || keyType == typeof(DateTimeOffset?);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            Type[] args = typeToConvert.GetGenericArguments();
+            Type keyType = args[0];
+            Type valueType = args[1];
+
+            Type converterType;
+            if (keyType == typeof(DateTime))
+                converterType = typeof(DictionaryDateTimeKeysConverterInner<>).MakeGenericType(valueType);
+            else if (keyType == typeof(DateTime?))
+                converterType = typeof(DictionaryNullableDateTimeKeysConverterInner<>).MakeGenericType(valueType);
+            else if (keyType == typeof(DateTimeOffset))
+                converterType = typeof(DictionaryDateTimeOffsetKeysConverterInner<>).MakeGenericType(valueType);
+            else
+                converterType = typeof(DictionaryNullableDateTimeOffsetKeysConverterInner<>).MakeGenericType(valueType);
+
+            return (JsonConverter)Activator.CreateInstance(converterType);
+        }
+
+        private sealed class DictionaryDateTimeKeysConverterInner<TValue> : JsonConverter<Dictionary<DateTime, TValue>>
+        {
+            public override Dictionary<DateTime, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartObject)
+                    throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+                Dictionary<DateTime, TValue> result = new();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                        return result;
+
+                    if (reader.TokenType != JsonTokenType.PropertyName)
+                        throw new JsonException($"Expected PropertyName, got {reader.TokenType}");
+
+                    string s = reader.GetString();
+                    if (DateTime.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime key) == false)
+                        throw new JsonException($"Could not parse date time from '{s}'");
+
+                    if (key.Kind == DateTimeKind.Unspecified)
+                        key = DateTime.SpecifyKind(key, DateTimeKind.Local);
+
+                    reader.Read();
+                    TValue value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+                    result[key] = value;
+                }
+
+                throw new JsonException("Unexpected end of JSON.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, Dictionary<DateTime, TValue> value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                foreach (KeyValuePair<DateTime, TValue> kvp in value)
+                {
+                    DateTime dt = kvp.Key;
+                    if (dt.Kind == DateTimeKind.Unspecified)
+                        dt = DateTime.SpecifyKind(dt, DateTimeKind.Local);
+                    writer.WritePropertyName(dt.GetDefaultRavenFormat());
+                    JsonSerializer.Serialize(writer, kvp.Value, options);
+                }
+                writer.WriteEndObject();
+            }
+        }
+
+        private sealed class DictionaryNullableDateTimeKeysConverterInner<TValue> : JsonConverter<Dictionary<DateTime?, TValue>>
+        {
+            public override Dictionary<DateTime?, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartObject)
+                    throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+                Dictionary<DateTime?, TValue> result = new();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                        return result;
+
+                    if (reader.TokenType != JsonTokenType.PropertyName)
+                        throw new JsonException($"Expected PropertyName, got {reader.TokenType}");
+
+                    string s = reader.GetString();
+                    DateTime? key;
+                    if (s == null)
+                    {
+                        key = null;
+                    }
+                    else
+                    {
+                        if (DateTime.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime parsed) == false)
+                            throw new JsonException($"Could not parse date time from '{s}'");
+
+                        key = parsed.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(parsed, DateTimeKind.Local) : parsed;
+                    }
+
+                    reader.Read();
+                    TValue value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+                    result[key] = value;
+                }
+
+                throw new JsonException("Unexpected end of JSON.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, Dictionary<DateTime?, TValue> value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                foreach (KeyValuePair<DateTime?, TValue> kvp in value)
+                {
+                    if (kvp.Key == null)
+                        throw new ArgumentException($"Cannot serialize a null DateTime key in a dictionary.");
+
+                    DateTime dt = kvp.Key.Value;
+                    if (dt.Kind == DateTimeKind.Unspecified)
+                        dt = DateTime.SpecifyKind(dt, DateTimeKind.Local);
+                    writer.WritePropertyName(dt.GetDefaultRavenFormat());
+                    JsonSerializer.Serialize(writer, kvp.Value, options);
+                }
+                writer.WriteEndObject();
+            }
+        }
+
+        private sealed class DictionaryDateTimeOffsetKeysConverterInner<TValue> : JsonConverter<Dictionary<DateTimeOffset, TValue>>
+        {
+            public override Dictionary<DateTimeOffset, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartObject)
+                    throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+                Dictionary<DateTimeOffset, TValue> result = new();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                        return result;
+
+                    if (reader.TokenType != JsonTokenType.PropertyName)
+                        throw new JsonException($"Expected PropertyName, got {reader.TokenType}");
+
+                    string s = reader.GetString();
+                    if (DateTimeOffset.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset key) == false)
+                        throw new JsonException($"Could not parse date time offset from '{s}'");
+
+                    reader.Read();
+                    TValue value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+                    result[key] = value;
+                }
+
+                throw new JsonException("Unexpected end of JSON.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, Dictionary<DateTimeOffset, TValue> value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                foreach (KeyValuePair<DateTimeOffset, TValue> kvp in value)
+                {
+                    DateTimeOffset dto = kvp.Key;
+                    string keyStr = dto.Offset == TimeSpan.Zero
+                        ? dto.UtcDateTime.GetDefaultRavenFormat(isUtc: true)
+                        : dto.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite, CultureInfo.InvariantCulture);
+                    writer.WritePropertyName(keyStr);
+                    JsonSerializer.Serialize(writer, kvp.Value, options);
+                }
+                writer.WriteEndObject();
+            }
+        }
+
+        private sealed class DictionaryNullableDateTimeOffsetKeysConverterInner<TValue> : JsonConverter<Dictionary<DateTimeOffset?, TValue>>
+        {
+            public override Dictionary<DateTimeOffset?, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.StartObject)
+                    throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+                Dictionary<DateTimeOffset?, TValue> result = new();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                        return result;
+
+                    if (reader.TokenType != JsonTokenType.PropertyName)
+                        throw new JsonException($"Expected PropertyName, got {reader.TokenType}");
+
+                    string s = reader.GetString();
+                    DateTimeOffset? key;
+                    if (s == null)
+                    {
+                        key = null;
+                    }
+                    else
+                    {
+                        if (DateTimeOffset.TryParseExact(s, DefaultFormat.DateTimeFormatsToRead, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset parsed) == false)
+                            throw new JsonException($"Could not parse date time offset from '{s}'");
+                        key = parsed;
+                    }
+
+                    reader.Read();
+                    TValue value = JsonSerializer.Deserialize<TValue>(ref reader, options);
+                    result[key] = value;
+                }
+
+                throw new JsonException("Unexpected end of JSON.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, Dictionary<DateTimeOffset?, TValue> value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                foreach (KeyValuePair<DateTimeOffset?, TValue> kvp in value)
+                {
+                    if (kvp.Key == null)
+                        throw new ArgumentException($"Cannot serialize a null DateTimeOffset key in a dictionary.");
+
+                    DateTimeOffset dto = kvp.Key.Value;
+                    string keyStr = dto.Offset == TimeSpan.Zero
+                        ? dto.UtcDateTime.GetDefaultRavenFormat(isUtc: true)
+                        : dto.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite, CultureInfo.InvariantCulture);
+                    writer.WritePropertyName(keyStr);
+                    JsonSerializer.Serialize(writer, kvp.Value, options);
+                }
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/EnumerableConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/EnumerableConverter.cs
@@ -31,6 +31,9 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
             if (typeToConvert == typeof(BlittableJsonReaderArray))
                 return false;
 
+            if (typeof(IDictionary).IsAssignableFrom(typeToConvert))
+                return false;
+
             if (_canConvertCache.TryGetValue(typeToConvert, out bool canConvert) == false)
             {
                 canConvert = ComputeCanConvert(typeToConvert);
@@ -99,7 +102,26 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
 
             public override IEnumerable<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
             {
-                throw new NotSupportedException($"{nameof(EnumerableConverter)} does not support reading.");
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                if (reader.TokenType != JsonTokenType.StartArray)
+                    throw new JsonException($"Expected StartArray token but got {reader.TokenType}.");
+
+                var list = new List<T>();
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndArray)
+                        break;
+
+                    T item = JsonSerializer.Deserialize<T>(ref reader, options);
+                    list.Add(item);
+                }
+
+                if (typeToConvert.IsArray)
+                    return list.ToArray();
+
+                return list;
             }
 
             public override void Write(Utf8JsonWriter writer, IEnumerable<T> value, JsonSerializerOptions options)

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/EnumerableConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/EnumerableConverter.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class EnumerableConverter : JsonConverterFactory
+    {
+        public static readonly EnumerableConverter Instance = new();
+
+        private Dictionary<Type, bool> _canConvertCache = new();
+
+        private EnumerableConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (typeToConvert == null)
+                return false;
+
+            if (typeToConvert == typeof(string))
+                return false;
+
+            if (typeToConvert == typeof(LazyStringValue))
+                return false;
+
+            if (typeToConvert == typeof(BlittableJsonReaderArray))
+                return false;
+
+            if (_canConvertCache.TryGetValue(typeToConvert, out bool canConvert) == false)
+            {
+                canConvert = ComputeCanConvert(typeToConvert);
+
+                // PERF: We are expecting a race condition here, this is an optimistic switch-on-change scheme.
+                //       It mostly works because the frequency of this call is very low.
+                _canConvertCache = new Dictionary<Type, bool>(_canConvertCache) { [typeToConvert] = canConvert };
+            }
+
+            return canConvert;
+        }
+
+        private static bool ComputeCanConvert(Type typeToConvert)
+        {
+            if (typeToConvert.IsArray)
+            {
+                if (typeToConvert.GetArrayRank() > 1)
+                    return false;
+
+                Type elementType = typeToConvert.GetElementType();
+                return elementType != null && elementType != typeof(object);
+            }
+
+            foreach (Type interfaceType in typeToConvert.GetInterfaces())
+            {
+                if (interfaceType.IsGenericType == false)
+                    continue;
+
+                if (interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    Type itemType = interfaceType.GetGenericArguments()[0];
+                    return itemType != typeof(object);
+                }
+            }
+
+            return false;
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            Type elementType = GetElementType(typeToConvert);
+            Type converterType = typeof(EnumerableConverterInner<>).MakeGenericType(elementType);
+            return (JsonConverter)Activator.CreateInstance(converterType, nonPublic: true);
+        }
+
+        private static Type GetElementType(Type typeToConvert)
+        {
+            if (typeToConvert.IsArray)
+                return typeToConvert.GetElementType() ?? typeof(object);
+
+            foreach (Type interfaceType in typeToConvert.GetInterfaces())
+            {
+                if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    return interfaceType.GetGenericArguments()[0];
+            }
+
+            return typeof(object);
+        }
+
+        private sealed class EnumerableConverterInner<T> : JsonConverter<IEnumerable<T>>
+        {
+            public override bool CanConvert(Type typeToConvert)
+            {
+                return typeof(IEnumerable<T>).IsAssignableFrom(typeToConvert);
+            }
+
+            public override IEnumerable<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(EnumerableConverter)} does not support reading.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, IEnumerable<T> value, JsonSerializerOptions options)
+            {
+                if (value == null)
+                {
+                    writer.WriteNullValue();
+                    return;
+                }
+
+                writer.WriteStartArray();
+                foreach (T item in value)
+                    JsonSerializer.Serialize(writer, item, typeof(T), options);
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/EnumerableConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/EnumerableConverter.cs
@@ -57,6 +57,12 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
                 return elementType != null && elementType != typeof(object);
             }
 
+            // Only handle interface and abstract types — concrete collection types (List<T>, HashSet<T>,
+            // Queue<T>, etc.) are already handled by STJ's built-in converters. If we intercept them,
+            // our Read path always returns List<T>, which breaks for HashSet<T>, Queue<T>, etc.
+            if (typeToConvert.IsInterface == false && typeToConvert.IsAbstract == false)
+                return false;
+
             foreach (Type interfaceType in typeToConvert.GetInterfaces())
             {
                 if (interfaceType.IsGenericType == false)
@@ -67,6 +73,13 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
                     Type itemType = interfaceType.GetGenericArguments()[0];
                     return itemType != typeof(object);
                 }
+            }
+
+            // Also check the type itself (it may be the IEnumerable<T> interface directly)
+            if (typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                Type itemType = typeToConvert.GetGenericArguments()[0];
+                return itemType != typeof(object);
             }
 
             return false;

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/LinqEnumerableConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/LinqEnumerableConverter.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    /// <summary>
+    /// This converter is used when a property is a Linq-To-Entities query, enumerating and
+    /// then serializing it as a json array.
+    /// </summary>
+    internal sealed class LinqEnumerableConverter : JsonConverterFactory
+    {
+        public static readonly LinqEnumerableConverter Instance = new();
+
+        private Dictionary<Type, bool> _canConvertCache = new();
+
+        private LinqEnumerableConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (typeToConvert.Namespace == null || typeToConvert == typeof(string) || typeToConvert.IsClass == false)
+                return false;
+
+            if (_canConvertCache.TryGetValue(typeToConvert, out bool canConvert) == false)
+            {
+                canConvert = false;
+                foreach (Type interfaceType in typeToConvert.GetInterfaces())
+                {
+                    if (interfaceType.IsGenericType == false)
+                        continue;
+
+                    Type genericInterfaceType = interfaceType.GetGenericTypeDefinition();
+                    if (typeof(IEnumerable<>) == genericInterfaceType && typeToConvert.Namespace.StartsWith("System.Linq"))
+                    {
+                        canConvert = true;
+                        break;
+                    }
+                }
+
+                // PERF: We are expecting a race condition here, this is an optimistic switch-on-change scheme.
+                //       It mostly works because the frequency of this call is very low.
+                _canConvertCache = new Dictionary<Type, bool>(_canConvertCache) { [typeToConvert] = canConvert };
+            }
+
+            return canConvert;
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            Type elementType = GetEnumerableElementType(typeToConvert);
+            Type converterType = typeof(LinqEnumerableConverterInner<>).MakeGenericType(elementType);
+            return (JsonConverter)Activator.CreateInstance(converterType, nonPublic: true);
+        }
+
+        private static Type GetEnumerableElementType(Type type)
+        {
+            foreach (Type interfaceType in type.GetInterfaces())
+            {
+                if (interfaceType.IsGenericType && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    return interfaceType.GetGenericArguments()[0];
+            }
+
+            return typeof(object);
+        }
+
+        private sealed class LinqEnumerableConverterInner<T> : JsonConverter<IEnumerable<T>>
+        {
+            public override bool CanConvert(Type typeToConvert)
+            {
+                return typeof(IEnumerable<T>).IsAssignableFrom(typeToConvert);
+            }
+
+            public override IEnumerable<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(LinqEnumerableConverter)} should not be used to deserialize collections from json - if this exception gets thrown, it is probably a bug.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, IEnumerable<T> value, JsonSerializerOptions options)
+            {
+                writer.WriteStartArray();
+                foreach (T item in value)
+                    JsonSerializer.Serialize(writer, item, options);
+                writer.WriteEndArray();
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/LuceneDateTimeConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/LuceneDateTimeConverter.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Raven.Client.Json.Serialization.NewtonsoftJson.Internal.Converters;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    /// <summary>
+    /// Converts Lucene date-time strings (17 numeric characters) to DateTime/DateTimeOffset.
+    /// Writing is not supported; this converter is read-only and intended as a fallback
+    /// when the primary ISO 8601 parse fails.
+    /// </summary>
+    internal sealed class LuceneDateTimeConverter : JsonConverterFactory
+    {
+        // 17 numeric characters on a datetime field == Lucene datetime
+        private static readonly Regex LuceneDateTimePattern = new Regex(@"^\d{17}$", RegexOptions.Compiled);
+
+        public static readonly LuceneDateTimeConverter Instance = new();
+
+        private LuceneDateTimeConverter()
+        {
+        }
+
+        /// <summary>
+        /// Tries to parse a Lucene date string. Returns <see cref="DateTime.MinValue"/> if the input
+        /// is not a 17-digit Lucene date string.
+        /// </summary>
+        internal static DateTime TryParseLucene(string input, bool isOffset)
+        {
+            if (input != null && LuceneDateTimePattern.IsMatch(input))
+                return DateTools.StringToDate(input);
+
+            return default;
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(DateTime)
+                || typeToConvert == typeof(DateTime?)
+                || typeToConvert == typeof(DateTimeOffset)
+                || typeToConvert == typeof(DateTimeOffset?);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (typeToConvert == typeof(DateTime))
+                return LuceneDateTimeConverterInner.Instance;
+            if (typeToConvert == typeof(DateTime?))
+                return LuceneNullableDateTimeConverterInner.Instance;
+            if (typeToConvert == typeof(DateTimeOffset))
+                return LuceneDateTimeOffsetConverterInner.Instance;
+            return LuceneNullableDateTimeOffsetConverterInner.Instance;
+        }
+
+        private sealed class LuceneDateTimeConverterInner : JsonConverter<DateTime>
+        {
+            public static readonly LuceneDateTimeConverterInner Instance = new();
+
+            public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                string s = reader.GetString();
+                DateTime lucene = TryParseLucene(s, isOffset: false);
+                if (lucene != default)
+                    return DateTime.SpecifyKind(lucene, DateTimeKind.Local);
+
+                return default;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(LuceneDateTimeConverter)} does not support writing.");
+            }
+        }
+
+        private sealed class LuceneNullableDateTimeConverterInner : JsonConverter<DateTime?>
+        {
+            public static readonly LuceneNullableDateTimeConverterInner Instance = new();
+
+            public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                string s = reader.GetString();
+                DateTime lucene = TryParseLucene(s, isOffset: false);
+                if (lucene != default)
+                    return DateTime.SpecifyKind(lucene, DateTimeKind.Local);
+
+                return null;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(LuceneDateTimeConverter)} does not support writing.");
+            }
+        }
+
+        private sealed class LuceneDateTimeOffsetConverterInner : JsonConverter<DateTimeOffset>
+        {
+            public static readonly LuceneDateTimeOffsetConverterInner Instance = new();
+
+            public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                string s = reader.GetString();
+                DateTime lucene = TryParseLucene(s, isOffset: true);
+                if (lucene != default)
+                    return new DateTimeOffset(lucene, DateTimeOffset.Now.Offset);
+
+                return default;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(LuceneDateTimeConverter)} does not support writing.");
+            }
+        }
+
+        private sealed class LuceneNullableDateTimeOffsetConverterInner : JsonConverter<DateTimeOffset?>
+        {
+            public static readonly LuceneNullableDateTimeOffsetConverterInner Instance = new();
+
+            public override DateTimeOffset? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                string s = reader.GetString();
+                DateTime lucene = TryParseLucene(s, isOffset: true);
+                if (lucene != default)
+                    return new DateTimeOffset(lucene, DateTimeOffset.Now.Offset);
+
+                return null;
+            }
+
+            public override void Write(Utf8JsonWriter writer, DateTimeOffset? value, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(LuceneDateTimeConverter)} does not support writing.");
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/MetadataDictionaryConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/MetadataDictionaryConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class MetadataDictionaryConverter : JsonConverter<IMetadataDictionary>
+    {
+        public static readonly MetadataDictionaryConverter Instance = new();
+
+        private MetadataDictionaryConverter()
+        {
+        }
+
+        public override IMetadataDictionary Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Dictionary<string, object> dict = JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, options);
+            return new MetadataAsDictionary(dict);
+        }
+
+        public override void Write(Utf8JsonWriter writer, IMetadataDictionary value, JsonSerializerOptions options)
+        {
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/MetadataDictionaryConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/MetadataDictionaryConverter.cs
@@ -23,6 +23,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
 
         public override void Write(Utf8JsonWriter writer, IMetadataDictionary value, JsonSerializerOptions options)
         {
+            throw new NotSupportedException($"{nameof(MetadataDictionaryConverter)} does not support writing. Metadata should be serialized via the blittable writer path, not through STJ directly.");
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/ParametersConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/ParametersConverter.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow;
+using Sparrow.Extensions;
+using Sparrow.Json;
+using Sparrow.Utils;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class ParametersConverter : JsonConverter<Parameters>
+    {
+        public static readonly ParametersConverter Instance = new ParametersConverter();
+
+        private static readonly HashSet<Assembly> RavenAssemblies = new HashSet<Assembly>
+        {
+            typeof(ParametersConverter).Assembly,
+            typeof(LazyStringValue).Assembly
+        };
+
+        private enum ParameterType
+        {
+            Unknown = 0,
+            DateTime,
+            DateTimeOffset,
+            Enumerable,
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            DateOnly,
+            TimeOnly,
+#endif
+            RavenAssembly,
+        }
+
+        private static readonly TypeCache<ParameterType> ConverterCache;
+
+        static ParametersConverter()
+        {
+            ConverterCache = new(256);
+            ConverterCache.Put(typeof(DateTime), ParameterType.DateTime);
+            ConverterCache.Put(typeof(DateTimeOffset), ParameterType.DateTimeOffset);
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            ConverterCache.Put(typeof(DateOnly), ParameterType.DateOnly);
+            ConverterCache.Put(typeof(TimeOnly), ParameterType.TimeOnly);
+#endif
+        }
+
+        private ParametersConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(Parameters);
+        }
+
+        public override Parameters Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException($"{nameof(ParametersConverter)} does not support reading.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Parameters value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+
+            foreach (KeyValuePair<string, object> kvp in value)
+            {
+                writer.WritePropertyName(kvp.Key);
+
+                object v = kvp.Value;
+                if (v == null)
+                {
+                    writer.WriteNullValue();
+                }
+                else
+                {
+                    Type vType = v.GetType();
+                    if (ConverterCache.TryGet(vType, out ParameterType pType) == false)
+                    {
+                        if (v is IEnumerable)
+                        {
+                            pType = ParameterType.Enumerable;
+                        }
+                        else if (IsRavenAssembly(v))
+                        {
+                            pType = ParameterType.RavenAssembly;
+                        }
+                        else
+                        {
+                            pType = ParameterType.Unknown;
+                        }
+
+                        ConverterCache.Put(vType, pType);
+                    }
+
+                    switch (pType)
+                    {
+                        case ParameterType.Unknown:
+                            JsonSerializer.Serialize(writer, v, vType, options);
+                            break;
+                        case ParameterType.DateTime:
+                            DateTime dateTime = (DateTime)v;
+                            if (dateTime.Kind == DateTimeKind.Unspecified)
+                                dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Local);
+                            writer.WriteStringValue(dateTime.GetDefaultRavenFormat());
+                            break;
+                        case ParameterType.DateTimeOffset:
+                            writer.WriteStringValue(((DateTimeOffset)v).UtcDateTime.GetDefaultRavenFormat(true));
+                            break;
+                        case ParameterType.Enumerable:
+                            JsonSerializer.Serialize(writer, v, vType, options);
+                            break;
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+                        case ParameterType.DateOnly:
+                            writer.WriteStringValue(((DateOnly)v).ToString(DefaultFormat.DateOnlyFormatToWrite, CultureInfo.InvariantCulture));
+                            break;
+                        case ParameterType.TimeOnly:
+                            writer.WriteStringValue(((TimeOnly)v).ToString(DefaultFormat.TimeOnlyFormatToWrite, CultureInfo.InvariantCulture));
+                            break;
+#endif
+                        case ParameterType.RavenAssembly:
+                            JsonSerializerOptions ravenOptions = GetRavenAssemblyOptions(options);
+                            JsonSerializer.Serialize(writer, v, vType, ravenOptions);
+                            break;
+                    }
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static bool IsRavenAssembly(object item)
+        {
+            if (item == null)
+                return false;
+
+            return RavenAssemblies.Contains(item.GetType().Assembly);
+        }
+
+        private static JsonSerializerOptions _ravenAssemblyOptions;
+
+        private static JsonSerializerOptions GetRavenAssemblyOptions(JsonSerializerOptions baseOptions)
+        {
+            JsonSerializerOptions existing = _ravenAssemblyOptions;
+            if (existing != null)
+                return existing;
+
+            JsonSerializerOptions created = new JsonSerializerOptions(baseOptions)
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
+            };
+
+            _ravenAssemblyOptions = created;
+            return created;
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/SizeConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/SizeConverter.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class SizeConverter : JsonConverterFactory
+    {
+        public static readonly SizeConverter Instance = new();
+
+        private SizeConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(Size) || typeToConvert == typeof(Size?);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (typeToConvert == typeof(Size))
+                return SizeConverterInner.Instance;
+
+            return NullableSizeConverter.Instance;
+        }
+
+        private sealed class SizeConverterInner : JsonConverter<Size>
+        {
+            public static readonly SizeConverterInner Instance = new();
+
+            public override Size Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.Number)
+                    throw new InvalidOperationException("Expected Number, Got " + reader.TokenType);
+
+                return new Size(reader.GetInt64(), SizeUnit.Bytes);
+            }
+
+            public override void Write(Utf8JsonWriter writer, Size value, JsonSerializerOptions options)
+            {
+                writer.WriteNumberValue(value.GetValue(SizeUnit.Bytes));
+            }
+        }
+
+        private sealed class NullableSizeConverter : JsonConverter<Size?>
+        {
+            public static readonly NullableSizeConverter Instance = new();
+
+            public override Size? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                if (reader.TokenType != JsonTokenType.Number)
+                    throw new InvalidOperationException("Expected Number, Got " + reader.TokenType);
+
+                return new Size(reader.GetInt64(), SizeUnit.Bytes);
+            }
+
+            public override void Write(Utf8JsonWriter writer, Size? value, JsonSerializerOptions options)
+            {
+                if (value == null)
+                {
+                    writer.WriteNullValue();
+                    return;
+                }
+
+                writer.WriteNumberValue(value.Value.GetValue(SizeUnit.Bytes));
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/StringDictionaryConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/StringDictionaryConverter.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    internal sealed class StringDictionaryConverter : JsonConverterFactory
+    {
+        private static readonly StringDictionaryConverter CurrentCulture = new(StringComparison.CurrentCulture);
+
+        private static readonly StringDictionaryConverter CurrentCultureIgnoreCase = new(StringComparison.CurrentCultureIgnoreCase);
+
+        private static readonly StringDictionaryConverter InvariantCulture = new(StringComparison.InvariantCulture);
+
+        private static readonly StringDictionaryConverter InvariantCultureIgnoreCase = new(StringComparison.InvariantCultureIgnoreCase);
+
+        private static readonly StringDictionaryConverter Ordinal = new(StringComparison.Ordinal);
+
+        private static readonly StringDictionaryConverter OrdinalIgnoreCase = new(StringComparison.OrdinalIgnoreCase);
+
+        private readonly StringComparer _comparer;
+
+        private StringDictionaryConverter(StringComparison stringComparison)
+        {
+            _comparer = GetStringComparer(stringComparison);
+        }
+
+        public static StringDictionaryConverter For(StringComparison stringComparison)
+        {
+            switch (stringComparison)
+            {
+                case StringComparison.CurrentCulture:
+                    return CurrentCulture;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    return CurrentCultureIgnoreCase;
+                case StringComparison.InvariantCulture:
+                    return InvariantCulture;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return InvariantCultureIgnoreCase;
+                case StringComparison.Ordinal:
+                    return Ordinal;
+                case StringComparison.OrdinalIgnoreCase:
+                    return OrdinalIgnoreCase;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(stringComparison));
+            }
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            if (typeToConvert.IsGenericType == false)
+                return false;
+
+            Type genericDef = typeToConvert.GetGenericTypeDefinition();
+            if (genericDef != typeof(Dictionary<,>) && genericDef != typeof(IDictionary<,>))
+                return false;
+
+            return typeToConvert.GetGenericArguments()[0] == typeof(string);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            Type valueType = typeToConvert.GetGenericArguments()[1];
+            Type converterType = typeof(StringDictionaryConverterInner<>).MakeGenericType(valueType);
+            return (JsonConverter)Activator.CreateInstance(converterType, _comparer);
+        }
+
+        private static StringComparer GetStringComparer(StringComparison stringComparison)
+        {
+            switch (stringComparison)
+            {
+                case StringComparison.CurrentCulture:
+                    return StringComparer.CurrentCulture;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    return StringComparer.CurrentCultureIgnoreCase;
+                case StringComparison.InvariantCulture:
+                    return StringComparer.InvariantCulture;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    return StringComparer.InvariantCultureIgnoreCase;
+                case StringComparison.Ordinal:
+                    return StringComparer.Ordinal;
+                case StringComparison.OrdinalIgnoreCase:
+                    return StringComparer.OrdinalIgnoreCase;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(stringComparison));
+            }
+        }
+
+        private sealed class StringDictionaryConverterInner<TValue> : JsonConverter<Dictionary<string, TValue>>
+        {
+            private readonly StringComparer _comparer;
+
+            public StringDictionaryConverterInner(StringComparer comparer)
+            {
+                _comparer = comparer;
+            }
+
+            public override bool CanConvert(Type typeToConvert)
+            {
+                return typeof(Dictionary<string, TValue>).IsAssignableFrom(typeToConvert)
+                    || typeToConvert == typeof(IDictionary<string, TValue>);
+            }
+
+            public override Dictionary<string, TValue> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                if (reader.TokenType != JsonTokenType.StartObject)
+                    throw new JsonException($"Expected StartObject, got {reader.TokenType}");
+
+                Dictionary<string, TValue> result = new(_comparer);
+
+                while (reader.Read())
+                {
+                    if (reader.TokenType == JsonTokenType.EndObject)
+                        return result;
+
+                    if (reader.TokenType != JsonTokenType.PropertyName)
+                        throw new JsonException($"Expected PropertyName, got {reader.TokenType}");
+
+                    string propertyName = reader.GetString();
+                    reader.Read();
+                    TValue propertyValue = JsonSerializer.Deserialize<TValue>(ref reader, options);
+                    result.Add(propertyName, propertyValue);
+                }
+
+                throw new JsonException("Unexpected end of JSON.");
+            }
+
+            public override void Write(Utf8JsonWriter writer, Dictionary<string, TValue> value, JsonSerializerOptions options)
+            {
+                throw new NotSupportedException($"{nameof(StringDictionaryConverter)} does not support writing.");
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/TimeOnlyConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/TimeOnlyConverter.cs
@@ -1,0 +1,96 @@
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Sparrow;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters
+{
+    // ISO 8601 standard
+    // More info available at: https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings#Roundtrip
+    internal sealed class TimeOnlyConverter : JsonConverterFactory
+    {
+        public static readonly TimeOnlyConverter Instance = new();
+
+        private TimeOnlyConverter()
+        {
+        }
+
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(TimeOnly) || typeToConvert == typeof(TimeOnly?);
+        }
+
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (typeToConvert == typeof(TimeOnly))
+                return TimeOnlyConverterInner.Instance;
+
+            return NullableTimeOnlyConverter.Instance;
+        }
+
+        private sealed class TimeOnlyConverterInner : JsonConverter<TimeOnly>
+        {
+            public static readonly TimeOnlyConverterInner Instance = new();
+
+            public override unsafe TimeOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidOperationException("Expected string, Got " + reader.TokenType);
+
+                string value = reader.GetString();
+
+                fixed (char* buffer = value.AsSpan())
+                {
+                    if (LazyStringParser.TryParseTimeOnly(buffer, value.Length, out TimeOnly timeOnly) == false)
+                        throw new InvalidOperationException("Expected TimeOnly, Got " + value);
+
+                    return timeOnly;
+                }
+            }
+
+            public override void Write(Utf8JsonWriter writer, TimeOnly value, JsonSerializerOptions options)
+            {
+                writer.WriteStringValue(value.ToString(DefaultFormat.TimeOnlyFormatToWrite, CultureInfo.InvariantCulture));
+            }
+        }
+
+        private sealed class NullableTimeOnlyConverter : JsonConverter<TimeOnly?>
+        {
+            public static readonly NullableTimeOnlyConverter Instance = new();
+
+            public override unsafe TimeOnly? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.Null)
+                    return null;
+
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidOperationException("Expected string, Got " + reader.TokenType);
+
+                string value = reader.GetString();
+
+                fixed (char* buffer = value.AsSpan())
+                {
+                    if (LazyStringParser.TryParseTimeOnly(buffer, value.Length, out TimeOnly timeOnly) == false)
+                        throw new InvalidOperationException("Expected TimeOnly, Got " + value);
+
+                    return timeOnly;
+                }
+            }
+
+            public override void Write(Utf8JsonWriter writer, TimeOnly? value, JsonSerializerOptions options)
+            {
+                if (value == null)
+                {
+                    writer.WriteNullValue();
+                    return;
+                }
+
+                writer.WriteStringValue(value.Value.ToString(DefaultFormat.TimeOnlyFormatToWrite, CultureInfo.InvariantCulture));
+            }
+        }
+    }
+}
+#endif

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/VectorConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/Converters/VectorConverter.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Raven.Client.Documents;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters;
+
+internal sealed class VectorConverter : JsonConverterFactory
+{
+    public static readonly VectorConverter Instance = new();
+
+    private VectorConverter()
+    {
+    }
+
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (typeToConvert.IsGenericType == false)
+            return false;
+
+        return typeToConvert.GetGenericTypeDefinition() == typeof(RavenVector<>);
+    }
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        Type elementType = typeToConvert.GetGenericArguments()[0];
+
+        if (elementType == typeof(float))
+            return VectorConverterInner<float>.Instance;
+        if (elementType == typeof(double))
+            return VectorConverterInner<double>.Instance;
+        if (elementType == typeof(decimal))
+            return VectorConverterInner<decimal>.Instance;
+        if (elementType == typeof(byte))
+            return VectorConverterInner<byte>.Instance;
+        if (elementType == typeof(ushort))
+            return VectorConverterInner<ushort>.Instance;
+        if (elementType == typeof(uint))
+            return VectorConverterInner<uint>.Instance;
+        if (elementType == typeof(ulong))
+            return VectorConverterInner<ulong>.Instance;
+        if (elementType == typeof(sbyte))
+            return VectorConverterInner<sbyte>.Instance;
+        if (elementType == typeof(short))
+            return VectorConverterInner<short>.Instance;
+        if (elementType == typeof(int))
+            return VectorConverterInner<int>.Instance;
+        if (elementType == typeof(long))
+            return VectorConverterInner<long>.Instance;
+#if NET6_0_OR_GREATER
+        if (elementType == typeof(Half))
+            return VectorConverterInner<Half>.Instance;
+#endif
+
+        throw new InvalidOperationException($"Type {elementType.FullName} is not supported for RavenVector<T>.");
+    }
+
+    private sealed class VectorConverterInner<T> : JsonConverter<RavenVector<T>>
+        where T : unmanaged
+#if NET7_0_OR_GREATER
+        , INumber<T>
+#endif
+    {
+        public static readonly VectorConverterInner<T> Instance = new();
+
+        private VectorConverterInner()
+        {
+        }
+
+        public override RavenVector<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+                return null;
+
+            if (reader.TokenType != JsonTokenType.StartObject)
+                throw new JsonException($"Expected StartObject token, got {reader.TokenType}.");
+
+            reader.Read(); // move to property name
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException($"Expected PropertyName token, got {reader.TokenType}.");
+
+            string propertyName = reader.GetString();
+            if (propertyName != Sparrow.Global.Constants.Naming.VectorPropertyName)
+                throw new JsonException($"Expected property '{Sparrow.Global.Constants.Naming.VectorPropertyName}', got '{propertyName}'.");
+
+            reader.Read(); // move to array start
+            if (reader.TokenType != JsonTokenType.StartArray)
+                throw new JsonException($"Expected StartArray token, got {reader.TokenType}.");
+
+            List<T> values = new List<T>();
+            while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+                values.Add(ReadElement(ref reader));
+
+            reader.Read(); // move past EndObject
+            if (reader.TokenType != JsonTokenType.EndObject)
+                throw new JsonException($"Expected EndObject token, got {reader.TokenType}.");
+
+            return new RavenVector<T>(values.ToArray());
+        }
+
+        private static T ReadElement(ref Utf8JsonReader reader)
+        {
+            if (typeof(T) == typeof(float))
+                return (T)(object)reader.GetSingle();
+            if (typeof(T) == typeof(double))
+                return (T)(object)reader.GetDouble();
+            if (typeof(T) == typeof(decimal))
+                return (T)(object)reader.GetDecimal();
+            if (typeof(T) == typeof(byte))
+                return (T)(object)reader.GetByte();
+            if (typeof(T) == typeof(ushort))
+                return (T)(object)reader.GetUInt16();
+            if (typeof(T) == typeof(uint))
+                return (T)(object)reader.GetUInt32();
+            if (typeof(T) == typeof(ulong))
+                return (T)(object)reader.GetUInt64();
+            if (typeof(T) == typeof(sbyte))
+                return (T)(object)reader.GetSByte();
+            if (typeof(T) == typeof(short))
+                return (T)(object)reader.GetInt16();
+            if (typeof(T) == typeof(int))
+                return (T)(object)reader.GetInt32();
+            if (typeof(T) == typeof(long))
+                return (T)(object)reader.GetInt64();
+#if NET6_0_OR_GREATER
+            if (typeof(T) == typeof(Half))
+                return (T)(object)(Half)reader.GetSingle();
+#endif
+
+            throw new InvalidOperationException($"Type {typeof(T).FullName} is not supported for RavenVector<T>.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, RavenVector<T> value, JsonSerializerOptions options)
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStartObject();
+            writer.WritePropertyName(Sparrow.Global.Constants.Naming.VectorPropertyName);
+            writer.WriteStartArray();
+
+            foreach (T element in value.Embedding)
+                WriteElement(writer, element);
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        private static void WriteElement(Utf8JsonWriter writer, T value)
+        {
+            if (typeof(T) == typeof(float))
+                writer.WriteNumberValue((float)(object)value);
+            else if (typeof(T) == typeof(double))
+                writer.WriteNumberValue((double)(object)value);
+            else if (typeof(T) == typeof(decimal))
+                writer.WriteNumberValue((decimal)(object)value);
+            else if (typeof(T) == typeof(byte))
+                writer.WriteNumberValue((byte)(object)value);
+            else if (typeof(T) == typeof(ushort))
+                writer.WriteNumberValue((ushort)(object)value);
+            else if (typeof(T) == typeof(uint))
+                writer.WriteNumberValue((uint)(object)value);
+            else if (typeof(T) == typeof(ulong))
+                writer.WriteNumberValue((ulong)(object)value);
+            else if (typeof(T) == typeof(sbyte))
+                writer.WriteNumberValue((sbyte)(object)value);
+            else if (typeof(T) == typeof(short))
+                writer.WriteNumberValue((short)(object)value);
+            else if (typeof(T) == typeof(int))
+                writer.WriteNumberValue((int)(object)value);
+            else if (typeof(T) == typeof(long))
+                writer.WriteNumberValue((long)(object)value);
+#if NET6_0_OR_GREATER
+            else if (typeof(T) == typeof(Half))
+                writer.WriteNumberValue((float)(Half)(object)value);
+#endif
+            else
+                throw new InvalidOperationException($"Type {typeof(T).FullName} is not supported for RavenVector<T>.");
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
@@ -288,7 +288,9 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             }
         }
 
-        // Cache known property names per entity type (property names are immutable per type)
+        // Cache known JSON property names per entity type.
+        // Includes both CLR names and attribute-specified JSON names ([JsonPropertyName], [JsonProperty], [DataMember])
+        // so that renamed properties are not misclassified as "missing".
         private static readonly ConcurrentDictionary<Type, HashSet<string>> _knownPropertyNamesCache = new();
 
         private static HashSet<string> GetKnownPropertyNames(Type type)
@@ -299,9 +301,19 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 for (Type current = t; current != null && current != typeof(object); current = current.BaseType)
                 {
                     foreach (var prop in current.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    {
                         names.Add(prop.Name);
+                        var jsonName = JsonPropertyNameResolver.GetJsonPropertyName(prop);
+                        if (jsonName != null)
+                            names.Add(jsonName);
+                    }
                     foreach (var field in current.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    {
                         names.Add(field.Name);
+                        var jsonName = JsonPropertyNameResolver.GetJsonPropertyName(field);
+                        if (jsonName != null)
+                            names.Add(jsonName);
+                    }
                 }
                 return names;
             });

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
@@ -32,13 +32,13 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 
                 _session.OnBeforeConversionToEntityInvoke(id, type, ref json);
 
+                if (trackEntity && _session.Conventions.PreserveDocumentPropertiesNotFoundOnModel)
+                    throw new NotSupportedException(
+                        $"{nameof(DocumentConventions.PreserveDocumentPropertiesNotFoundOnModel)} is not yet supported with the System.Text.Json serializer. " +
+                        "Disable this convention or use the Newtonsoft.Json serializer.");
+
                 var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
                 var entity = defaultValue;
-
-                // TODO: RavenDB-23037 Missing property tracking is not yet implemented for STJ.
-                // The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataSetter
-                // to capture properties present in JSON but missing from the CLR type. STJ needs
-                // an equivalent approach (e.g., JsonTypeInfo modifier or UnmappedMemberHandling).
 
                 var documentTypeAsString = _session.Conventions.GetClrType(id, json);
                 if (documentTypeAsString != null)

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Sparrow;
@@ -32,20 +34,17 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 
                 _session.OnBeforeConversionToEntityInvoke(id, type, ref json);
 
-                if (trackEntity && _session.Conventions.PreserveDocumentPropertiesNotFoundOnModel)
-                    throw new NotSupportedException(
-                        $"{nameof(DocumentConventions.PreserveDocumentPropertiesNotFoundOnModel)} is not yet supported with the System.Text.Json serializer. " +
-                        "Disable this convention or use the Newtonsoft.Json serializer.");
-
                 var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
                 var entity = defaultValue;
 
+                Type entityType = type;
                 var documentTypeAsString = _session.Conventions.GetClrType(id, json);
                 if (documentTypeAsString != null)
                 {
                     var documentType = _session.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
                     if (documentType != null && type.IsAssignableFrom(documentType))
                     {
+                        entityType = documentType;
                         entity = _session.Conventions.Serialization.DeserializeEntityFromBlittable(documentType, json);
                     }
                 }
@@ -53,6 +52,11 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 if (Equals(entity, defaultValue))
                 {
                     entity = _session.Conventions.Serialization.DeserializeEntityFromBlittable(type, json);
+                }
+
+                if (trackEntity && _session.Conventions.PreserveDocumentPropertiesNotFoundOnModel && entity != null)
+                {
+                    CaptureMissingProperties(entity, entityType, json);
                 }
 
                 if (id != null)
@@ -131,11 +135,22 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             if (documentInfo != null)
                 _session.OnBeforeConversionToDocumentInvoke(documentInfo.Id, entity);
 
-            // TODO: RavenDB-23037 Missing property round-tripping (FillMissingProperties) is not yet
-            // implemented for STJ. The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataGetter.
             BlittableJsonReaderObject document;
             using (var writer = new SystemTextJsonBlittableWriter(_session.Context, documentInfo))
                 document = ToBlittableInternal(entity, _session.Conventions, _session.Context, _session.JsonSerializer, writer);
+
+            // Inject missing properties (properties in the original JSON that aren't on the CLR type)
+            if (MissingProperties != null && MissingProperties.TryGetValue(entity, out var missingProps) && missingProps.Count > 0)
+            {
+                if (document.Modifications == null)
+                    document.Modifications = new DynamicJsonValue(document);
+
+                foreach (var kvp in missingProps)
+                    document.Modifications[(string)kvp.Key] = kvp.Value;
+
+                using (var old = document)
+                    document = _session.Context.ReadObject(document, "restore/missingProperties");
+            }
 
             if (documentInfo != null)
                 _session.OnAfterConversionToDocumentInvoke(documentInfo.Id, entity, ref document);
@@ -242,6 +257,54 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
         public void RemoveFromMissing<T>(T entity)
         {
             MissingProperties?.Remove(entity);
+        }
+
+        /// <summary>
+        /// Compare the blittable's property names against the entity type's known CLR properties.
+        /// Any properties in the JSON that don't exist on the CLR type are captured as missing
+        /// properties for later round-trip preservation.
+        /// </summary>
+        private void CaptureMissingProperties(object entity, Type entityType, BlittableJsonReaderObject json)
+        {
+            var knownProperties = GetKnownPropertyNames(entityType);
+            var propertyNames = json.GetPropertyNames();
+
+            for (int i = 0; i < propertyNames.Length; i++)
+            {
+                var propName = propertyNames[i];
+
+                if (propName == Constants.Documents.Metadata.Key)
+                    continue;
+
+                if (knownProperties.Contains(propName))
+                    continue;
+
+                // This property exists in JSON but not on the CLR type — capture its value
+                var propIndex = json.GetPropertyIndex(propName);
+                var propDetails = new BlittableJsonReaderObject.PropertyDetails();
+                json.GetPropertyByIndex(propIndex, ref propDetails);
+
+                RegisterMissingProperties(entity, propName, propDetails.Value);
+            }
+        }
+
+        // Cache known property names per entity type (property names are immutable per type)
+        private static readonly ConcurrentDictionary<Type, HashSet<string>> _knownPropertyNamesCache = new();
+
+        private static HashSet<string> GetKnownPropertyNames(Type type)
+        {
+            return _knownPropertyNamesCache.GetOrAdd(type, static t =>
+            {
+                var names = new HashSet<string>(StringComparer.Ordinal);
+                for (Type current = t; current != null && current != typeof(object); current = current.BaseType)
+                {
+                    foreach (var prop in current.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                        names.Add(prop.Name);
+                    foreach (var field in current.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                        names.Add(field.Name);
+                }
+                return names;
+            });
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Raven.Client.Documents.Session;
+using Sparrow;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class SessionBlittableJsonConverter : BlittableJsonConverterWithMissingProperties, ISessionBlittableJsonConverter
+    {
+        private readonly InMemoryDocumentSessionOperations _session;
+
+        public SessionBlittableJsonConverter(InMemoryDocumentSessionOperations session)
+            : base(session.Conventions.Serialization)
+        {
+            _session = session ?? throw new ArgumentNullException(nameof(session));
+        }
+
+        public object FromBlittable(Type type, ref BlittableJsonReaderObject json, string id, bool trackEntity)
+        {
+            try
+            {
+                if (type == typeof(BlittableJsonReaderObject))
+                {
+                    return json;
+                }
+
+                _session.OnBeforeConversionToEntityInvoke(id, type, ref json);
+
+                var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
+                var entity = defaultValue;
+
+                // TODO: RavenDB-23037 Missing property tracking is not yet implemented for STJ.
+                // The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataSetter
+                // to capture properties present in JSON but missing from the CLR type. STJ needs
+                // an equivalent approach (e.g., JsonTypeInfo modifier or UnmappedMemberHandling).
+
+                var documentTypeAsString = _session.Conventions.GetClrType(id, json);
+                if (documentTypeAsString != null)
+                {
+                    var documentType = _session.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
+                    if (documentType != null && type.IsAssignableFrom(documentType))
+                    {
+                        entity = _session.Conventions.Serialization.DeserializeEntityFromBlittable(documentType, json);
+                    }
+                }
+
+                if (Equals(entity, defaultValue))
+                {
+                    entity = _session.Conventions.Serialization.DeserializeEntityFromBlittable(type, json);
+                }
+
+                if (id != null)
+                    _session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, id);
+
+                return entity;
+            }
+            catch (Exception ex)
+            {
+                string jsonAsString = TryReadBlittableAsString(json);
+
+                throw new InvalidOperationException($"Could not convert document {id} to entity of type {type}. Json: {jsonAsString}",
+                    ex);
+            }
+
+            string TryReadBlittableAsString(BlittableJsonReaderObject jsonToRead)
+            {
+                var jsString = string.Empty;
+
+                using (var memoryStream = RecyclableMemoryStreamFactory.GetRecyclableStream())
+                {
+                    try
+                    {
+                        jsonToRead.WriteJsonToAsync(memoryStream).AsTask().ConfigureAwait(false).GetAwaiter().GetResult();
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+
+                    memoryStream.Position = 0;
+
+                    try
+                    {
+                        using (var sr = new StreamReader(memoryStream))
+                        {
+                            jsString = sr.ReadToEnd();
+                        }
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
+
+                return jsString;
+            }
+        }
+
+        public T FromBlittable<T>(ref BlittableJsonReaderObject json, string id, bool trackEntity)
+        {
+            return (T)FromBlittable(typeof(T), ref json, id, trackEntity);
+        }
+
+        public void PopulateEntity(object entity, string id, BlittableJsonReaderObject json)
+        {
+            var jsonSerializer = _session.Conventions.Serialization.CreateSerializer();
+            PopulateEntity(entity, id, json, jsonSerializer);
+        }
+
+        public void PopulateEntity(object entity, string id, BlittableJsonReaderObject json, IJsonSerializer jsonSerializer)
+        {
+            if (id == null)
+                throw new ArgumentNullException(nameof(id));
+
+            PopulateEntity(entity, json, jsonSerializer);
+
+            _session.GenerateEntityIdOnTheClient.TrySetIdentity(entity, id);
+        }
+
+        public BlittableJsonReaderObject ToBlittable(object entity, DocumentInfo documentInfo)
+        {
+            if (entity is BlittableJsonReaderObject blittable)
+                return blittable;
+
+            if (documentInfo != null)
+                _session.OnBeforeConversionToDocumentInvoke(documentInfo.Id, entity);
+
+            // TODO: RavenDB-23037 Missing property round-tripping (FillMissingProperties) is not yet
+            // implemented for STJ. The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataGetter.
+            using (var writer = new SystemTextJsonBlittableWriter(_session.Context, documentInfo))
+            {
+                var document = ToBlittableInternal(entity, _session.Conventions, _session.Context, _session.JsonSerializer, writer);
+
+                if (documentInfo != null)
+                    _session.OnAfterConversionToDocumentInvoke(documentInfo.Id, entity, ref document);
+
+                return document;
+            }
+        }
+
+        public void Clear()
+        {
+            MissingProperties?.Clear();
+        }
+
+        public void RemoveFromMissing<T>(T entity)
+        {
+            MissingProperties?.Remove(entity);
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SessionBlittableJsonConverter.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.IO;
 using System.Linq;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Sparrow;
 using Sparrow.Json;
+using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 {
@@ -130,15 +133,105 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 
             // TODO: RavenDB-23037 Missing property round-tripping (FillMissingProperties) is not yet
             // implemented for STJ. The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataGetter.
+            BlittableJsonReaderObject document;
             using (var writer = new SystemTextJsonBlittableWriter(_session.Context, documentInfo))
+                document = ToBlittableInternal(entity, _session.Conventions, _session.Context, _session.JsonSerializer, writer);
+
+            if (documentInfo != null)
+                _session.OnAfterConversionToDocumentInvoke(documentInfo.Id, entity, ref document);
+
+            return document;
+        }
+
+        private BlittableJsonReaderObject SerializeViaParseBuffer(object entity, SystemTextJsonJsonSerializer stjSerializer, DocumentInfo documentInfo)
+        {
+            var context = _session.Context;
+            var conventions = _session.Conventions;
+            var type = entity.GetType();
+
+            // Set up identity removal via the resolver
+            bool isDynamicObject = entity is IDynamicMetaObjectProvider;
+            bool hasIdentityProperty = conventions.GetIdentityProperty(type) != null;
+
+            if (isDynamicObject == false)
             {
-                var document = ToBlittableInternal(entity, _session.Conventions, _session.Context, _session.JsonSerializer, writer);
-
-                if (documentInfo != null)
-                    _session.OnAfterConversionToDocumentInvoke(documentInfo.Id, entity, ref document);
-
-                return document;
+                RavenJsonTypeInfoResolver.RootEntity = hasIdentityProperty ? entity : null;
+                RavenJsonTypeInfoResolver.RemovedIdentityProperty = false;
             }
+
+            BlittableJsonReaderObject document;
+            try
+            {
+                document = stjSerializer.SerializeToBlittable(entity, type, context);
+            }
+            finally
+            {
+                RavenJsonTypeInfoResolver.RootEntity = null;
+            }
+
+            // Remove identity property if the resolver didn't handle it
+            bool changes = false;
+            if (isDynamicObject || (hasIdentityProperty && RavenJsonTypeInfoResolver.RemovedIdentityProperty == false))
+            {
+                changes = BlittableJsonConverterHelper.TryRemoveIdentityProperty(document, type, conventions, isDynamicObject);
+            }
+
+            // Inject @metadata
+            changes |= InjectMetadata(document, documentInfo);
+
+            if (changes)
+            {
+                using (var old = document)
+                {
+                    document = context.ReadObject(document, "convert/entityToBlittable");
+                }
+            }
+
+            return document;
+        }
+
+        private static bool InjectMetadata(BlittableJsonReaderObject document, DocumentInfo documentInfo)
+        {
+            if (documentInfo == null)
+                return false;
+
+            object metadataValue = null;
+
+            if (documentInfo.Metadata?.Modifications != null && documentInfo.Metadata.Modifications.Properties.Count > 0)
+            {
+                // Modified metadata blittable — apply modifications, then use the blittable itself
+                // (ReadObject will handle the Modifications overlay)
+                metadataValue = documentInfo.Metadata;
+            }
+            else if (documentInfo.Metadata != null)
+            {
+                // Existing metadata blittable — use directly as nested value
+                metadataValue = documentInfo.Metadata;
+            }
+            else if (documentInfo.MetadataInstance != null)
+            {
+                var metadata = new DynamicJsonValue();
+                foreach (var kvp in documentInfo.MetadataInstance)
+                    metadata[kvp.Key] = kvp.Value;
+                metadataValue = metadata;
+            }
+            else if (documentInfo.Collection != null)
+            {
+                var metadata = new DynamicJsonValue();
+                metadata[Constants.Documents.Metadata.Collection] = documentInfo.Collection;
+                if (documentInfo.Id != null)
+                    metadata[Constants.Documents.Metadata.Id] = documentInfo.Id;
+                metadataValue = metadata;
+            }
+
+            if (metadataValue == null)
+                return false;
+
+            if (document.Modifications == null)
+                document.Modifications = new DynamicJsonValue(document);
+
+            document.Modifications[Constants.Documents.Metadata.Key] = metadataValue;
+            return true;
         }
 
         public void Clear()

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Raven.Client.Documents.Session;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class SubscriptionBlittableJsonConverter : BlittableJsonConverterWithMissingProperties, ISubscriptionsBlittableJsonConverter
+    {
+        public SubscriptionBlittableJsonConverter(ISerializationConventions conventions) : base(conventions)
+        {
+        }
+
+        public T FromBlittable<T>(BlittableJsonReaderObject json, string id)
+        {
+            return (T)FromBlittable(typeof(T), json, id);
+        }
+
+        public object FromBlittable(Type type, BlittableJsonReaderObject json, string id)
+        {
+            try
+            {
+                // TODO: RavenDB-23037 Missing property tracking is not yet implemented for STJ.
+                // The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataSetter.
+
+                var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
+                var entity = defaultValue;
+
+                var documentTypeAsString = Conventions.Conventions.GetClrType(id, json);
+                if (documentTypeAsString != null)
+                {
+                    var documentType = Conventions.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
+                    if (documentType != null && type.IsAssignableFrom(documentType))
+                    {
+                        entity = Conventions.DeserializeEntityFromBlittable(documentType, json);
+                    }
+                }
+
+                if (Equals(entity, defaultValue))
+                {
+                    entity = Conventions.DeserializeEntityFromBlittable(type, json);
+                }
+
+                return entity;
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Could not convert document {id} to entity of type {type}",
+                    ex);
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
@@ -1,6 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Raven.Client.Documents.Conventions;
+using System.Reflection;
 using Raven.Client.Documents.Session;
 using Sparrow.Json;
 
@@ -21,20 +22,17 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
         {
             try
             {
-                if (Conventions.Conventions.PreserveDocumentPropertiesNotFoundOnModel)
-                    throw new NotSupportedException(
-                        $"{nameof(DocumentConventions.PreserveDocumentPropertiesNotFoundOnModel)} is not yet supported with the System.Text.Json serializer. " +
-                        "Disable this convention or use the Newtonsoft.Json serializer.");
-
                 var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
                 var entity = defaultValue;
 
+                Type entityType = type;
                 var documentTypeAsString = Conventions.Conventions.GetClrType(id, json);
                 if (documentTypeAsString != null)
                 {
                     var documentType = Conventions.Conventions.ResolveTypeFromClrTypeName(documentTypeAsString);
                     if (documentType != null && type.IsAssignableFrom(documentType))
                     {
+                        entityType = documentType;
                         entity = Conventions.DeserializeEntityFromBlittable(documentType, json);
                     }
                 }
@@ -44,6 +42,11 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                     entity = Conventions.DeserializeEntityFromBlittable(type, json);
                 }
 
+                if (Conventions.Conventions.PreserveDocumentPropertiesNotFoundOnModel && entity != null)
+                {
+                    CaptureMissingProperties(entity, entityType, json);
+                }
+
                 return entity;
             }
             catch (Exception ex)
@@ -51,6 +54,47 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 throw new InvalidOperationException($"Could not convert document {id} to entity of type {type}",
                     ex);
             }
+        }
+
+        private void CaptureMissingProperties(object entity, Type entityType, BlittableJsonReaderObject json)
+        {
+            var knownProperties = GetKnownPropertyNames(entityType);
+            var propertyNames = json.GetPropertyNames();
+
+            for (int i = 0; i < propertyNames.Length; i++)
+            {
+                var propName = propertyNames[i];
+
+                if (propName == Constants.Documents.Metadata.Key)
+                    continue;
+
+                if (knownProperties.Contains(propName))
+                    continue;
+
+                var propIndex = json.GetPropertyIndex(propName);
+                var propDetails = new BlittableJsonReaderObject.PropertyDetails();
+                json.GetPropertyByIndex(propIndex, ref propDetails);
+
+                RegisterMissingProperties(entity, propName, propDetails.Value);
+            }
+        }
+
+        private static readonly ConcurrentDictionary<Type, HashSet<string>> _knownPropertyNamesCache = new();
+
+        private static HashSet<string> GetKnownPropertyNames(Type type)
+        {
+            return _knownPropertyNamesCache.GetOrAdd(type, static t =>
+            {
+                var names = new HashSet<string>(StringComparer.Ordinal);
+                for (Type current = t; current != null && current != typeof(object); current = current.BaseType)
+                {
+                    foreach (var prop in current.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                        names.Add(prop.Name);
+                    foreach (var field in current.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                        names.Add(field.Name);
+                }
+                return names;
+            });
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Session;
 using Sparrow.Json;
 
@@ -20,8 +21,10 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
         {
             try
             {
-                // TODO: RavenDB-23037 Missing property tracking is not yet implemented for STJ.
-                // The Newtonsoft path uses DefaultRavenContractResolver.RegisterExtensionDataSetter.
+                if (Conventions.Conventions.PreserveDocumentPropertiesNotFoundOnModel)
+                    throw new NotSupportedException(
+                        $"{nameof(DocumentConventions.PreserveDocumentPropertiesNotFoundOnModel)} is not yet supported with the System.Text.Json serializer. " +
+                        "Disable this convention or use the Newtonsoft.Json serializer.");
 
                 var defaultValue = InMemoryDocumentSessionOperations.GetDefaultValue(type);
                 var entity = defaultValue;

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SubscriptionBlittableJsonConverter.cs
@@ -79,6 +79,9 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             }
         }
 
+        // Cache known JSON property names per entity type.
+        // Includes both CLR names and attribute-specified JSON names ([JsonPropertyName], [JsonProperty], [DataMember])
+        // so that renamed properties are not misclassified as "missing".
         private static readonly ConcurrentDictionary<Type, HashSet<string>> _knownPropertyNamesCache = new();
 
         private static HashSet<string> GetKnownPropertyNames(Type type)
@@ -89,9 +92,19 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 for (Type current = t; current != null && current != typeof(object); current = current.BaseType)
                 {
                     foreach (var prop in current.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    {
                         names.Add(prop.Name);
+                        var jsonName = JsonPropertyNameResolver.GetJsonPropertyName(prop);
+                        if (jsonName != null)
+                            names.Add(jsonName);
+                    }
                     foreach (var field in current.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                    {
                         names.Add(field.Name);
+                        var jsonName = JsonPropertyNameResolver.GetJsonPropertyName(field);
+                        if (jsonName != null)
+                            names.Add(jsonName);
+                    }
                 }
                 return names;
             });

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableEntitySerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableEntitySerializer.cs
@@ -8,7 +8,6 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 {
     internal sealed class SystemTextJsonBlittableEntitySerializer
     {
-        private readonly LightWeightThreadLocal<SystemTextJsonBlittableReader> _reader;
         private readonly LightWeightThreadLocal<JsonSerializerOptions> _options;
 
         private readonly GenerateEntityIdOnTheClient _generateEntityIdOnTheClient;
@@ -17,15 +16,17 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
         {
             _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(conventions.Conventions, generateIdAsync: null);
             _options = new LightWeightThreadLocal<JsonSerializerOptions>(() => conventions.CreateJsonSerializerOptions());
-            _reader = new LightWeightThreadLocal<SystemTextJsonBlittableReader>(() => new SystemTextJsonBlittableReader());
         }
 
         public object EntityFromJsonStream(Type type, BlittableJsonReaderObject json)
         {
-            _reader.Value.Initialize(json);
+            using var reader = new SystemTextJsonBlittableReader();
+            reader.Initialize(json);
 
-            ReadOnlySpan<byte> utf8Json = _reader.Value.GetUtf8Json();
-            object entity = JsonSerializer.Deserialize(utf8Json, type, _options.Value);
+            object entity = JsonSerializer.Deserialize(reader.GetUtf8Json(), type, _options.Value);
+
+            // Return native memory immediately - we're done with the UTF-8 bytes
+            reader.ReturnMemory();
 
             if (entity != null)
                 TrySetIdentityFromMetadata(entity, json);

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableEntitySerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableEntitySerializer.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Text.Json;
+using Raven.Client.Documents.Identity;
+using Sparrow.Json;
+using Sparrow.Threading;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class SystemTextJsonBlittableEntitySerializer
+    {
+        private readonly LightWeightThreadLocal<SystemTextJsonBlittableReader> _reader;
+        private readonly LightWeightThreadLocal<JsonSerializerOptions> _options;
+
+        private readonly GenerateEntityIdOnTheClient _generateEntityIdOnTheClient;
+
+        public SystemTextJsonBlittableEntitySerializer(SystemTextJsonSerializationConventions conventions)
+        {
+            _generateEntityIdOnTheClient = new GenerateEntityIdOnTheClient(conventions.Conventions, generateIdAsync: null);
+            _options = new LightWeightThreadLocal<JsonSerializerOptions>(() => conventions.CreateJsonSerializerOptions());
+            _reader = new LightWeightThreadLocal<SystemTextJsonBlittableReader>(() => new SystemTextJsonBlittableReader());
+        }
+
+        public object EntityFromJsonStream(Type type, BlittableJsonReaderObject json)
+        {
+            _reader.Value.Initialize(json);
+
+            ReadOnlySpan<byte> utf8Json = _reader.Value.GetUtf8Json();
+            object entity = JsonSerializer.Deserialize(utf8Json, type, _options.Value);
+
+            if (entity != null)
+                TrySetIdentityFromMetadata(entity, json);
+
+            return entity;
+        }
+
+        private void TrySetIdentityFromMetadata(object entity, BlittableJsonReaderObject json)
+        {
+            if (json.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false || metadata == null)
+                return;
+
+            if (metadata.TryGet(Constants.Documents.Metadata.Id, out string id) && id != null)
+            {
+                bool isProjection = metadata.TryGet(Constants.Documents.Metadata.Projection, out bool projection) && projection;
+
+                _generateEntityIdOnTheClient.TrySetIdentity(entity, id, isProjection);
+                return;
+            }
+
+            if (json.TryGet(Constants.Documents.Metadata.Id, out string topLevelId) && topLevelId != null)
+            {
+                if (_generateEntityIdOnTheClient.TryGetIdFromInstance(entity, out string existing) && existing != null)
+                    return;
+
+                _generateEntityIdOnTheClient.TrySetIdentity(entity, topLevelId);
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableEntitySerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableEntitySerializer.cs
@@ -23,10 +23,16 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             using var reader = new SystemTextJsonBlittableReader();
             reader.Initialize(json);
 
-            object entity = JsonSerializer.Deserialize(reader.GetUtf8Json(), type, _options.Value);
-
-            // Return native memory immediately - we're done with the UTF-8 bytes
-            reader.ReturnMemory();
+            object entity;
+            try
+            {
+                entity = JsonSerializer.Deserialize(reader.GetUtf8Json(), type, _options.Value);
+            }
+            finally
+            {
+                // Return native memory immediately - we're done with the UTF-8 bytes
+                reader.ReturnMemory();
+            }
 
             if (entity != null)
                 TrySetIdentityFromMetadata(entity, json);

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableReader.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableReader.cs
@@ -19,26 +19,26 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             int estimatedSize = Math.Max(blittable.Size * 2, 512);
             _allocation = _context.GetMemory(estimatedSize);
 
-            using var stream = new UnmanagedMemoryStream(_allocation.Address, 0, _allocation.SizeInBytes, FileAccess.Write);
-            try
+            while (true)
             {
-                blittable.WriteJsonTo(stream);
-                _length = (int)stream.Position;
-            }
-            catch (NotSupportedException)
-            {
-                // Buffer too small - grow in-place or reallocate
-                int needed = Math.Max(_allocation.SizeInBytes * 2, estimatedSize * 2);
-                if (_context.GrowAllocation(_allocation, needed - _allocation.SizeInBytes) == false)
+                using var stream = new UnmanagedMemoryStream(_allocation.Address, 0, _allocation.SizeInBytes, FileAccess.Write);
+                try
                 {
-                    var newAllocation = _context.GetMemory(needed);
-                    _context.ReturnMemory(_allocation);
-                    _allocation = newAllocation;
+                    blittable.WriteJsonTo(stream);
+                    _length = (int)stream.Position;
+                    break;
                 }
-
-                using var retryStream = new UnmanagedMemoryStream(_allocation.Address, 0, _allocation.SizeInBytes, FileAccess.Write);
-                blittable.WriteJsonTo(retryStream);
-                _length = (int)retryStream.Position;
+                catch (NotSupportedException)
+                {
+                    // Buffer too small - keep doubling until WriteJsonTo succeeds
+                    int needed = _allocation.SizeInBytes * 2;
+                    if (_context.GrowAllocation(_allocation, needed - _allocation.SizeInBytes) == false)
+                    {
+                        var newAllocation = _context.GetMemory(needed);
+                        _context.ReturnMemory(_allocation);
+                        _allocation = newAllocation;
+                    }
+                }
             }
         }
 

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableReader.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableReader.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.IO;
+using Sparrow;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class SystemTextJsonBlittableReader : IJsonReader
+    {
+        private RecyclableMemoryStream _stream;
+
+        public void Initialize(BlittableJsonReaderObject blittable)
+        {
+            _stream?.Dispose();
+            _stream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+
+            blittable.WriteJsonTo(_stream);
+        }
+
+        public ReadOnlySpan<byte> GetUtf8Json()
+        {
+            _stream.TryGetBuffer(out ArraySegment<byte> buffer);
+            return new ReadOnlySpan<byte>(buffer.Array, buffer.Offset, buffer.Count);
+        }
+
+        public void Dispose()
+        {
+            _stream?.Dispose();
+            _stream = null;
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableReader.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableReader.cs
@@ -1,32 +1,70 @@
 using System;
-using Microsoft.IO;
-using Sparrow;
+using System.IO;
 using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 {
-    internal sealed class SystemTextJsonBlittableReader : IJsonReader
+    internal sealed unsafe class SystemTextJsonBlittableReader : IJsonReader
     {
-        private RecyclableMemoryStream _stream;
+        private AllocatedMemoryData _allocation;
+        private JsonOperationContext _context;
+        private int _length;
 
         public void Initialize(BlittableJsonReaderObject blittable)
         {
-            _stream?.Dispose();
-            _stream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+            _context = blittable._context;
 
-            blittable.WriteJsonTo(_stream);
+            // Blittable binary is more compact than UTF-8 JSON text.
+            // Allocate 2x blittable size from context native memory as initial estimate.
+            int estimatedSize = Math.Max(blittable.Size * 2, 512);
+            _allocation = _context.GetMemory(estimatedSize);
+
+            using var stream = new UnmanagedMemoryStream(_allocation.Address, 0, _allocation.SizeInBytes, FileAccess.Write);
+            try
+            {
+                blittable.WriteJsonTo(stream);
+                _length = (int)stream.Position;
+            }
+            catch (NotSupportedException)
+            {
+                // Buffer too small - grow in-place or reallocate
+                int needed = Math.Max(_allocation.SizeInBytes * 2, estimatedSize * 2);
+                if (_context.GrowAllocation(_allocation, needed - _allocation.SizeInBytes) == false)
+                {
+                    var newAllocation = _context.GetMemory(needed);
+                    _context.ReturnMemory(_allocation);
+                    _allocation = newAllocation;
+                }
+
+                using var retryStream = new UnmanagedMemoryStream(_allocation.Address, 0, _allocation.SizeInBytes, FileAccess.Write);
+                blittable.WriteJsonTo(retryStream);
+                _length = (int)retryStream.Position;
+            }
         }
 
         public ReadOnlySpan<byte> GetUtf8Json()
         {
-            _stream.TryGetBuffer(out ArraySegment<byte> buffer);
-            return new ReadOnlySpan<byte>(buffer.Array, buffer.Offset, buffer.Count);
+            return new ReadOnlySpan<byte>(_allocation.Address, _length);
+        }
+
+        /// <summary>
+        /// Return the native memory to the context immediately.
+        /// Call this as soon as deserialization is complete, while still in the same context scope.
+        /// </summary>
+        public void ReturnMemory()
+        {
+            if (_allocation != null && _context != null)
+            {
+                _context.ReturnMemory(_allocation);
+                _allocation = null;
+                _context = null;
+            }
         }
 
         public void Dispose()
         {
-            _stream?.Dispose();
-            _stream = null;
+            // Reader is cached in LightWeightThreadLocal and outlives the session/context.
+            // Don't return memory here - use ReturnMemory() explicitly after deserialization.
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableWriter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableWriter.cs
@@ -20,10 +20,13 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
         private bool _first;
         private readonly DocumentInfo _documentInfo;
 
+        public JsonOperationContext Context { get; }
+
         public SystemTextJsonBlittableWriter(JsonOperationContext context, DocumentInfo documentInfo = null,
             BlittableJsonDocumentBuilder.UsageMode? mode = null, BlittableWriter<UnmanagedWriteBuffer> writer = null,
             LazyStringValue idField = null, LazyStringValue keyField = null, LazyStringValue collectionField = null)
         {
+            Context = context;
             _manualBlittableJsonDocumentBuilder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context, mode ?? BlittableJsonDocumentBuilder.UsageMode.None, writer);
             _manualBlittableJsonDocumentBuilder.Reset(mode ?? BlittableJsonDocumentBuilder.UsageMode.None);
             _manualBlittableJsonDocumentBuilder.StartWriteObjectDocument();

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableWriter.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonBlittableWriter.cs
@@ -1,0 +1,790 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Raven.Client.Documents.Session;
+using Sparrow;
+using Sparrow.Extensions;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class SystemTextJsonBlittableWriter : IJsonWriter
+    {
+        private readonly LazyStringValue _metadataKey;
+        private readonly LazyStringValue _metadataCollection;
+        private readonly LazyStringValue _metadataId;
+
+        private readonly ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer> _manualBlittableJsonDocumentBuilder;
+        private bool _first;
+        private readonly DocumentInfo _documentInfo;
+
+        public SystemTextJsonBlittableWriter(JsonOperationContext context, DocumentInfo documentInfo = null,
+            BlittableJsonDocumentBuilder.UsageMode? mode = null, BlittableWriter<UnmanagedWriteBuffer> writer = null,
+            LazyStringValue idField = null, LazyStringValue keyField = null, LazyStringValue collectionField = null)
+        {
+            _manualBlittableJsonDocumentBuilder = new ManualBlittableJsonDocumentBuilder<UnmanagedWriteBuffer>(context, mode ?? BlittableJsonDocumentBuilder.UsageMode.None, writer);
+            _manualBlittableJsonDocumentBuilder.Reset(mode ?? BlittableJsonDocumentBuilder.UsageMode.None);
+            _manualBlittableJsonDocumentBuilder.StartWriteObjectDocument();
+            _documentInfo = documentInfo;
+            _first = true;
+
+            _metadataId = idField ?? context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Id);
+            _metadataKey = keyField ?? context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Key);
+            _metadataCollection = collectionField ?? context.GetLazyStringForFieldWithCaching(Constants.Documents.Metadata.Collection);
+        }
+
+        public void WriteStartObject()
+        {
+            _manualBlittableJsonDocumentBuilder.StartWriteObject();
+            if (!_first)
+                return;
+            _first = false;
+            WriteMetadataFromDocumentInfo();
+        }
+
+        private void WriteMetadataFromDocumentInfo()
+        {
+            if (_documentInfo == null)
+                return;
+            if (_documentInfo.Metadata?.Modifications != null && _documentInfo.Metadata.Modifications.Properties.Count > 0)
+            {
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataKey);
+                _manualBlittableJsonDocumentBuilder.StartWriteObject();
+
+                foreach (var prop in _documentInfo.Metadata.Modifications.Properties)
+                {
+                    _manualBlittableJsonDocumentBuilder.WritePropertyName(prop.Item1);
+                    WritePropertyValue(prop.Name, prop.Value);
+                }
+
+                if (_documentInfo.Collection != null)
+                {
+                    _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataCollection);
+                    _manualBlittableJsonDocumentBuilder.WriteValue(_documentInfo.Collection);
+                }
+
+                _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+                _documentInfo.Metadata.Modifications = null;
+            }
+            else if (_documentInfo.Metadata != null)
+            {
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataKey);
+                _manualBlittableJsonDocumentBuilder.StartWriteObject();
+
+                for (int i = 0; i < _documentInfo.Metadata.Count; i++)
+                {
+                    var propertyDetails = new BlittableJsonReaderObject.PropertyDetails();
+                    _documentInfo.Metadata.GetPropertyByIndex(i, ref propertyDetails);
+                    _manualBlittableJsonDocumentBuilder.WritePropertyName(propertyDetails.Name);
+
+                    WritePropertyValue(propertyDetails);
+                }
+                _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+            }
+            else if (_documentInfo.MetadataInstance != null)
+            {
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataKey);
+                WriteMetadata(_documentInfo.MetadataInstance);
+            }
+            else if (_documentInfo.Collection != null)
+            {
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataKey);
+                _manualBlittableJsonDocumentBuilder.StartWriteObject();
+
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataCollection);
+                _manualBlittableJsonDocumentBuilder.WriteValue(_documentInfo.Collection);
+
+                if (_documentInfo.Id != null)
+                {
+                    _manualBlittableJsonDocumentBuilder.WritePropertyName(_metadataId);
+                    _manualBlittableJsonDocumentBuilder.WriteValue(_documentInfo.Id);
+                }
+
+                _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+            }
+        }
+
+        public void WriteMetadata(IMetadataDictionary metadata)
+        {
+            _manualBlittableJsonDocumentBuilder.StartWriteObject();
+
+            foreach (var kvp in metadata)
+            {
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(kvp.Key);
+
+                WritePropertyValue(kvp.Key, kvp.Value);
+            }
+
+            _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+        }
+
+        private void WritePropertyValue(BlittableJsonReaderObject.PropertyDetails prop)
+        {
+            switch (prop.Token & BlittableJsonReaderBase.TypesMask)
+            {
+                case BlittableJsonToken.StartObject:
+                    if (prop.Value is BlittableJsonReaderObject obj)
+                        WriteObject(obj);
+                    break;
+                case BlittableJsonToken.StartArray:
+                    _manualBlittableJsonDocumentBuilder.StartWriteArray();
+                    if (prop.Value is BlittableJsonReaderArray array)
+                    {
+                        foreach (var entry in array)
+                        {
+                            if (entry is BlittableJsonReaderObject entryObj)
+                                WriteObject(entryObj);
+                            else
+                                WritePropertyValue(prop.Name, entry);
+                        }
+                    }
+                    _manualBlittableJsonDocumentBuilder.WriteArrayEnd();
+                    break;
+                case BlittableJsonToken.Integer:
+                    _manualBlittableJsonDocumentBuilder.WriteValue((long)prop.Value);
+                    break;
+                case BlittableJsonToken.LazyNumber:
+                    if (prop.Value is LazyNumberValue ldv)
+                    {
+                        _manualBlittableJsonDocumentBuilder.WriteValue(ldv);
+                    }
+                    else if (prop.Value is double d)
+                    {
+                        _manualBlittableJsonDocumentBuilder.WriteValue(d);
+                    }
+                    else
+                    {
+                        _manualBlittableJsonDocumentBuilder.WriteValue((float)prop.Value);
+                    }
+                    break;
+                case BlittableJsonToken.String:
+                    _manualBlittableJsonDocumentBuilder.WriteValue((LazyStringValue)prop.Value);
+                    break;
+                case BlittableJsonToken.CompressedString:
+                    _manualBlittableJsonDocumentBuilder.WriteValue((LazyCompressedStringValue)prop.Value);
+                    break;
+                case BlittableJsonToken.Boolean:
+                    _manualBlittableJsonDocumentBuilder.WriteValue((bool)prop.Value);
+                    break;
+                case BlittableJsonToken.Null:
+                    _manualBlittableJsonDocumentBuilder.WriteValueNull();
+                    break;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteObject(BlittableJsonReaderObject obj)
+        {
+            var propDetails = new BlittableJsonReaderObject.PropertyDetails();
+
+            _manualBlittableJsonDocumentBuilder.StartWriteObject();
+            for (int i = 0; i < obj.Count; i++)
+            {
+                obj.GetPropertyByIndex(i, ref propDetails);
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(propDetails.Name);
+                WritePropertyValue(propDetails);
+            }
+
+            _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+        }
+
+        private void WritePropertyValue(string propName, object value)
+        {
+            switch (value)
+            {
+                case null:
+                    WriteNull();
+                    break;
+                case string strValue:
+                    WriteValue(strValue);
+                    break;
+                case char ch:
+                    WriteValue(ch);
+                    break;
+                case bool b:
+                    WriteValue(b);
+                    break;
+                case LazyStringValue lazyStringValue:
+                    _manualBlittableJsonDocumentBuilder.WriteValue(lazyStringValue);
+                    break;
+                case short s:
+                    WriteValue(s);
+                    break;
+                case int i:
+                    WriteValue(i);
+                    break;
+                case long l:
+                    WriteValue(l);
+                    break;
+                case ushort us:
+                    WriteValue(us);
+                    break;
+                case uint ui:
+                    WriteValue(ui);
+                    break;
+                case ulong ul:
+                    WriteValue(ul);
+                    break;
+                case double d:
+                    WriteValue(d);
+                    break;
+                case decimal decVal:
+                    WriteValue(decVal);
+                    break;
+                case float f:
+                    WriteValue(f);
+                    break;
+                case byte b:
+                    WriteValue(b);
+                    break;
+                case sbyte sb:
+                    WriteValue(sb);
+                    break;
+                case LazyNumberValue lazyNumber:
+                    _manualBlittableJsonDocumentBuilder.WriteValue(lazyNumber);
+                    break;
+                case DateTime dt:
+                    WriteValue(dt);
+                    break;
+                case DateTimeOffset dto:
+                    WriteValue(dto);
+                    break;
+                case TimeSpan ts:
+                    WriteValue(ts);
+                    break;
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+                case TimeOnly to:
+                    WriteValue(to);
+                    break;
+                case DateOnly @do:
+                    WriteValue(@do);
+                    break;
+#endif
+                case IDictionary<string, string> dics:
+                    WriteDictionary(dics);
+                    break;
+                case IDictionary<string, object> dico:
+                    WriteDictionary(dico);
+                    break;
+                case IDictionary iDictionary:
+                    WriteDictionary(iDictionary);
+                    break;
+                case DynamicJsonValue val:
+                    _manualBlittableJsonDocumentBuilder.StartWriteObject();
+                    foreach (var prop in val.Properties)
+                    {
+                        _manualBlittableJsonDocumentBuilder.WritePropertyName(prop.Name);
+                        WritePropertyValue(prop.Name, prop.Value);
+                    }
+                    _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+                    break;
+                case IEnumerable enumerable:
+                    _manualBlittableJsonDocumentBuilder.StartWriteArray();
+                    foreach (var entry in enumerable)
+                    {
+                        WritePropertyValue(propName, entry);
+                    }
+                    _manualBlittableJsonDocumentBuilder.WriteArrayEnd();
+                    break;
+
+                default:
+                    throw new NotSupportedException($"The value type {value.GetType().FullName} of key {propName} is not supported in the metadata");
+            }
+        }
+
+        private void WriteDictionary(IDictionary iDictionary)
+        {
+            _manualBlittableJsonDocumentBuilder.StartWriteObject();
+            foreach (DictionaryEntry item in iDictionary)
+            {
+                string key = item.Key.ToString();
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(key);
+                WritePropertyValue(key, item.Value);
+            }
+            _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+        }
+
+        private void WriteDictionary<T>(IDictionary<string, T> dic)
+        {
+            _manualBlittableJsonDocumentBuilder.StartWriteObject();
+            foreach (var item in dic)
+            {
+                _manualBlittableJsonDocumentBuilder.WritePropertyName(item.Key);
+                WritePropertyValue(item.Key, item.Value);
+            }
+            _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+        }
+
+        public void WriteEndObject()
+        {
+            _manualBlittableJsonDocumentBuilder.WriteObjectEnd();
+        }
+
+        public void FinalizeDocument()
+        {
+            _manualBlittableJsonDocumentBuilder.FinalizeDocument();
+        }
+
+        public void WriteStartArray()
+        {
+            _manualBlittableJsonDocumentBuilder.StartWriteArray();
+        }
+
+        public void WriteEndArray()
+        {
+            _manualBlittableJsonDocumentBuilder.WriteArrayEnd();
+        }
+
+        public void WritePropertyName(string name)
+        {
+            _manualBlittableJsonDocumentBuilder.WritePropertyName(name);
+        }
+
+        public void WritePropertyName(string name, bool escape)
+        {
+            _manualBlittableJsonDocumentBuilder.WritePropertyName(name);
+        }
+
+        public void WriteNull()
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(string value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(LazyCompressedStringValue value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(LazyStringValue value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(LazyNumberValue value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(short value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(int value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(long value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(float value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(double value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(bool value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(byte value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(decimal value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(DateTime dt)
+        {
+            string value = dt.GetDefaultRavenFormat();
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(DateTimeOffset dto)
+        {
+            string value = dto.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite);
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+        public void WriteValue(TimeOnly to)
+        {
+            string value = to.ToString(DefaultFormat.TimeOnlyFormatToWrite);
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(DateOnly @do)
+        {
+            string value = @do.ToString(DefaultFormat.DateOnlyFormatToWrite);
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(TimeOnly? to)
+        {
+            if (to != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(to.Value.ToString(DefaultFormat.TimeOnlyFormatToWrite));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(DateOnly? @do)
+        {
+            if (@do != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(@do.Value.ToString(DefaultFormat.DateOnlyFormatToWrite));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+#endif
+
+        public void WriteValue(int? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(long? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(float? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(double? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(bool? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(short? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(byte? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(decimal? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(DateTime? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value.GetDefaultRavenFormat());
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(DateTimeOffset? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value.ToString(DefaultFormat.DateTimeOffsetFormatsToWrite));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(Guid value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value.ToString());
+        }
+
+        public void WriteValue(Guid? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value.ToString());
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(char value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value.ToString());
+        }
+
+        public void WriteValue(char? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value.ToString());
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(sbyte value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(sbyte? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(ushort value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(ushort? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(uint value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(uint? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(ulong value)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(value);
+        }
+
+        public void WriteValue(ulong? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value);
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(TimeSpan ts)
+        {
+            _manualBlittableJsonDocumentBuilder.WriteValue(ts.ToString("c"));
+        }
+
+        public void WriteValue(TimeSpan? value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.Value.ToString("c"));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(byte[] value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(Convert.ToBase64String(value));
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteValue(Uri value)
+        {
+            if (value != null)
+                _manualBlittableJsonDocumentBuilder.WriteValue(value.ToString());
+            else
+                _manualBlittableJsonDocumentBuilder.WriteValueNull();
+        }
+
+        public void WriteVector<T>(ReadOnlySpan<T> value) where T : unmanaged
+        {
+            _manualBlittableJsonDocumentBuilder.WriteVector(value);
+        }
+
+        public void WriteValue(object value)
+        {
+            switch (value)
+            {
+                case BlittableJsonReaderObject readerObject:
+                    if (false == readerObject.HasParent)
+                    {
+                        _manualBlittableJsonDocumentBuilder.WriteEmbeddedBlittableDocument(readerObject);
+                    }
+                    else
+                    {
+                        using (BlittableJsonReaderObject clonedBlittable = readerObject.CloneOnTheSameContext())
+                        {
+                            _manualBlittableJsonDocumentBuilder.WriteEmbeddedBlittableDocument(clonedBlittable);
+                        }
+                    }
+                    return;
+                case LazyStringValue lazyStringValue:
+                    _manualBlittableJsonDocumentBuilder.WriteValue(lazyStringValue);
+                    return;
+                case null:
+                    WriteNull();
+                    return;
+                case string strValue:
+                    WriteValue(strValue);
+                    return;
+                case bool boolValue:
+                    WriteValue(boolValue);
+                    return;
+                case int intValue:
+                    WriteValue(intValue);
+                    return;
+                case long longValue:
+                    WriteValue(longValue);
+                    return;
+                case double doubleValue:
+                    WriteValue(doubleValue);
+                    return;
+                case float floatValue:
+                    WriteValue(floatValue);
+                    return;
+                case decimal decimalValue:
+                    WriteValue(decimalValue);
+                    return;
+                case DateTime dtValue:
+                    WriteValue(dtValue);
+                    return;
+                case DateTimeOffset dtoValue:
+                    WriteValue(dtoValue);
+                    return;
+                case Guid guidValue:
+                    WriteValue(guidValue);
+                    return;
+                case TimeSpan tsValue:
+                    WriteValue(tsValue);
+                    return;
+                case Uri uriValue:
+                    WriteValue(uriValue);
+                    return;
+                case byte[] bytesValue:
+                    WriteValue(bytesValue);
+                    return;
+                default:
+                    throw new NotSupportedException($"The value type {value.GetType().FullName} is not supported");
+            }
+        }
+
+        public BlittableJsonReaderObject CreateReader()
+        {
+            return _manualBlittableJsonDocumentBuilder.CreateReader();
+        }
+
+        public void Flush()
+        {
+            // nothing to do
+        }
+
+        public void Close()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteComment(string text)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteEnd()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteEndConstructor()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteStartConstructor(string name)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteUndefined()
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteRaw(string json)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteRawValue(string json)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void WriteWhitespace(string ws)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Dispose()
+        {
+            _manualBlittableJsonDocumentBuilder.Dispose();
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
@@ -74,7 +74,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                     foreach (var kvp in metadata)
                     {
                         utf8Writer.WritePropertyName(kvp.Key);
-                        WriteMetadataValue(utf8Writer, kvp.Value);
+                        SystemTextJsonSerializationConventions.WriteMetadataValue(utf8Writer, kvp.Value);
                     }
                     utf8Writer.WriteEndObject();
                 }
@@ -83,6 +83,8 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 using var doc = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(value, objectType, Options));
                 foreach (var property in doc.RootElement.EnumerateObject())
                 {
+                    if (property.Name == Constants.Documents.Metadata.Key)
+                        continue;
                     property.WriteTo(utf8Writer);
                 }
 
@@ -99,40 +101,6 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             {
                 return context.ParseBuffer(ptr, utf8Json.Length, "serialize/entity",
                     BlittableJsonDocumentBuilder.UsageMode.None);
-            }
-        }
-
-        private static void WriteMetadataValue(Utf8JsonWriter writer, object value)
-        {
-            switch (value)
-            {
-                case string s:
-                    writer.WriteStringValue(s);
-                    break;
-                case long l:
-                    writer.WriteNumberValue(l);
-                    break;
-                case int i:
-                    writer.WriteNumberValue(i);
-                    break;
-                case bool b:
-                    writer.WriteBooleanValue(b);
-                    break;
-                case double d:
-                    writer.WriteNumberValue(d);
-                    break;
-                case float f:
-                    writer.WriteNumberValue(f);
-                    break;
-                case decimal dec:
-                    writer.WriteNumberValue(dec);
-                    break;
-                case null:
-                    writer.WriteNullValue();
-                    break;
-                default:
-                    JsonSerializer.Serialize(writer, value);
-                    break;
             }
         }
 

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
@@ -1,7 +1,7 @@
 using System;
-using System.IO;
 using System.Text.Json;
-using Sparrow;
+using Raven.Client.Documents.Session;
+using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 {
@@ -21,14 +21,110 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 
         public void Serialize(IJsonWriter writer, object value, Type objectType)
         {
-            using var stream = RecyclableMemoryStreamFactory.GetRecyclableStream();
-            using (var utf8Writer = new Utf8JsonWriter((Stream)stream))
+            if (writer is SystemTextJsonBlittableWriter stjWriter)
+            {
+                // Serialize entity to UTF-8 in context native memory
+                using var bufferWriter = new ContextMemoryBufferWriter(stjWriter.Context);
+                using (var utf8Writer = new Utf8JsonWriter((System.Buffers.IBufferWriter<byte>)bufferWriter))
+                {
+                    JsonSerializer.Serialize(utf8Writer, value, objectType, Options);
+                }
+                WriteJsonToBlittableWriter(writer, bufferWriter.WrittenSpan);
+            }
+            else
+            {
+                var bytes = JsonSerializer.SerializeToUtf8Bytes(value, objectType, Options);
+                WriteJsonToBlittableWriter(writer, bytes);
+            }
+        }
+
+        /// <summary>
+        /// Serialize entity to UTF-8 bytes in context native memory, then parse directly into
+        /// a BlittableJsonReaderObject using the context's own parser. Bypasses the IJsonWriter
+        /// token walk entirely.
+        /// </summary>
+        internal unsafe BlittableJsonReaderObject SerializeToBlittable(object value, Type objectType, JsonOperationContext context)
+        {
+            using var bufferWriter = new ContextMemoryBufferWriter(context);
+            using (var utf8Writer = new Utf8JsonWriter((System.Buffers.IBufferWriter<byte>)bufferWriter))
             {
                 JsonSerializer.Serialize(utf8Writer, value, objectType, Options);
             }
 
-            stream.TryGetBuffer(out var buffer);
-            WriteJsonToBlittableWriter(writer, new ReadOnlySpan<byte>(buffer.Array, buffer.Offset, buffer.Count));
+            return ParseBufferToBlittable(bufferWriter, context);
+        }
+
+        /// <summary>
+        /// Serialize entity with @metadata prefix to UTF-8 bytes, then parse into blittable.
+        /// Same approach as WriteEntityToStream but targets a context buffer instead of HTTP stream.
+        /// </summary>
+        internal unsafe BlittableJsonReaderObject SerializeToBlittableWithMetadata(object value, Type objectType,
+            IMetadataDictionary metadata, JsonOperationContext context)
+        {
+            using var bufferWriter = new ContextMemoryBufferWriter(context);
+            using (var utf8Writer = new Utf8JsonWriter((System.Buffers.IBufferWriter<byte>)bufferWriter, new System.Text.Json.JsonWriterOptions { SkipValidation = true }))
+            {
+                utf8Writer.WriteStartObject();
+
+                // Write @metadata first
+                if (metadata != null && metadata.Count > 0)
+                {
+                    utf8Writer.WritePropertyName(Constants.Documents.Metadata.Key);
+                    utf8Writer.WriteStartObject();
+                    foreach (var kvp in metadata)
+                    {
+                        utf8Writer.WritePropertyName(kvp.Key);
+                        WriteMetadataValue(utf8Writer, kvp.Value);
+                    }
+                    utf8Writer.WriteEndObject();
+                }
+
+                // Serialize entity properties into the same object
+                using var doc = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(value, objectType, Options));
+                foreach (var property in doc.RootElement.EnumerateObject())
+                {
+                    property.WriteTo(utf8Writer);
+                }
+
+                utf8Writer.WriteEndObject();
+            }
+
+            return ParseBufferToBlittable(bufferWriter, context);
+        }
+
+        private static unsafe BlittableJsonReaderObject ParseBufferToBlittable(ContextMemoryBufferWriter bufferWriter, JsonOperationContext context)
+        {
+            var utf8Json = bufferWriter.WrittenSpan;
+            fixed (byte* ptr = utf8Json)
+            {
+                return context.ParseBuffer(ptr, utf8Json.Length, "serialize/entity",
+                    BlittableJsonDocumentBuilder.UsageMode.None);
+            }
+        }
+
+        private static void WriteMetadataValue(Utf8JsonWriter writer, object value)
+        {
+            switch (value)
+            {
+                case string s:
+                    writer.WriteStringValue(s);
+                    break;
+                case long l:
+                    writer.WriteNumberValue(l);
+                    break;
+                case bool b:
+                    writer.WriteBooleanValue(b);
+                    break;
+                case double d:
+                    writer.WriteNumberValue(d);
+                    break;
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                default:
+                    writer.WriteStringValue(value.ToString());
+                    break;
+            }
         }
 
         public object Deserialize(IJsonReader reader, Type type)
@@ -50,39 +146,19 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
             {
                 switch (jsonReader.TokenType)
                 {
-                    case JsonTokenType.StartObject:
-                        writer.WriteStartObject();
-                        break;
-                    case JsonTokenType.EndObject:
-                        writer.WriteEndObject();
-                        break;
-                    case JsonTokenType.StartArray:
-                        writer.WriteStartArray();
-                        break;
-                    case JsonTokenType.EndArray:
-                        writer.WriteEndArray();
-                        break;
-                    case JsonTokenType.PropertyName:
-                        writer.WritePropertyName(jsonReader.GetString());
-                        break;
-                    case JsonTokenType.String:
-                        writer.WriteValue(jsonReader.GetString());
-                        break;
+                    case JsonTokenType.StartObject: writer.WriteStartObject(); break;
+                    case JsonTokenType.EndObject: writer.WriteEndObject(); break;
+                    case JsonTokenType.StartArray: writer.WriteStartArray(); break;
+                    case JsonTokenType.EndArray: writer.WriteEndArray(); break;
+                    case JsonTokenType.PropertyName: writer.WritePropertyName(jsonReader.GetString()); break;
+                    case JsonTokenType.String: writer.WriteValue(jsonReader.GetString()); break;
                     case JsonTokenType.Number:
-                        if (jsonReader.TryGetInt64(out long l))
-                            writer.WriteValue(l);
-                        else
-                            writer.WriteValue(jsonReader.GetDouble());
+                        if (jsonReader.TryGetInt64(out long l)) writer.WriteValue(l);
+                        else writer.WriteValue(jsonReader.GetDouble());
                         break;
-                    case JsonTokenType.True:
-                        writer.WriteValue(true);
-                        break;
-                    case JsonTokenType.False:
-                        writer.WriteValue(false);
-                        break;
-                    case JsonTokenType.Null:
-                        writer.WriteNull();
-                        break;
+                    case JsonTokenType.True: writer.WriteValue(true); break;
+                    case JsonTokenType.False: writer.WriteValue(false); break;
+                    case JsonTokenType.Null: writer.WriteNull(); break;
                 }
             }
         }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Text.Json;
+using Sparrow;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 {
@@ -19,25 +21,31 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
 
         public void Serialize(IJsonWriter writer, object value, Type objectType)
         {
-            byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(value, objectType, Options);
-            WriteJsonToBlittableWriter(writer, bytes);
+            using var stream = RecyclableMemoryStreamFactory.GetRecyclableStream();
+            using (var utf8Writer = new Utf8JsonWriter((Stream)stream))
+            {
+                JsonSerializer.Serialize(utf8Writer, value, objectType, Options);
+            }
+
+            stream.TryGetBuffer(out var buffer);
+            WriteJsonToBlittableWriter(writer, new ReadOnlySpan<byte>(buffer.Array, buffer.Offset, buffer.Count));
         }
 
         public object Deserialize(IJsonReader reader, Type type)
         {
-            SystemTextJsonBlittableReader stjReader = (SystemTextJsonBlittableReader)reader;
+            var stjReader = (SystemTextJsonBlittableReader)reader;
             return JsonSerializer.Deserialize(stjReader.GetUtf8Json(), type, Options);
         }
 
         public T Deserialize<T>(IJsonReader reader)
         {
-            SystemTextJsonBlittableReader stjReader = (SystemTextJsonBlittableReader)reader;
+            var stjReader = (SystemTextJsonBlittableReader)reader;
             return JsonSerializer.Deserialize<T>(stjReader.GetUtf8Json(), Options);
         }
 
-        private static void WriteJsonToBlittableWriter(IJsonWriter writer, byte[] utf8Json)
+        private static void WriteJsonToBlittableWriter(IJsonWriter writer, ReadOnlySpan<byte> utf8Json)
         {
-            Utf8JsonReader jsonReader = new Utf8JsonReader(utf8Json);
+            var jsonReader = new Utf8JsonReader(utf8Json);
             while (jsonReader.Read())
             {
                 switch (jsonReader.TokenType)

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Text.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
+{
+    internal sealed class SystemTextJsonJsonSerializer : IJsonSerializer
+    {
+        public JsonSerializerOptions Options { get; }
+
+        public SystemTextJsonJsonSerializer(JsonSerializerOptions options)
+        {
+            Options = options;
+        }
+
+        public void Serialize(IJsonWriter writer, object value)
+        {
+            Serialize(writer, value, value?.GetType() ?? typeof(object));
+        }
+
+        public void Serialize(IJsonWriter writer, object value, Type objectType)
+        {
+            byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(value, objectType, Options);
+            WriteJsonToBlittableWriter(writer, bytes);
+        }
+
+        public object Deserialize(IJsonReader reader, Type type)
+        {
+            SystemTextJsonBlittableReader stjReader = (SystemTextJsonBlittableReader)reader;
+            return JsonSerializer.Deserialize(stjReader.GetUtf8Json(), type, Options);
+        }
+
+        public T Deserialize<T>(IJsonReader reader)
+        {
+            SystemTextJsonBlittableReader stjReader = (SystemTextJsonBlittableReader)reader;
+            return JsonSerializer.Deserialize<T>(stjReader.GetUtf8Json(), Options);
+        }
+
+        private static void WriteJsonToBlittableWriter(IJsonWriter writer, byte[] utf8Json)
+        {
+            Utf8JsonReader jsonReader = new Utf8JsonReader(utf8Json);
+            while (jsonReader.Read())
+            {
+                switch (jsonReader.TokenType)
+                {
+                    case JsonTokenType.StartObject:
+                        writer.WriteStartObject();
+                        break;
+                    case JsonTokenType.EndObject:
+                        writer.WriteEndObject();
+                        break;
+                    case JsonTokenType.StartArray:
+                        writer.WriteStartArray();
+                        break;
+                    case JsonTokenType.EndArray:
+                        writer.WriteEndArray();
+                        break;
+                    case JsonTokenType.PropertyName:
+                        writer.WritePropertyName(jsonReader.GetString());
+                        break;
+                    case JsonTokenType.String:
+                        writer.WriteValue(jsonReader.GetString());
+                        break;
+                    case JsonTokenType.Number:
+                        if (jsonReader.TryGetInt64(out long l))
+                            writer.WriteValue(l);
+                        else
+                            writer.WriteValue(jsonReader.GetDouble());
+                        break;
+                    case JsonTokenType.True:
+                        writer.WriteValue(true);
+                        break;
+                    case JsonTokenType.False:
+                        writer.WriteValue(false);
+                        break;
+                    case JsonTokenType.Null:
+                        writer.WriteNull();
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/Internal/SystemTextJsonJsonSerializer.cs
@@ -112,17 +112,26 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                 case long l:
                     writer.WriteNumberValue(l);
                     break;
+                case int i:
+                    writer.WriteNumberValue(i);
+                    break;
                 case bool b:
                     writer.WriteBooleanValue(b);
                     break;
                 case double d:
                     writer.WriteNumberValue(d);
                     break;
+                case float f:
+                    writer.WriteNumberValue(f);
+                    break;
+                case decimal dec:
+                    writer.WriteNumberValue(dec);
+                    break;
                 case null:
                     writer.WriteNullValue();
                     break;
                 default:
-                    writer.WriteStringValue(value.ToString());
+                    JsonSerializer.Serialize(writer, value);
                     break;
             }
         }
@@ -154,6 +163,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson.Internal
                     case JsonTokenType.String: writer.WriteValue(jsonReader.GetString()); break;
                     case JsonTokenType.Number:
                         if (jsonReader.TryGetInt64(out long l)) writer.WriteValue(l);
+                        else if (jsonReader.TryGetDecimal(out decimal dec)) writer.WriteValue(dec);
                         else writer.WriteValue(jsonReader.GetDouble());
                         break;
                     case JsonTokenType.True: writer.WriteValue(true); break;

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization.Metadata;
+using Sparrow.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson
+{
+    internal sealed class RavenJsonTypeInfoResolver : DefaultJsonTypeInfoResolver
+    {
+        private readonly SystemTextJsonSerializationConventions _conventions;
+
+        [ThreadStatic]
+        internal static object RootEntity;
+
+        [ThreadStatic]
+        internal static bool RemovedIdentityProperty;
+
+        public RavenJsonTypeInfoResolver(SystemTextJsonSerializationConventions conventions)
+        {
+            _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+            Modifiers.Add(ModifyTypeInfo);
+        }
+
+        private void ModifyTypeInfo(JsonTypeInfo typeInfo)
+        {
+            if (typeInfo.Kind != JsonTypeInfoKind.Object)
+                return;
+
+            bool isRecord = typeInfo.Type.IsRecord();
+
+            FilterProperties(typeInfo, isRecord);
+            SetupNonPublicConstructor(typeInfo);
+            SetupIdentityPropertyConditionalSerialization(typeInfo);
+        }
+
+        private void FilterProperties(JsonTypeInfo typeInfo, bool isRecord)
+        {
+            for (int i = typeInfo.Properties.Count - 1; i >= 0; i--)
+            {
+                JsonPropertyInfo property = typeInfo.Properties[i];
+                if (ShouldFilterProperty(property, isRecord))
+                    typeInfo.Properties.RemoveAt(i);
+            }
+        }
+
+        private bool ShouldFilterProperty(JsonPropertyInfo property, bool isRecord)
+        {
+            ICustomAttributeProvider attributeProvider = property.AttributeProvider;
+            if (attributeProvider == null)
+                return false;
+
+            if (attributeProvider is EventInfo)
+                return true;
+
+            if (attributeProvider is FieldInfo fieldInfo)
+                return ShouldFilterField(fieldInfo);
+
+            if (attributeProvider is PropertyInfo propertyInfo)
+                return ShouldFilterProperty(propertyInfo, isRecord);
+
+            if (HasCompilerGeneratedAttribute(attributeProvider))
+                return true;
+
+            if (HasJsonIgnoreAttribute(attributeProvider))
+                return true;
+
+            return false;
+        }
+
+        private bool ShouldFilterField(FieldInfo fieldInfo)
+        {
+            if (fieldInfo.IsPublic == false && fieldInfo.IsDefined(typeof(ForceJsonSerializationAttribute)) == false)
+                return true;
+
+#if NETSTANDARD2_0
+            if (fieldInfo.FieldType.IsByRef)
+#else
+            if (fieldInfo.FieldType.IsByRef || fieldInfo.FieldType.IsByRefLike)
+#endif
+            {
+                if (_conventions.IgnoreByRefMembers == false)
+                    ThrowByRefNotSupported();
+                return true;
+            }
+
+            if (fieldInfo.FieldType == typeof(IntPtr) || fieldInfo.FieldType.IsPointer)
+            {
+                if (_conventions.IgnoreUnsafeMembers == false)
+                    ThrowPointersNotSupported();
+                return true;
+            }
+
+            if (HasCompilerGeneratedAttribute(fieldInfo))
+                return true;
+
+            if (HasJsonIgnoreAttribute(fieldInfo))
+                return true;
+
+            return false;
+        }
+
+        private bool ShouldFilterProperty(PropertyInfo propertyInfo, bool isRecord)
+        {
+            if (isRecord && propertyInfo.Name == Sparrow.Extensions.TypeExtensions.RecordEqualityContractPropertyName)
+                return true;
+
+#if NETSTANDARD2_0
+            if (propertyInfo.PropertyType.IsByRef)
+#else
+            if (propertyInfo.PropertyType.IsByRef || propertyInfo.PropertyType.IsByRefLike)
+#endif
+            {
+                if (_conventions.IgnoreByRefMembers == false)
+                    ThrowByRefNotSupported();
+                return true;
+            }
+
+            if (propertyInfo.PropertyType == typeof(IntPtr) || propertyInfo.PropertyType.IsPointer)
+            {
+                if (_conventions.IgnoreUnsafeMembers == false)
+                    ThrowPointersNotSupported();
+                return true;
+            }
+
+            if (HasCompilerGeneratedAttribute(propertyInfo))
+                return true;
+
+            if (HasJsonIgnoreAttribute(propertyInfo))
+                return true;
+
+            return false;
+        }
+
+        private static bool HasCompilerGeneratedAttribute(ICustomAttributeProvider member)
+        {
+            return member.GetCustomAttributes(typeof(CompilerGeneratedAttribute), true).Length > 0;
+        }
+
+        private static bool HasJsonIgnoreAttribute(ICustomAttributeProvider member)
+        {
+            // Check both Newtonsoft and STJ JsonIgnore by attribute full name to avoid
+            // hard dependency issues. STJ's own [JsonIgnore] is already handled by
+            // DefaultJsonTypeInfoResolver, but Newtonsoft's [JsonIgnore] is not.
+            object[] attributes = member.GetCustomAttributes(true);
+            for (int i = 0; i < attributes.Length; i++)
+            {
+                string fullName = attributes[i].GetType().FullName;
+                if (fullName == "Newtonsoft.Json.JsonIgnoreAttribute")
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void SetupIdentityPropertyConditionalSerialization(JsonTypeInfo typeInfo)
+        {
+            if (_conventions.Conventions == null)
+                return;
+
+            MemberInfo identityProperty = _conventions.Conventions.GetIdentityProperty(typeInfo.Type);
+            if (identityProperty == null)
+                return;
+
+            for (int i = 0; i < typeInfo.Properties.Count; i++)
+            {
+                JsonPropertyInfo property = typeInfo.Properties[i];
+                if (property.Name == identityProperty.Name)
+                {
+                    property.ShouldSerialize = ShouldSerializeIdentityProperty;
+                    break;
+                }
+            }
+        }
+
+        private static bool ShouldSerializeIdentityProperty(object containingObject, object propertyValue)
+        {
+            if (containingObject == null)
+                return true;
+
+            object rootEntity = RootEntity;
+            if (rootEntity == null)
+                return true;
+
+            if (ReferenceEquals(rootEntity, containingObject) == false)
+                return true;
+
+            if (RemovedIdentityProperty == false)
+            {
+                RemovedIdentityProperty = true;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void SetupNonPublicConstructor(JsonTypeInfo typeInfo)
+        {
+            // STJ by default only uses public parameterless constructors.
+            // Replicate Newtonsoft's AllowNonPublicDefaultConstructor behavior.
+            if (typeInfo.CreateObject != null)
+                return;
+
+            ConstructorInfo constructor = typeInfo.Type.GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                Type.EmptyTypes,
+                modifiers: null);
+
+            if (constructor != null)
+            {
+                typeInfo.CreateObject = () => constructor.Invoke(null);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowByRefNotSupported() =>
+            throw new NotSupportedException(
+                "By-ref fields and properties in documents cannot be serialized. " +
+                "You can set RavenDB to ignore them by setting DocumentConventions::Serialization::ThrowErrorOnByRefFields to 'false'. " +
+                "For more details, see https://github.com/JamesNK/Newtonsoft.Json/issues/1552.");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowPointersNotSupported() =>
+            throw new NotSupportedException(
+                "Pointer type fields and properties in documents cannot be serialized. " +
+                "You can set RavenDB to ignore them by setting DocumentConventions::Serialization::ThrowOnUnsafeMembers to 'false'");
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
@@ -218,8 +218,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
         private static void ThrowByRefNotSupported() =>
             throw new NotSupportedException(
                 "By-ref fields and properties in documents cannot be serialized. " +
-                $"You can set RavenDB to ignore them by setting {nameof(SystemTextJsonSerializationConventions)}.{nameof(SystemTextJsonSerializationConventions.IgnoreByRefMembers)} to 'true'. " +
-                "For more details, see https://github.com/JamesNK/Newtonsoft.Json/issues/1552.");
+                $"You can set RavenDB to ignore them by setting {nameof(SystemTextJsonSerializationConventions)}.{nameof(SystemTextJsonSerializationConventions.IgnoreByRefMembers)} to 'true'.");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowPointersNotSupported() =>

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
@@ -218,13 +218,13 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
         private static void ThrowByRefNotSupported() =>
             throw new NotSupportedException(
                 "By-ref fields and properties in documents cannot be serialized. " +
-                "You can set RavenDB to ignore them by setting DocumentConventions::Serialization::ThrowErrorOnByRefFields to 'false'. " +
+                $"You can set RavenDB to ignore them by setting {nameof(SystemTextJsonSerializationConventions)}.{nameof(SystemTextJsonSerializationConventions.IgnoreByRefMembers)} to 'true'. " +
                 "For more details, see https://github.com/JamesNK/Newtonsoft.Json/issues/1552.");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowPointersNotSupported() =>
             throw new NotSupportedException(
                 "Pointer type fields and properties in documents cannot be serialized. " +
-                "You can set RavenDB to ignore them by setting DocumentConventions::Serialization::ThrowOnUnsafeMembers to 'false'");
+                $"You can set RavenDB to ignore them by setting {nameof(SystemTextJsonSerializationConventions)}.{nameof(SystemTextJsonSerializationConventions.IgnoreUnsafeMembers)} to 'true'.");
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/RavenJsonTypeInfoResolver.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Sparrow.Extensions;
 using Sparrow.Json;
@@ -21,6 +23,42 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
         {
             _conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
             Modifiers.Add(ModifyTypeInfo);
+        }
+
+        /// <summary>
+        /// Returns a resolver that tries the user's source-generated context first,
+        /// then falls back to reflection, applying Raven modifications to both.
+        /// </summary>
+        internal IJsonTypeInfoResolver WithSourceGenerationContext(JsonSerializerContext context)
+        {
+            return new SourceGenCombinedResolver(context, this);
+        }
+
+        private sealed class SourceGenCombinedResolver : IJsonTypeInfoResolver
+        {
+            private readonly JsonSerializerContext _context;
+            private readonly RavenJsonTypeInfoResolver _fallback;
+
+            public SourceGenCombinedResolver(JsonSerializerContext context, RavenJsonTypeInfoResolver fallback)
+            {
+                _context = context;
+                _fallback = fallback;
+            }
+
+            public JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+            {
+                // Try the source-generated context first (returns null for unknown types)
+                JsonTypeInfo typeInfo = ((IJsonTypeInfoResolver)_context).GetTypeInfo(type, options);
+                if (typeInfo != null)
+                {
+                    // Apply Raven modifications (identity property handling, property filtering)
+                    _fallback.ModifyTypeInfo(typeInfo);
+                    return typeInfo;
+                }
+
+                // Fall back to reflection-based resolver (Raven mods applied via Modifiers)
+                return ((IJsonTypeInfoResolver)_fallback).GetTypeInfo(type, options);
+            }
         }
 
         private void ModifyTypeInfo(JsonTypeInfo typeInfo)

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/RavenSerializationBinder.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/RavenSerializationBinder.cs
@@ -74,7 +74,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
             if (_forbiddenTypesCache.Contains(type))
                 ThrowForbiddenType(type);
 
-            if (type.Namespace != null && _forbiddenNamespaces.Any(@namespace => @namespace.StartsWith(type.Namespace)))
+            if (type.Namespace != null && _forbiddenNamespaces.Any(@namespace => type.Namespace.StartsWith(@namespace)))
             {
                 UpdateCache(ref _forbiddenTypesCache, type);
                 ThrowForbiddenNamespace(type);

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/RavenSerializationBinder.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/RavenSerializationBinder.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson
+{
+    internal sealed class RavenSerializationBinder
+    {
+        public static readonly RavenSerializationBinder Instance = new();
+
+        private HashSet<Type> _forbiddenTypesCache = new();
+
+        private HashSet<Type> _safeTypesCache = new();
+
+        private readonly HashSet<string> _forbiddenNamespaces = new() { "Microsoft.VisualStudio" };
+
+        private bool _used;
+
+        /// <summary>
+        /// https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html#known-net-rce-gadgets
+        /// </summary>
+        private static readonly HashSet<string> ForbiddenTypes = new()
+        {
+            "System.Configuration.Install.AssemblyInstaller",
+            "System.Activities.Presentation.WorkflowDesigner",
+            "System.Windows.ResourceDictionary",
+            "System.Windows.Data.ObjectDataProvider",
+            "System.Windows.Forms.BindingSource",
+            "Microsoft.Exchange.Management.SystemManager.WinForms.ExchangeSettingsProvider",
+            "System.Data.DataViewManager",
+            "System.Xml.XmlDocument",
+            "System.Xml.XmlDataDocument",
+            "System.Management.Automation.PSObject"
+        };
+
+        public void ValidateType(Type type)
+        {
+            _used = true;
+            AssertType(type);
+        }
+
+        public void RegisterForbiddenNamespace(string @namespace)
+        {
+            if (@namespace == null)
+                throw new ArgumentNullException(nameof(@namespace));
+
+            AssertNotUsed();
+
+            _forbiddenNamespaces.Add(@namespace);
+        }
+
+        public void RegisterForbiddenType(Type type)
+        {
+            AssertNotUsed();
+
+            UpdateCache(ref _forbiddenTypesCache, type);
+        }
+
+        public void RegisterSafeType(Type type)
+        {
+            AssertNotUsed();
+
+            UpdateCache(ref _safeTypesCache, type);
+        }
+
+        private void AssertType(Type type)
+        {
+            if (type == null)
+                return;
+
+            if (_safeTypesCache.Contains(type))
+                return;
+
+            if (_forbiddenTypesCache.Contains(type))
+                ThrowForbiddenType(type);
+
+            if (type.Namespace != null && _forbiddenNamespaces.Any(@namespace => @namespace.StartsWith(type.Namespace)))
+            {
+                UpdateCache(ref _forbiddenTypesCache, type);
+                ThrowForbiddenNamespace(type);
+            }
+
+            if (ForbiddenTypes.Contains(type.FullName))
+            {
+                UpdateCache(ref _forbiddenTypesCache, type);
+                ThrowForbiddenType(type);
+            }
+
+            if (type.IsGenericType)
+            {
+                Type[] genericArguments = type.GetGenericArguments();
+                for (int i = 0; i < genericArguments.Length; i++)
+                {
+                    try
+                    {
+                        AssertType(genericArguments[i]);
+                    }
+                    catch (Exception e)
+                    {
+                        throw new InvalidOperationException(
+                            "Generic type: " + type.FullName + ", contains a generic argument " +
+                            genericArguments[i].FullName + " that is blocked from serialization", e);
+                    }
+                }
+            }
+
+            UpdateCache(ref _safeTypesCache, type);
+        }
+
+        private void AssertNotUsed()
+        {
+            if (_used)
+                throw new InvalidOperationException("Cannot perform this operation, because binder was already used.");
+        }
+
+        private static void UpdateCache(ref HashSet<Type> cache, Type type)
+        {
+            cache = new HashSet<Type>(cache)
+            {
+                type
+            };
+        }
+
+        private static void ThrowForbiddenType(Type type)
+        {
+            throw new InvalidOperationException(
+                $"Cannot resolve type '{type.FullName}' because the type is on a blacklist due to security reasons. " +
+                "Please customize json deserializer in the conventions and override the serialization binder with your own logic if you want to allow this type.");
+        }
+
+        private static void ThrowForbiddenNamespace(Type type)
+        {
+            throw new InvalidOperationException(
+                $"Cannot resolve type '{type.FullName}' because the namespace is on a blacklist due to security reasons. " +
+                "Please customize json deserializer in the conventions and override the serialization binder with your own logic if you want to allow this type.");
+        }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -157,12 +157,14 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
         {
             var options = ((SystemTextJsonJsonSerializer)serializer).Options;
 
-            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { SkipValidation = true });
-            writer.WriteStartObject();
-
-            // Write @metadata first
+            // Serialize entity directly to stream: produces {"prop1":...,"prop2":...}
+            JsonSerializer.Serialize(stream, entity, entity.GetType(), options);
             if (metadata != null && metadata.Count > 0)
             {
+                stream.SetLength(stream.Length - 1); // Remove trailing }
+                stream.WriteByte((byte)',');
+
+                using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { SkipValidation = true });
                 writer.WritePropertyName(Constants.Documents.Metadata.Key);
                 writer.WriteStartObject();
                 foreach (var kvp in metadata)
@@ -171,20 +173,9 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
                     WriteMetadataValue(writer, kvp.Value);
                 }
                 writer.WriteEndObject();
+                writer.Flush();
+                stream.WriteByte((byte)'}');
             }
-
-            // Serialize entity to a JsonDocument so we can iterate its top-level properties
-            // and write them into our existing object (which already has @metadata).
-            using var doc = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(entity, entity.GetType(), options));
-            foreach (var property in doc.RootElement.EnumerateObject())
-            {
-                if (property.Name == Constants.Documents.Metadata.Key)
-                    continue; // already written above
-                property.WriteTo(writer);
-            }
-
-            writer.WriteEndObject();
-            writer.Flush();
         }
 
         internal static void WriteMetadataValue(Utf8JsonWriter writer, object value)

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -193,17 +193,26 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
                 case long l:
                     writer.WriteNumberValue(l);
                     break;
+                case int i:
+                    writer.WriteNumberValue(i);
+                    break;
                 case bool b:
                     writer.WriteBooleanValue(b);
                     break;
                 case double d:
                     writer.WriteNumberValue(d);
                     break;
+                case float f:
+                    writer.WriteNumberValue(f);
+                    break;
+                case decimal dec:
+                    writer.WriteNumberValue(dec);
+                    break;
                 case null:
                     writer.WriteNullValue();
                     break;
                 default:
-                    writer.WriteStringValue(value.ToString());
+                    JsonSerializer.Serialize(writer, value);
                     break;
             }
         }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Raven.Client.Documents.Conventions;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson
@@ -10,5 +12,18 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
         public bool IgnoreByRefMembers { get; set; }
 
         public bool IgnoreUnsafeMembers { get; set; }
+
+        internal JsonSerializerOptions CreateJsonSerializerOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                TypeInfoResolver = new RavenJsonTypeInfoResolver(this),
+                NumberHandling = JsonNumberHandling.AllowReadingFromString,
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.Never
+            };
+
+            return options;
+        }
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -223,6 +223,21 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
                 case null:
                     writer.WriteNullValue();
                     break;
+                case IMetadataDictionary dict:
+                    writer.WriteStartObject();
+                    foreach (var kvp in dict)
+                    {
+                        writer.WritePropertyName(kvp.Key);
+                        WriteMetadataValue(writer, kvp.Value);
+                    }
+                    writer.WriteEndObject();
+                    break;
+                case object[] arr:
+                    writer.WriteStartArray();
+                    foreach (var item in arr)
+                        WriteMetadataValue(writer, item);
+                    writer.WriteEndArray();
+                    break;
                 default:
                     JsonSerializer.Serialize(writer, value);
                     break;

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -20,6 +20,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
         private Func<Type, BlittableJsonReaderObject, object> _deserializeEntityFromBlittable;
         private bool _ignoreByRefMembers;
         private bool _ignoreUnsafeMembers;
+        private System.Text.Json.Serialization.JsonSerializerContext _sourceGenerationContext;
         private JsonSerializerOptions _cachedSerializerOptions;
         private JsonSerializerOptions _cachedDeserializerOptions;
 
@@ -73,6 +74,21 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
             {
                 Conventions?.AssertNotFrozen();
                 _ignoreUnsafeMembers = value;
+            }
+        }
+
+        /// <summary>
+        ///     Set a source-generated <see cref="System.Text.Json.Serialization.JsonSerializerContext"/>
+        ///     to avoid runtime reflection. Types included in the context use compile-time
+        ///     generated metadata; types not in the context fall back to reflection.
+        /// </summary>
+        public System.Text.Json.Serialization.JsonSerializerContext SourceGenerationContext
+        {
+            get => _sourceGenerationContext;
+            set
+            {
+                Conventions?.AssertNotFrozen();
+                _sourceGenerationContext = value;
             }
         }
 
@@ -135,9 +151,13 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
 
         internal JsonSerializerOptions CreateJsonSerializerOptions()
         {
+            var ravenResolver = new RavenJsonTypeInfoResolver(this);
+
             var options = new JsonSerializerOptions
             {
-                TypeInfoResolver = new RavenJsonTypeInfoResolver(this),
+                TypeInfoResolver = _sourceGenerationContext != null
+                    ? ravenResolver.WithSourceGenerationContext(_sourceGenerationContext)
+                    : ravenResolver,
                 NumberHandling = JsonNumberHandling.AllowReadingFromString,
                 PropertyNameCaseInsensitive = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.Never

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -1,17 +1,134 @@
+using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Raven.Client.Documents.Conventions;
+using Raven.Client.Documents.Session;
+using Raven.Client.Documents.Subscriptions;
+using Raven.Client.Json.Serialization.SystemTextJson.Internal;
+using Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters;
+using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson
 {
-    // Minimal stub - will be filled in when the full STJ serialization conventions are implemented.
-    internal sealed class SystemTextJsonSerializationConventions
+    public class SystemTextJsonSerializationConventions : ISerializationConventions
     {
-        public DocumentConventions Conventions { get; set; }
+        private BlittableJsonConverter _defaultConverter;
+        private Action<JsonSerializerOptions> _customizeJsonSerializerOptions;
+        private Func<Type, BlittableJsonReaderObject, object> _deserializeEntityFromBlittable;
+        private bool _ignoreByRefMembers;
+        private bool _ignoreUnsafeMembers;
+        private JsonSerializerOptions _cachedSerializerOptions;
+        private JsonSerializerOptions _cachedDeserializerOptions;
 
-        public bool IgnoreByRefMembers { get; set; }
+        public DocumentConventions Conventions { get; private set; }
 
-        public bool IgnoreUnsafeMembers { get; set; }
+        public SystemTextJsonSerializationConventions()
+        {
+            _defaultConverter = new BlittableJsonConverter(this);
+            _ignoreByRefMembers = false;
+            _ignoreUnsafeMembers = false;
+            CustomizeJsonSerializerOptions = _ => { };
+        }
+
+        /// <summary>
+        ///     Register an action to customize the JsonSerializerOptions used by the DocumentStore.
+        /// </summary>
+        public Action<JsonSerializerOptions> CustomizeJsonSerializerOptions
+        {
+            get => _customizeJsonSerializerOptions;
+            set
+            {
+                Conventions?.AssertNotFrozen();
+                _customizeJsonSerializerOptions = value;
+            }
+        }
+
+        public Func<Type, BlittableJsonReaderObject, object> DeserializeEntityFromBlittable
+        {
+            get => _deserializeEntityFromBlittable;
+            set
+            {
+                Conventions?.AssertNotFrozen();
+                _deserializeEntityFromBlittable = value;
+            }
+        }
+
+        public bool IgnoreByRefMembers
+        {
+            get => _ignoreByRefMembers;
+            set
+            {
+                Conventions?.AssertNotFrozen();
+                _ignoreByRefMembers = value;
+            }
+        }
+
+        public bool IgnoreUnsafeMembers
+        {
+            get => _ignoreUnsafeMembers;
+            set
+            {
+                Conventions?.AssertNotFrozen();
+                _ignoreUnsafeMembers = value;
+            }
+        }
+
+        void ISerializationConventions.Initialize(DocumentConventions conventions)
+        {
+            Conventions = conventions ?? throw new ArgumentNullException(nameof(conventions));
+
+            if (_deserializeEntityFromBlittable == null)
+                _deserializeEntityFromBlittable = new SystemTextJsonBlittableEntitySerializer(this).EntityFromJsonStream;
+        }
+
+        IBlittableJsonConverter ISerializationConventions.DefaultConverter => _defaultConverter;
+
+        public ISubscriptionsBlittableJsonConverter CreateConverter<T>(SubscriptionBatch<T> batch)
+        {
+            return new SubscriptionBlittableJsonConverter(this);
+        }
+
+        ISessionBlittableJsonConverter ISerializationConventions.CreateConverter(InMemoryDocumentSessionOperations session)
+        {
+            return new SessionBlittableJsonConverter(session);
+        }
+
+        IJsonSerializer ISerializationConventions.CreateDeserializer(CreateDeserializerOptions options)
+        {
+            JsonSerializerOptions jsonOptions = GetOrCreateOptions(ref _cachedDeserializerOptions);
+            return new SystemTextJsonJsonSerializer(jsonOptions);
+        }
+
+        IJsonSerializer ISerializationConventions.CreateSerializer(CreateSerializerOptions options)
+        {
+            JsonSerializerOptions jsonOptions = GetOrCreateOptions(ref _cachedSerializerOptions);
+            return new SystemTextJsonJsonSerializer(jsonOptions);
+        }
+
+        IJsonWriter ISerializationConventions.CreateWriter(JsonOperationContext context)
+        {
+            return new SystemTextJsonBlittableWriter(context);
+        }
+
+        object ISerializationConventions.DeserializeEntityFromBlittable(Type type, BlittableJsonReaderObject json)
+        {
+            return DeserializeEntityFromBlittable(type, json);
+        }
+
+        T ISerializationConventions.DeserializeEntityFromBlittable<T>(BlittableJsonReaderObject json)
+        {
+            return (T)DeserializeEntityFromBlittable(typeof(T), json);
+        }
+
+        private JsonSerializerOptions GetOrCreateOptions(ref JsonSerializerOptions cached)
+        {
+            if (cached != null)
+                return cached;
+
+            JsonSerializerOptions options = CreateJsonSerializerOptions();
+            cached = options;
+            return options;
+        }
 
         internal JsonSerializerOptions CreateJsonSerializerOptions()
         {
@@ -23,7 +140,30 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
                 DefaultIgnoreCondition = JsonIgnoreCondition.Never
             };
 
+            InitializeConverters(options);
+            CustomizeJsonSerializerOptions(options);
+
             return options;
+        }
+
+        private void InitializeConverters(JsonSerializerOptions options)
+        {
+            if (Conventions == null || Conventions.SaveEnumsAsIntegers == false)
+                options.Converters.Add(new JsonStringEnumConverter());
+
+            options.Converters.Add(DateTimeISO8601Converter.Instance);
+            options.Converters.Add(LuceneDateTimeConverter.Instance);
+            options.Converters.Add(DictionaryDateTimeKeysConverter.Instance);
+            options.Converters.Add(ParametersConverter.Instance);
+            options.Converters.Add(LinqEnumerableConverter.Instance);
+            options.Converters.Add(MetadataDictionaryConverter.Instance);
+            options.Converters.Add(SizeConverter.Instance);
+#if FEATURE_DATEONLY_TIMEONLY_SUPPORT
+            options.Converters.Add(DateOnlyConverter.Instance);
+            options.Converters.Add(TimeOnlyConverter.Instance);
+#endif
+            options.Converters.Add(VectorConverter.Instance);
+            options.Converters.Add(EnumerableConverter.Instance);
         }
     }
 }

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Raven.Client.Documents.Conventions;
@@ -144,6 +145,67 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
             CustomizeJsonSerializerOptions(options);
 
             return options;
+        }
+
+        /// <summary>
+        /// Writes an entity with @metadata directly to a stream as UTF-8 JSON,
+        /// bypassing the blittable intermediate format. Used by bulk insert.
+        /// </summary>
+        internal void WriteEntityToStream(Stream stream, object entity, IMetadataDictionary metadata, IJsonSerializer serializer)
+        {
+            var options = ((SystemTextJsonJsonSerializer)serializer).Options;
+
+            using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { SkipValidation = true });
+            writer.WriteStartObject();
+
+            // Write @metadata first
+            if (metadata != null && metadata.Count > 0)
+            {
+                writer.WritePropertyName(Constants.Documents.Metadata.Key);
+                writer.WriteStartObject();
+                foreach (var kvp in metadata)
+                {
+                    writer.WritePropertyName(kvp.Key);
+                    WriteMetadataValue(writer, kvp.Value);
+                }
+                writer.WriteEndObject();
+            }
+
+            // Serialize entity to a JsonDocument so we can iterate its top-level properties
+            // and write them into our existing object (which already has @metadata).
+            using var doc = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(entity, entity.GetType(), options));
+            foreach (var property in doc.RootElement.EnumerateObject())
+            {
+                property.WriteTo(writer);
+            }
+
+            writer.WriteEndObject();
+            writer.Flush();
+        }
+
+        private static void WriteMetadataValue(Utf8JsonWriter writer, object value)
+        {
+            switch (value)
+            {
+                case string s:
+                    writer.WriteStringValue(s);
+                    break;
+                case long l:
+                    writer.WriteNumberValue(l);
+                    break;
+                case bool b:
+                    writer.WriteBooleanValue(b);
+                    break;
+                case double d:
+                    writer.WriteNumberValue(d);
+                    break;
+                case null:
+                    writer.WriteNullValue();
+                    break;
+                default:
+                    writer.WriteStringValue(value.ToString());
+                    break;
+            }
         }
 
         private void InitializeConverters(JsonSerializerOptions options)

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -1,0 +1,14 @@
+using Raven.Client.Documents.Conventions;
+
+namespace Raven.Client.Json.Serialization.SystemTextJson
+{
+    // Minimal stub - will be filled in when the full STJ serialization conventions are implemented.
+    internal sealed class SystemTextJsonSerializationConventions
+    {
+        public DocumentConventions Conventions { get; set; }
+
+        public bool IgnoreByRefMembers { get; set; }
+
+        public bool IgnoreUnsafeMembers { get; set; }
+    }
+}

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Raven.Client.Documents.Conventions;
@@ -188,6 +189,8 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
 
         internal static void WriteMetadataValue(Utf8JsonWriter writer, object value)
         {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
+            
             switch (value)
             {
                 case string s:

--- a/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
+++ b/src/Raven.Client/Json/Serialization/SystemTextJson/SystemTextJsonSerializationConventions.cs
@@ -7,6 +7,7 @@ using Raven.Client.Documents.Session;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Json.Serialization.SystemTextJson.Internal;
 using Raven.Client.Json.Serialization.SystemTextJson.Internal.Converters;
+using Sparrow.Extensions;
 using Sparrow.Json;
 
 namespace Raven.Client.Json.Serialization.SystemTextJson
@@ -176,6 +177,8 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
             using var doc = JsonDocument.Parse(JsonSerializer.SerializeToUtf8Bytes(entity, entity.GetType(), options));
             foreach (var property in doc.RootElement.EnumerateObject())
             {
+                if (property.Name == Constants.Documents.Metadata.Key)
+                    continue; // already written above
                 property.WriteTo(writer);
             }
 
@@ -183,7 +186,7 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
             writer.Flush();
         }
 
-        private static void WriteMetadataValue(Utf8JsonWriter writer, object value)
+        internal static void WriteMetadataValue(Utf8JsonWriter writer, object value)
         {
             switch (value)
             {
@@ -207,6 +210,15 @@ namespace Raven.Client.Json.Serialization.SystemTextJson
                     break;
                 case decimal dec:
                     writer.WriteNumberValue(dec);
+                    break;
+                case DateTime dt:
+                    writer.WriteStringValue(dt.GetDefaultRavenFormat(isUtc: dt.Kind == DateTimeKind.Utc));
+                    break;
+                case DateTimeOffset dto:
+                    writer.WriteStringValue(dto.UtcDateTime.GetDefaultRavenFormat(isUtc: true));
+                    break;
+                case TimeSpan ts:
+                    writer.WriteStringValue(ts.ToString("c"));
                     break;
                 case null:
                     writer.WriteNullValue();

--- a/src/Raven.Client/Raven.Client.csproj
+++ b/src/Raven.Client/Raven.Client.csproj
@@ -157,6 +157,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
     <PackageReference Include="Raven.CodeAnalysis" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.CSharp" />

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -8,7 +8,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Lambda2Js;
-using Newtonsoft.Json;
 using Raven.Client.Documents.Conventions;
 using Raven.Client.Documents.Linq;
 using Raven.Client.Documents.Queries;
@@ -1242,10 +1241,8 @@ namespace Raven.Client.Util
                 if (context.Node is not MemberExpression memberExpression)
                     return;
 
-                var jsonPropertyAttribute = memberExpression.Member.GetCustomAttributes()
-                                                                    .OfType<JsonPropertyAttribute>()
-                                                                    .FirstOrDefault();
-                if (jsonPropertyAttribute == null)
+                string propertyName = Raven.Client.Json.JsonPropertyNameResolver.GetJsonPropertyName(memberExpression.Member);
+                if (propertyName == null)
                     return;
 
                 context.PreventDefault();
@@ -1255,7 +1252,7 @@ namespace Raven.Client.Util
                 {
                     context.Visitor.Visit(memberExpression.Expression);
                     writer.Write(".");
-                    writer.Write(jsonPropertyAttribute.PropertyName ?? memberExpression.Member.Name);
+                    writer.Write(propertyName);
                 }
             }
         }

--- a/test/FastTests/Client/SystemTextJsonEndToEndBenchmarks.cs
+++ b/test/FastTests/Client/SystemTextJsonEndToEndBenchmarks.cs
@@ -246,19 +246,31 @@ namespace FastTests.Client
                     await session.SaveChangesAsync();
                 }
 
-                // Measure
-                var sw = Stopwatch.StartNew();
+                // Measure - split into load, modify, save phases
+                long loadMs = 0, saveMs = 0;
+                var totalSw = Stopwatch.StartNew();
                 for (int i = 0; i < MeasuredIterations; i++)
                 {
                     using var session = store.OpenAsyncSession();
+
+                    var loadSw = Stopwatch.StartNew();
                     var entity = await session.LoadAsync<Order>($"orders/{i}");
+                    loadSw.Stop();
+                    loadMs += loadSw.ElapsedMilliseconds;
+
                     entity.Total += 100;
                     entity.Notes = $"Updated at iteration {i}";
-                    await session.SaveChangesAsync();
-                }
-                sw.Stop();
 
-                results.Add($"  {name,-12} {sw.ElapsedMilliseconds,6}ms ({sw.ElapsedMilliseconds * 1000.0 / MeasuredIterations:F1} us/op)");
+                    var saveSw = Stopwatch.StartNew();
+                    await session.SaveChangesAsync();
+                    saveSw.Stop();
+                    saveMs += saveSw.ElapsedMilliseconds;
+                }
+                totalSw.Stop();
+
+                results.Add($"  {name,-12} Total: {totalSw.ElapsedMilliseconds,5}ms  " +
+                            $"Load: {loadMs,5}ms ({loadMs * 1000.0 / MeasuredIterations:F0} us/op)  " +
+                            $"Save: {saveMs,5}ms ({saveMs * 1000.0 / MeasuredIterations:F0} us/op)");
             }
 
             foreach (var line in results)

--- a/test/FastTests/Client/SystemTextJsonEndToEndBenchmarks.cs
+++ b/test/FastTests/Client/SystemTextJsonEndToEndBenchmarks.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Linq;
+using Raven.Client.Documents.Session;
+using Raven.Client.Json.Serialization.NewtonsoftJson;
+using Raven.Client.Json.Serialization.SystemTextJson;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Client
+{
+    public class SystemTextJsonEndToEndBenchmarks : RavenTestBase
+    {
+        public SystemTextJsonEndToEndBenchmarks(Xunit.ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private const int WarmupIterations = 5;
+        private const int MeasuredIterations = 50;
+        private const int BulkInsertCount = 1000;
+        private const int QueryDocCount = 200;
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task BenchmarkStoreAndLoad()
+        {
+            var results = new List<string> { "", "=== Store & Load (single document, " + MeasuredIterations + " iterations) ===" };
+
+            foreach (var (name, conventions) in GetSerializers())
+            {
+                using var store = GetDocumentStore(new Options
+                {
+                    ModifyDocumentStore = s => s.Conventions.Serialization = conventions
+                });
+
+                // Warmup
+                for (int i = 0; i < WarmupIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    await session.StoreAsync(CreateMediumEntity(i), $"warmup/{i}");
+                    await session.SaveChangesAsync();
+                }
+
+                // Measure Store
+                var storeSw = Stopwatch.StartNew();
+                for (int i = 0; i < MeasuredIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    await session.StoreAsync(CreateMediumEntity(i), $"bench/{i}");
+                    await session.SaveChangesAsync();
+                }
+                storeSw.Stop();
+
+                // Measure Load
+                var loadSw = Stopwatch.StartNew();
+                for (int i = 0; i < MeasuredIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var entity = await session.LoadAsync<Order>($"bench/{i}");
+                    GC.KeepAlive(entity);
+                }
+                loadSw.Stop();
+
+                results.Add($"  {name,-12} Store: {storeSw.ElapsedMilliseconds,6}ms ({storeSw.ElapsedMilliseconds * 1000.0 / MeasuredIterations:F1} us/op)  " +
+                            $"Load: {loadSw.ElapsedMilliseconds,6}ms ({loadSw.ElapsedMilliseconds * 1000.0 / MeasuredIterations:F1} us/op)");
+            }
+
+            foreach (var line in results)
+                Output.WriteLine(line);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task BenchmarkBulkInsert()
+        {
+            var results = new List<string> { "", $"=== Bulk Insert ({BulkInsertCount} documents) ===" };
+
+            foreach (var (name, conventions) in GetSerializers())
+            {
+                using var store = GetDocumentStore(new Options
+                {
+                    ModifyDocumentStore = s => s.Conventions.Serialization = conventions
+                });
+
+                // Warmup
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < 50; i++)
+                        await bulk.StoreAsync(CreateMediumEntity(i));
+                }
+
+                // Measure
+                var sw = Stopwatch.StartNew();
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < BulkInsertCount; i++)
+                        await bulk.StoreAsync(CreateMediumEntity(i));
+                }
+                sw.Stop();
+
+                // Verify
+                using (var session = store.OpenAsyncSession())
+                {
+                    var count = await session.Query<Order>().CountAsync();
+                    Assert.True(count > 0);
+                }
+
+                results.Add($"  {name,-12} {sw.ElapsedMilliseconds,6}ms ({sw.ElapsedMilliseconds * 1000.0 / BulkInsertCount:F1} us/doc)");
+            }
+
+            foreach (var line in results)
+                Output.WriteLine(line);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task BenchmarkQuery()
+        {
+            var results = new List<string> { "", $"=== Query ({QueryDocCount} docs, {MeasuredIterations} queries) ===" };
+
+            foreach (var (name, conventions) in GetSerializers())
+            {
+                using var store = GetDocumentStore(new Options
+                {
+                    ModifyDocumentStore = s => s.Conventions.Serialization = conventions
+                });
+
+                // Seed data
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < QueryDocCount; i++)
+                        await bulk.StoreAsync(CreateMediumEntity(i));
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                // Warmup
+                for (int i = 0; i < WarmupIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var _ = await session.Query<Order>()
+                        .Where(x => x.Total > 500)
+                        .ToListAsync();
+                }
+
+                // Measure
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < MeasuredIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var result = await session.Query<Order>()
+                        .Where(x => x.Total > 500)
+                        .Take(50)
+                        .ToListAsync();
+                    GC.KeepAlive(result);
+                }
+                sw.Stop();
+
+                results.Add($"  {name,-12} {sw.ElapsedMilliseconds,6}ms ({sw.ElapsedMilliseconds * 1000.0 / MeasuredIterations:F1} us/query)");
+            }
+
+            foreach (var line in results)
+                Output.WriteLine(line);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task BenchmarkStreaming()
+        {
+            var results = new List<string> { "", $"=== Stream ({QueryDocCount} docs, {MeasuredIterations / 5} streams) ===" };
+            int streamIterations = MeasuredIterations / 5;
+
+            foreach (var (name, conventions) in GetSerializers())
+            {
+                using var store = GetDocumentStore(new Options
+                {
+                    ModifyDocumentStore = s => s.Conventions.Serialization = conventions
+                });
+
+                // Seed data
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < QueryDocCount; i++)
+                        await bulk.StoreAsync(CreateMediumEntity(i));
+                }
+
+                Indexes.WaitForIndexing(store);
+
+                // Warmup
+                for (int i = 0; i < 2; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var stream = await session.Advanced.StreamAsync<Order>("orders/");
+                    while (await stream.MoveNextAsync())
+                        GC.KeepAlive(stream.Current.Document);
+                }
+
+                // Measure
+                var sw = Stopwatch.StartNew();
+                int totalDocs = 0;
+                for (int i = 0; i < streamIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var stream = await session.Advanced.StreamAsync<Order>("orders/");
+                    while (await stream.MoveNextAsync())
+                    {
+                        GC.KeepAlive(stream.Current.Document);
+                        totalDocs++;
+                    }
+                }
+                sw.Stop();
+
+                results.Add($"  {name,-12} {sw.ElapsedMilliseconds,6}ms ({totalDocs} docs, {sw.ElapsedMilliseconds * 1000.0 / totalDocs:F1} us/doc)");
+            }
+
+            foreach (var line in results)
+                Output.WriteLine(line);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task BenchmarkModifyAndSave()
+        {
+            var results = new List<string> { "", $"=== Load-Modify-Save ({MeasuredIterations} iterations) ===" };
+
+            foreach (var (name, conventions) in GetSerializers())
+            {
+                using var store = GetDocumentStore(new Options
+                {
+                    ModifyDocumentStore = s => s.Conventions.Serialization = conventions
+                });
+
+                // Seed data
+                using (var bulk = store.BulkInsert())
+                {
+                    for (int i = 0; i < MeasuredIterations; i++)
+                        await bulk.StoreAsync(CreateMediumEntity(i), $"orders/{i}");
+                }
+
+                // Warmup
+                for (int i = 0; i < WarmupIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var entity = await session.LoadAsync<Order>($"orders/{i}");
+                    entity.Total += 1;
+                    await session.SaveChangesAsync();
+                }
+
+                // Measure
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < MeasuredIterations; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var entity = await session.LoadAsync<Order>($"orders/{i}");
+                    entity.Total += 100;
+                    entity.Notes = $"Updated at iteration {i}";
+                    await session.SaveChangesAsync();
+                }
+                sw.Stop();
+
+                results.Add($"  {name,-12} {sw.ElapsedMilliseconds,6}ms ({sw.ElapsedMilliseconds * 1000.0 / MeasuredIterations:F1} us/op)");
+            }
+
+            foreach (var line in results)
+                Output.WriteLine(line);
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task BenchmarkLargeDocuments()
+        {
+            int count = 20;
+            var results = new List<string> { "", $"=== Large Documents (100-item nested, {count} docs) ===" };
+
+            foreach (var (name, conventions) in GetSerializers())
+            {
+                using var store = GetDocumentStore(new Options
+                {
+                    ModifyDocumentStore = s => s.Conventions.Serialization = conventions
+                });
+
+                var docs = Enumerable.Range(0, count).Select(CreateLargeEntity).ToList();
+
+                // Measure Store
+                var storeSw = Stopwatch.StartNew();
+                for (int i = 0; i < count; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    await session.StoreAsync(docs[i], $"reports/{i}");
+                    await session.SaveChangesAsync();
+                }
+                storeSw.Stop();
+
+                // Measure Load
+                var loadSw = Stopwatch.StartNew();
+                for (int i = 0; i < count; i++)
+                {
+                    using var session = store.OpenAsyncSession();
+                    var entity = await session.LoadAsync<Report>($"reports/{i}");
+                    GC.KeepAlive(entity);
+                }
+                loadSw.Stop();
+
+                results.Add($"  {name,-12} Store: {storeSw.ElapsedMilliseconds,6}ms ({storeSw.ElapsedMilliseconds * 1000.0 / count:F0} us/doc)  " +
+                            $"Load: {loadSw.ElapsedMilliseconds,6}ms ({loadSw.ElapsedMilliseconds * 1000.0 / count:F0} us/doc)");
+            }
+
+            foreach (var line in results)
+                Output.WriteLine(line);
+        }
+
+        // === Helpers ===
+
+        private static List<(string Name, Raven.Client.Json.Serialization.ISerializationConventions Conventions)> GetSerializers()
+        {
+            return new List<(string, Raven.Client.Json.Serialization.ISerializationConventions)>
+            {
+                ("Newtonsoft", new NewtonsoftJsonSerializationConventions()),
+                ("STJ", new SystemTextJsonSerializationConventions())
+            };
+        }
+
+        private static Order CreateMediumEntity(int i)
+        {
+            return new Order
+            {
+                Id = $"orders/{i}",
+                CustomerName = $"Customer {i}",
+                Email = $"customer{i}@example.com",
+                OrderDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(i),
+                Total = 100m + i * 13.7m,
+                Tax = 10m + i * 1.37m,
+                IsShipped = i % 3 == 0,
+                Notes = $"Order notes for item {i}",
+                ShippingAddress = new Address
+                {
+                    Street = $"{i} Main St",
+                    City = "Springfield",
+                    State = "IL",
+                    ZipCode = "62701"
+                },
+                Lines = new List<OrderLine>
+                {
+                    new OrderLine { ProductName = $"Product A-{i}", Quantity = i + 1, Price = 29.99m },
+                    new OrderLine { ProductName = $"Product B-{i}", Quantity = 2, Price = 49.99m }
+                },
+                Tags = new List<string> { "tag1", "tag2", $"tag{i}" }
+            };
+        }
+
+        private static Report CreateLargeEntity(int i)
+        {
+            var report = new Report
+            {
+                Id = $"reports/{i}",
+                Title = $"Report {i}",
+                GeneratedAt = new DateTime(2026, 4, 11, 12, 0, 0, DateTimeKind.Utc),
+                Items = new List<ReportItem>()
+            };
+            for (int j = 0; j < 100; j++)
+            {
+                report.Items.Add(new ReportItem
+                {
+                    ProductName = $"Product {j}",
+                    Quantity = j * 10,
+                    UnitPrice = 9.99m + j,
+                    TotalPrice = (9.99m + j) * (j * 10),
+                    Category = j % 5 == 0 ? "Electronics" : j % 3 == 0 ? "Clothing" : "Food"
+                });
+            }
+            return report;
+        }
+
+        // === Entity Classes ===
+
+        private class Order
+        {
+            public string Id { get; set; }
+            public string CustomerName { get; set; }
+            public string Email { get; set; }
+            public DateTime OrderDate { get; set; }
+            public decimal Total { get; set; }
+            public decimal Tax { get; set; }
+            public bool IsShipped { get; set; }
+            public string Notes { get; set; }
+            public Address ShippingAddress { get; set; }
+            public List<OrderLine> Lines { get; set; }
+            public List<string> Tags { get; set; }
+        }
+
+        private class Address
+        {
+            public string Street { get; set; }
+            public string City { get; set; }
+            public string State { get; set; }
+            public string ZipCode { get; set; }
+        }
+
+        private class OrderLine
+        {
+            public string ProductName { get; set; }
+            public int Quantity { get; set; }
+            public decimal Price { get; set; }
+        }
+
+        private class Report
+        {
+            public string Id { get; set; }
+            public string Title { get; set; }
+            public DateTime GeneratedAt { get; set; }
+            public List<ReportItem> Items { get; set; }
+        }
+
+        private class ReportItem
+        {
+            public string ProductName { get; set; }
+            public int Quantity { get; set; }
+            public decimal UnitPrice { get; set; }
+            public decimal TotalPrice { get; set; }
+            public string Category { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Client/SystemTextJsonEndToEndBenchmarks.cs
+++ b/test/FastTests/Client/SystemTextJsonEndToEndBenchmarks.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Documents.Linq;
-using Raven.Client.Documents.Session;
 using Raven.Client.Json.Serialization.NewtonsoftJson;
 using Raven.Client.Json.Serialization.SystemTextJson;
 using Tests.Infrastructure;

--- a/test/FastTests/Client/SystemTextJsonSerializationTests.cs
+++ b/test/FastTests/Client/SystemTextJsonSerializationTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Raven.Client.Documents;
 using Raven.Client.Json.Serialization.SystemTextJson;
+using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -413,6 +414,59 @@ namespace FastTests.Client
             public List<int> Scores { get; set; }
             public Dictionary<string, string> Metadata { get; set; }
             public int[] Numbers { get; set; }
+        }
+
+        // Entity that only has Name — "ExtraField" and "ExtraNumber" are not on this type
+        private class PartialEntity
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task PreserveDocumentPropertiesNotFoundOnModel_RoundTrips()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            // Store a document with extra properties using an anonymous type
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new
+                {
+                    Name = "John",
+                    ExtraField = "should be preserved",
+                    ExtraNumber = 42
+                }, "items/1");
+                await session.SaveChangesAsync();
+            }
+
+            // Load as PartialEntity (missing ExtraField and ExtraNumber), modify, save
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = await session.LoadAsync<PartialEntity>("items/1");
+                Assert.Equal("John", entity.Name);
+
+                entity.Name = "Jane";
+                await session.SaveChangesAsync();
+            }
+
+            // Verify extra properties survived the round-trip by loading as dynamic
+            using (var session = store.OpenAsyncSession())
+            {
+                var raw = await session.LoadAsync<BlittableJsonReaderObject>("items/1");
+                Assert.True(raw.TryGet("Name", out string name));
+                Assert.Equal("Jane", name);
+                Assert.True(raw.TryGet("ExtraField", out string extraField));
+                Assert.Equal("should be preserved", extraField);
+                Assert.True(raw.TryGet("ExtraNumber", out long extraNumber));
+                Assert.Equal(42, extraNumber);
+            }
         }
     }
 }

--- a/test/FastTests/Client/SystemTextJsonSerializationTests.cs
+++ b/test/FastTests/Client/SystemTextJsonSerializationTests.cs
@@ -104,6 +104,7 @@ namespace FastTests.Client
                 Assert.Equal(TimeSpan.FromHours(2.5), loaded.TimeSpanProp);
                 Assert.Equal(7, loaded.NullableIntProp);
                 Assert.Null(loaded.NullableIntNull);
+                Assert.Equal(new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.FromHours(2)), loaded.DateTimeOffsetProp);
                 Assert.Null(loaded.NullableDateTimeProp);
                 Assert.Null(loaded.NullString);
             }

--- a/test/FastTests/Client/SystemTextJsonSerializationTests.cs
+++ b/test/FastTests/Client/SystemTextJsonSerializationTests.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Json.Serialization.SystemTextJson;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Client
+{
+    public class SystemTextJsonSerializationTests : RavenTestBase
+    {
+        public SystemTextJsonSerializationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanStoreAndLoadWithSystemTextJson()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            var now = DateTime.UtcNow;
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Id = "users/1",
+                    Name = "Oren",
+                    Age = 42,
+                    IsActive = true,
+                    CreatedAt = now
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<User>("users/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("Oren", loaded.Name);
+                Assert.Equal(42, loaded.Age);
+                Assert.True(loaded.IsActive);
+                Assert.Equal(now.Date, loaded.CreatedAt.Date);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanHandleMultiplePropertyTypes()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            var entity = new AllTypesEntity
+            {
+                Id = "alltypes/1",
+                StringProp = "hello",
+                IntProp = 42,
+                LongProp = 9_999_999_999L,
+                DoubleProp = 3.14,
+                DecimalProp = 99.99m,
+                BoolProp = true,
+                DateTimeProp = new DateTime(2025, 6, 15, 10, 30, 0, DateTimeKind.Utc),
+                DateTimeOffsetProp = new DateTimeOffset(2025, 6, 15, 10, 30, 0, TimeSpan.FromHours(2)),
+                GuidProp = Guid.Parse("12345678-1234-1234-1234-123456789abc"),
+                TimeSpanProp = TimeSpan.FromHours(2.5),
+                NullableIntProp = 7,
+                NullableIntNull = null,
+                NullableDateTimeProp = null,
+                NullString = null
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<AllTypesEntity>("alltypes/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("hello", loaded.StringProp);
+                Assert.Equal(42, loaded.IntProp);
+                Assert.Equal(9_999_999_999L, loaded.LongProp);
+                Assert.Equal(3.14, loaded.DoubleProp);
+                Assert.Equal(99.99m, loaded.DecimalProp);
+                Assert.True(loaded.BoolProp);
+                Assert.Equal(new DateTime(2025, 6, 15, 10, 30, 0, DateTimeKind.Utc), loaded.DateTimeProp);
+                Assert.Equal(Guid.Parse("12345678-1234-1234-1234-123456789abc"), loaded.GuidProp);
+                Assert.Equal(TimeSpan.FromHours(2.5), loaded.TimeSpanProp);
+                Assert.Equal(7, loaded.NullableIntProp);
+                Assert.Null(loaded.NullableIntNull);
+                Assert.Null(loaded.NullableDateTimeProp);
+                Assert.Null(loaded.NullString);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanHandleNestedObjects()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            var order = new Order
+            {
+                Id = "orders/1",
+                CustomerId = "customers/1",
+                Total = 150.50m,
+                Lines = new List<OrderLine>
+                {
+                    new OrderLine { ProductName = "Widget", Quantity = 3, Price = 25.00m },
+                    new OrderLine { ProductName = "Gadget", Quantity = 1, Price = 75.50m }
+                }
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(order);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<Order>("orders/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("customers/1", loaded.CustomerId);
+                Assert.Equal(150.50m, loaded.Total);
+                Assert.Equal(2, loaded.Lines.Count);
+                Assert.Equal("Widget", loaded.Lines[0].ProductName);
+                Assert.Equal(3, loaded.Lines[0].Quantity);
+                Assert.Equal(25.00m, loaded.Lines[0].Price);
+                Assert.Equal("Gadget", loaded.Lines[1].ProductName);
+                Assert.Equal(1, loaded.Lines[1].Quantity);
+                Assert.Equal(75.50m, loaded.Lines[1].Price);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanHandleCollections()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            var entity = new CollectionEntity
+            {
+                Id = "collections/1",
+                Tags = new List<string> { "alpha", "beta", "gamma" },
+                Scores = new List<int> { 10, 20, 30 },
+                Metadata = new Dictionary<string, string>
+                {
+                    ["key1"] = "value1",
+                    ["key2"] = "value2"
+                },
+                Numbers = new[] { 1, 2, 3, 4, 5 }
+            };
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(entity);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<CollectionEntity>("collections/1");
+                Assert.NotNull(loaded);
+                Assert.Equal(new List<string> { "alpha", "beta", "gamma" }, loaded.Tags);
+                Assert.Equal(new List<int> { 10, 20, 30 }, loaded.Scores);
+                Assert.Equal("value1", loaded.Metadata["key1"]);
+                Assert.Equal("value2", loaded.Metadata["key2"]);
+                Assert.Equal(new[] { 1, 2, 3, 4, 5 }, loaded.Numbers);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanQueryWithSystemTextJson()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User { Name = "Alice", Age = 30, IsActive = true });
+                await session.StoreAsync(new User { Name = "Bob", Age = 25, IsActive = false });
+                await session.StoreAsync(new User { Name = "Charlie", Age = 35, IsActive = true });
+                await session.SaveChangesAsync();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var activeUsers = await session.Query<User>()
+                    .Where(u => u.IsActive)
+                    .OrderBy(u => u.Name)
+                    .ToListAsync();
+
+                Assert.Equal(2, activeUsers.Count);
+                Assert.Equal("Alice", activeUsers[0].Name);
+                Assert.Equal("Charlie", activeUsers[1].Name);
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var youngUsers = await session.Query<User>()
+                    .Where(u => u.Age < 32)
+                    .ToListAsync();
+
+                Assert.Equal(2, youngUsers.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanModifyAndSaveChangesWithSystemTextJson()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Id = "users/1",
+                    Name = "Original",
+                    Age = 20,
+                    IsActive = false,
+                    CreatedAt = DateTime.UtcNow
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+                user.Name = "Modified";
+                user.Age = 30;
+                user.IsActive = true;
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+                Assert.Equal("Modified", user.Name);
+                Assert.Equal(30, user.Age);
+                Assert.True(user.IsActive);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanBulkInsertWithSystemTextJson()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            const int count = 100;
+
+            await using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    await bulkInsert.StoreAsync(new User
+                    {
+                        Id = $"users/{i}",
+                        Name = $"User {i}",
+                        Age = 20 + (i % 50),
+                        IsActive = i % 2 == 0,
+                        CreatedAt = DateTime.UtcNow
+                    });
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user0 = await session.LoadAsync<User>("users/0");
+                Assert.NotNull(user0);
+                Assert.Equal("User 0", user0.Name);
+                Assert.Equal(20, user0.Age);
+                Assert.True(user0.IsActive);
+
+                var user99 = await session.LoadAsync<User>("users/99");
+                Assert.NotNull(user99);
+                Assert.Equal("User 99", user99.Name);
+                Assert.Equal(69, user99.Age);
+                Assert.False(user99.IsActive);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanDeleteWithSystemTextJson()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions();
+                }
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new User
+                {
+                    Id = "users/1",
+                    Name = "ToDelete",
+                    Age = 25,
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+                Assert.NotNull(user);
+                session.Delete(user);
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var user = await session.LoadAsync<User>("users/1");
+                Assert.Null(user);
+            }
+        }
+
+        private class User
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+            public bool IsActive { get; set; }
+            public DateTime CreatedAt { get; set; }
+        }
+
+        private class Order
+        {
+            public string Id { get; set; }
+            public string CustomerId { get; set; }
+            public List<OrderLine> Lines { get; set; }
+            public decimal Total { get; set; }
+        }
+
+        private class OrderLine
+        {
+            public string ProductName { get; set; }
+            public int Quantity { get; set; }
+            public decimal Price { get; set; }
+        }
+
+        private class AllTypesEntity
+        {
+            public string Id { get; set; }
+            public string StringProp { get; set; }
+            public int IntProp { get; set; }
+            public long LongProp { get; set; }
+            public double DoubleProp { get; set; }
+            public decimal DecimalProp { get; set; }
+            public bool BoolProp { get; set; }
+            public DateTime DateTimeProp { get; set; }
+            public DateTimeOffset DateTimeOffsetProp { get; set; }
+            public Guid GuidProp { get; set; }
+            public TimeSpan TimeSpanProp { get; set; }
+            public int? NullableIntProp { get; set; }
+            public int? NullableIntNull { get; set; }
+            public DateTime? NullableDateTimeProp { get; set; }
+            public string NullString { get; set; }
+        }
+
+        private class CollectionEntity
+        {
+            public string Id { get; set; }
+            public List<string> Tags { get; set; }
+            public List<int> Scores { get; set; }
+            public Dictionary<string, string> Metadata { get; set; }
+            public int[] Numbers { get; set; }
+        }
+    }
+}

--- a/test/FastTests/Client/SystemTextJsonSourceGenerationTests.cs
+++ b/test/FastTests/Client/SystemTextJsonSourceGenerationTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Json.Serialization.SystemTextJson;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Client
+{
+    public partial class SystemTextJsonSourceGenerationTests : RavenTestBase
+    {
+        public SystemTextJsonSourceGenerationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanStoreAndLoadWithSourceGenContext()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions
+                    {
+                        SourceGenerationContext = TestJsonContext.Default
+                    };
+                }
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Id = "orders/1",
+                    CustomerId = "customers/1",
+                    Total = 150.50m,
+                    Lines = new List<OrderLine>
+                    {
+                        new OrderLine { ProductName = "Widget", Quantity = 3, Price = 25.00m },
+                        new OrderLine { ProductName = "Gadget", Quantity = 1, Price = 75.50m }
+                    }
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("orders/1");
+                Assert.NotNull(order);
+                Assert.Equal("customers/1", order.CustomerId);
+                Assert.Equal(150.50m, order.Total);
+                Assert.Equal(2, order.Lines.Count);
+                Assert.Equal("Widget", order.Lines[0].ProductName);
+                Assert.Equal(3, order.Lines[0].Quantity);
+                Assert.Equal(25.00m, order.Lines[0].Price);
+                Assert.Equal("Gadget", order.Lines[1].ProductName);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanQueryWithSourceGenContext()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions
+                    {
+                        SourceGenerationContext = TestJsonContext.Default
+                    };
+                }
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order { Id = "orders/1", CustomerId = "customers/1", Total = 100m, Lines = new List<OrderLine>() });
+                await session.StoreAsync(new Order { Id = "orders/2", CustomerId = "customers/2", Total = 200m, Lines = new List<OrderLine>() });
+                await session.StoreAsync(new Order { Id = "orders/3", CustomerId = "customers/1", Total = 300m, Lines = new List<OrderLine>() });
+                await session.SaveChangesAsync();
+            }
+
+            Indexes.WaitForIndexing(store);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var orders = await session.Query<Order>()
+                    .Where(o => o.CustomerId == "customers/1")
+                    .OrderBy(o => o.Total)
+                    .ToListAsync();
+
+                Assert.Equal(2, orders.Count);
+                Assert.Equal(100m, orders[0].Total);
+                Assert.Equal(300m, orders[1].Total);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanModifyAndSaveChangesWithSourceGenContext()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions
+                    {
+                        SourceGenerationContext = TestJsonContext.Default
+                    };
+                }
+            });
+
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new Order
+                {
+                    Id = "orders/1",
+                    CustomerId = "customers/1",
+                    Total = 50m,
+                    Lines = new List<OrderLine>()
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("orders/1");
+                order.Total = 999m;
+                order.Lines.Add(new OrderLine { ProductName = "New Item", Quantity = 5, Price = 10m });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order = await session.LoadAsync<Order>("orders/1");
+                Assert.Equal(999m, order.Total);
+                Assert.Single(order.Lines);
+                Assert.Equal("New Item", order.Lines[0].ProductName);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task CanBulkInsertWithSourceGenContext()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions
+                    {
+                        SourceGenerationContext = TestJsonContext.Default
+                    };
+                }
+            });
+
+            await using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < 50; i++)
+                {
+                    await bulkInsert.StoreAsync(new Order
+                    {
+                        Id = $"orders/{i}",
+                        CustomerId = $"customers/{i % 5}",
+                        Total = i * 10m,
+                        Lines = new List<OrderLine>
+                        {
+                            new OrderLine { ProductName = $"Product {i}", Quantity = i + 1, Price = i * 2.5m }
+                        }
+                    });
+                }
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var order0 = await session.LoadAsync<Order>("orders/0");
+                Assert.NotNull(order0);
+                Assert.Equal("customers/0", order0.CustomerId);
+                Assert.Equal(0m, order0.Total);
+
+                var order49 = await session.LoadAsync<Order>("orders/49");
+                Assert.NotNull(order49);
+                Assert.Equal("customers/4", order49.CustomerId);
+                Assert.Equal(490m, order49.Total);
+                Assert.Equal("Product 49", order49.Lines[0].ProductName);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.ClientApi)]
+        public async Task TypesNotInContextFallBackToReflection()
+        {
+            using var store = GetDocumentStore(new Options
+            {
+                ModifyDocumentStore = s =>
+                {
+                    s.Conventions.Serialization = new SystemTextJsonSerializationConventions
+                    {
+                        SourceGenerationContext = TestJsonContext.Default
+                    };
+                }
+            });
+
+            // FallbackEntity is NOT listed in the JsonSerializerContext,
+            // so it should fall back to reflection-based serialization
+            using (var session = store.OpenAsyncSession())
+            {
+                await session.StoreAsync(new FallbackEntity
+                {
+                    Id = "fallback/1",
+                    Value = "reflection works"
+                });
+                await session.SaveChangesAsync();
+            }
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var loaded = await session.LoadAsync<FallbackEntity>("fallback/1");
+                Assert.NotNull(loaded);
+                Assert.Equal("reflection works", loaded.Value);
+            }
+        }
+
+        // --- Entity classes ---
+
+        public class Order
+        {
+            public string Id { get; set; }
+            public string CustomerId { get; set; }
+            public decimal Total { get; set; }
+            public List<OrderLine> Lines { get; set; }
+        }
+
+        public class OrderLine
+        {
+            public string ProductName { get; set; }
+            public int Quantity { get; set; }
+            public decimal Price { get; set; }
+        }
+
+        // This type is intentionally NOT included in the source-gen context
+        public class FallbackEntity
+        {
+            public string Id { get; set; }
+            public string Value { get; set; }
+        }
+
+        // --- Source-generated context ---
+        // The [JsonSerializable] attributes tell the compiler to generate
+        // serialization metadata for these types at build time, avoiding
+        // runtime reflection.
+
+        [JsonSerializable(typeof(Order))]
+        [JsonSerializable(typeof(OrderLine))]
+        [JsonSerializable(typeof(List<OrderLine>))]
+        internal partial class TestJsonContext : JsonSerializerContext
+        {
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB_14234.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_14234.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Session;
-using Raven.Client.Json.Serialization.NewtonsoftJson.Internal;
+using Raven.Client.Json.Serialization;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -74,27 +74,27 @@ namespace SlowTests.Issues
         public void ShouldAssignTheTypeOfDerivedProperties()
         {
             var entity5 = new IDocumentWithPropertyTypeOverride5();
-            var type5 = BlittableJsonConverter.GetPropertyType(nameof(entity5.Reference), entity5.GetType());
+            var type5 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity5.Reference), entity5.GetType());
             Assert.Equal(typeof(IRefDerived_Class), type5);
 
             var entity4 = new DocumentWithPropertyTypeOverride4();
-            var type4 = BlittableJsonConverter.GetPropertyType(nameof(entity4.Reference), entity4.GetType());
+            var type4 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity4.Reference), entity4.GetType());
             Assert.Equal(typeof(RefDerived3), type4);
 
             var entity3 = new DocumentWithPropertyTypeOverride3();
-            var type3 = BlittableJsonConverter.GetPropertyType(nameof(entity3.Reference), entity3.GetType());
+            var type3 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity3.Reference), entity3.GetType());
             Assert.Equal(typeof(RefDerived3), type3);
 
             var entity2 = new DocumentWithPropertyTypeOverride2();
-            var type2 = BlittableJsonConverter.GetPropertyType(nameof(entity2.Reference), entity2.GetType());
+            var type2 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity2.Reference), entity2.GetType());
             Assert.Equal(typeof(RefDerived2), type2);
 
             var entity1 = new DocumentWithPropertyTypeOverride1();
-            var type1 = BlittableJsonConverter.GetPropertyType(nameof(entity1.Reference), entity1.GetType());
+            var type1 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity1.Reference), entity1.GetType());
             Assert.Equal(typeof(RefDerived2), type1);
 
             var entity0 = new DocumentBase();
-            var type0 = BlittableJsonConverter.GetPropertyType(nameof(entity0.Reference), entity0.GetType());
+            var type0 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity0.Reference), entity0.GetType());
             Assert.Equal(typeof(RefDerived1), type0);
         }
 
@@ -102,27 +102,27 @@ namespace SlowTests.Issues
         public void ShouldAssignTheTypeOfDerivedPropertiesWithInterface()
         {
             var entity5 = new IDocumentWithPropertyTypeOverride5();
-            var type5 = BlittableJsonConverter.GetPropertyType(nameof(entity5.Reference), entity5.GetType());
+            var type5 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity5.Reference), entity5.GetType());
             Assert.Equal(typeof(IRefDerived_Class), type5);
 
             var entity4 = new IDocumentWithPropertyTypeOverride4();
-            var type4 = BlittableJsonConverter.GetPropertyType(nameof(entity4.Reference), entity4.GetType());
+            var type4 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity4.Reference), entity4.GetType());
             Assert.Equal(typeof(IRefDerived3), type4);
 
             var entity3 = new IDocumentWithPropertyTypeOverride3();
-            var type3 = BlittableJsonConverter.GetPropertyType(nameof(entity3.Reference), entity3.GetType());
+            var type3 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity3.Reference), entity3.GetType());
             Assert.Equal(typeof(IRefDerived3), type3);
 
             var entity2 = new IDocumentWithPropertyTypeOverride2();
-            var type2 = BlittableJsonConverter.GetPropertyType(nameof(entity2.Reference), entity2.GetType());
+            var type2 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity2.Reference), entity2.GetType());
             Assert.Equal(typeof(IRefDerived2), type2);
 
             var entity1 = new IDocumentWithPropertyTypeOverride1();
-            var type1 = BlittableJsonConverter.GetPropertyType(nameof(entity1.Reference), entity1.GetType());
+            var type1 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity1.Reference), entity1.GetType());
             Assert.Equal(typeof(IRefDerived2), type1);
 
             var entity0 = new IDocumentWithPropertyTypeOverrideBase();
-            var type0 = BlittableJsonConverter.GetPropertyType(nameof(entity0.Reference), entity0.GetType());
+            var type0 = BlittableJsonConverterHelper.GetPropertyType(nameof(entity0.Reference), entity0.GetType());
             Assert.Equal(typeof(IRefBase), type0);
         }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23037

### Additional description

## Overview

Adds System.Text.Json (STJ) as an alternative serialization provider for the RavenDB .NET client, selectable via `DocumentConventions.Serialization`. The existing Newtonsoft.Json path is unchanged and remains the default.

```csharp
var store = new DocumentStore
{
    Urls = new[] { "http://localhost:8080" },
    Database = "MyDb"
};
store.Conventions.Serialization = new SystemTextJsonSerializationConventions();
store.Initialize();
```

## Approach

The client already had a serializer-agnostic abstraction layer (`ISerializationConventions`, `IJsonSerializer`, `IJsonReader`, `IJsonWriter`, `IBlittableJsonConverter`) with no Newtonsoft type references in the interfaces. Only one implementation existed (`NewtonsoftJsonSerializationConventions` in `NewtonsoftJson/`). This PR creates a parallel `SystemTextJson/` implementation tree.

### Architecture

**Deserialization (Blittable to Entity):**
`BlittableJsonReaderObject` writes to context-allocated native memory as UTF-8 JSON, then `Utf8JsonReader` (a zero-alloc ref struct) parses those bytes and STJ deserializes to the entity.

The existing Newtonsoft path uses `BlittableJsonReader` which walks the blittable structure, allocates `CurrentItem` objects on a `Stack<>`, and boxes every value. Despite the intermediate buffer, STJ throughput is better because of less boxing and faster deserialization.

A custom `Utf8JsonReader` backed by blittable was investigated and ruled out: `Utf8JsonReader` is a `ref struct` (cannot be subclassed), `JsonSerializer.Deserialize()` only accepts `ref Utf8JsonReader`, and the blittable binary format is not valid UTF-8 JSON.

**Serialization (Entity to Blittable):**
For non-session paths (bulk insert default converter), entity is serialized to UTF-8 in context native memory via `Utf8JsonWriter`, then fed directly to `context.ParseBuffer()` which uses the blittable's own `UnmanagedJsonParser` to build the document in a single pass. Same code path as network data parsing.

For the session path (which needs metadata injection from `DocumentInfo`), the UTF-8 bytes are token-walked into `IJsonWriter` which builds the blittable with metadata inline. A `ParseBuffer` approach was tried but reverted because injecting metadata via `Modifications` + `ReadObject` builds the blittable twice, which is slower for small documents.

**Bulk Insert optimization:**
For bulk insert, the blittable is purely an intermediary (entity to blittable to UTF-8 on wire). The STJ path bypasses the blittable entirely, writing the entity with `@metadata` directly to the HTTP stream via `Utf8JsonWriter`. This eliminates the UTF-8 to blittable to UTF-8 round trip.

### What was built

**24 new files** in `SystemTextJson/` tree:
- `SystemTextJsonSerializationConventions` - public entry point implementing `ISerializationConventions`
- `SystemTextJsonBlittableWriter/Reader` - bridges blittable format with STJ via context native memory
- `SystemTextJsonJsonSerializer` - bridges `IJsonSerializer` with STJ
- `ContextMemoryBufferWriter` - `IBufferWriter<byte>` backed by `JsonOperationContext` arena memory, grows via `GrowAllocation()` in-place
- 12 converters ported: DateTime (ISO8601 + Lucene fallback), DateOnly, TimeOnly, Size, MetadataDictionary, Enumerable, LinqEnumerable, StringDictionary, Parameters, DictionaryDateTimeKeys, Vector
- `RavenJsonTypeInfoResolver` - STJ equivalent of `DefaultRavenContractResolver` (member filtering, identity property removal via thread-statics, non-public constructor support, `[ForceJsonSerialization]` attribute, both Newtonsoft and STJ `[JsonIgnore]`)
- `RavenSerializationBinder` - forbidden type validation (same OWASP RCE gadget list)
- Full blittable converter infrastructure (session, subscription, entity serializer)

**Shared infrastructure improvements (benefit both serializers):**
- `BlittableJsonConverterHelper` - serializer-agnostic blittable logic extracted from Newtonsoft-specific `BlittableJsonConverterBase`
- `JsonPropertyNameResolver` - LINQ/query property name resolution checking both `JsonPropertyAttribute` (Newtonsoft) and `JsonPropertyNameAttribute` (STJ), with per-MemberInfo caching
- `BlittableJsonConverterHelper.GetPropertyType` - cached (Type, propertyName) reflection lookup
- `GenerateEntityIdOnTheClient._backingFieldCache` - cached backing field lookup for read-only identity properties
- Compiled expression copier for `PopulateEntity` (STJ has no `JsonSerializer.Populate()`)

### Attribute handling

Data model classes in Raven.Client use only `[JsonIgnore]` (Newtonsoft) and `[ForceJsonSerialization]` (Sparrow custom attribute). No `[JsonProperty]` for renaming, no `[JsonExtensionData]`, no `[JsonConverter]` on properties. The `RavenJsonTypeInfoResolver` checks for both Newtonsoft and STJ `[JsonIgnore]` by namespace string comparison (avoids compile-time dependency issues on netstandard2.0/2.1).

## Performance (needs validation)

These numbers are from a single dev machine (AMD Ryzen 9 5950X, .NET 10.0.5) and should be validated independently before drawing conclusions.

**End-to-end against real RavenDB (medium-sized entities, 12 properties + nested objects):**

| Operation | Newtonsoft | STJ | Result |
|-----------|-----------|-----|--------|
| Store (single doc, 50 iter) | 83ms | 127ms | NJ 35% faster |
| **Load (single doc, 50 iter)** | 80ms | **47ms** | **STJ 41% faster** |
| **Bulk Insert (1000 docs)** | 164ms | **102ms** | **STJ 38% faster** |
| **Query (50 queries over 200 docs)** | 218ms | **181ms** | **STJ 17% faster** |
| **Stream (200 docs, 10 streams)** | 302ms | **284ms** | **STJ 6% faster** |
| Load-Modify-Save (50 iter) | 116ms | 134ms | network noise |
| **Store large (100-item nested, 20 docs)** | 202ms | **156ms** | **STJ 23% faster** |
| **Load large (100-item nested, 20 docs)** | 80ms | **44ms** | **STJ 45% faster** |

STJ wins 6 of 8 operations. The Newtonsoft win on small-doc store is due to the two-pass serialize path in the session code path. Load-Modify-Save is dominated by network round-trip time.

## Known limitations

- **Missing property tracking** (`PreserveDocumentPropertiesNotFoundOnModel`) is not implemented for the STJ path (marked with TODOs). This feature preserves JSON properties that don't map to CLR properties during round-trip and requires an STJ-specific approach to replace Newtonsoft's `ExtensionDataSetter`/`ExtensionDataGetter`.
- **Polymorphic `$type` handling** not yet tested/implemented. Newtonsoft's `TypeNameHandling.Auto` embeds `$type` metadata; STJ handles polymorphism differently.
- **Small-document session store** is slower with STJ due to the two-pass serialize path (entity to UTF-8 to blittable). Cannot be eliminated because `Utf8JsonWriter` is sealed. Profiling shows the current bottleneck is `BlittableJsonDocumentBuilder.Dispose()` (arena buffer pool management), not our serialization code.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
