### PR TITLE
RavenDB-26398 Fix transient test failure in sharded side-by-side index reset tests

### DIFF
--- a/test/FastTests/Client/DatabaseChangesTests.cs
+++ b/test/FastTests/Client/DatabaseChangesTests.cs
@@ -1,8 +1,6 @@
 ﻿﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client.Exceptions.Database;
-using Raven.Client.Extensions;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Tests.Core.Utils.Entities;
@@ -72,22 +70,15 @@ namespace FastTests.Client
             }
 
             await store.Maintenance.Server.SendAsync(new DeleteDatabasesOperation(store.Database, true)).ConfigureAwait(false);
-            using (var changes = store.Changes())
-            {
-                var message = string.Empty;
-                changes.OnError += exception => Volatile.Write(ref message, exception.Message);
-                var obs = changes.ForDocumentsInCollection<User>();
-                var task = obs.EnsureSubscribedNow();
-                var timeout = TimeSpan.FromSeconds(30);
-                if (await Task.WhenAny(task, Task.Delay(timeout)) != task)
-                    throw new TimeoutException($"{timeout} {message}");
 
-                var e = await Assert.ThrowsAnyAsync<Exception>(() => task);
-                if (e is AggregateException ae)
-                    e = ae.ExtractSingleInnerException();
-                
-                Assert.Equal(typeof(DatabaseDoesNotExistException), e.GetType());
-            }
+            await AssertWaitForExceptionAsync<DatabaseDoesNotExistException>(async () =>
+            {
+                using (var changes = store.Changes())
+                {
+                    var obs = changes.ForDocumentsInCollection<User>();
+                    await obs.EnsureSubscribedNow();
+                }
+            }, timeout: 30_000);
         }
 
         [RavenTheory(RavenTestCategory.ClientApi | RavenTestCategory.ChangesApi)]

--- a/test/SlowTests/Issues/RavenDB-22036.cs
+++ b/test/SlowTests/Issues/RavenDB-22036.cs
@@ -25,14 +25,15 @@ public class RavenDB_22036 : RavenTestBase
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
-            
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
                 Maps = { "from user in docs.Users select new { user.FirstName }" },
                 Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
 
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.SideBySide)).ExecuteOnAll();
@@ -65,14 +66,15 @@ public class RavenDB_22036 : RavenTestBase
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
-            
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
                 Maps = { "from user in docs.Users select new { user.FirstName }" },
                 Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
 
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.InPlace)).ExecuteOnAll();
@@ -105,14 +107,15 @@ public class RavenDB_22036 : RavenTestBase
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
-            
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
                 Maps = { "from user in docs.Users select new { user.FirstName }" },
                 Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, indexResetMode: IndexResetMode.SideBySide)).ExecuteOnAll();
@@ -158,13 +161,14 @@ public class RavenDB_22036 : RavenTestBase
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName)).ExecuteOnAll();
@@ -203,18 +207,19 @@ public class RavenDB_22036 : RavenTestBase
         {
             record.Settings[RavenConfiguration.GetKey(x => x.Indexing.ResetMode)] = IndexResetMode.SideBySide.ToString();
         };
-        
+
         using (var store = GetDocumentStore(options))
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName)).ExecuteOnAll();
@@ -253,13 +258,14 @@ public class RavenDB_22036 : RavenTestBase
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
@@ -310,13 +316,14 @@ public class RavenDB_22036 : RavenTestBase
         {
             const string indexName = "Users/ByName";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();
@@ -368,13 +375,14 @@ public class RavenDB_22036 : RavenTestBase
             const string indexName = "Users/ByName";
             const string replacementIndexName = $"{Constants.Documents.Indexing.SideBySideIndexNamePrefix}{indexName}";
 
-            store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
+            var putResult = store.Maintenance.Send(new PutIndexesOperation(new IndexDefinition
             {
-                Maps = { "from user in docs.Users select new { user.FirstName }" }, 
-                Type = IndexType.Map, 
+                Maps = { "from user in docs.Users select new { user.FirstName }" },
+                Type = IndexType.Map,
                 Name = indexName
             }));
-            
+            Sharding.WaitForRaftIndexOnShards(store, putResult[0].RaftCommandIndex);
+
             store.Maintenance.ForTesting(() => new StopIndexingOperation()).ExecuteOnAll();
             
             store.Maintenance.ForTesting(() => new ResetIndexOperation(indexName, IndexResetMode.SideBySide)).ExecuteOnAll();

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -11,6 +11,7 @@ using Raven.Client.Documents.Operations;
 using Raven.Client.ServerWide;
 using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Sharding;
+using Raven.Client.Util;
 using Raven.Server;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Replication;
@@ -50,6 +51,19 @@ public partial class RavenTestBase
             Subscriptions = new ShardedSubscriptionTestBase(_parent);
             Replication = new ShardedReplicationTestBase(_parent);
             Etl = new ShardedEtlTestBase(_parent);
+        }
+
+        public void WaitForRaftIndexOnShards(IDocumentStore store, long raftCommandIndex)
+        {
+            var record = store.Maintenance.Server.Send(new GetDatabaseRecordOperation(store.Database));
+            if (record.IsSharded == false)
+                return;
+
+            foreach (var shardNumber in record.Sharding.Shards.Keys)
+            {
+                var shardName = ShardHelper.ToShardName(store.Database, shardNumber);
+                AsyncHelpers.RunSync(() => _parent.Databases.WaitForRaftIndex(shardName, raftCommandIndex));
+            }
         }
 
         public DocumentStore GetDocumentStore(Options options = null, [CallerMemberName] string caller = null, Dictionary<int, DatabaseTopology> shards = null)

--- a/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.Sharding.cs
@@ -59,10 +59,16 @@ public partial class RavenTestBase
             if (record.IsSharded == false)
                 return;
 
+            var servers = _parent.GetServers();
             foreach (var shardNumber in record.Sharding.Shards.Keys)
             {
                 var shardName = ShardHelper.ToShardName(store.Database, shardNumber);
-                AsyncHelpers.RunSync(() => _parent.Databases.WaitForRaftIndex(shardName, raftCommandIndex));
+                foreach (var server in servers)
+                {
+                    var database = AsyncHelpers.RunSync(() => server.ServerStore.DatabasesLandlord.TryGetOrCreateResourceStore(shardName));
+                    if (database != null)
+                        AsyncHelpers.RunSync(() => database.RachisLogIndexNotifications.WaitForIndexNotification(raftCommandIndex, TimeSpan.FromSeconds(15)));
+                }
             }
         }
 

--- a/test/Tests.Infrastructure/RavenTestBase.cs
+++ b/test/Tests.Infrastructure/RavenTestBase.cs
@@ -609,7 +609,7 @@ namespace FastTests
         {
             await WaitAndAssertForValueAsync(async () =>
                 await act().ContinueWith(t =>
-                    t.Exception?.InnerException?.GetType()), typeof(T), timeout, interval);
+                    t.Exception?.Flatten().InnerException?.GetType()), typeof(T), timeout, interval);
         }
 
         protected static async Task<T> AssertWaitForNotNullAsync<T>(Func<Task<T>> act, int timeout = 15000, int interval = 100) where T : class


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26398

This is a 6.2 version for https://github.com/ravendb/ravendb/pull/22642

### Additional description

`PutIndexesOperation` commits through Raft but only waits for orchestrator nodes to process the entry, not shard nodes. This creates a race where:

1. The shard creates the index during initial database load (from the latest database record)
2. The test calls `ResetIndex(SideBySide)`, creating a replacement index
3. `HandleDatabaseRecordChange` for the PutIndex Raft entry fires afterward
4. In `HandleStaticIndexChange`, the Noop path deletes the replacement index (since the index already exists with the same definition)
5. The test assertion finds the replacement is gone

Fix: capture the `RaftCommandIndex` from `PutIndexesOperation` and wait for each shard to fully process it via `Sharding.WaitForRaftIndexOnShards` immediately after index creation, before `StopIndexingOperation`. The helper method is added to `ShardingTestBase` so other tests can reuse it. Applied to all 8 tests in the file since they share the same pattern.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed