### PR TITLE
RavenDB-26399 AI Connection Strings: Fix tooltip for "Prompt Cache Key"

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/AzureOpenAiSettings.tsx
@@ -155,7 +155,7 @@ export default function AzureOpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTa
                     />
                 </div>
             )}
-            <PromptCacheField baseName="azureOpenAiSettings" />
+            <PromptCacheField baseName="azureOpenAiSettings" serverDefaultValue={true} />
             <TemperatureField baseName="azureOpenAiSettings" />
             {formValues.modelType === "TextEmbeddings" && (
                 <EmbeddingsMaxConcurrentBatches baseName="azureOpenAiSettings" />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/GoogleSettings.tsx
@@ -108,7 +108,7 @@ export default function GoogleSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     options={getModelOptions(formValues.modelType)}
                 />
             </div>
-            <PromptCacheField baseName="googleSettings" />
+            <PromptCacheField baseName="googleSettings" serverDefaultValue={false} />
             <div className="mb-2">
                 <FormLabel>
                     Dimensions <OptionalLabel />

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/OpenAiSettings.tsx
@@ -193,7 +193,7 @@ export default function OpenAiSettings({ isUsedByAnyTask }: { isUsedByAnyTask: b
                     />
                 </div>
             )}
-            <PromptCacheField baseName="openAiSettings" />
+            <PromptCacheField baseName="openAiSettings" serverDefaultValue={true} />
             <TemperatureField baseName="openAiSettings" />
             {formValues.modelType === "TextEmbeddings" && <EmbeddingsMaxConcurrentBatches baseName="openAiSettings" />}
             <div className="d-flex mb-2">

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
@@ -25,6 +25,29 @@ export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
 
     const fieldName = `${baseName}.enablePromptCache` satisfies FieldPath<FormData>;
 
+    function getDescriptionForDefaultPromptCacheKey(baseName: PromptCacheFieldProps["baseName"]) {
+        switch (baseName) {
+            case "openAiSettings":
+            case "azureOpenAiSettings":
+                return (
+                    <>
+                        <strong>Default:</strong> <code>True</code>
+                        <br />
+                        The server sends the cache key by default.
+                    </>
+                );
+
+            case "googleSettings":
+                return (
+                    <>
+                        <strong>Default:</strong> <code>False</code>
+                        <br />
+                        The server does not send the cache key by default.
+                    </>
+                );
+        }
+    }
+
     return (
         <div className="mb-2">
             <FormLabel>
@@ -32,16 +55,21 @@ export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
                 <PopoverWithHoverWrapper
                     message={
                         <>
-                            Controls whether RavenDB sends <code>prompt_cache_key</code> with chat completion requests.
+                            Controls whether RavenDB includes the <code>prompt_cache_key</code> field in chat completion
+                            requests sent to the AI provider.
+                            <br />
+                            <br />
+                            This allows the provider to reuse cached prompt prefixes instead of reprocessing the entire
+                            conversation history across turns in the same conversation, reducing latency and cost.
+                            <br />
+                            <br />
                             <ul className="mb-0">
+                                <li>{getDescriptionForDefaultPromptCacheKey(baseName)}</li>
                                 <li className="mt-1">
-                                    <strong>Default:</strong> use the server&apos;s provider-specific behavior.
+                                    <strong>True:</strong> Always send the cache key.
                                 </li>
                                 <li className="mt-1">
-                                    <strong>True:</strong> always send the field.
-                                </li>
-                                <li className="mt-1">
-                                    <strong>False:</strong> never send the field.
+                                    <strong>False:</strong> Never send the cache key.
                                 </li>
                             </ul>
                         </>

--- a/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/settings/connectionStrings/editForms/aiFields/PromptCacheField.tsx
@@ -12,9 +12,10 @@ type FormData = ConnectionFormData<AiConnection>;
 
 interface PromptCacheFieldProps {
     baseName: Extract<FormData["connectorType"], "azureOpenAiSettings" | "googleSettings" | "openAiSettings">;
+    serverDefaultValue: boolean;
 }
 
-export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
+export default function PromptCacheField({ baseName, serverDefaultValue }: PromptCacheFieldProps) {
     const { control } = useFormContext<FormData>();
 
     const modelType = useWatch({ control, name: "modelType" });
@@ -24,29 +25,6 @@ export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
     }
 
     const fieldName = `${baseName}.enablePromptCache` satisfies FieldPath<FormData>;
-
-    function getDescriptionForDefaultPromptCacheKey(baseName: PromptCacheFieldProps["baseName"]) {
-        switch (baseName) {
-            case "openAiSettings":
-            case "azureOpenAiSettings":
-                return (
-                    <>
-                        <strong>Default:</strong> <code>True</code>
-                        <br />
-                        The server sends the cache key by default.
-                    </>
-                );
-
-            case "googleSettings":
-                return (
-                    <>
-                        <strong>Default:</strong> <code>False</code>
-                        <br />
-                        The server does not send the cache key by default.
-                    </>
-                );
-        }
-    }
 
     return (
         <div className="mb-2">
@@ -64,7 +42,13 @@ export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
                             <br />
                             <br />
                             <ul className="mb-0">
-                                <li>{getDescriptionForDefaultPromptCacheKey(baseName)}</li>
+                                <li>
+                                    <strong>Default:</strong> <code>{serverDefaultValue ? "True" : "False"}</code>
+                                    <br />
+                                    {serverDefaultValue
+                                        ? "The server sends the cache key by default."
+                                        : "The server does not send the cache key by default."}
+                                </li>
                                 <li className="mt-1">
                                     <strong>True:</strong> Always send the cache key.
                                 </li>
@@ -83,7 +67,7 @@ export default function PromptCacheField({ baseName }: PromptCacheFieldProps) {
     );
 }
 
-const promptCacheOptions: SelectOption<boolean>[] = [
+const promptCacheOptions: SelectOption<boolean | null>[] = [
     { label: "Default", value: null },
     { label: "True", value: true },
     { label: "False", value: false },


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26399/AI-Connection-Strings-Fix-tooltip-for-Prompt-Cache-Key

### Additional description
Fix tooltip for "Prompt Cache Key" in AI Connection Strings

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 
(documentation is handled in https://issues.hibernatingrhinos.com/issue/RDoc-3792/AI-connection-strings-Enable-prompt-caching)

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
