### PR TITLE
Ravendb-25541 : `Receive` is called twice if we have also `Handle`

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -34,6 +34,7 @@ internal class AiConversation : IAiConversationOperations
     private delegate Task HandleActionDelegate(JsonOperationContext context, AiAgentActionRequest actionRequest, CancellationToken token);
 
     private readonly Dictionary<string, HandleActionDelegate> _invocations = new();
+    private readonly HashSet<string> _dispatchedToolIds = new();
 
     public AiConversation(AiOperations aiOperations, string agentId, string conversationId, AiConversationCreationOptions options, string changeVector)
     {
@@ -242,6 +243,8 @@ internal class AiConversation : IAiConversationOperations
 
     public async Task<AiAnswer<TAnswer>> RunAsync<TAnswer>(CancellationToken token = default)
     {
+        _dispatchedToolIds.Clear();
+
         while (true)
         {
             var r = await RunAsyncInternal<TAnswer>(streamPropertyPath: null, streamedChunksCallback: null, token).ConfigureAwait(false);
@@ -262,6 +265,9 @@ internal class AiConversation : IAiConversationOperations
         {
             foreach (var action in _actionRequests)
             {
+                if (_dispatchedToolIds.Add(action.ToolId) == false)
+                    continue;
+
                 if (_invocations.TryGetValue(action.Name, out var invocation))
                 {
                     // error handling here is expected to be done by the invocation based on the error strategy the user choose
@@ -291,7 +297,7 @@ internal class AiConversation : IAiConversationOperations
     {
         if (
             // if this is null, it is the first time we call RunAsync, so we are going to the server to get the pending actions
-            _actionRequests != null &&
+            _actionRequests is { Count: 0 } &&
             // otherwise, we already went to the server and have nothing new to tell it, so we are done
             _promptParts.Count == 0 && _actionResponses.Count == 0 && _attachmentsCommands.Count == 0)
         {

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25541.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-25541.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_25541 : RavenTestBase
+    {
+        public RavenDB_25541(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task ReceiveAndHandleCalledOnce(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agent = new AiAgentConfiguration("my assistant", config.ConnectionStringName,
+                "Always call both tools- tool 'whoami' and the tool 'randomDocument' tools to gather context before answering the user.")
+            {
+                Actions =
+                [
+                    new AiAgentToolAction
+                    {
+                        Name = "whoami",
+                        ParametersSampleObject = "{}",
+                        Description = "Describe who this user is, preferences, etc"
+                    },
+                    new AiAgentToolAction
+                    {
+                        Name = "randomDocument",
+                        ParametersSampleObject = "{}",
+                        Description = "Get a random document from the database"
+                    }
+                ]
+            };
+
+            var identifier = (await store.AI.CreateAgentAsync(agent, AiAgentBasics.OutputSchema.Instance)).Identifier;
+            var chat = store.AI.Conversation(identifier, "chats/",
+                new AiConversationCreationOptions());
+
+            int receiveCalled = 0;
+            int handleCalled = 0;
+            chat.Receive<object>("whoami", (a, args) =>
+            {
+                receiveCalled++;
+            });
+
+            chat.Handle<object>("randomDocument", (a, args) =>
+            {
+                handleCalled++;
+                return new object();
+            });
+
+            chat.SetUserPrompt("Give me 15 real cities names, one per line");
+            var r = await chat.RunAsync<AiAgentBasics.OutputSchema>();
+            Assert.Equal(1, handleCalled);
+            Assert.Equal(1, receiveCalled);
+            Assert.Equal(AiConversationResult.ActionRequired, r.Status);
+
+            await chat.RunAsync<AiAgentBasics.OutputSchema>();
+            Assert.Equal(2, receiveCalled);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25541/Receive-is-called-twice-if-we-have-also-Handle

### Additional description

Handle was invoking Receive when we have them both, and receive was not handled yet.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
