### PR TITLE
RavenDB-25624 Add custom OpenTelemetry environment variable reader due to internal issues with SDK.

### DIFF
--- a/src/Raven.Server/Monitoring/OpenTelemetry/OpenTelemetryEnvironmentVariablesReader.cs
+++ b/src/Raven.Server/Monitoring/OpenTelemetry/OpenTelemetryEnvironmentVariablesReader.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections;
+using Microsoft.Extensions.Configuration;
+
+namespace Raven.Server.Monitoring.OpenTelemetry;
+
+public class OpenTelemetryEnvironmentVariablesReader : ConfigurationProvider, IConfigurationSource
+{
+    private const string OTelPrefix = "OTEL_";
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        return this;
+    }
+
+    public override void Load()
+    {
+        var variables = Environment.GetEnvironmentVariables();
+        foreach (DictionaryEntry variable in variables)
+        {
+            var key = variable.Key.ToString();
+
+            if (string.IsNullOrEmpty(key) || key.StartsWith(OTelPrefix) == false)
+                continue;
+
+            Data[key] = variable.Value?.ToString();
+        }
+    }
+}

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -334,6 +335,11 @@ namespace Raven.Server
                 }
 
                 var webHostBuilder = new WebHostBuilder()
+                    .ConfigureAppConfiguration(builder =>
+                    {
+                        if (Configuration.Monitoring.OpenTelemetry.Enabled)
+                            builder.Add(new OpenTelemetryEnvironmentVariablesReader());
+                    })
                     .ConfigureMicrosoftLogging(Configuration.Logs, ServerStore.NotificationCenter)
                     .CaptureStartupErrors(captureStartupErrors: true)
                     .UseKestrel(ConfigureKestrel)
@@ -496,7 +502,7 @@ namespace Raven.Server
                 throw;
             }
         }
-        
+
         private void StartOpenTelemetry()
         {
             MetricsManager = new MetricsManager(ServerStore.Server, _openTelemetryInitialized); 
@@ -518,7 +524,6 @@ namespace Raven.Server
             openTelemetryBuilder.WithMetrics(ConfigureMetrics);
             void ConfigureMetrics(MeterProviderBuilder builder)
             {
-                builder.ConfigureResource(x => x.AddEnvironmentVariableDetector());
                 var configuration = Configuration.Monitoring.OpenTelemetry;
                 builder.SetResourceBuilder(
                     ResourceBuilder.CreateDefault()


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25624

### Additional description

OpenTelemetry does not read environment variables when an IConfiguration instance is available in memory. To work around this, we must read the variables manually. We cannot use a prefix argument when adding environment variables because it strips the prefix from the keys, whereas the OTel SDK specifically requires the OTEL_ prefix.

Fixes: https://github.com/ravendb/ravendb/issues/21964

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
