### PR TITLE
RavenDB-26300 Support `In` inside `When` conditional clause.

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -793,7 +793,7 @@ public static partial class CoraxQueryBuilder
     {
         PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
-        var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(expression.Arguments[0], builderParameters.QueryParameters);
+        var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(expression.Arguments[0], builderParameters.Metadata.Query, builderParameters.Metadata, builderParameters.QueryParameters);
         if (constantExpressionResult == false)
             return new CoraxWhenQuery();
             

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.cs
@@ -793,7 +793,7 @@ public static partial class CoraxQueryBuilder
     {
         PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
-        var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery((BinaryExpression)expression.Arguments[0], builderParameters.QueryParameters);
+        var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(expression.Arguments[0], builderParameters.QueryParameters);
         if (constantExpressionResult == false)
             return new CoraxWhenQuery();
             

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -727,7 +727,7 @@ namespace Raven.Server.Documents.Queries
         {
             PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
-            var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery((BinaryExpression)expression.Arguments[0], parameters);
+            var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(expression.Arguments[0], parameters);
             if (constantExpressionResult == false)
                 return new LuceneWhenQuery();
             

--- a/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
+++ b/src/Raven.Server/Documents/Queries/LuceneQueryBuilder.cs
@@ -727,7 +727,7 @@ namespace Raven.Server.Documents.Queries
         {
             PortableExceptions.ThrowIf<ArgumentException>(expression.Arguments.Count != 2, $"Method `when` requires exactly 2 arguments, but got {expression.Arguments.Count}");
 
-            var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(expression.Arguments[0], parameters);
+            var constantExpressionResult = QueryBuilderHelper.EvaluateConstantExpressionForWhenQuery(expression.Arguments[0], query, metadata, parameters);
             if (constantExpressionResult == false)
                 return new LuceneWhenQuery();
             

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -894,6 +894,12 @@ public static class QueryBuilderHelper
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
 
+        if (expression is TrueExpression)
+            return true;
+
+        if (expression is NegatedExpression negated)
+            return EvaluateConstantExpressionForWhenQuery(negated.Expression, parameters) == false;
+
         if (expression is InExpression inExpression)
             return EvaluateInExpressionForWhenQuery(inExpression, parameters);
 

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax;
@@ -889,16 +890,20 @@ public static class QueryBuilderHelper
         return GenerateEmbeddings.FromArray(allocator, scope, memory, options, bytesRequired);
     }
     
-    public static bool EvaluateConstantExpressionForWhenQuery(BinaryExpression constantExpression, BlittableJsonReaderObject parameters)
+    public static bool EvaluateConstantExpressionForWhenQuery(QueryExpression expression, BlittableJsonReaderObject parameters)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        if (expression is InExpression inExpression)
+            return EvaluateInExpressionForWhenQuery(inExpression, parameters);
+
+        if (expression is not BinaryExpression constantExpression)
+            throw new InvalidOperationException($"Expected binary or in expression, but got: '{expression}' of type '{expression.Type}'.");
+
         if (constantExpression.Operator is OperatorType.And or OperatorType.Or)
         {
-            PortableExceptions.ThrowIfNot<ArgumentException>(constantExpression.Left is BinaryExpression, $"Expected binary expression, but got: '{constantExpression.Left.ToString()}' of type '{constantExpression.Left.Type}'.");
-            PortableExceptions.ThrowIfNot<ArgumentException>(constantExpression.Right is BinaryExpression, $"Expected binary expression, but got: '{constantExpression.Right.ToString()}' of type '{constantExpression.Right.Type}'.");
-            
-            var leftResult = EvaluateConstantExpressionForWhenQuery((BinaryExpression)constantExpression.Left, parameters);
-            var rightResult = EvaluateConstantExpressionForWhenQuery((BinaryExpression)constantExpression.Right, parameters);
+            var leftResult = EvaluateConstantExpressionForWhenQuery(constantExpression.Left, parameters);
+            var rightResult = EvaluateConstantExpressionForWhenQuery(constantExpression.Right, parameters);
             return (constantExpression.Operator) switch
             {
                 OperatorType.And => leftResult && rightResult,
@@ -906,7 +911,7 @@ public static class QueryBuilderHelper
                 _ => throw new InvalidOperationException("Should not happen!")
             };
         }
-        
+
         if (constantExpression.Left is not FieldExpression leftField)
             throw new InvalidOperationException($"Expected parameter field (e.g. $p0), but got: '{constantExpression.Left}'.");
         
@@ -1054,5 +1059,114 @@ public static class QueryBuilderHelper
             default:
                 return false;
         }
+    }
+
+    private static bool EvaluateInExpressionForWhenQuery(InExpression inExpression, BlittableJsonReaderObject parameters)
+    {
+        if (inExpression.Source is not FieldExpression sourceField)
+            throw new InvalidOperationException($"Expected parameter field (e.g. $p0), but got: '{inExpression.Source}'.");
+
+        PortableExceptions.ThrowIfNot<InvalidOperationException>(sourceField.FieldValue.StartsWith('$'),
+            $"Expected parameter field (e.g. $p0), but got: '{sourceField.FieldValue}'.");
+
+        object paramValue;
+        bool paramIsMissing;
+        if (parameters == null || parameters.TryGet(new StringSegment(sourceField.FieldValue, 1, sourceField.FieldValue.Length - 1), out paramValue) == false)
+        {
+            paramValue = null;
+            paramIsMissing = true;
+        }
+        else
+        {
+            paramIsMissing = false;
+        }
+
+        if (paramIsMissing || paramValue is null)
+        {
+            foreach (QueryExpression value in inExpression.Values)
+            {
+                if (value is ValueExpression { Value: ValueTokenType.Null })
+                    return inExpression.All == false;
+            }
+
+            return false;
+        }
+        
+        if (paramValue is BlittableJsonReaderArray array)
+            return WhenInArrayToArrayExpressionEvaluator(array, inExpression);
+
+        return WhenInScalarExpressionEvaluator(GetValueAsString(paramValue), inExpression);
+    }
+
+    private static HashSet<string> MaterializeInList(InExpression inExpression)
+    {
+        var set = new HashSet<string>(inExpression.Values.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (QueryExpression value in inExpression.Values)
+        {
+            if (value is not ValueExpression valueExpression)
+                throw new InvalidOperationException($"Expected value expression in 'in' list, but got: '{value}' of type '{value.Type}'.");
+
+            var valueAsString = valueExpression.Value == ValueTokenType.Null
+                ? Corax.Constants.NullValue
+                : GetValueAsString(valueExpression.Token);
+
+            set.Add(valueAsString);
+        }
+
+        return set;
+    }
+
+    private static bool WhenInScalarExpressionEvaluator(string paramValueAsString, InExpression inExpression)
+    {
+        int matches = 0;
+        paramValueAsString ??= Corax.Constants.NullValue;
+        foreach (QueryExpression value in inExpression.Values)
+        {
+            if (value is not ValueExpression valueExpression)
+                throw new InvalidOperationException($"Expected value expression in 'in' list, but got: '{value}' of type '{value.Type}'.");
+
+            var valueAsString = valueExpression.Value == ValueTokenType.Null
+                ? Corax.Constants.NullValue
+                : GetValueAsString(valueExpression.Token);
+
+            if (string.Equals(paramValueAsString, valueAsString, StringComparison.OrdinalIgnoreCase))
+            {
+                if (inExpression.All == false)
+                    return true;
+
+                matches++;
+            }
+        }
+
+        return inExpression.All && matches == inExpression.Values.Count;
+    }
+
+    private static bool WhenInArrayToArrayExpressionEvaluator(BlittableJsonReaderArray array, InExpression inExpression)
+    {
+        HashSet<string> valuesSet = MaterializeInList(inExpression);
+        
+        if (inExpression.All)
+        {
+            HashSet<string> parameterValues = new(array.Length, StringComparer.OrdinalIgnoreCase);
+            foreach (var value in array)
+            {
+                var valueAsString = value is null 
+                    ? Corax.Constants.NullValue 
+                    : GetValueAsString(value.ToString());
+                
+                parameterValues.Add(valueAsString);
+            }
+
+            return parameterValues.IsSubsetOf(valuesSet);
+        }
+
+        foreach (object element in array)
+        {
+            var elementAsString = element is null ? Corax.Constants.NullValue : GetValueAsString(element);
+            if (valuesSet.Contains(elementAsString))
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
+++ b/src/Raven.Server/Documents/Queries/QueryBuilderHelper.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+    using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax;
@@ -393,23 +391,7 @@ public static class QueryBuilderHelper
 
             foreach (var (value, type) in GetValues(query, metadata, parameters, valueToken))
             {
-                string valueAsString;
-                switch (type)
-                {
-                    case ValueTokenType.Long:
-                        var valueAsLong = (long)value;
-                        valueAsString = valueAsLong.ToString(CultureInfo.InvariantCulture);
-                        break;
-                    case ValueTokenType.Double:
-                        var valueAsDbl = (double)value;
-                        valueAsString = valueAsDbl.ToString("G");
-                        break;
-                    default:
-                        valueAsString = value?.ToString();
-                        break;
-                }
-
-                yield return (valueAsString, type);
+                yield return (FormatAsInValueString(value, type), type);
             }
         }
     }
@@ -890,7 +872,7 @@ public static class QueryBuilderHelper
         return GenerateEmbeddings.FromArray(allocator, scope, memory, options, bytesRequired);
     }
     
-    public static bool EvaluateConstantExpressionForWhenQuery(QueryExpression expression, BlittableJsonReaderObject parameters)
+    public static bool EvaluateConstantExpressionForWhenQuery(QueryExpression expression, Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters)
     {
         RuntimeHelpers.EnsureSufficientExecutionStack();
 
@@ -898,18 +880,18 @@ public static class QueryBuilderHelper
             return true;
 
         if (expression is NegatedExpression negated)
-            return EvaluateConstantExpressionForWhenQuery(negated.Expression, parameters) == false;
+            return EvaluateConstantExpressionForWhenQuery(negated.Expression, query, metadata, parameters) == false;
 
         if (expression is InExpression inExpression)
-            return EvaluateInExpressionForWhenQuery(inExpression, parameters);
+            return EvaluateInExpressionForWhenQuery(inExpression, query, metadata, parameters);
 
         if (expression is not BinaryExpression constantExpression)
             throw new InvalidOperationException($"Expected binary or in expression, but got: '{expression}' of type '{expression.Type}'.");
 
         if (constantExpression.Operator is OperatorType.And or OperatorType.Or)
         {
-            var leftResult = EvaluateConstantExpressionForWhenQuery(constantExpression.Left, parameters);
-            var rightResult = EvaluateConstantExpressionForWhenQuery(constantExpression.Right, parameters);
+            var leftResult = EvaluateConstantExpressionForWhenQuery(constantExpression.Left, query, metadata, parameters);
+            var rightResult = EvaluateConstantExpressionForWhenQuery(constantExpression.Right, query, metadata, parameters);
             return (constantExpression.Operator) switch
             {
                 OperatorType.And => leftResult && rightResult,
@@ -946,10 +928,11 @@ public static class QueryBuilderHelper
         {
             case ValueTokenType.Null:
             {
-                return (ParamIsMissing: paramIsMissing, ParamValue: paramValue) switch
+                bool paramIsNull = paramIsMissing || paramValue is null;
+                return constantExpression.Operator switch
                 {
-                    (ParamIsMissing: true, _) when constantExpression.Operator is OperatorType.Equal => true,
-                    (ParamIsMissing: _, null) when constantExpression.Operator is OperatorType.Equal => true,
+                    OperatorType.Equal => paramIsNull,
+                    OperatorType.NotEqual => paramIsNull == false,
                     _ => false
                 };
             }
@@ -1067,7 +1050,7 @@ public static class QueryBuilderHelper
         }
     }
 
-    private static bool EvaluateInExpressionForWhenQuery(InExpression inExpression, BlittableJsonReaderObject parameters)
+    private static bool EvaluateInExpressionForWhenQuery(InExpression inExpression, Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters)
     {
         if (inExpression.Source is not FieldExpression sourceField)
             throw new InvalidOperationException($"Expected parameter field (e.g. $p0), but got: '{inExpression.Source}'.");
@@ -1075,67 +1058,27 @@ public static class QueryBuilderHelper
         PortableExceptions.ThrowIfNot<InvalidOperationException>(sourceField.FieldValue.StartsWith('$'),
             $"Expected parameter field (e.g. $p0), but got: '{sourceField.FieldValue}'.");
 
-        object paramValue;
-        bool paramIsMissing;
-        if (parameters == null || parameters.TryGet(new StringSegment(sourceField.FieldValue, 1, sourceField.FieldValue.Length - 1), out paramValue) == false)
-        {
-            paramValue = null;
-            paramIsMissing = true;
-        }
-        else
-        {
-            paramIsMissing = false;
-        }
+        object paramValue = null;
+        parameters?.TryGet(new StringSegment(sourceField.FieldValue, 1, sourceField.FieldValue.Length - 1), out paramValue);
 
-        if (paramIsMissing || paramValue is null)
-        {
-            foreach (QueryExpression value in inExpression.Values)
-            {
-                if (value is ValueExpression { Value: ValueTokenType.Null })
-                    return inExpression.All == false;
-            }
-
-            return false;
-        }
-        
         if (paramValue is BlittableJsonReaderArray array)
-            return WhenInArrayToArrayExpressionEvaluator(array, inExpression);
+            return WhenInArrayToArrayExpressionEvaluator(array, inExpression, query, metadata, parameters);
 
-        return WhenInScalarExpressionEvaluator(GetValueAsString(paramValue), inExpression);
+        var paramType = GetValueTokenType(paramValue, metadata.QueryText, parameters);
+        var paramValueUnwrapped = UnwrapParameter(paramValue, paramType);
+        return WhenInScalarExpressionEvaluator(FormatAsInValueString(paramValueUnwrapped, paramType), inExpression, query, metadata, parameters);
     }
 
-    private static HashSet<string> MaterializeInList(InExpression inExpression)
-    {
-        var set = new HashSet<string>(inExpression.Values.Count, StringComparer.OrdinalIgnoreCase);
-        foreach (QueryExpression value in inExpression.Values)
-        {
-            if (value is not ValueExpression valueExpression)
-                throw new InvalidOperationException($"Expected value expression in 'in' list, but got: '{value}' of type '{value.Type}'.");
-
-            var valueAsString = valueExpression.Value == ValueTokenType.Null
-                ? Corax.Constants.NullValue
-                : GetValueAsString(valueExpression.Token);
-
-            set.Add(valueAsString);
-        }
-
-        return set;
-    }
-
-    private static bool WhenInScalarExpressionEvaluator(string paramValueAsString, InExpression inExpression)
+    private static bool WhenInScalarExpressionEvaluator(string paramValueAsString, InExpression inExpression, Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters)
     {
         int matches = 0;
+        int count = 0;
         paramValueAsString ??= Corax.Constants.NullValue;
-        foreach (QueryExpression value in inExpression.Values)
+        foreach (var (valueAsString, _) in GetValuesForIn(query, inExpression, metadata, parameters))
         {
-            if (value is not ValueExpression valueExpression)
-                throw new InvalidOperationException($"Expected value expression in 'in' list, but got: '{value}' of type '{value.Type}'.");
-
-            var valueAsString = valueExpression.Value == ValueTokenType.Null
-                ? Corax.Constants.NullValue
-                : GetValueAsString(valueExpression.Token);
-
-            if (string.Equals(paramValueAsString, valueAsString, StringComparison.OrdinalIgnoreCase))
+            count++;
+            var inValue = valueAsString ?? Corax.Constants.NullValue;
+            if (string.Equals(paramValueAsString, inValue, StringComparison.OrdinalIgnoreCase))
             {
                 if (inExpression.All == false)
                     return true;
@@ -1144,35 +1087,48 @@ public static class QueryBuilderHelper
             }
         }
 
-        return inExpression.All && matches == inExpression.Values.Count;
+        return inExpression.All && matches == count;
     }
 
-    private static bool WhenInArrayToArrayExpressionEvaluator(BlittableJsonReaderArray array, InExpression inExpression)
+    private static bool WhenInArrayToArrayExpressionEvaluator(BlittableJsonReaderArray array, InExpression inExpression, Query query, QueryMetadata metadata, BlittableJsonReaderObject parameters)
     {
-        HashSet<string> valuesSet = MaterializeInList(inExpression);
-        
+        var valuesSet = new HashSet<string>(inExpression.Values.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var (valueAsString, _) in GetValuesForIn(query, inExpression, metadata, parameters))
+        {
+            valuesSet.Add(valueAsString ?? Corax.Constants.NullValue);
+        }
+
         if (inExpression.All)
         {
             HashSet<string> parameterValues = new(array.Length, StringComparer.OrdinalIgnoreCase);
-            foreach (var value in array)
+            foreach (var (elementValue, elementType) in UnwrapArray(array, metadata.QueryText, parameters))
             {
-                var valueAsString = value is null 
-                    ? Corax.Constants.NullValue 
-                    : GetValueAsString(value.ToString());
-                
-                parameterValues.Add(valueAsString);
+                parameterValues.Add(FormatAsInValueString(elementValue, elementType) ?? Corax.Constants.NullValue);
             }
 
             return parameterValues.IsSubsetOf(valuesSet);
         }
 
-        foreach (object element in array)
+        foreach (var (elementValue, elementType) in UnwrapArray(array, metadata.QueryText, parameters))
         {
-            var elementAsString = element is null ? Corax.Constants.NullValue : GetValueAsString(element);
+            var elementAsString = FormatAsInValueString(elementValue, elementType) ?? Corax.Constants.NullValue;
             if (valuesSet.Contains(elementAsString))
                 return true;
         }
 
         return false;
+    }
+
+    private static string FormatAsInValueString(object value, ValueTokenType type)
+    {
+        return type switch
+        {
+            ValueTokenType.Long => ((long)value).ToString(CultureInfo.InvariantCulture),
+            ValueTokenType.Double => ((double)value).ToString("G", CultureInfo.InvariantCulture),
+            ValueTokenType.True => LuceneDocumentConverterBase.TrueString,
+            ValueTokenType.False => LuceneDocumentConverterBase.FalseString,
+            ValueTokenType.Null => null,
+            _ => GetValueAsString(value),
+        };
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB-26300.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26300.cs
@@ -1,0 +1,485 @@
+using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26300(ITestOutputHelper output) : RavenTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInLong(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "4", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", 1)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", 4)
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", (object)null)
+                .Count();
+            Assert.Equal(2, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInString(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "aaa", Number = 1 });
+        session.Store(new Dto { Tag = "ddd", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('aaa', 'bbb', 'ccc'), Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('aaa', 'bbb', 'ccc'), Number != 1)")
+                .AddParameter("myVar", "AAA")
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('aaa', 'bbb', 'ccc'), Number != 1)")
+                .AddParameter("myVar", "ddd")
+                .Count();
+            Assert.Equal(2, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInDouble(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1.5", Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1.5, 2.5, 3.5), Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1.5, 2.5, 3.5), Number != 1)")
+                .AddParameter("myVar", 4.5)
+                .Count();
+            Assert.Equal(1, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithAllIn(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in (1), Number != 1)")
+                .AddParameter("myVar", 1)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", 1)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in ('aaa'), Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in ('aaa', 'bbb'), Number != 1)")
+                .AddParameter("myVar", "aaa")
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in (1, 2, 3), Number != 1)")
+                .Count();
+            Assert.Equal(1, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInCombinedWithAndOr(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Attach = true, Number = 1 });
+        session.Store(new Dto { Tag = "1", Attach = true, Number = 2 });
+        session.Store(new Dto { Tag = "3", Attach = false, Number = 3 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2), Number != 1) and Attach == true")
+                .AddParameter("myVar", 1)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2), Number != 1) and Attach == true")
+                .AddParameter("myVar", 3)
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where Number > 0 and not when($myVar in (1, 2), Number == 1)")
+                .AddParameter("myVar", 1)
+                .Count();
+            Assert.Equal(2, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where Number > 0 and not when($myVar in (1, 2), Number == 1)")
+                .AddParameter("myVar", 3)
+                .Count();
+            Assert.Equal(3, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInNull(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = null, Number = 1 });
+        session.Store(new Dto { Tag = "aaa", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (null, 1, 2), Number != 1)")
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (null, 1, 2), Number != 1)")
+                .AddParameter("myVar", (object)null)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", (object)null)
+                .Count();
+            Assert.Equal(2, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInMixedParameterAndValueTypes(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('1', '2', '3'), Number != 1)")
+                .AddParameter("myVar", 1L)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('1', '2', '3'), Number != 1)")
+                .AddParameter("myVar", 4L)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", "1")
+                .Count();
+            Assert.Equal(0, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", 1.0)
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", 1.5)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1.0, 2.0, 3.0), Number != 1)")
+                .AddParameter("myVar", 1L)
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('True', 'False'), Number != 1)")
+                .AddParameter("myVar", true)
+                .Count();
+            Assert.Equal(0, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInArrayParameter(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", new[] { 1, 5 })
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", new[] { 4, 5 })
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('aaa', 'bbb'), Number != 1)")
+                .AddParameter("myVar", new[] { "aaa", "zzz" })
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in ('aaa', 'bbb'), Number != 1)")
+                .AddParameter("myVar", new[] { "xxx", "zzz" })
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", new[] { 1, 2 })
+                .Count();
+            Assert.Equal(0, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", new[] { 1, 5 })
+                .Count();
+            Assert.Equal(1, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", Array.Empty<int>())
+                .Count();
+            Assert.Equal(1, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar all in (1, 2, 3), Number != 1)")
+                .AddParameter("myVar", Array.Empty<int>())
+                .Count();
+            Assert.Equal(0, result);
+        }
+    }
+
+    private class Dto
+    {
+        public string Id { get; set; }
+        public string Tag { get; set; }
+        public bool Attach { get; set; }
+        public int Number { get; set; }
+    }
+
+    private class Index : AbstractIndexCreationTask<Dto>
+    {
+        public Index()
+        {
+            Map = dtos => from dto in dtos
+                select new
+                {
+                    dto.Tag, dto.Attach, dto.Number
+                };
+        }
+    }
+}

--- a/test/SlowTests.Issues/Issues/RavenDB-26300.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26300.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using FastTests;
 using Raven.Client.Documents.Indexes;
+using Raven.Server.Utils;
 using Tests.Infrastructure;
 using Xunit;
 
@@ -312,6 +314,123 @@ public class RavenDB_26300(ITestOutputHelper output) : RavenTestBase(output)
     [RavenTheory(RavenTestCategory.Querying)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenAllInNullWithNullOrMissingParam(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "2", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        var result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p all in (null), Number != 1)")
+            .AddParameter("p", (object)null)
+            .WaitForNonStaleResults()
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p all in (null, null), Number != 1)")
+            .AddParameter("p", (object)null)
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p all in (null, 1), Number != 1)")
+            .AddParameter("p", (object)null)
+            .Count();
+        Assert.Equal(2, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p all in (null), Number != 1)")
+            .Count();
+        Assert.Equal(1, result);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenNotEqualNullWithNonNullParam(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "2", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        var result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p != null, Number != 1)")
+            .AddParameter("p", 5L)
+            .WaitForNonStaleResults()
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p != null, Number != 1)")
+            .AddParameter("p", "hello")
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p != null, Number != 1)")
+            .AddParameter("p", 1.5)
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p != null, Number != 1)")
+            .AddParameter("p", true)
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p != null, Number != 1)")
+            .AddParameter("p", (object)null)
+            .Count();
+        Assert.Equal(2, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p != null, Number != 1)")
+            .Count();
+        Assert.Equal(2, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p == null, Number != 1)")
+            .AddParameter("p", 5L)
+            .Count();
+        Assert.Equal(2, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p == null, Number != 1)")
+            .AddParameter("p", (object)null)
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p == null, Number != 1)")
+            .Count();
+        Assert.Equal(1, result);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
     public void WhenOperatorWithInMixedParameterAndValueTypes(Options options, bool useAutoIndex)
     {
         using var store = GetDocumentStore(options);
@@ -372,7 +491,7 @@ public class RavenDB_26300(ITestOutputHelper output) : RavenTestBase(output)
                 .RawQuery<Dto>($"from {indexName} where when($myVar in (1.0, 2.0, 3.0), Number != 1)")
                 .AddParameter("myVar", 1L)
                 .Count();
-            Assert.Equal(1, result);
+            Assert.Equal(0, result);
         }
 
         {
@@ -563,6 +682,252 @@ public class RavenDB_26300(ITestOutputHelper output) : RavenTestBase(output)
                 .RawQuery<Dto>($"from {indexName} where when(true and not $p in (1, 2), Number != 1)")
                 .Count();
             Assert.Equal(2, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithInArrayParameterLazyNumberValueRepresentationMismatch(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        {
+            var result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($myVar in (1.5, 2.5), Number != 1)")
+                .AddParameter("myVar", new[] { 1.50m })
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(0, result);
+        }
+    }
+    
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenInDoubleTrailingZerosAreEqual(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "2", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        var result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in (1.50), Number != 1)")
+            .AddParameter("p", 1.5)
+            .WaitForNonStaleResults()
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in (1.500), Number != 1)")
+            .AddParameter("p", 1.5)
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in (1.5, 2.5), Number != 1)")
+            .AddParameter("p", 1.50m)
+            .Count();
+        Assert.Equal(1, result);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenInParameterReferenceInList(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "2", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        var result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in ($p0, $p1), Number != 1)")
+            .AddParameter("p", 1)
+            .AddParameter("p0", 1)
+            .AddParameter("p1", 2)
+            .WaitForNonStaleResults()
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in ($p0, $p1), Number != 1)")
+            .AddParameter("p", 3)
+            .AddParameter("p0", 1)
+            .AddParameter("p1", 2)
+            .Count();
+        Assert.Equal(2, result);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenInArrayAllInLongArrayVsDoubleList(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "2", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        var result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($arr all in (1.0, 2.0), Number != 1)")
+            .AddParameter("arr", new[] { 1, 2 })
+            .WaitForNonStaleResults()
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($arr in (1.0, 2.0), Number != 1)")
+            .AddParameter("arr", new[] { 1, 5 })
+            .Count();
+        Assert.Equal(1, result);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenInArrayParameterAsList(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "2", Number = 2 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        var result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in ($arr), Number != 1)")
+            .AddParameter("p", 1)
+            .AddParameter("arr", new[] { 1, 3 })
+            .WaitForNonStaleResults()
+            .Count();
+        Assert.Equal(1, result);
+
+        result = session.Advanced
+            .RawQuery<Dto>($"from {indexName} where when($p in ($arr), Number != 1)")
+            .AddParameter("p", 2)
+            .AddParameter("arr", new[] { 1, 3 })
+            .Count();
+        Assert.Equal(2, result);
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [CriticalCultures]
+    public void WhenInDoubleIsCultureInsensitive(CultureInfo cultureInfo)
+    {
+        using (CultureHelper.EnsureCulture(cultureInfo))
+        {
+            using var store = GetDocumentStore();
+            using var session = store.OpenSession();
+            session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+            session.Store(new Dto { Tag = "1", Number = 1 });
+            session.Store(new Dto { Tag = "2", Number = 2 });
+            session.SaveChanges();
+
+            var result = session.Advanced
+                .RawQuery<Dto>("from Dtos where when($p in (1.5, 2.5), Number != 1)")
+                .AddParameter("p", 1.5)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [CriticalCultures]
+    public void WhenInLongIsCultureInsensitive(CultureInfo cultureInfo)
+    {
+        using (CultureHelper.EnsureCulture(cultureInfo))
+        {
+            using var store = GetDocumentStore();
+            using var session = store.OpenSession();
+            session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+            session.Store(new Dto { Tag = "1", Number = 1 });
+            session.Store(new Dto { Tag = "2", Number = 2 });
+            session.SaveChanges();
+
+            var result = session.Advanced
+                .RawQuery<Dto>("from Dtos where when($p in (1_000, 2_000), Number != 1)")
+                .AddParameter("p", 1000)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+            
+            result = session.Advanced
+                .RawQuery<Dto>("from Dtos where when($p in (1_000, 2_000), Number != 1)")
+                .AddParameter("p", 1000D)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Querying)]
+    [CriticalCultures]
+    public void WhenInAllInIsCultureInsensitive(CultureInfo cultureInfo)
+    {
+        using (CultureHelper.EnsureCulture(cultureInfo))
+        {
+            using var store = GetDocumentStore();
+            using var session = store.OpenSession();
+            session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+            session.Store(new Dto { Tag = "1", Number = 1 });
+            session.Store(new Dto { Tag = "2", Number = 2 });
+            session.SaveChanges();
+
+            var result = session.Advanced
+                .RawQuery<Dto>("from Dtos where when($arr all in (1.5, 2.5), Number != 1)")
+                .AddParameter("arr", new[] { 1.5, 2.5 })
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(1, result);
         }
     }
 

--- a/test/SlowTests.Issues/Issues/RavenDB-26300.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-26300.cs
@@ -463,6 +463,109 @@ public class RavenDB_26300(ITestOutputHelper output) : RavenTestBase(output)
         }
     }
 
+    [RavenTheory(RavenTestCategory.Querying)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { true })]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.All, DatabaseMode = RavenDatabaseMode.All, Data = new object[] { false })]
+    public void WhenOperatorWithNotInInsideCondition(Options options, bool useAutoIndex)
+    {
+        using var store = GetDocumentStore(options);
+        using var session = store.OpenSession();
+        session.Advanced.MaxNumberOfRequestsPerSession = int.MaxValue;
+        session.Store(new Dto { Tag = "1", Number = 1 });
+        session.Store(new Dto { Tag = "1", Number = 2 });
+        session.Store(new Dto { Tag = "1", Number = 3 });
+        session.SaveChanges();
+
+        var indexName = useAutoIndex ? "Dtos" : "index 'Index'";
+
+        if (useAutoIndex == false)
+        {
+            new Index().Execute(store);
+            Indexes.WaitForIndexing(store);
+        }
+
+        int result;
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p in (1, 2), Number != 1)")
+                .AddParameter("p", 1)
+                .WaitForNonStaleResults()
+                .Count();
+            Assert.Equal(3, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p in (1, 2), Number != 1)")
+                .AddParameter("p", 99)
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($p0 == 1 and not $p1 in (1, 2), Number != 1)")
+                .AddParameter("p0", 1)
+                .AddParameter("p1", 99)
+                .Count();
+            Assert.Equal(2, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($p0 == 1 and not $p1 in (1, 2), Number != 1)")
+                .AddParameter("p0", 1)
+                .AddParameter("p1", 1)
+                .Count();
+            Assert.Equal(3, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when($p0 == 1 and not $p1 in (1, 2), Number != 1)")
+                .AddParameter("p0", 99)
+                .AddParameter("p1", 99)
+                .Count();
+            Assert.Equal(3, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p in ('aaa', 'bbb'), Number != 1)")
+                .AddParameter("p", "aaa")
+                .Count();
+            Assert.Equal(3, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p in ('aaa', 'bbb'), Number != 1)")
+                .AddParameter("p", "zzz")
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p all in (1, 2, 3), Number != 1)")
+                .AddParameter("p", new[] { 1, 2, 3 })
+                .Count();
+            Assert.Equal(3, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p all in (1, 2, 3), Number != 1)")
+                .AddParameter("p", new[] { 1, 99 })
+                .Count();
+            Assert.Equal(2, result);
+        }
+
+        {
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p in (1, 2), Number != 1)")
+                .AddParameter("p", (object)null)
+                .Count();
+            Assert.Equal(2, result);
+
+            result = session.Advanced
+                .RawQuery<Dto>($"from {indexName} where when(true and not $p in (1, 2), Number != 1)")
+                .Count();
+            Assert.Equal(2, result);
+        }
+    }
+
     private class Dto
     {
         public string Id { get; set; }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26300
### Additional description

Adds support for:
- In
- All In
- `true and not ()`

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
