### PR TITLE
RavenDB-26398 Fix transient test failure in sharded side-by-side index reset tests

### DIFF
--- a/test/SlowTests.Issues/Issues/RavenDB-22036.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-22036.cs
@@ -1,10 +1,14 @@
 using System;
 using FastTests;
 using Raven.Client;
+using Raven.Client.Documents;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.Indexes;
 using Raven.Client.Exceptions;
+using Raven.Client.ServerWide.Operations;
+using Raven.Client.Util;
 using Raven.Server.Config;
+using Raven.Server.Utils;
 using Tests.Infrastructure;
 using Tests.Infrastructure.Extensions;
 using Xunit;
@@ -16,6 +20,19 @@ public class RavenDB_22036 : RavenTestBase
     public RavenDB_22036(ITestOutputHelper output) : base(output)
     {
     }
+
+    private void WaitForIndexRaftOnShards(IDocumentStore store, long raftCommandIndex)
+    {
+        var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+        if (record.IsSharded == false)
+            return;
+
+        foreach (var shardNumber in record.Sharding.Shards.Keys)
+        {
+            var shardName = ShardHelper.ToShardName(store.Database, shardNumber);
+            AsyncHelpers.RunSync(() => Databases.WaitForRaftIndex(shardName, raftCommandIndex));
+        }
+    }
     
     [RavenTheory(RavenTestCategory.Indexes)]
     [RavenData(DatabaseMode = RavenDatabaseMode.All)]
@@ -24,15 +41,16 @@ public class RavenDB_22036 : RavenTestBase
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
-            
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
                 Maps = { "from user in docs.Users select new { user.FirstName }" },
                 Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
 
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.SideBySide)).ExecuteOnAll();
             
@@ -64,15 +82,16 @@ public class RavenDB_22036 : RavenTestBase
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
-            
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
                 Maps = { "from user in docs.Users select new { user.FirstName }" },
                 Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
 
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.InPlace)).ExecuteOnAll();
             
@@ -104,15 +123,16 @@ public class RavenDB_22036 : RavenTestBase
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
-            
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
                 Maps = { "from user in docs.Users select new { user.FirstName }" },
                 Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.SideBySide)).ExecuteOnAll();
             
@@ -157,14 +177,15 @@ public class RavenDB_22036 : RavenTestBase
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName)).ExecuteOnAll();
             
@@ -202,19 +223,20 @@ public class RavenDB_22036 : RavenTestBase
         {
             record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ResetMode)] = IndexResetMode.SideBySide.ToString();
         };
-        
+
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName)).ExecuteOnAll();
             
@@ -252,14 +274,15 @@ public class RavenDB_22036 : RavenTestBase
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
             
@@ -309,14 +332,15 @@ public class RavenDB_22036 : RavenTestBase
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
             
@@ -367,14 +391,15 @@ public class RavenDB_22036 : RavenTestBase
             const string indexName = "Users/ByName";
             const string replacementIndexName = $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
+            WaitForIndexRaftOnShards(store, putResult[0].RaftCommandIndex);
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
             


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26398

### Additional description

`PutIndexesOperation` commits through Raft but only waits for orchestrator nodes to process the entry, not shard nodes. This creates a race where:

1. The shard creates the index during initial database load (from the latest database record)
2. The test calls `ResetIndex(SideBySide)`, creating a replacement index
3. `HandleDatabaseRecordChange` for the PutIndex Raft entry fires afterward
4. In `HandleStaticIndexChange`, the Noop path deletes the replacement index (since the index already exists with the same definition)
5. The test assertion finds the replacement is gone

Fix: after `StopIndexingOperation.ExecuteOnAll()` (which ensures shards are loaded), wait for each shard to fully process the PutIndex Raft entry via `Databases.WaitForRaftIndex`. Applied to all 8 tests in the file since they share the same pattern.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed