### PR TITLE
RavenDB-26397 Fix transient test failures (disposal errors, topology races, stale assertions)

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -306,7 +306,7 @@ namespace Raven.Server.Rachis
 
                 ContextPool = new ClusterContextPool(changes, _persistentState, configuration.Memory.MaxContextSizeToKeep);
                 TxMerger = new ClusterTransactionOperationsMerger(configuration, time, shutdown);
-                TxMerger.Initialize(ContextPool, IsEncrypted, PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager);
+                TxMerger.Initialize(ContextPool, IsEncrypted, PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager || env.Options.ForceUsing32BitsPager);
                 TxMerger.Start();
 
                 ClusterTopology topology;

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -3270,14 +3270,17 @@ namespace Raven.Server
 
         private static bool IsExpectedShutdownException(Exception e)
         {
-            return e switch
+            if (e is IOException or SocketException)
+                return true;
+
+            if (e is AggregateException ae)
             {
-                IOException => true,
-                SocketException => true,
-                AggregateException ae => ae.Flatten().InnerExceptions.Count > 0 &&
-                                         ae.Flatten().InnerExceptions.All(ie => ie is IOException or SocketException),
-                _ => false
-            };
+                AggregateException flattened = ae.Flatten();
+                return flattened.InnerExceptions.Count > 0 &&
+                       flattened.InnerExceptions.All(ie => ie is IOException or SocketException);
+            }
+
+            return false;
         }
 
         private void CloseTcpListeners(List<TcpListener> listeners)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -3214,7 +3214,7 @@ namespace Raven.Server
                 ea.Execute(() => AdminConsolePipe?.Dispose());
                 ea.Execute(() => LogStreamPipe?.Dispose());
                 ea.Execute(() => _redirectingWebHost?.Dispose());
-                ea.Execute(() => _webHost?.Dispose());
+                DisposeWebHost();
                 ea.Execute(() => _tcpContextPool?.Dispose());
                 if (_tcpListenerStatus != null)
                 {
@@ -3251,6 +3251,33 @@ namespace Raven.Server
 
                 ea.ThrowIfNeeded();
             }
+        }
+
+        private void DisposeWebHost()
+        {
+            try
+            {
+                _webHost?.Dispose();
+            }
+            catch (Exception e) when (IsExpectedShutdownException(e))
+            {
+                // During shutdown, active HTTP connections may throw I/O exceptions
+                // (broken pipe, connection reset) as they are torn down. This is expected.
+                if (_tcpLogger.IsInfoEnabled)
+                    _tcpLogger.Info("Ignoring expected I/O error during web host shutdown", e);
+            }
+        }
+
+        private static bool IsExpectedShutdownException(Exception e)
+        {
+            return e switch
+            {
+                IOException => true,
+                SocketException => true,
+                AggregateException ae => ae.Flatten().InnerExceptions.Count > 0 &&
+                                         ae.Flatten().InnerExceptions.All(ie => ie is IOException or SocketException),
+                _ => false
+            };
         }
 
         private void CloseTcpListeners(List<TcpListener> listeners)

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -3214,7 +3214,7 @@ namespace Raven.Server
                 ea.Execute(() => AdminConsolePipe?.Dispose());
                 ea.Execute(() => LogStreamPipe?.Dispose());
                 ea.Execute(() => _redirectingWebHost?.Dispose());
-                DisposeWebHost();
+                ea.Execute(() => DisposeWebHost());
                 ea.Execute(() => _tcpContextPool?.Dispose());
                 if (_tcpListenerStatus != null)
                 {

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -250,12 +250,10 @@ namespace Voron.Impl
             var env = previous._env;
             env.Options.AssertNoCatastrophicFailure();
 
-            if (env.Options.Encryption.IsEnabled)
-                throw new InvalidOperationException(
-                    $"Async commit isn't supported in encrypted environments. We don't carry {nameof(IPagerLevelTransactionState.CryptoPagerTransactionState)} from previous tx");
-            if (PlatformDetails.Is32Bits || env.Options.ForceUsing32BitsPager)
-                throw new InvalidOperationException(
-                    $"Async commit isn't supported in 32bits environments. We don't carry {nameof(IPagerLevelTransactionState.PagerTransactionState32Bits)} from previous tx");
+            Debug.Assert(env.Options.Encryption.IsEnabled == false,
+                $"Async commit isn't supported in encrypted environments. We don't carry {nameof(IPagerLevelTransactionState.CryptoPagerTransactionState)} from previous tx");
+            Debug.Assert((PlatformDetails.Is32Bits || env.Options.ForceUsing32BitsPager) == false,
+                $"Async commit isn't supported in 32bits environments. We don't carry {nameof(IPagerLevelTransactionState.PagerTransactionState32Bits)} from previous tx");
 
             FlushInProgressLockTaken = previous.FlushInProgressLockTaken;
             CurrentTransactionHolder = previous.CurrentTransactionHolder;

--- a/src/Voron/Impl/LowLevelTransaction.cs
+++ b/src/Voron/Impl/LowLevelTransaction.cs
@@ -250,10 +250,12 @@ namespace Voron.Impl
             var env = previous._env;
             env.Options.AssertNoCatastrophicFailure();
 
-            Debug.Assert(env.Options.Encryption.IsEnabled == false,
-                $"Async commit isn't supported in encrypted environments. We don't carry {nameof(IPagerLevelTransactionState.CryptoPagerTransactionState)} from previous tx");
-            Debug.Assert((PlatformDetails.Is32Bits || env.Options.ForceUsing32BitsPager) == false,
-                $"Async commit isn't supported in 32bits environments. We don't carry {nameof(IPagerLevelTransactionState.PagerTransactionState32Bits)} from previous tx");
+            if (env.Options.Encryption.IsEnabled)
+                throw new InvalidOperationException(
+                    $"Async commit isn't supported in encrypted environments. We don't carry {nameof(IPagerLevelTransactionState.CryptoPagerTransactionState)} from previous tx");
+            if (PlatformDetails.Is32Bits || env.Options.ForceUsing32BitsPager)
+                throw new InvalidOperationException(
+                    $"Async commit isn't supported in 32bits environments. We don't carry {nameof(IPagerLevelTransactionState.PagerTransactionState32Bits)} from previous tx");
 
             FlushInProgressLockTaken = previous.FlushInProgressLockTaken;
             CurrentTransactionHolder = previous.CurrentTransactionHolder;

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -787,19 +787,7 @@ namespace Voron
 
                 foreach (var file in Directory.GetFiles(TempPath.FullPath).Where(x => x.EndsWith(BuffersFileExtension, StringComparison.OrdinalIgnoreCase) || x.EndsWith(TempFileExtension, StringComparison.OrdinalIgnoreCase)))
                 {
-                    try
-                    {
-                        File.Delete(file);
-                    }
-                    catch (IOException)
-                    {
-                        // On Windows, a previous environment's pager may still hold the file handle
-                        // (e.g. pending GC finalization). The file will be cleaned up on next startup.
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        // Same as above — file is still in use by another handle.
-                    }
+                    File.Delete(file);
                 }
             }
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -787,7 +787,19 @@ namespace Voron
 
                 foreach (var file in Directory.GetFiles(TempPath.FullPath).Where(x => x.EndsWith(BuffersFileExtension, StringComparison.OrdinalIgnoreCase) || x.EndsWith(TempFileExtension, StringComparison.OrdinalIgnoreCase)))
                 {
-                    File.Delete(file);
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch (IOException)
+                    {
+                        // On Windows, a previous environment's pager may still hold the file handle
+                        // (e.g. pending GC finalization). The file will be cleaned up on next startup.
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        // Same as above — file is still in use by another handle.
+                    }
                 }
             }
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -787,7 +787,24 @@ namespace Voron
 
                 foreach (var file in Directory.GetFiles(TempPath.FullPath).Where(x => x.EndsWith(BuffersFileExtension, StringComparison.OrdinalIgnoreCase) || x.EndsWith(TempFileExtension, StringComparison.OrdinalIgnoreCase)))
                 {
-                    File.Delete(file);
+                    for (int i = 0; i < 5; i++)
+                    {
+                        try
+                        {
+                            File.Delete(file);
+                            break;
+                        }
+                        catch (UnauthorizedAccessException) when (i < 4)
+                        {
+                            // On Windows, memory-mapped file handles may not be fully released by
+                            // the kernel yet even after the pager is disposed. Retry after a brief delay.
+                            Thread.Sleep(50);
+                        }
+                        catch (IOException) when (i < 4)
+                        {
+                            Thread.Sleep(50);
+                        }
+                    }
                 }
             }
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -787,23 +787,25 @@ namespace Voron
 
                 foreach (var file in Directory.GetFiles(TempPath.FullPath).Where(x => x.EndsWith(BuffersFileExtension, StringComparison.OrdinalIgnoreCase) || x.EndsWith(TempFileExtension, StringComparison.OrdinalIgnoreCase)))
                 {
-                    for (int i = 0; i < 5; i++)
+                    DeleteTempFile(file);
+                }
+            }
+
+            private static void DeleteTempFile(string file)
+            {
+                const int retries = 5;
+                for (int i = 0; i < retries; i++)
+                {
+                    try
                     {
-                        try
-                        {
-                            File.Delete(file);
-                            break;
-                        }
-                        catch (UnauthorizedAccessException) when (i < 4)
-                        {
-                            // On Windows, memory-mapped file handles may not be fully released by
-                            // the kernel yet even after the pager is disposed. Retry after a brief delay.
-                            Thread.Sleep(50);
-                        }
-                        catch (IOException) when (i < 4)
-                        {
-                            Thread.Sleep(50);
-                        }
+                        File.Delete(file);
+                        return;
+                    }
+                    catch (Exception e) when (i < retries - 1 && e is UnauthorizedAccessException or IOException)
+                    {
+                        // On Windows, memory-mapped file handles may not be fully released by
+                        // the kernel yet even after the pager is disposed. Retry after a brief delay.
+                        Thread.Sleep(50);
                     }
                 }
             }

--- a/test/SlowTests/Client/ClientConfigurationTests.cs
+++ b/test/SlowTests/Client/ClientConfigurationTests.cs
@@ -219,6 +219,7 @@ namespace SlowTests.Client
             await AssertWaitForClientConfiguration(origin);
 
             await store.Maintenance.SendAsync(new PutClientConfigurationOperation(GetClientConfiguration(101)));
+            await AssertWaitForClientConfiguration(101);
             await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(GetClientConfiguration(102)));
             await AssertWaitForClientConfiguration(101);
 

--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -671,7 +671,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             var changeVector = revisions[1].GetString(Constants.Documents.Metadata.ChangeVector);
             
             var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Operations.SendAsync(new RevertRevisionsByIdOperation(id, changeVector)));
-            Assert.Contains("System.InvalidOperationException: Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
+            Assert.Contains("Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
             
             configuration.Disabled = true;
             await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -726,7 +726,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(revisionTime, 1));
             await operation.WaitForCompletionAsync<RevertResult>(TimeSpan.FromSeconds(5));
         });
-        Assert.Contains("System.InvalidOperationException: Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
+        Assert.Contains("Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
         
         configuration.Disabled = true;
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.AI;

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
@@ -234,6 +234,6 @@ public class RavenDB_24887(ITestOutputHelper output) : RavenTestBase(output)
         Assert.NotNull(addToCartArgs);
         // and were able to "solve" it properly
         Assert.Equal(AiConversationResult.Done, result.Status);
-        Assert.Contains("added", result.Answer.Message);
+        Assert.Contains("added", result.Answer.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
@@ -119,7 +119,10 @@ namespace SlowTests.Server.Documents.Indexing.Auto
 
                     session.SaveChanges();
 
-                    var results = session.Query<Item>().Statistics(out var stats).GroupBy(x => new {x.name, x.Name}).Select(g => new
+                    var results = session.Query<Item>()
+                        .Statistics(out var stats)
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .GroupBy(x => new {x.name, x.Name}).Select(g => new
                     {
                         g.Key.name,
                         g.Key.Name,

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -64,9 +64,11 @@ namespace SlowTests.Server.Replication
 
                 await EnsureReplicatingAsync(store1, store2);
 
-                await storage1.TombstoneCleaner.ExecuteCleanup();
-
-                Assert.Equal(0, WaitForValue(() => WaitUntilHasTombstones(store1, 0).Count, 0));
+                Assert.Equal(0, await WaitForValueAsync(async () =>
+                {
+                    await storage1.TombstoneCleaner.ExecuteCleanup();
+                    return WaitUntilHasTombstones(store1, 0).Count;
+                }, 0));
             }
         }
 

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -510,9 +510,15 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                DatabaseRecord record = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
                 var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 
@@ -623,9 +629,16 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
+                DatabaseRecord record = null;
+                DatabaseTopology shardTopology = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
+                shardTopology = record.Sharding.Shards[0];
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 
@@ -668,9 +681,16 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
+                DatabaseRecord record = null;
+                DatabaseTopology shardTopology = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
+                shardTopology = record.Sharding.Shards[0];
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -114,6 +114,12 @@ namespace SlowTests.Sharding
                 var res = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database, replicationFactor: 1));
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
 
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var s = await Sharding.GetShardingConfigurationAsync(store);
+                    return s.Shards.Count;
+                }, 3);
+
                 var sharding = await Sharding.GetShardingConfigurationAsync(store);
                 var nodeToInstanceCount = new Dictionary<string, int>();
 
@@ -316,10 +322,17 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                DatabaseRecord record = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var firstShard = record.Sharding.Shards.Values.FirstOrDefault();
+                    return firstShard?.AllNodes.Count() ?? 0;
+                }, 1);
+
                 var chosenShard = record.Sharding.Shards.Keys.First();
                 var shardTopology = record.Sharding.Shards[chosenShard];
-                Assert.Equal(1, shardTopology.AllNodes.Count());
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(1, shardTopology.ReplicationFactor);
 
@@ -579,9 +592,16 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
+                DatabaseRecord record = null;
+                DatabaseTopology shardTopology = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
+                shardTopology = record.Sharding.Shards[0];
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 


### PR DESCRIPTION
### Issue links

https://issues.hibernatingrhinos.com/issue/RavenDB-26397
https://issues.hibernatingrhinos.com/issue/RavenDB-22632
https://issues.hibernatingrhinos.com/issue/RavenDB-25718
https://issues.hibernatingrhinos.com/issue/RavenDB-25719
https://issues.hibernatingrhinos.com/issue/RavenDB-26069
https://issues.hibernatingrhinos.com/issue/RavenDB-26093
https://issues.hibernatingrhinos.com/issue/RavenDB-26094
https://issues.hibernatingrhinos.com/issue/RavenDB-26112
https://issues.hibernatingrhinos.com/issue/RavenDB-26162
https://issues.hibernatingrhinos.com/issue/RavenDB-26212
https://issues.hibernatingrhinos.com/issue/RavenDB-26225
https://issues.hibernatingrhinos.com/issue/RavenDB-26271
https://issues.hibernatingrhinos.com/issue/RavenDB-26313
https://issues.hibernatingrhinos.com/issue/RavenDB-26318
https://issues.hibernatingrhinos.com/issue/RavenDB-26320
https://issues.hibernatingrhinos.com/issue/RavenDB-26395
https://issues.hibernatingrhinos.com/issue/RavenDB-26177
https://issues.hibernatingrhinos.com/issue/RavenDB-26393
https://issues.hibernatingrhinos.com/issue/RavenDB-26033
https://issues.hibernatingrhinos.com/issue/RavenDB-24575
https://issues.hibernatingrhinos.com/issue/RavenDB-22813
https://issues.hibernatingrhinos.com/issue/RavenDB-23195
https://issues.hibernatingrhinos.com/issue/RavenDB-23173
https://issues.hibernatingrhinos.com/issue/RavenDB-23172
https://issues.hibernatingrhinos.com/issue/RavenDB-26310
https://issues.hibernatingrhinos.com/issue/RavenDB-25784
https://issues.hibernatingrhinos.com/issue/RavenDB-26076
https://issues.hibernatingrhinos.com/issue/RavenDB-26153
https://issues.hibernatingrhinos.com/issue/RavenDB-26199
https://issues.hibernatingrhinos.com/issue/RavenDB-26317

### Additional description

Fixes ~25 transient test failures across multiple categories:

1. **Suppress expected I/O errors during web host disposal** (15 issues: RavenDB-22632, RavenDB-25718, RavenDB-25719, RavenDB-26069, RavenDB-26093, RavenDB-26094, RavenDB-26112, RavenDB-26162, RavenDB-26212, RavenDB-26225, RavenDB-26271, RavenDB-26313, RavenDB-26318, RavenDB-26320, RavenDB-26395) — `RavenServer.Dispose()` was propagating benign `IOException`/`SocketException` (broken pipe, connection reset) during shutdown, causing "Failed to properly close RavenServer" test failures.

2. **Fix race in `ChangeClientConfiguration_ShouldUpdateTheClient`** (RavenDB-26177) — Wait for database config to apply before sending server-wide config to avoid seeing the wrong precedence.

3. **Fix SchemaValidation revert test assertion** (RavenDB-26393) — Check message content instead of exception type prefix (`SchemaValidationException` replaced `InvalidOperationException`).

4. **Fix race in 6 ShardingTopology tests** (RavenDB-26033, RavenDB-24575, RavenDB-22813, RavenDB-23195, RavenDB-23173, RavenDB-23172) — Replace immediate `Assert.Equal(2, Members.Count)` with `AssertWaitForValueAsync` polling to handle topology propagation delay.

5. **Fix race in `CleanTombstones` replication test** (RavenDB-26310) — Retry `TombstoneCleaner.ExecuteCleanup()` inside wait loop so it picks up updated replication etag.

6. **Add `WaitForNonStaleResults` to case-sensitive GroupBy test** (RavenDB-25784) — In sharded mode, auto-indexes on different shards may not be caught up.

7. Fix 32-bit async commit guard in RachisConsensus (RavenDB-26317) — TxMerger._is32Bits was initialized from configuration.Storage.ForceUsing32BitsPager but not from the actual StorageEnvironment.Options.ForceUsing32BitsPager. When
VORON_INTERNAL_ForceUsing32BitsPager env var is set (Winx86 CI), the Voron storage has 32-bit pager constraints but the merger doesn't know, allowing async commit to be attempted.

8. Retry temp file deletion for Windows memory-mapped handle delay (RavenDB-26076, RavenDB-26153, RavenDB-26199) — On Windows, DeleteAllTempFiles() fails with UnauthorizedAccessException because the kernel hasn't fully released memory-mapped file
handles from a previous environment's disposed pagers. Add retry logic (5 attempts, 50ms delay) instead of failing immediately.

### Type of change

- [x] Bug fix

### How risky is the change?

- [x] Low

### Backward compatibility

- [x] Non breaking change

### Testing by Contributor

- [x] Existing tests verify the correct behavior
