### PR TITLE
RavenDB-26367 Reset `_hasMoreTombstones` between cleanup iterations

### DIFF
--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -98,7 +98,7 @@ namespace Raven.Server.ServerWide.Maintenance
         private long _lastIndexCleanupTimeInTicks;
         internal long _lastTombstonesCleanupTimeInTicks;
         internal long _lastExpiredCompareExchangeCleanupTimeInTicks;
-        private bool _hasMoreTombstones = false;
+
 
         public (ClusterObserverLogEntry[] List, long Iteration) ReadDecisionsForDatabase()
         {
@@ -179,6 +179,7 @@ namespace Raven.Server.ServerWide.Maintenance
             var cleanupIndexes = now.Ticks - _lastIndexCleanupTimeInTicks >= _server.Configuration.Indexing.CleanupInterval.AsTimeSpan.Ticks;
             var cleanupTombstones = now.Ticks - _lastTombstonesCleanupTimeInTicks >= _server.Configuration.Cluster.CompareExchangeTombstonesCleanupInterval.AsTimeSpan.Ticks;
             var cleanupExpiredCompareExchange = now.Ticks - _lastExpiredCompareExchangeCleanupTimeInTicks >= _server.Configuration.Cluster.CompareExchangeExpiredCleanupInterval.AsTimeSpan.Ticks;
+            var hasMoreTombstones = false;
 
             foreach (var database in databases)
             {
@@ -284,7 +285,7 @@ namespace Raven.Server.ServerWide.Maintenance
                             switch (cleanupState)
                             {
                                 case CompareExchangeTombstonesCleanupState.InvalidDatabaseObservationState:
-                                    _hasMoreTombstones = true;
+                                    hasMoreTombstones = true;
                                     break;
                                 case CompareExchangeTombstonesCleanupState.HasMoreTombstones:
                                     Debug.Assert(cmd != null, $"Expected to get command {nameof(CleanCompareExchangeTombstonesCommand)} but it was null");
@@ -315,15 +316,14 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (cleanupTombstones)
             {
-                _hasMoreTombstones = false;
                 foreach (var cmd in cleanCompareExchangeTombstonesCommands)
                 {
                     var result = await _server.SendToLeaderAsync(cmd);
                     await _server.Cluster.WaitForIndexNotification(result.Index);
-                    _hasMoreTombstones |= (bool)result.Result;
+                    hasMoreTombstones |= (bool)result.Result;
                 }
 
-                if (_hasMoreTombstones == false)
+                if (hasMoreTombstones == false)
                     _lastTombstonesCleanupTimeInTicks = now.Ticks;
             }
 

--- a/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
+++ b/src/Raven.Server/ServerWide/Maintenance/ClusterObserver.cs
@@ -315,12 +315,12 @@ namespace Raven.Server.ServerWide.Maintenance
 
             if (cleanupTombstones)
             {
+                _hasMoreTombstones = false;
                 foreach (var cmd in cleanCompareExchangeTombstonesCommands)
                 {
                     var result = await _server.SendToLeaderAsync(cmd);
                     await _server.Cluster.WaitForIndexNotification(result.Index);
-                    var hasMore = (bool)result.Result;
-                    _hasMoreTombstones |= hasMore;
+                    _hasMoreTombstones |= (bool)result.Result;
                 }
 
                 if (_hasMoreTombstones == false)

--- a/test/SlowTests/Issues/RavenDB_26367.cs
+++ b/test/SlowTests/Issues/RavenDB_26367.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.CompareExchange;
+using Raven.Client.Documents.Session;
+using Raven.Server.Config;
+using Raven.Server.ServerWide.Context;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26367 : ClusterTestBase
+{
+    public RavenDB_26367(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.CompareExchange | RavenTestCategory.Cluster)]
+    public async Task ObserverShouldRespectTombstoneCleanupIntervalAfterMultiBatchCleanup()
+    {
+        // Background: the observer cleans compare-exchange tombstones in batches of 8192 per
+        // command. A gate (`now - _lastTombstonesCleanupTimeInTicks >= CompareExchangeTombstonesCleanupInterval`)
+        // throttles how often the observer looks for work.
+        //
+        // Before the fix, the internal `_hasMoreTombstones` flag was never reset between
+        // observer iterations. Once a single iteration returned hasMore=true (which happens
+        // whenever there are more tombstones than fit in a single batch), the flag remained
+        // true forever. Because the tick is only updated when `_hasMoreTombstones == false`,
+        // `_lastTombstonesCleanupTimeInTicks` would never advance again and the gate would
+        // evaluate to true on every observer iteration — effectively running the tombstone
+        // cleanup check every cycle instead of waiting for the configured interval.
+        //
+        // With the fix, the flag is reset at the top of each cleanup loop, so once the queue
+        // drains the tick is updated and the gate kicks back in.
+
+        const int tombstoneCount = 9000;          // > 8192 (one batch) => the multi-batch iteration returns hasMore=true.
+        const int cleanupIntervalInMin = 10;      // default; long enough that the gate should block all cleanup attempts during our observation window.
+        const int observationWindowMs = 5_000;    // Window during which we count observer cleanup attempts.
+
+        var settings = new Dictionary<string, string>
+        {
+            { RavenConfiguration.GetKey(x => x.Cluster.CompareExchangeTombstonesCleanupInterval), cleanupIntervalInMin.ToString() }
+        };
+
+        var (_, leader) = await CreateRaftCluster(1, customSettings: settings);
+        using var store = GetDocumentStore(new Options
+        {
+            Server = leader
+        });
+
+        // Create `tombstoneCount` compare-exchange values, then delete them all. We leave the
+        // observer running so that the moment the cluster-transaction gate opens it will see
+        // thousands of tombstones to clean — guaranteeing the first cleanup command returns
+        // hasMore=true, which is what triggers the bug.
+        var indexes = new ConcurrentDictionary<int, long>();
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, tombstoneCount),
+            new ParallelOptions { MaxDegreeOfParallelism = 32 },
+            async (i, _) =>
+            {
+                var res = await store.Operations.SendAsync(new PutCompareExchangeValueOperation<int>($"cx/{i}", i, index: 0));
+                Assert.True(res.Successful, $"Failed to put compare-exchange value cx/{i}");
+                indexes[i] = res.Index;
+            });
+
+        await Parallel.ForEachAsync(
+            Enumerable.Range(0, tombstoneCount),
+            new ParallelOptions { MaxDegreeOfParallelism = 32 },
+            async (i, _) =>
+            {
+                var res = await store.Operations.SendAsync(new DeleteCompareExchangeValueOperation<int>($"cx/{i}", indexes[i]));
+                Assert.True(res.Successful, $"Failed to delete compare-exchange value cx/{i}");
+            });
+
+        // Advance the cluster-wide transaction raft index past the tombstone etags so the
+        // observer is allowed to clean them.
+        using (var session = store.OpenAsyncSession(new SessionOptions
+        {
+            TransactionMode = TransactionMode.ClusterWide,
+        }))
+        {
+            await session.StoreAsync(new TombstoneBumpMarker());
+            await session.SaveChangesAsync();
+        }
+
+        long tombstonesBefore;
+        using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            tombstonesBefore = leader.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database);
+        }
+        // Some tombstones may already have been cleaned by the observer while we were issuing
+        // deletes; all we need is that there are enough left to force at least two cleanup
+        // iterations (i.e., at least one multi-batch result).
+        Assert.True(tombstonesBefore > 8192, $"Expected more than 8192 tombstones in place before cleanup, got {tombstonesBefore}.");
+
+        // Force the next observer iteration to run the tombstone cleanup immediately.
+        leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks = 0;
+
+        // Wait for all tombstones to drain (requires >= 2 cleanup iterations).
+        var allDrained = await WaitForValueAsync(() =>
+        {
+            using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
+            using (context.OpenReadTransaction())
+            {
+                return leader.ServerStore.Cluster.GetNumberOfCompareExchangeTombstones(context, store.Database) == 0;
+            }
+        }, expectedVal: true, timeout: 60_000, interval: 250);
+
+        Assert.True(allDrained, "Expected all compare-exchange tombstones to be drained by the observer.");
+
+        // Now count how many times the observer attempts tombstone cleanup during a short
+        // observation window. With the configured interval of `cleanupIntervalInMin` minutes,
+        // the gate should block all attempts after the drain — provided the tick was properly
+        // updated.
+        var cleanupAttempts = 0;
+        leader.ServerStore.Observer.ForTestingPurposesOnly().OnDiagnosticLog = message =>
+        {
+            // This specific diagnostic line is emitted at the top of GetCleanCompareExchangeTombstonesCommand,
+            // i.e., once per observer iteration where the cleanup gate was open.
+            if (message != null && message.StartsWith("Starting GetCleanCompareExchangeTombstonesCommand"))
+                Interlocked.Increment(ref cleanupAttempts);
+        };
+
+        try
+        {
+            await Task.Delay(observationWindowMs);
+        }
+        finally
+        {
+            leader.ServerStore.Observer.ForTestingPurposesOnly().OnDiagnosticLog = null;
+        }
+
+        // With the fix: the tick was updated after the drain, so the interval gate blocks all
+        // cleanup attempts during the observation window => we expect 0 attempts.
+        //
+        // Without the fix: the stale `_hasMoreTombstones=true` from the multi-batch iteration
+        // is never reset, the tick is never updated, and the gate is permanently open. With
+        // the 1-second observer sample period we see roughly `observationWindowMs / 1000` attempts.
+        Assert.Equal(0, cleanupAttempts);
+    }
+
+    private sealed class TombstoneBumpMarker
+    {
+        public string Id { get; set; }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26367

### Additional description

The cluster observer's `_hasMoreTombstones` flag was never reset between
iterations. Once a cleanup iteration returned `hasMore=true` the flag stayed `true` forever. Because
`_lastTombstonesCleanupTimeInTicks` is only updated when `_hasMoreTombstones`
is `false`, the tick was never advanced again and the
`CompareExchangeTombstonesCleanupInterval` gate
(`now - _lastTombstonesCleanupTimeInTicks >= interval`) remained permanently
open.

Fix: reset `_hasMoreTombstones = false` at the top of the cleanup loop so it
reflects only the current iteration's results. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
