### PR TITLE
 RavenDB-22347 Add comprehensive tests for dictionary patching with special character keys

### DIFF
--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -253,7 +253,8 @@ namespace Raven.Client.Documents.Session
                 case nameof(JavaScriptDictionary<TKey, TValue>.Add):
                     object value;
                     (key, value) = GetKeyAndValue<TKey, TValue>(call);
-                    patchRequest.Script = $"this.{pathScript}.{key} = args.val_{_valsCount};";
+                    var formattedKey = FormatKeyForJavaScript(key);
+                    patchRequest.Script = $"this.{pathScript}[{formattedKey}] = args.val_{_valsCount};";
                     if (DocumentStore.Conventions.SaveEnumsAsIntegersForPatching && value is Enum)
                     {
                         value = Convert.ToInt32(value);
@@ -263,7 +264,8 @@ namespace Raven.Client.Documents.Session
                     break;
                 case nameof(JavaScriptDictionary<TKey, TValue>.Remove):
                     key = GetKey(call);
-                    patchRequest.Script = $"delete this.{pathScript}.{key};";
+                    formattedKey = FormatKeyForJavaScript(key);
+                    patchRequest.Script = $"delete this.{pathScript}[{formattedKey}];";
                     break;
                 default:
                     throw new InvalidOperationException("Unsupported method: " + call.Method.Name);
@@ -400,6 +402,14 @@ namespace Raven.Client.Documents.Session
         private static void ThrowUnsupportedExpression(Expression expression)
         {
             throw new InvalidOperationException("Unsupported expression: " + expression);
+        }
+
+        private static string FormatKeyForJavaScript(object key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key), "Dictionary key cannot be null");
+
+            return $"\"{JavascriptConversionExtensions.EscapeForJsString(key.ToString())}\"";
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.Patch.cs
@@ -409,7 +409,7 @@ namespace Raven.Client.Documents.Session
             if (key == null)
                 throw new ArgumentNullException(nameof(key), "Dictionary key cannot be null");
 
-            return $"\"{JavascriptConversionExtensions.EscapeForJsString(key.ToString())}\"";
+            return JavascriptConversionExtensions.ToJsStringLiteral(key.ToString());
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
+++ b/src/Raven.Client/Documents/Session/InMemoryDocumentSessionOperations.cs
@@ -310,6 +310,7 @@ namespace Raven.Client.Documents.Session
                     JavascriptConversionExtensions.LinqMethodsSupport.Instance,
                     JavascriptConversionExtensions.NullableSupport.Instance,
                     JavascriptConversionExtensions.PatchDictionaryEnumSupport.Instance,
+                    JavascriptConversionExtensions.PatchPathWrappedConstantSupport.Instance,
                 ])
             {
                 CustomMetadataProvider = new PropertyNameConventionJSMetadataProvider(RequestExecutor.Conventions)

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2235,17 +2235,7 @@ namespace Raven.Client.Util
 
             private static void WriteStringLiteral(string str, JavascriptWriter writer)
             {
-                writer.Write('"');
-                writer.Write(
-                    str
-                        .Replace("\\", "\\\\")
-                        .Replace("\r", "\\r")
-                        .Replace("\n", "\\n")
-                        .Replace("\t", "\\t")
-                        .Replace("\0", "\\0")
-                        .Replace("\"", "\\\""));
-
-                writer.Write('"');
+                writer.Write(ToJsStringLiteral(str));
             }
         }
 
@@ -2834,9 +2824,7 @@ namespace Raven.Client.Util
                 using (writer.Operation(mce))
                 {
                     writer.Write("new RegExp(");
-                    writer.Write("\"");
-                    writer.Write(EscapeForJsString(pattern));
-                    writer.Write("\"");
+                    writer.Write(ToJsStringLiteral(pattern));
 
                     if (flags.Length > 0)
                     {
@@ -2880,19 +2868,16 @@ namespace Raven.Client.Util
 
         }
 
-        internal static string EscapeForJsString(string value)
+        /// <summary>
+        /// Returns a JS string literal including surrounding quotes, with all special characters escaped.
+        /// e.g. input: key"with"quotes => output: "key\"with\"quotes"
+        /// </summary>
+        internal static string ToJsStringLiteral(string value)
         {
             if (value == null)
-                return string.Empty;
+                return "null";
 
-            return value
-                .Replace("\\", "\\\\")        // Must be first!
-                .Replace("\"", "\\\"")        // Escape quotes
-                .Replace("\r", "\\r")         // Escape CR
-                .Replace("\n", "\\n")         // Escape LF
-                .Replace("\u2028", "\\u2028") // CRITICAL: Escape Line Separator
-                .Replace("\u2029", "\\u2029") // CRITICAL: Escape Paragraph Separator
-                .Replace("\t", "\\t");        // Optional: nice for debugging readability
+            return JsonConvert.ToString(value);
         }
 
         internal sealed class PatchPathWrappedConstantSupport : JavascriptConversionExtension
@@ -2921,15 +2906,6 @@ namespace Raven.Client.Util
                         return;
                     }
 
-                    // For string values, write them as quoted strings
-                    if (value is string stringValue)
-                    {
-                        writer.Write("\"");
-                        writer.Write(EscapeForJsString(stringValue));
-                        writer.Write("\"");
-                        return;
-                    }
-
                     // For numeric values, write them directly
                     if (value is int || value is long || value is short || value is byte ||
                         value is uint || value is ulong || value is ushort || value is sbyte ||
@@ -2939,10 +2915,8 @@ namespace Raven.Client.Util
                         return;
                     }
 
-                    // For any other type, convert to string and quote it
-                    writer.Write("\"");
-                    writer.Write(EscapeForJsString(value.ToString()));
-                    writer.Write("\"");
+                    // For string and any other type, write as a quoted JS string literal
+                    writer.Write(ToJsStringLiteral(value.ToString()));
                 }
             }
         }

--- a/src/Raven.Client/Util/JavascriptConversionExtensions.cs
+++ b/src/Raven.Client/Util/JavascriptConversionExtensions.cs
@@ -2878,19 +2878,72 @@ namespace Raven.Client.Util
                 return flags;
             }
 
-            private static string EscapeForJsString(string pattern)
-            {
-                if (pattern == null)
-                    return string.Empty;
+        }
 
-                return pattern
-                    .Replace("\\", "\\\\")        // Must be first!
-                    .Replace("\"", "\\\"")        // Escape quotes
-                    .Replace("\r", "\\r")         // Escape CR
-                    .Replace("\n", "\\n")         // Escape LF
-                    .Replace("\u2028", "\\u2028") // CRITICAL: Escape Line Separator
-                    .Replace("\u2029", "\\u2029") // CRITICAL: Escape Paragraph Separator
-                    .Replace("\t", "\\t");        // Optional: nice for debugging readablity
+        internal static string EscapeForJsString(string value)
+        {
+            if (value == null)
+                return string.Empty;
+
+            return value
+                .Replace("\\", "\\\\")        // Must be first!
+                .Replace("\"", "\\\"")        // Escape quotes
+                .Replace("\r", "\\r")         // Escape CR
+                .Replace("\n", "\\n")         // Escape LF
+                .Replace("\u2028", "\\u2028") // CRITICAL: Escape Line Separator
+                .Replace("\u2029", "\\u2029") // CRITICAL: Escape Paragraph Separator
+                .Replace("\t", "\\t");        // Optional: nice for debugging readability
+        }
+
+        internal sealed class PatchPathWrappedConstantSupport : JavascriptConversionExtension
+        {
+            public static readonly PatchPathWrappedConstantSupport Instance = new PatchPathWrappedConstantSupport();
+
+            private PatchPathWrappedConstantSupport()
+            {
+            }
+
+            public override void ConvertToJavascript(JavascriptConversionContext context)
+            {
+                if (context.Node is not MemberExpression memberExpression ||
+                    IsWrappedConstantExpression(memberExpression) == false)
+                    return;
+
+                LinqPathProvider.GetValueFromExpressionWithoutConversion(memberExpression, out var value);
+                var writer = context.GetWriter();
+                context.PreventDefault();
+
+                using (writer.Operation(JavascriptOperationTypes.Literal))
+                {
+                    if (value == null)
+                    {
+                        writer.Write("null");
+                        return;
+                    }
+
+                    // For string values, write them as quoted strings
+                    if (value is string stringValue)
+                    {
+                        writer.Write("\"");
+                        writer.Write(EscapeForJsString(stringValue));
+                        writer.Write("\"");
+                        return;
+                    }
+
+                    // For numeric values, write them directly
+                    if (value is int || value is long || value is short || value is byte ||
+                        value is uint || value is ulong || value is ushort || value is sbyte ||
+                        value is float || value is double || value is decimal)
+                    {
+                        writer.Write(value.ToInvariantString());
+                        return;
+                    }
+
+                    // For any other type, convert to string and quote it
+                    writer.Write("\"");
+                    writer.Write(EscapeForJsString(value.ToString()));
+                    writer.Write("\"");
+                }
             }
         }
 

--- a/test/FastTests/Issues/RavenDB-22347.cs
+++ b/test/FastTests/Issues/RavenDB-22347.cs
@@ -11,8 +11,146 @@ namespace FastTests.Issues
         {
         }
 
+        [RavenTheory(RavenTestCategory.Patching)]
+        [InlineData("Key1")]
+        [InlineData("key-with-dash")]
+        [InlineData("key with space")]
+        [InlineData("key.with.dot")]
+        [InlineData("back\\slash")]
+        [InlineData("ke\"y1")]
+        [InlineData("it's a \"test\"\\path.with-dashes and spaces")]
+        [InlineData("line1\nline2")]
+        [InlineData("col1\tcol2")]
+        [InlineData("")]
+        public void CanPatchDictionaryViaIndexerWithVariousKeys(string key)
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { key, "OriginalValue" },
+                        { "Untouched", "Untouched" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[key], "Updated");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.True(values.TryGet(key, out string value), $"Key '{key}' should exist");
+                Assert.Equal("Updated", value);
+                Assert.True(values.TryGet("Untouched", out value));
+                Assert.Equal("Untouched", value);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching)]
+        [InlineData("NewKey")]
+        [InlineData("key-with-dash")]
+        [InlineData("key with space")]
+        [InlineData("key.with.dot")]
+        [InlineData("back\\slash")]
+        [InlineData("key\"with\"quotes")]
+        [InlineData("it's a \"test\"\\path.with-dashes and spaces")]
+        [InlineData("line1\nline2")]
+        [InlineData("col1\tcol2")]
+        [InlineData("")]
+        public void CanAddDictionaryEntryWithVariousKeys(string key)
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Existing", "ExistingValue" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, "AddedValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet(key, out string value), $"Key '{key}' should exist");
+                Assert.Equal("AddedValue", value);
+                Assert.True(values.TryGet("Existing", out value));
+                Assert.Equal("ExistingValue", value);
+            }
+        }
+
+        [RavenTheory(RavenTestCategory.Patching)]
+        [InlineData("Key1")]
+        [InlineData("key-with-dash")]
+        [InlineData("key with space")]
+        [InlineData("key.with.dot")]
+        [InlineData("back\\slash")]
+        [InlineData("key\"with\"quotes")]
+        [InlineData("it's a \"test\"\\path.with-dashes and spaces")]
+        [InlineData("line1\nline2")]
+        [InlineData("col1\tcol2")]
+        public void CanRemoveDictionaryEntryWithVariousKeys(string key)
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { key, "ToBeRemoved" },
+                        { "Surviving", "SurvivingValue" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(key));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.False(values.TryGet(key, out string _), $"Key '{key}' should have been removed");
+                Assert.True(values.TryGet("Surviving", out string value));
+                Assert.Equal("SurvivingValue", value);
+            }
+        }
+
         [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryValueWithIndexerAndKeyFromObjectProperty()
+        public void CanPatchDictionaryViaIndexerWithKeyFromObjectProperty()
         {
             using var store = GetDocumentStore();
 
@@ -50,7 +188,7 @@ namespace FastTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryValueWithIndexerAndKeyFromVariable()
+        public void CanAddDictionaryEntryWithKeyFromObjectProperty()
         {
             using var store = GetDocumentStore();
 
@@ -60,83 +198,7 @@ namespace FastTests.Issues
                 {
                     Values = new Dictionary<string, string>
                     {
-                        { "Key1", "Value1" },
-                        { "Key2", "Value2" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            var key = "Key1";
-
-            using (var session = store.OpenSession())
-            {
-                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[key], "UpdatedValue");
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-
-                Assert.True(values.TryGet("Key1", out string value));
-                Assert.Equal("UpdatedValue", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithAdderAndKeyFromObjectProperty()
-        {
-            using var store = GetDocumentStore();
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { "Key1", "Value1" },
-                        { "Key2", "Value2" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            var keyHolder = new KeyHolder { Key = "Key3" };
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyHolder.Key, "Value3"));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(3, values.Count);
-
-                Assert.True(values.TryGet("Key3", out string value));
-                Assert.Equal("Value3", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanRemoveDictionaryKeyWithAdderAndKeyFromObjectProperty()
-        {
-            using var store = GetDocumentStore();
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { "Key1", "Value1" },
-                        { "Key2", "Value2" },
-                        { "Key3", "Value3" }
+                        { "Key1", "Value1" }
                     }
                 }, "docs/1");
                 session.SaveChanges();
@@ -147,7 +209,7 @@ namespace FastTests.Issues
             using (var session = store.OpenSession())
             {
                 var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(keyHolder.Key));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyHolder.Key, "Value2"));
                 session.SaveChanges();
             }
 
@@ -157,178 +219,14 @@ namespace FastTests.Issues
                 Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
                 Assert.Equal(2, values.Count);
 
-                Assert.True(values.TryGet("Key1", out string _));
-                Assert.True(values.TryGet("Key3", out string _));
-                Assert.False(values.TryGet("Key2", out string _));
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithKeyContainingSpecialCharacters()
-        {
-            using var store = GetDocumentStore();
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { "Key1", "Value1" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            var specialKeys = new[] { "key-with-dash", "key with space", "key.with", "key\"with\"quotes" };
-
-            foreach (var key in specialKeys)
-            {
-                using (var session = store.OpenSession())
-                {
-                    var doc = session.Load<Document>("docs/1");
-                    session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, $"Value for {key}"));
-                    session.SaveChanges();
-                }
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(5, values.Count);
-
-                foreach (var key in specialKeys)
-                {
-                    Assert.True(values.TryGet(key, out string value), $"Key '{key}' should exist");
-                    Assert.Equal($"Value for {key}", value);
-                }
-            }
-        }
-
-        // --- Additional tests below ---
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryValueWithIndexerAndKeyContainingQuotes()
-        {
-            // Ayende's review: test indexer path with key containing embedded quotes
-            using var store = GetDocumentStore();
-
-            var keyWithQuotes = "ke\"y1";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { keyWithQuotes, "OriginalValue" },
-                        { "Key2", "Value2" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            var obj = new { Key = keyWithQuotes };
-
-            using (var session = store.OpenSession())
-            {
-                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[obj.Key], "UpdatedValue");
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-
-                Assert.True(values.TryGet(keyWithQuotes, out string value));
-                Assert.Equal("UpdatedValue", value);
-                Assert.True(values.TryGet("Key2", out value));
+                Assert.True(values.TryGet("Key2", out string value));
                 Assert.Equal("Value2", value);
             }
         }
 
         [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryValueWithIndexerAndKeyContainingSpecialCharacters()
+        public void CanRemoveDictionaryEntryWithKeyFromObjectProperty()
         {
-            // Test PatchPathWrappedConstantSupport with various special characters in the key
-            using var store = GetDocumentStore();
-
-            var specialKeys = new[] { "key-with-dash", "key with space", "key.with.dot", "back\\slash" };
-
-            foreach (var specialKey in specialKeys)
-            {
-                using (var session = store.OpenSession())
-                {
-                    session.Store(new Document
-                    {
-                        Values = new Dictionary<string, string>
-                        {
-                            { specialKey, "OriginalValue" }
-                        }
-                    }, "docs/1");
-                    session.SaveChanges();
-                }
-
-                using (var session = store.OpenSession())
-                {
-                    session.Advanced.Patch<Document, string>("docs/1", x => x.Values[specialKey], "Updated");
-                    session.SaveChanges();
-                }
-
-                using (var commands = store.Commands())
-                {
-                    var doc = commands.Get("docs/1").BlittableJson;
-                    Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                    Assert.True(values.TryGet(specialKey, out string value), $"Key '{specialKey}' should exist");
-                    Assert.Equal("Updated", value);
-                }
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanAddDictionaryEntryWithKeyFromVariable()
-        {
-            // Tests Add path with simple string variable (not object property)
-            using var store = GetDocumentStore();
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { "Key1", "Value1" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            var key = "NewKey";
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, "NewValue"));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(2, values.Count);
-
-                Assert.True(values.TryGet("NewKey", out string value));
-                Assert.Equal("NewValue", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanRemoveDictionaryEntryWithKeyFromVariable()
-        {
-            // Tests Remove path with simple string variable
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -344,12 +242,12 @@ namespace FastTests.Issues
                 session.SaveChanges();
             }
 
-            var key = "Key1";
+            var keyHolder = new KeyHolder { Key = "Key1" };
 
             using (var session = store.OpenSession())
             {
                 var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(key));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(keyHolder.Key));
                 session.SaveChanges();
             }
 
@@ -366,48 +264,8 @@ namespace FastTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Patching)]
-        public void CanRemoveDictionaryEntryWithSpecialCharacterKey()
-        {
-            using var store = GetDocumentStore();
-
-            var specialKey = "key-with-dash";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { specialKey, "Value1" },
-                        { "Key2", "Value2" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(specialKey));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(1, values.Count);
-
-                Assert.False(values.TryGet(specialKey, out string _));
-                Assert.True(values.TryGet("Key2", out string value));
-                Assert.Equal("Value2", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
         public void CanAddAndRemoveDictionaryEntriesInSameSession()
         {
-            // Tests patch merging with the new bracket notation
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -426,7 +284,7 @@ namespace FastTests.Issues
             using (var session = store.OpenSession())
             {
                 var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("Key3", "Value3"));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("key-three", "Value3"));
                 session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove("Key1"));
                 session.SaveChanges();
             }
@@ -440,7 +298,7 @@ namespace FastTests.Issues
                 Assert.False(values.TryGet("Key1", out string _));
                 Assert.True(values.TryGet("Key2", out string value));
                 Assert.Equal("Value2", value);
-                Assert.True(values.TryGet("Key3", out value));
+                Assert.True(values.TryGet("key-three", out value));
                 Assert.Equal("Value3", value);
             }
         }
@@ -448,7 +306,6 @@ namespace FastTests.Issues
         [RavenFact(RavenTestCategory.Patching)]
         public void CanAddMultipleDictionaryEntriesWithSpecialKeysInSameSession()
         {
-            // Tests patch merging with multiple special-character keys
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -485,159 +342,9 @@ namespace FastTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Patching)]
-        public void CanOverwriteExistingDictionaryEntryWithSpecialCharacterKey()
+        public void CanAddDictionaryEntryWithKeyValuePairOverload()
         {
             using var store = GetDocumentStore();
-
-            var specialKey = "my-key.with";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { specialKey, "OriginalValue" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(specialKey, "OverwrittenValue"));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(1, values.Count);
-
-                Assert.True(values.TryGet(specialKey, out string value));
-                Assert.Equal("OverwrittenValue", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithKeyContainingBackslash()
-        {
-            // Backslash must be escaped first in EscapeForJsString to avoid double-escaping
-            using var store = GetDocumentStore();
-
-            var key = "path\\to\\thing";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { "Key1", "Value1" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, "BackslashValue"));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(2, values.Count);
-
-                Assert.True(values.TryGet(key, out string value));
-                Assert.Equal("BackslashValue", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithKeyContainingNewlineAndTab()
-        {
-            using var store = GetDocumentStore();
-
-            var keyWithNewline = "line1\nline2";
-            var keyWithTab = "col1\tcol2";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>()
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyWithNewline, "NewlineValue"));
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyWithTab, "TabValue"));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(2, values.Count);
-
-                Assert.True(values.TryGet(keyWithNewline, out string value));
-                Assert.Equal("NewlineValue", value);
-                Assert.True(values.TryGet(keyWithTab, out value));
-                Assert.Equal("TabValue", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithKeyContainingMixedSpecialCharacters()
-        {
-            // A key that exercises multiple escape rules simultaneously
-            using var store = GetDocumentStore();
-
-            var crazyKey = "it's a \"test\"\\path.with-dashes and spaces";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>()
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(crazyKey, "CrazyValue"));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-
-                Assert.True(values.TryGet(crazyKey, out string value));
-                Assert.Equal("CrazyValue", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithKeyValuePairAndSpecialCharacterKey()
-        {
-            // Tests the KeyValuePair overload of Add
-            using var store = GetDocumentStore();
-
-            var specialKey = "my-special.key";
 
             using (var session = store.OpenSession())
             {
@@ -655,7 +362,7 @@ namespace FastTests.Issues
             {
                 var doc = session.Load<Document>("docs/1");
                 session.Advanced.Patch(doc, x => x.Values,
-                    dict => dict.Add(new KeyValuePair<string, string>(specialKey, "SpecialValue")));
+                    dict => dict.Add(new KeyValuePair<string, string>("my-special.key", "SpecialValue")));
                 session.SaveChanges();
             }
 
@@ -665,7 +372,7 @@ namespace FastTests.Issues
                 Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
                 Assert.Equal(2, values.Count);
 
-                Assert.True(values.TryGet(specialKey, out string value));
+                Assert.True(values.TryGet("my-special.key", out string value));
                 Assert.Equal("SpecialValue", value);
             }
         }
@@ -673,7 +380,6 @@ namespace FastTests.Issues
         [RavenFact(RavenTestCategory.Patching)]
         public void CanPatchDictionaryWithEnumKeyUsingAdd()
         {
-            // Regression: enum keys should work with bracket notation
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -711,7 +417,6 @@ namespace FastTests.Issues
         [RavenFact(RavenTestCategory.Patching)]
         public void CanPatchDictionaryWithEnumKeyUsingRemove()
         {
-            // Regression: enum key Remove should work with bracket notation
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -749,7 +454,6 @@ namespace FastTests.Issues
         [RavenFact(RavenTestCategory.Patching)]
         public void CanPatchDictionaryWithEnumKeyUsingIndexer()
         {
-            // Regression: indexer patch with enum key
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -784,42 +488,43 @@ namespace FastTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithEmptyStringKey()
+        public void CanPatchDictionaryWithComplexValueAndSpecialCharacterKey()
         {
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
             {
-                session.Store(new Document
+                session.Store(new NestedDocument
                 {
-                    Values = new Dictionary<string, string>()
+                    Items = new Dictionary<string, NestedValue>()
                 }, "docs/1");
                 session.SaveChanges();
             }
 
+            var key = "item-one";
+
             using (var session = store.OpenSession())
             {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("", "EmptyKeyValue"));
+                session.Advanced.Patch<NestedDocument, NestedValue>("docs/1",
+                    x => x.Items[key], new NestedValue { Name = "Test", Score = 42 });
                 session.SaveChanges();
             }
 
             using (var commands = store.Commands())
             {
                 var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(1, values.Count);
-
-                Assert.True(values.TryGet("", out string value));
-                Assert.Equal("EmptyKeyValue", value);
+                Assert.True(doc.TryGet(nameof(NestedDocument.Items), out BlittableJsonReaderObject items));
+                Assert.True(items.TryGet(key, out BlittableJsonReaderObject nested));
+                Assert.True(nested.TryGet(nameof(NestedValue.Name), out string name));
+                Assert.Equal("Test", name);
+                Assert.True(nested.TryGet(nameof(NestedValue.Score), out int score));
+                Assert.Equal(42, score);
             }
         }
 
         [RavenFact(RavenTestCategory.Patching)]
         public void PatchDoesNotAffectNonDictionaryProperties()
         {
-            // Regression: adding PatchPathWrappedConstantSupport to path compilation
-            // should not break simple property patching
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -854,7 +559,6 @@ namespace FastTests.Issues
         [RavenFact(RavenTestCategory.Patching)]
         public void IncrementStillWorksWithPatchPathWrappedConstantSupport()
         {
-            // Regression: Increment uses the same _pathScriptCompilationOptions
             using var store = GetDocumentStore();
 
             using (var session = store.OpenSession())
@@ -878,116 +582,6 @@ namespace FastTests.Issues
             {
                 var doc = session.Load<DocumentWithMultipleProperties>("docs/1");
                 Assert.Equal(15, doc.Count);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithLiteralSpecialCharacterKeyInIndexer()
-        {
-            // Literal string key with special chars in the indexer expression
-            using var store = GetDocumentStore();
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { "my-key", "OriginalValue" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                session.Advanced.Patch<Document, string>("docs/1", x => x.Values["my-key"], "Updated");
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-
-                Assert.True(values.TryGet("my-key", out string value));
-                Assert.Equal("Updated", value);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanPatchDictionaryWithComplexValueAndSpecialCharacterKey()
-        {
-            // Dictionary with complex value types and special character keys via indexer
-            using var store = GetDocumentStore();
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new NestedDocument
-                {
-                    Items = new Dictionary<string, NestedValue>()
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            var key = "item-one";
-
-            using (var session = store.OpenSession())
-            {
-                session.Advanced.Patch<NestedDocument, NestedValue>("docs/1",
-                    x => x.Items[key], new NestedValue { Name = "Test", Score = 42 });
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(NestedDocument.Items), out BlittableJsonReaderObject items));
-                Assert.True(items.TryGet(key, out BlittableJsonReaderObject nested));
-                Assert.True(nested.TryGet(nameof(NestedValue.Name), out string name));
-                Assert.Equal("Test", name);
-                Assert.True(nested.TryGet(nameof(NestedValue.Score), out int score));
-                Assert.Equal(42, score);
-            }
-        }
-
-        [RavenFact(RavenTestCategory.Patching)]
-        public void CanRemoveDictionaryEntryWithQuotesInKey()
-        {
-            // Remove with a key containing embedded quotes
-            using var store = GetDocumentStore();
-
-            var keyWithQuotes = "key\"with\"quotes";
-
-            using (var session = store.OpenSession())
-            {
-                session.Store(new Document
-                {
-                    Values = new Dictionary<string, string>
-                    {
-                        { keyWithQuotes, "QuotedValue" },
-                        { "NormalKey", "NormalValue" }
-                    }
-                }, "docs/1");
-                session.SaveChanges();
-            }
-
-            using (var session = store.OpenSession())
-            {
-                var doc = session.Load<Document>("docs/1");
-                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(keyWithQuotes));
-                session.SaveChanges();
-            }
-
-            using (var commands = store.Commands())
-            {
-                var doc = commands.Get("docs/1").BlittableJson;
-                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
-                Assert.Equal(1, values.Count);
-
-                Assert.False(values.TryGet(keyWithQuotes, out string _));
-                Assert.True(values.TryGet("NormalKey", out string value));
-                Assert.Equal("NormalValue", value);
             }
         }
 

--- a/test/FastTests/Issues/RavenDB-22347.cs
+++ b/test/FastTests/Issues/RavenDB-22347.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using Sparrow.Json;
 using Tests.Infrastructure;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace FastTests.Issues
 {
@@ -207,6 +206,791 @@ namespace FastTests.Issues
             }
         }
 
+        // --- Additional tests below ---
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryValueWithIndexerAndKeyContainingQuotes()
+        {
+            // Ayende's review: test indexer path with key containing embedded quotes
+            using var store = GetDocumentStore();
+
+            var keyWithQuotes = "ke\"y1";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { keyWithQuotes, "OriginalValue" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var obj = new { Key = keyWithQuotes };
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[obj.Key], "UpdatedValue");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet(keyWithQuotes, out string value));
+                Assert.Equal("UpdatedValue", value);
+                Assert.True(values.TryGet("Key2", out value));
+                Assert.Equal("Value2", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryValueWithIndexerAndKeyContainingSpecialCharacters()
+        {
+            // Test PatchPathWrappedConstantSupport with various special characters in the key
+            using var store = GetDocumentStore();
+
+            var specialKeys = new[] { "key-with-dash", "key with space", "key.with.dot", "back\\slash" };
+
+            foreach (var specialKey in specialKeys)
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Document
+                    {
+                        Values = new Dictionary<string, string>
+                        {
+                            { specialKey, "OriginalValue" }
+                        }
+                    }, "docs/1");
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    session.Advanced.Patch<Document, string>("docs/1", x => x.Values[specialKey], "Updated");
+                    session.SaveChanges();
+                }
+
+                using (var commands = store.Commands())
+                {
+                    var doc = commands.Get("docs/1").BlittableJson;
+                    Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                    Assert.True(values.TryGet(specialKey, out string value), $"Key '{specialKey}' should exist");
+                    Assert.Equal("Updated", value);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanAddDictionaryEntryWithKeyFromVariable()
+        {
+            // Tests Add path with simple string variable (not object property)
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var key = "NewKey";
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, "NewValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet("NewKey", out string value));
+                Assert.Equal("NewValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanRemoveDictionaryEntryWithKeyFromVariable()
+        {
+            // Tests Remove path with simple string variable
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var key = "Key1";
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(key));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.False(values.TryGet("Key1", out string _));
+                Assert.True(values.TryGet("Key2", out string value));
+                Assert.Equal("Value2", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanRemoveDictionaryEntryWithSpecialCharacterKey()
+        {
+            using var store = GetDocumentStore();
+
+            var specialKey = "key-with-dash";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { specialKey, "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(specialKey));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.False(values.TryGet(specialKey, out string _));
+                Assert.True(values.TryGet("Key2", out string value));
+                Assert.Equal("Value2", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanAddAndRemoveDictionaryEntriesInSameSession()
+        {
+            // Tests patch merging with the new bracket notation
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("Key3", "Value3"));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove("Key1"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.False(values.TryGet("Key1", out string _));
+                Assert.True(values.TryGet("Key2", out string value));
+                Assert.Equal("Value2", value);
+                Assert.True(values.TryGet("Key3", out value));
+                Assert.Equal("Value3", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanAddMultipleDictionaryEntriesWithSpecialKeysInSameSession()
+        {
+            // Tests patch merging with multiple special-character keys
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>()
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("key-one", "v1"));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("key.two", "v2"));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("key three", "v3"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(3, values.Count);
+
+                Assert.True(values.TryGet("key-one", out string value));
+                Assert.Equal("v1", value);
+                Assert.True(values.TryGet("key.two", out value));
+                Assert.Equal("v2", value);
+                Assert.True(values.TryGet("key three", out value));
+                Assert.Equal("v3", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanOverwriteExistingDictionaryEntryWithSpecialCharacterKey()
+        {
+            using var store = GetDocumentStore();
+
+            var specialKey = "my-key.with";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { specialKey, "OriginalValue" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(specialKey, "OverwrittenValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.True(values.TryGet(specialKey, out string value));
+                Assert.Equal("OverwrittenValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithKeyContainingBackslash()
+        {
+            // Backslash must be escaped first in EscapeForJsString to avoid double-escaping
+            using var store = GetDocumentStore();
+
+            var key = "path\\to\\thing";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, "BackslashValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet(key, out string value));
+                Assert.Equal("BackslashValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithKeyContainingNewlineAndTab()
+        {
+            using var store = GetDocumentStore();
+
+            var keyWithNewline = "line1\nline2";
+            var keyWithTab = "col1\tcol2";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>()
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyWithNewline, "NewlineValue"));
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyWithTab, "TabValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet(keyWithNewline, out string value));
+                Assert.Equal("NewlineValue", value);
+                Assert.True(values.TryGet(keyWithTab, out value));
+                Assert.Equal("TabValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithKeyContainingMixedSpecialCharacters()
+        {
+            // A key that exercises multiple escape rules simultaneously
+            using var store = GetDocumentStore();
+
+            var crazyKey = "it's a \"test\"\\path.with-dashes and spaces";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>()
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(crazyKey, "CrazyValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet(crazyKey, out string value));
+                Assert.Equal("CrazyValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithKeyValuePairAndSpecialCharacterKey()
+        {
+            // Tests the KeyValuePair overload of Add
+            using var store = GetDocumentStore();
+
+            var specialKey = "my-special.key";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values,
+                    dict => dict.Add(new KeyValuePair<string, string>(specialKey, "SpecialValue")));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet(specialKey, out string value));
+                Assert.Equal("SpecialValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithEnumKeyUsingAdd()
+        {
+            // Regression: enum keys should work with bracket notation
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new EnumKeyDocument
+                {
+                    Checks = new Dictionary<Parts, string>
+                    {
+                        { Parts.Engine, "Good" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<EnumKeyDocument>("docs/1");
+                session.Advanced.Patch(doc, x => x.Checks, dict => dict.Add(Parts.Gears, "Bad"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(EnumKeyDocument.Checks), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet("Engine", out string value));
+                Assert.Equal("Good", value);
+                Assert.True(values.TryGet("Gears", out value));
+                Assert.Equal("Bad", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithEnumKeyUsingRemove()
+        {
+            // Regression: enum key Remove should work with bracket notation
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new EnumKeyDocument
+                {
+                    Checks = new Dictionary<Parts, string>
+                    {
+                        { Parts.Engine, "Good" },
+                        { Parts.Gears, "Bad" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<EnumKeyDocument>("docs/1");
+                session.Advanced.Patch(doc, x => x.Checks, dict => dict.Remove(Parts.Engine));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(EnumKeyDocument.Checks), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.False(values.TryGet("Engine", out string _));
+                Assert.True(values.TryGet("Gears", out string value));
+                Assert.Equal("Bad", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithEnumKeyUsingIndexer()
+        {
+            // Regression: indexer patch with enum key
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new EnumKeyDocument
+                {
+                    Checks = new Dictionary<Parts, string>
+                    {
+                        { Parts.Engine, "Good" },
+                        { Parts.Gears, "Good" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<EnumKeyDocument, string>("docs/1", x => x.Checks[Parts.Engine], "Bad");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(EnumKeyDocument.Checks), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet("Engine", out string value));
+                Assert.Equal("Bad", value);
+                Assert.True(values.TryGet("Gears", out value));
+                Assert.Equal("Good", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithEmptyStringKey()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>()
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add("", "EmptyKeyValue"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.True(values.TryGet("", out string value));
+                Assert.Equal("EmptyKeyValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void PatchDoesNotAffectNonDictionaryProperties()
+        {
+            // Regression: adding PatchPathWrappedConstantSupport to path compilation
+            // should not break simple property patching
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new DocumentWithMultipleProperties
+                {
+                    Name = "Original",
+                    Count = 10,
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<DocumentWithMultipleProperties, string>("docs/1", x => x.Name, "Updated");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<DocumentWithMultipleProperties>("docs/1");
+                Assert.Equal("Updated", doc.Name);
+                Assert.Equal(10, doc.Count);
+                Assert.Equal("Value1", doc.Values["Key1"]);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void IncrementStillWorksWithPatchPathWrappedConstantSupport()
+        {
+            // Regression: Increment uses the same _pathScriptCompilationOptions
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new DocumentWithMultipleProperties
+                {
+                    Name = "Test",
+                    Count = 10,
+                    Values = new Dictionary<string, string>()
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Increment<DocumentWithMultipleProperties, int>("docs/1", x => x.Count, 5);
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<DocumentWithMultipleProperties>("docs/1");
+                Assert.Equal(15, doc.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithLiteralSpecialCharacterKeyInIndexer()
+        {
+            // Literal string key with special chars in the indexer expression
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "my-key", "OriginalValue" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values["my-key"], "Updated");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet("my-key", out string value));
+                Assert.Equal("Updated", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithComplexValueAndSpecialCharacterKey()
+        {
+            // Dictionary with complex value types and special character keys via indexer
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new NestedDocument
+                {
+                    Items = new Dictionary<string, NestedValue>()
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var key = "item-one";
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<NestedDocument, NestedValue>("docs/1",
+                    x => x.Items[key], new NestedValue { Name = "Test", Score = 42 });
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(NestedDocument.Items), out BlittableJsonReaderObject items));
+                Assert.True(items.TryGet(key, out BlittableJsonReaderObject nested));
+                Assert.True(nested.TryGet(nameof(NestedValue.Name), out string name));
+                Assert.Equal("Test", name);
+                Assert.True(nested.TryGet(nameof(NestedValue.Score), out int score));
+                Assert.Equal(42, score);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanRemoveDictionaryEntryWithQuotesInKey()
+        {
+            // Remove with a key containing embedded quotes
+            using var store = GetDocumentStore();
+
+            var keyWithQuotes = "key\"with\"quotes";
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { keyWithQuotes, "QuotedValue" },
+                        { "NormalKey", "NormalValue" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(keyWithQuotes));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(1, values.Count);
+
+                Assert.False(values.TryGet(keyWithQuotes, out string _));
+                Assert.True(values.TryGet("NormalKey", out string value));
+                Assert.Equal("NormalValue", value);
+            }
+        }
+
         private class Document
         {
             public Dictionary<string, string> Values { get; set; }
@@ -215,6 +999,35 @@ namespace FastTests.Issues
         private class KeyHolder
         {
             public string Key { get; set; }
+        }
+
+        private class EnumKeyDocument
+        {
+            public Dictionary<Parts, string> Checks { get; set; }
+        }
+
+        private enum Parts
+        {
+            Engine = 42,
+            Gears = 102,
+        }
+
+        private class DocumentWithMultipleProperties
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+            public Dictionary<string, string> Values { get; set; }
+        }
+
+        private class NestedDocument
+        {
+            public Dictionary<string, NestedValue> Items { get; set; }
+        }
+
+        private class NestedValue
+        {
+            public string Name { get; set; }
+            public int Score { get; set; }
         }
     }
 }

--- a/test/FastTests/Issues/RavenDB-22347.cs
+++ b/test/FastTests/Issues/RavenDB-22347.cs
@@ -22,6 +22,12 @@ namespace FastTests.Issues
         [InlineData("line1\nline2")]
         [InlineData("col1\tcol2")]
         [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\u2028")]
+        [InlineData("\u2029")]
+        [InlineData("\u3712")]
+        [InlineData("\ud83d\ude00")]
+        [InlineData("key \ud83d\udd11 with emoji")]
         public void CanPatchDictionaryViaIndexerWithVariousKeys(string key)
         {
             using var store = GetDocumentStore();
@@ -67,6 +73,12 @@ namespace FastTests.Issues
         [InlineData("line1\nline2")]
         [InlineData("col1\tcol2")]
         [InlineData("")]
+        [InlineData("\r\n")]
+        [InlineData("\u2028")]
+        [InlineData("\u2029")]
+        [InlineData("\u3712")]
+        [InlineData("\ud83d\ude00")]
+        [InlineData("key \ud83d\udd11 with emoji")]
         public void CanAddDictionaryEntryWithVariousKeys(string key)
         {
             using var store = GetDocumentStore();
@@ -113,6 +125,12 @@ namespace FastTests.Issues
         [InlineData("it's a \"test\"\\path.with-dashes and spaces")]
         [InlineData("line1\nline2")]
         [InlineData("col1\tcol2")]
+        [InlineData("\r\n")]
+        [InlineData("\u2028")]
+        [InlineData("\u2029")]
+        [InlineData("\u3712")]
+        [InlineData("\ud83d\ude00")]
+        [InlineData("key \ud83d\udd11 with emoji")]
         public void CanRemoveDictionaryEntryWithVariousKeys(string key)
         {
             using var store = GetDocumentStore();

--- a/test/FastTests/Issues/RavenDB-22347.cs
+++ b/test/FastTests/Issues/RavenDB-22347.cs
@@ -28,6 +28,8 @@ namespace FastTests.Issues
         [InlineData("\u3712")]
         [InlineData("\ud83d\ude00")]
         [InlineData("key \ud83d\udd11 with emoji")]
+        [InlineData("'key'")]
+        [InlineData("\"key\"")]
         public void CanPatchDictionaryViaIndexerWithVariousKeys(string key)
         {
             using var store = GetDocumentStore();
@@ -79,6 +81,8 @@ namespace FastTests.Issues
         [InlineData("\u3712")]
         [InlineData("\ud83d\ude00")]
         [InlineData("key \ud83d\udd11 with emoji")]
+        [InlineData("'key'")]
+        [InlineData("\"key\"")]
         public void CanAddDictionaryEntryWithVariousKeys(string key)
         {
             using var store = GetDocumentStore();
@@ -131,6 +135,8 @@ namespace FastTests.Issues
         [InlineData("\u3712")]
         [InlineData("\ud83d\ude00")]
         [InlineData("key \ud83d\udd11 with emoji")]
+        [InlineData("'key'")]
+        [InlineData("\"key\"")]
         public void CanRemoveDictionaryEntryWithVariousKeys(string key)
         {
             using var store = GetDocumentStore();

--- a/test/FastTests/Issues/RavenDB-22347.cs
+++ b/test/FastTests/Issues/RavenDB-22347.cs
@@ -1,0 +1,220 @@
+using System.Collections.Generic;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Issues
+{
+    public class RavenDB_22347 : RavenTestBase
+    {
+        public RavenDB_22347(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryValueWithIndexerAndKeyFromObjectProperty()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var obj = new { Key = "Key1" };
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[obj.Key], "UpdatedValue");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet("Key1", out string value));
+                Assert.Equal("UpdatedValue", value);
+                Assert.True(values.TryGet("Key2", out value));
+                Assert.Equal("Value2", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryValueWithIndexerAndKeyFromVariable()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var key = "Key1";
+
+            using (var session = store.OpenSession())
+            {
+                session.Advanced.Patch<Document, string>("docs/1", x => x.Values[key], "UpdatedValue");
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+
+                Assert.True(values.TryGet("Key1", out string value));
+                Assert.Equal("UpdatedValue", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithAdderAndKeyFromObjectProperty()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var keyHolder = new KeyHolder { Key = "Key3" };
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(keyHolder.Key, "Value3"));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(3, values.Count);
+
+                Assert.True(values.TryGet("Key3", out string value));
+                Assert.Equal("Value3", value);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanRemoveDictionaryKeyWithAdderAndKeyFromObjectProperty()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" },
+                        { "Key2", "Value2" },
+                        { "Key3", "Value3" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var keyHolder = new KeyHolder { Key = "Key2" };
+
+            using (var session = store.OpenSession())
+            {
+                var doc = session.Load<Document>("docs/1");
+                session.Advanced.Patch(doc, x => x.Values, dict => dict.Remove(keyHolder.Key));
+                session.SaveChanges();
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(2, values.Count);
+
+                Assert.True(values.TryGet("Key1", out string _));
+                Assert.True(values.TryGet("Key3", out string _));
+                Assert.False(values.TryGet("Key2", out string _));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Patching)]
+        public void CanPatchDictionaryWithKeyContainingSpecialCharacters()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Document
+                {
+                    Values = new Dictionary<string, string>
+                    {
+                        { "Key1", "Value1" }
+                    }
+                }, "docs/1");
+                session.SaveChanges();
+            }
+
+            var specialKeys = new[] { "key-with-dash", "key with space", "key.with", "key\"with\"quotes" };
+
+            foreach (var key in specialKeys)
+            {
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<Document>("docs/1");
+                    session.Advanced.Patch(doc, x => x.Values, dict => dict.Add(key, $"Value for {key}"));
+                    session.SaveChanges();
+                }
+            }
+
+            using (var commands = store.Commands())
+            {
+                var doc = commands.Get("docs/1").BlittableJson;
+                Assert.True(doc.TryGet(nameof(Document.Values), out BlittableJsonReaderObject values));
+                Assert.Equal(5, values.Count);
+
+                foreach (var key in specialKeys)
+                {
+                    Assert.True(values.TryGet(key, out string value), $"Key '{key}' should exist");
+                    Assert.Equal($"Value for {key}", value);
+                }
+            }
+        }
+
+        private class Document
+        {
+            public Dictionary<string, string> Values { get; set; }
+        }
+
+        private class KeyHolder
+        {
+            public string Key { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

  https://issues.hibernatingrhinos.com/issue/RavenDB-22347

  ### Additional description

  Follow-up to PR #22127 (dictionary patching with variable keys and special characters).

  1. **Comprehensive test coverage** — 20 additional tests on top of the PR's original 6, covering:
     - Indexer patch with keys containing quotes, dashes, spaces, dots, backslashes
     - Add/Remove via variable keys and object property keys
     - Patch merging (multiple Add/Remove in same session)
     - KeyValuePair overload with special character keys
     - Escape edge cases: newlines, tabs, mixed special characters, empty string key
     - Enum key regression tests (Add, Remove, Indexer)
     - Complex object values with special character keys
     - Regression tests ensuring non-dictionary Patch and Increment still work after PatchPathWrappedConstantSupport was added to path compilation

  2. **Replace hand-rolled JS string escaping with `JsonConvert.ToString`** — Consolidates three duplicate escape implementations (`EscapeForJsString`, `WriteStringLiteral`, and inline escaping in `FormatKeyForJavaScript`) into a single
  `ToJsStringLiteral` helper. 

  ### Type of change

  - [x] Bug fix

  ### How risky is the change?

  - [x] Low

  ### Backward compatibility

  - [x] Non breaking change

  ### Is it platform specific issue?

  - [x] No

  ### Documentation update

  - [x] No documentation update is needed

  ### Testing by Contributor

  - [x] Tests have been added that prove the fix is effective or that the feature works
  - [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)

  ### Testing by RavenDB QA team

  - [x] No special testing by RavenDB QA team is needed

  ### Is there any existing behavior change of other features due to this change?

  - [x] No

  ### UI work

  - [x] No UI work is needed