### PR TITLE
RavenDB-26385 OptimisticConcurrencyMode: Update XML comments

### DIFF
--- a/src/Raven.Client/Documents/Session/SessionOptions.cs
+++ b/src/Raven.Client/Documents/Session/SessionOptions.cs
@@ -45,26 +45,30 @@ namespace Raven.Client.Documents.Session
     {
         /// <summary>
         /// No optimistic concurrency checks are performed.<br/>
-        /// PUT and DELETE commands are sent without a change vector, so the server does not check for concurrent modifications.
+        /// During <see cref="DocumentSession.SaveChanges"/>, PUT and DELETE commands are sent without a change vector, so the server does not check for concurrent modifications.
         /// </summary>
         None,
 
         /// <summary>
         /// Optimistic concurrency checks are performed for written (PUT) and deleted (DELETE) entities only.<br/>
-        /// Each PUT/DELETE command includes the entity's change vector so the server rejects the operation
-        /// if the document was modified by another session since it was loaded.<br/>
-        /// Entities that were loaded but not modified are <b>not</b> checked.
+        /// Entities that are tracked by the session but were not modified/deleted are <b>not</b> checked.<br/>
+        /// <br/>
+        /// During <see cref="DocumentSession.SaveChanges"/>, each PUT/DELETE command includes the entity's change vector so the server rejects the save operation
+        /// if the document was modified by another session since it was first tracked by the session.<br/>
+        /// <br/>
+        /// This mode is incompatible with <see cref="SessionOptions.NoTracking"/>
+        /// and <see cref="TransactionMode.ClusterWide"/>.
         /// </summary>
         Writes,
 
         /// <summary>
-        /// Optimistic concurrency checks are performed for <b>all</b> entities in the session — both modified and not modified.<br/>
-        /// In addition to the per-command change vector checks from <see cref="Writes"/>,
-        /// <see cref="DocumentSession.SaveChanges"/> verifies that no tracked entity
-        /// was modified by another session since it was loaded.<br/>
+        /// Optimistic concurrency checks are performed for <b>all</b> entities tracked by the session - both modified and not modified.<br/>
         /// <br/>
-        /// This mode is incompatible with <see cref="SessionOptions.NoTracking"/>
-        /// and <see cref="TransactionMode.ClusterWide"/>.
+        /// During <see cref="DocumentSession.SaveChanges"/>, the session sends the change vector of <b>all</b> tracked documents to the server.
+        /// The server rejects the save operation if any of these documents was modified by another session since it was first tracked by the session.<br/>
+        /// <br/>
+        /// This mode is incompatible with <see cref="SessionOptions.NoTracking"/>,
+        /// <see cref="TransactionMode.ClusterWide"/>, and sharded databases.
         /// </summary>
         WritesAndReads
     }


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26385/OptimisticConcurrencyMode-Update-XML-comments

### Additional description
Update XML comments for `enum OptimisticConcurrencyMode`

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
