### PR TITLE
RavenDB-26389 Correct CWT reference management when using buffers from ArrayPool.

### DIFF
--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/CachingQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/CachingQuery.cs
@@ -246,15 +246,16 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
                 {
                     if (Buffer == null) 
                         return;
-                    ArrayPool<ulong>.Shared.Return(Buffer);
                     
                     // The finalizer started when this object held the only existing reference to Buffer
                     // via the ConditionalWeakTable (_joinLifetimes). The CWT removes an element only when
                     // there is no other reference to the key (in this case Buffer).
-                    // However, since we returned our buffer to the pool, we actually increased the reference count (so eviction is stopped).
+                    // However, since we returned our buffer to the pool, we actually will increase the reference count (so eviction from CWT will stop).
                     // Additionally, CWT has a requirement that keys must be unique, however without manually removing the reference
-                    // there is a chance to get exactly the same buffer for eviction registration soon.
+                    // there is a chance to get exactly the same buffer for to add into CWT before even removing it from the table.
                     _joinLifetimes.Remove(Buffer);
+                    
+                    ArrayPool<ulong>.Shared.Return(Buffer);
                 }
             }
 

--- a/src/Raven.Server/Documents/Queries/LuceneIntegration/CachingQuery.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneIntegration/CachingQuery.cs
@@ -247,6 +247,14 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
                     if (Buffer == null) 
                         return;
                     ArrayPool<ulong>.Shared.Return(Buffer);
+                    
+                    // The finalizer started when this object held the only existing reference to Buffer
+                    // via the ConditionalWeakTable (_joinLifetimes). The CWT removes an element only when
+                    // there is no other reference to the key (in this case Buffer).
+                    // However, since we returned our buffer to the pool, we actually increased the reference count (so eviction is stopped).
+                    // Additionally, CWT has a requirement that keys must be unique, however without manually removing the reference
+                    // there is a chance to get exactly the same buffer for eviction registration soon.
+                    _joinLifetimes.Remove(Buffer);
                 }
             }
 
@@ -263,8 +271,15 @@ namespace Raven.Server.Documents.Queries.LuceneIntegration
                 }
 
                 var array = (ulong[])value;
+
+
+                var returnBuffer = new ReturnBuffer();
+                _joinLifetimes.Add(array, returnBuffer);
                 
-                _joinLifetimes.Add(array, new ReturnBuffer{Buffer = array});
+                // Lazily initialize the return buffer. If any error occurs during the Add method,
+                // we will not have an unreferenced object that would return our buffer to the pool.
+                // In such case, the array will simply be released by GC.
+                returnBuffer.Buffer = array;                
             }
 
             public override float GetSumOfSquaredWeights()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26389

### Additional description

QueryClauseCache eviction callback creates ReturnBuffer with Buffer set before registering it in ConditionalWeakTable. If registration fails, the orphaned finalizer returns the ArrayPool buffer while a FastBitArrayScorer is still reading from it — use-after-free causing intermittent false positives in range queries under concurrent index updates.
### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
