### PR TITLE
RavenDB-26344 Restore from snapshot fails to preserve sparsity in Raven.voron

### DIFF
--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -297,6 +297,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 BackupMethods.Full.Restore(
                     zipEntries,
                     restoreDirectory,
+                    IsSparseRegionsSupported(),
                     journalDir: null,
                     onProgress: message =>
                     {
@@ -305,7 +306,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         onProgress.Invoke(restoreResult.Progress);
                     },
                     RestoreConfiguration.MaxReadOpsPerSecond,
-                    disableSparseRegions: GetDisableSparseRegions(restoreSettings),
                     cancellationToken: OperationCancelToken.Token);
             }
 
@@ -313,6 +313,18 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                 throw new InvalidDataException("Cannot restore the snapshot without the settings file!");
 
             return restoreSettings;
+
+            bool IsSparseRegionsSupported()
+            {
+                if (restoreSettings?.DatabaseRecord?.Settings?.TryGetValue(
+                        RavenConfiguration.GetKey(x => x.Storage.DisableSparseRegions), out var value) == true
+                    && bool.TryParse(value, out var disableSparseRegions))
+                {
+                    return disableSparseRegions == false;
+                }
+
+                return ServerStore.Configuration.Storage.DisableSparseRegions == false;
+            }
         }
 
         private async Task RestoreFromSmugglerFileAsync(Action<IOperationProgress> onProgress, DocumentDatabase database, string smugglerFile, JsonOperationContext context, int? maxReadOpsPerSecond)
@@ -400,18 +412,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     index?.Dispose();
                 }
             }
-        }
-
-        private bool GetDisableSparseRegions(RestoreSettings restoreSettings)
-        {
-            if (restoreSettings?.DatabaseRecord?.Settings?.TryGetValue(
-                    RavenConfiguration.GetKey(x => x.Storage.DisableSparseRegions), out var value) == true
-                && bool.TryParse(value, out var perDatabaseSetting))
-            {
-                return perDatabaseSetting;
-            }
-
-            return ServerStore.Configuration.Storage.DisableSparseRegions;
         }
 
         public override void Dispose()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -16,6 +16,7 @@ using Raven.Client.ServerWide.Operations;
 using Raven.Client.ServerWide.Operations.Configuration;
 using Raven.Client.ServerWide.Operations.OngoingTasks;
 using Raven.Client.Util;
+using Raven.Server.Config;
 using Raven.Server.Json;
 using Raven.Server.Routing;
 using Raven.Server.ServerWide;
@@ -304,6 +305,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                         onProgress.Invoke(restoreResult.Progress);
                     },
                     RestoreConfiguration.MaxReadOpsPerSecond,
+                    disableSparseRegions: GetDisableSparseRegions(restoreSettings),
                     cancellationToken: OperationCancelToken.Token);
             }
 
@@ -398,6 +400,20 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
                     index?.Dispose();
                 }
             }
+        }
+
+        private bool GetDisableSparseRegions(RestoreSettings restoreSettings)
+        {
+            // Check per-database setting from the snapshot's database record first,
+            // fall back to server-wide configuration
+            if (restoreSettings?.DatabaseRecord.Settings.TryGetValue(
+                    RavenConfiguration.GetKey(x => x.Storage.DisableSparseRegions), out var value) == true
+                && bool.TryParse(value, out var perDatabaseSetting))
+            {
+                return perDatabaseSetting;
+            }
+
+            return ServerStore.Configuration.Storage.DisableSparseRegions;
         }
 
         public override void Dispose()

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -406,7 +406,7 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
         {
             // Check per-database setting from the snapshot's database record first,
             // fall back to server-wide configuration
-            if (restoreSettings?.DatabaseRecord.Settings.TryGetValue(
+            if (restoreSettings?.DatabaseRecord?.Settings?.TryGetValue(
                     RavenConfiguration.GetKey(x => x.Storage.DisableSparseRegions), out var value) == true
                 && bool.TryParse(value, out var perDatabaseSetting))
             {

--- a/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
+++ b/src/Raven.Server/Documents/PeriodicBackup/Restore/RestoreSnapshotTask.cs
@@ -404,8 +404,6 @@ namespace Raven.Server.Documents.PeriodicBackup.Restore
 
         private bool GetDisableSparseRegions(RestoreSettings restoreSettings)
         {
-            // Check per-database setting from the snapshot's database record first,
-            // fall back to server-wide configuration
             if (restoreSettings?.DatabaseRecord?.Settings?.TryGetValue(
                     RavenConfiguration.GetKey(x => x.Storage.DisableSparseRegions), out var value) == true
                 && bool.TryParse(value, out var perDatabaseSetting))

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -352,7 +352,7 @@ namespace Voron.Impl.Backup
                     };
 
                     if (useSparse)
-                        decompressionStream.CopyToSparse(output, progressCallback, cancellationToken);
+                        decompressionStream.CopyToPreservingSparseRegions(output, progressCallback, cancellationToken);
                     else
                         decompressionStream.CopyTo(output, progressCallback, cancellationToken);
                 }

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -283,22 +283,22 @@ namespace Voron.Impl.Backup
 
         public void Restore(VoronPathSetting backupPath,
             VoronPathSetting voronDataDir,
+            bool sparseRegionsSupported = true,
             VoronPathSetting journalDir = null,
             Action<string> onProgress = null,
             int? maxReadOpsPerSecond = null,
-            bool disableSparseRegions = false,
             CancellationToken cancellationToken = default)
         {
             using (var zip = System.IO.Compression.ZipFile.Open(backupPath.FullPath, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
-                Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, disableSparseRegions, cancellationToken);
+                Restore(zip.Entries, voronDataDir, sparseRegionsSupported, journalDir, onProgress, maxReadOpsPerSecond, cancellationToken);
         }
 
         public void Restore(IEnumerable<ZipArchiveEntry> entries,
             VoronPathSetting voronDataDir,
+            bool sparseRegionsSupported = true,
             VoronPathSetting journalDir = null,
             Action<string> onProgress = null,
             int? maxReadOpsPerSecond = null,
-            bool disableSparseRegions = false,
             CancellationToken cancellationToken = default)
         {
             journalDir ??= voronDataDir.Combine("Journals");
@@ -332,7 +332,7 @@ namespace Voron.Impl.Backup
                     // we don't know the uncompressed size of the file for the zstd stream (the uncompressed size is stored at the end of the file).
                     var isZstd = decompressionStream is ZstdStream;
                     bool isVoronDataFile = string.Equals(entry.Name, Constants.DatabaseFilename, StringComparison.OrdinalIgnoreCase);
-                    bool useSparse = isVoronDataFile && disableSparseRegions == false && SparseFileHelper.TryMarkFileAsSparse(output);
+                    bool useSparse = isVoronDataFile && sparseRegionsSupported && SparseFileHelper.TryMarkFileAsSparse(output);
 
                     Action<int> progressCallback = readCount =>
                     {

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -331,10 +331,6 @@ namespace Voron.Impl.Backup
                 {
                     // we don't know the uncompressed size of the file for the zstd stream (the uncompressed size is stored at the end of the file).
                     var isZstd = decompressionStream is ZstdStream;
-
-                    // For .voron data files, use sparse-aware copy to avoid writing zero regions.
-                    // This preserves the original file's sparsity and prevents disk-full errors when
-                    // restoring databases that had significant free space (hole-punched regions).
                     bool isVoronDataFile = string.Equals(entry.Name, Constants.DatabaseFilename, StringComparison.OrdinalIgnoreCase);
                     bool useSparse = isVoronDataFile && disableSparseRegions == false && SparseFileHelper.TryMarkFileAsSparse(output);
 

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -286,10 +286,11 @@ namespace Voron.Impl.Backup
             VoronPathSetting journalDir = null,
             Action<string> onProgress = null,
             int? maxReadOpsPerSecond = null,
+            bool disableSparseRegions = false,
             CancellationToken cancellationToken = default)
         {
             using (var zip = System.IO.Compression.ZipFile.Open(backupPath.FullPath, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
-                Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, cancellationToken: cancellationToken);
+                Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, disableSparseRegions, cancellationToken);
         }
 
         public void Restore(IEnumerable<ZipArchiveEntry> entries,

--- a/src/Voron/Impl/Backup/FullBackup.cs
+++ b/src/Voron/Impl/Backup/FullBackup.cs
@@ -289,7 +289,7 @@ namespace Voron.Impl.Backup
             CancellationToken cancellationToken = default)
         {
             using (var zip = System.IO.Compression.ZipFile.Open(backupPath.FullPath, ZipArchiveMode.Read, System.Text.Encoding.UTF8))
-                Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, cancellationToken);
+                Restore(zip.Entries, voronDataDir, journalDir, onProgress, maxReadOpsPerSecond, cancellationToken: cancellationToken);
         }
 
         public void Restore(IEnumerable<ZipArchiveEntry> entries,
@@ -297,6 +297,7 @@ namespace Voron.Impl.Backup
             VoronPathSetting journalDir = null,
             Action<string> onProgress = null,
             int? maxReadOpsPerSecond = null,
+            bool disableSparseRegions = false,
             CancellationToken cancellationToken = default)
         {
             journalDir ??= voronDataDir.Combine("Journals");
@@ -329,7 +330,14 @@ namespace Voron.Impl.Backup
                 {
                     // we don't know the uncompressed size of the file for the zstd stream (the uncompressed size is stored at the end of the file).
                     var isZstd = decompressionStream is ZstdStream;
-                    decompressionStream.CopyTo(output, readCount =>
+
+                    // For .voron data files, use sparse-aware copy to avoid writing zero regions.
+                    // This preserves the original file's sparsity and prevents disk-full errors when
+                    // restoring databases that had significant free space (hole-punched regions).
+                    bool isVoronDataFile = string.Equals(entry.Name, Constants.DatabaseFilename, StringComparison.OrdinalIgnoreCase);
+                    bool useSparse = isVoronDataFile && disableSparseRegions == false && SparseFileHelper.TryMarkFileAsSparse(output);
+
+                    Action<int> progressCallback = readCount =>
                     {
                         rateGate?.WaitToProceed();
 
@@ -340,7 +348,12 @@ namespace Voron.Impl.Backup
                             onProgress?.Invoke(
                                 $"Restoring file: '{entry.Name}', {new Size(totalRead, SizeUnit.Bytes)}{(isZstd ? string.Empty : "/" + new Size(entry.Length, SizeUnit.Bytes))}");
                         }
-                    }, cancellationToken);
+                    };
+
+                    if (useSparse)
+                        decompressionStream.CopyToSparse(output, progressCallback, cancellationToken);
+                    else
+                        decompressionStream.CopyTo(output, progressCallback, cancellationToken);
                 }
 
                 onProgress?.Invoke($"Restored file: '{entry.Name}' to: '{dst}', " +

--- a/src/Voron/Impl/Backup/SparseFileHelper.cs
+++ b/src/Voron/Impl/Backup/SparseFileHelper.cs
@@ -10,15 +10,16 @@ namespace Voron.Impl.Backup
         private const uint FSCTL_SET_SPARSE = 0x000900c4;
 
         /// <summary>
-        /// Marks a file as sparse so that unwritten regions become holes on disk.
+        /// Prepares a file for sparse-aware restore logic.
         /// On Windows, this calls FSCTL_SET_SPARSE. On POSIX (Linux/macOS), unwritten
-        /// regions are automatically sparse on modern filesystems — no setup needed.
+        /// regions are left unwritten and the filesystem may account for them as holes,
+        /// so there is no additional setup required here.
         /// Returns false if sparse files are not supported on this filesystem.
         /// </summary>
         public static bool TryMarkFileAsSparse(FileStream file)
         {
             if (PlatformDetails.RunningOnPosix)
-                return true; // unwritten regions are automatic holes on ext4/xfs/btrfs/APFS
+                return true;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
                 return false;

--- a/src/Voron/Impl/Backup/SparseFileHelper.cs
+++ b/src/Voron/Impl/Backup/SparseFileHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Sparrow.Platform;
+
+namespace Voron.Impl.Backup
+{
+    internal static class SparseFileHelper
+    {
+        private const uint FSCTL_SET_SPARSE = 0x000900c4;
+
+        /// <summary>
+        /// Marks a file as sparse so that unwritten regions become holes on disk.
+        /// On Windows, this calls FSCTL_SET_SPARSE. On POSIX (Linux/macOS), unwritten
+        /// regions are automatically sparse on modern filesystems — no setup needed.
+        /// Returns false if sparse files are not supported on this filesystem.
+        /// </summary>
+        public static bool TryMarkFileAsSparse(FileStream file)
+        {
+            if (PlatformDetails.RunningOnPosix)
+                return true; // unwritten regions are automatic holes on ext4/xfs/btrfs/APFS
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) == false)
+                return false;
+
+            return MarkSparseWindows(file);
+        }
+
+        private static bool MarkSparseWindows(FileStream file)
+        {
+            try
+            {
+                bool result = DeviceIoControl(
+                    file.SafeFileHandle.DangerousGetHandle(),
+                    FSCTL_SET_SPARSE,
+                    IntPtr.Zero,
+                    0,
+                    IntPtr.Zero,
+                    0,
+                    out _,
+                    IntPtr.Zero);
+
+                return result;
+            }
+            catch
+            {
+                // If DeviceIoControl fails (e.g., unsupported filesystem like FAT32),
+                // fall back to normal (non-sparse) file writing
+                return false;
+            }
+        }
+
+        [DllImport("Kernel32.dll", SetLastError = true)]
+        private static extern bool DeviceIoControl(
+            IntPtr hDevice,
+            uint IoControlCode,
+            IntPtr InBuffer,
+            uint InBufferSize,
+            IntPtr OutBuffer,
+            int OutBufferSize,
+            out int BytesReturned,
+            IntPtr Overlapped);
+    }
+}

--- a/src/Voron/Impl/Backup/SparseFileHelper.cs
+++ b/src/Voron/Impl/Backup/SparseFileHelper.cs
@@ -10,11 +10,8 @@ namespace Voron.Impl.Backup
         private const uint FSCTL_SET_SPARSE = 0x000900c4;
 
         /// <summary>
-        /// Prepares a file for sparse-aware restore logic.
-        /// On Windows, this calls FSCTL_SET_SPARSE. On POSIX (Linux/macOS), unwritten
-        /// regions are left unwritten and the filesystem may account for them as holes,
-        /// so there is no additional setup required here.
-        /// Returns false if sparse files are not supported on this filesystem.
+        /// Marks a file as sparse. On Windows calls FSCTL_SET_SPARSE; on POSIX unwritten regions are
+        /// automatically holes so no setup is needed. Returns false if sparse is not supported.
         /// </summary>
         public static bool TryMarkFileAsSparse(FileStream file)
         {
@@ -45,8 +42,6 @@ namespace Voron.Impl.Backup
             }
             catch
             {
-                // If DeviceIoControl fails (e.g., unsupported filesystem like FAT32),
-                // fall back to normal (non-sparse) file writing
                 return false;
             }
         }

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,11 +48,17 @@ namespace Voron.Impl.Backup
 
             try
             {
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                Debug.Assert(bufferSize / pageSize < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration,
+                    $"Below code assumes buffer holds fewer pages ({bufferSize / pageSize}) than the sparse threshold ({FreeSpaceHandling.NumberOfFreePagesForSparseConsideration})");
+
                 Array.Clear(zeroBuffer, 0, DefaultBufferSize);
 
                 long logicalPosition = 0;
                 long destinationPosition = 0;
                 int contiguousZeroPages = 0;
+                int subPageTail = 0;
+                int subPageTailOffset = 0;
 
                 int count;
                 while ((count = source.ReadAtLeast(readBuffer.AsSpan(0, bufferSize), bufferSize, throwOnEndOfStream: false)) > 0)
@@ -59,11 +66,22 @@ namespace Voron.Impl.Backup
                     cancellationToken.ThrowIfCancellationRequested();
                     onProgress?.Invoke(count);
 
+                    if (count < bufferSize)
+                    {
+                        // Final read — strip any sub-page tail so all code below works with page-aligned data only.
+                        // The tail will be written after the loop.
+                        subPageTail = count % pageSize;
+                        subPageTailOffset = count - subPageTail;
+                        count -= subPageTail;
+
+                        if (count == 0)
+                            break;
+                    }
+
                     var span = new ReadOnlySpan<byte>(readBuffer, 0, count);
 
                     // Fast path: first and last bytes non-zero means no sparse region can start/end in this buffer
-                    // (max internal zero run is 9 pages, far below the 512-page threshold).
-                    if (count == bufferSize && span[0] != 0 && span[count - 1] != 0)
+                    if (span[0] != 0 && span[count - 1] != 0)
                     {
                         if (contiguousZeroPages > 0)
                             HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
@@ -74,22 +92,12 @@ namespace Voron.Impl.Backup
                     }
 
                     int firstNonZero = span.IndexOfAnyExcept((byte)0);
+                    bool isEntireBufferZero = firstNonZero == -1;
 
-                    if (firstNonZero == -1)
+                    if (isEntireBufferZero)
                     {
-                        int wholeZeroPages = count / pageSize;
-                        contiguousZeroPages += wholeZeroPages;
-                        logicalPosition += (long)wholeZeroPages * pageSize;
-
-                        int zeroTail = count - (wholeZeroPages * pageSize);
-                        if (zeroTail > 0)
-                        {
-                            if (contiguousZeroPages > 0)
-                                HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
-
-                            FlushPendingWrite(destination, readBuffer, wholeZeroPages * pageSize, zeroTail, logicalPosition, ref destinationPosition);
-                            logicalPosition += zeroTail;
-                        }
+                        contiguousZeroPages += count / pageSize;
+                        logicalPosition += count;
                         continue;
                     }
 
@@ -103,31 +111,25 @@ namespace Voron.Impl.Backup
                         HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                     int contentStart = leadingZeroPages * pageSize;
-                    int contentEnd = Math.Min(((lastNonZero / pageSize) + 1) * pageSize, count);
+                    int contentEnd = ((lastNonZero / pageSize) + 1) * pageSize;
                     int contentLength = contentEnd - contentStart;
 
                     FlushPendingWrite(destination, readBuffer, contentStart, contentLength, logicalPosition, ref destinationPosition);
                     logicalPosition += contentLength;
 
-                    int trailingBytes = count - contentEnd;
-                    int trailingZeroPages = trailingBytes / pageSize;
+                    int trailingZeroPages = (count - contentEnd) / pageSize;
                     contiguousZeroPages = trailingZeroPages;
                     logicalPosition += (long)trailingZeroPages * pageSize;
-
-                    int trailingZeroTail = trailingBytes - (trailingZeroPages * pageSize);
-                    if (trailingZeroTail > 0)
-                    {
-                        if (contiguousZeroPages > 0)
-                            HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
-
-                        int tailStart = contentEnd + (trailingZeroPages * pageSize);
-                        FlushPendingWrite(destination, readBuffer, tailStart, trailingZeroTail, logicalPosition, ref destinationPosition);
-                        logicalPosition += trailingZeroTail;
-                    }
                 }
 
                 if (contiguousZeroPages > 0)
                     HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
+
+                if (subPageTail > 0)
+                {
+                    FlushPendingWrite(destination, readBuffer, subPageTailOffset, subPageTail, logicalPosition, ref destinationPosition);
+                    logicalPosition += subPageTail;
+                }
 
                 if (logicalPosition > 0)
                     destination.SetLength(logicalPosition);

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -33,22 +33,15 @@ namespace Voron.Impl.Backup
         }
 
         /// <summary>
-        /// Copies from source to destination while detecting contiguous zero-page regions
-        /// and skipping them, creating a sparse file. The destination file must already be
-        /// marked as sparse on Windows (via SparseFileHelper.TryMarkFileAsSparse).
+        /// Copies from source to destination while detecting contiguous zero-page regions and skipping them to create a sparse file.
+        /// The destination file must already be marked as sparse on Windows (via <see cref="SparseFileHelper.TryMarkFileAsSparse"/>).
+        /// Zero runs shorter than <see cref="FreeSpaceHandling.NumberOfFreePagesForSparseConsideration"/> pages are written normally.
         /// </summary>
-        /// <remarks>
-        /// Zero regions shorter than FreeSpaceHandling.NumberOfFreePagesForSparseConsideration pages (1 MB) are written
-        /// normally to avoid creating fragmented sparse holes with negligible benefit.
-        /// This threshold matches the one used by Voron's flush pipeline in FreeSpaceHandling.GetSparseRegions.
-        /// </remarks>
-        public static void CopyToPreservingSparseRegions(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
+        public static void CopyToPreservingSparseRegions(this Stream source, FileStream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
             int pageSize = Constants.Storage.PageSize;
             int minZeroPagesForHole = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
 
-            // Use a buffer that is a multiple of page size for aligned zero-detection.
-            // DefaultBufferSize (81920) = 10 pages of 8192 bytes each.
             int bufferSize = DefaultBufferSize;
             var readBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
             var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
@@ -58,10 +51,10 @@ namespace Voron.Impl.Backup
             {
                 Array.Clear(zeroBuffer, 0, DefaultBufferSize);
 
-                long logicalPosition = 0;     // tracks the logical position in the output stream
-                long destinationPosition = 0; // tracks where destination stream is actually positioned
-                int contiguousZeroPages = 0;  // accumulated count of consecutive zero pages across buffer boundaries
-                int partialPageBytes = 0;     // accumulated bytes of a page that spans multiple reads
+                long logicalPosition = 0;
+                long destinationPosition = 0;
+                int contiguousZeroPages = 0;
+                int partialPageBytes = 0;
 
                 int count;
                 while ((count = source.Read(readBuffer, 0, bufferSize)) != 0)
@@ -93,8 +86,7 @@ namespace Voron.Impl.Backup
 
                     if (fullPages > 0)
                     {
-                        // Process full pages - detect zero pages and batch writes
-                        int pendingWriteStart = -1; // start offset within buffer of pending non-zero data
+                        int pendingWriteStart = -1;
 
                         for (int i = 0; i < fullPages; i++)
                         {
@@ -103,7 +95,6 @@ namespace Voron.Impl.Backup
 
                             if (isZeroPage)
                             {
-                                // Flush any pending non-zero data before accumulating zeros
                                 if (pendingWriteStart >= 0)
                                 {
                                     int writeLength = pageOffset - pendingWriteStart;
@@ -116,16 +107,13 @@ namespace Voron.Impl.Backup
                             }
                             else
                             {
-                                // Non-zero page encountered - check if we need to flush accumulated zeros
                                 if (contiguousZeroPages > 0)
                                 {
                                     if (contiguousZeroPages < minZeroPagesForHole)
                                     {
-                                        // Small zero run - write it (not worth creating a sparse hole)
                                         long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
                                         WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
                                     }
-                                    // else: large zero run - skip it (creates a sparse hole)
 
                                     contiguousZeroPages = 0;
                                 }
@@ -137,7 +125,6 @@ namespace Voron.Impl.Backup
                             logicalPosition += pageSize;
                         }
 
-                        // Flush any pending non-zero writes from this buffer
                         if (pendingWriteStart >= 0)
                         {
                             int writeEnd = offset + (fullPages * pageSize);
@@ -173,14 +160,12 @@ namespace Voron.Impl.Backup
                     logicalPosition += partialPageBytes;
                 }
 
-                // After all data is read, flush any trailing zeros below threshold
                 if (contiguousZeroPages > 0 && contiguousZeroPages < minZeroPagesForHole)
                 {
                     long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
                     WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
                 }
 
-                // Set the correct file length (the file may end with a sparse hole)
                 if (logicalPosition > 0)
                 {
                     destination.SetLength(logicalPosition);
@@ -236,8 +221,6 @@ namespace Voron.Impl.Backup
 
         private static void WriteZeros(Stream destination, byte[] zeroBuffer, long logicalOffset, long length, ref long destinationPosition)
         {
-            // For small zero runs that don't meet the sparse threshold, we need to actually write them.
-            // Seek to position and write zero bytes.
             if (destinationPosition != logicalOffset)
             {
                 destination.Seek(logicalOffset, SeekOrigin.Begin);

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -68,8 +68,9 @@ namespace Voron.Impl.Backup
 
                     if (count < bufferSize)
                     {
-                        // Final read — strip any sub-page tail so all code below works with page-aligned data only.
-                        // The tail will be written after the loop.
+                        // final read — strip any sub-page tail so all code below works with page-aligned data only,
+                        // the tail will be written after the loop
+
                         subPageTail = count % pageSize;
                         subPageTailOffset = count - subPageTail;
                         count -= subPageTail;
@@ -80,13 +81,17 @@ namespace Voron.Impl.Backup
 
                     var span = new ReadOnlySpan<byte>(readBuffer, 0, count);
 
-                    // Fast path: first and last bytes non-zero means no sparse region can start/end in this buffer
                     if (span[0] != 0 && span[count - 1] != 0)
                     {
-                        if (contiguousZeroPages > 0)
-                            HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
+                        // first and last bytes non-zero means no sparse region can start/end in this buffer
 
-                        FlushPendingWrite(destination, readBuffer, 0, count, logicalPosition, ref destinationPosition);
+                        if (contiguousZeroPages > 0)
+                        {
+                            HandleContiguousZeroPages(destination, zeroBuffer, contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
+                            contiguousZeroPages = 0;
+                        }
+
+                        WriteData(destination, readBuffer, 0, count, logicalPosition, ref destinationPosition);
                         logicalPosition += count;
                         continue;
                     }
@@ -107,14 +112,14 @@ namespace Voron.Impl.Backup
                     contiguousZeroPages += leadingZeroPages;
                     logicalPosition += (long)leadingZeroPages * pageSize;
 
-                    if (contiguousZeroPages > 0)
-                        HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
+                    if (contiguousZeroPages > 0) 
+                        HandleContiguousZeroPages(destination, zeroBuffer, contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                     int contentStart = leadingZeroPages * pageSize;
                     int contentEnd = ((lastNonZero / pageSize) + 1) * pageSize;
                     int contentLength = contentEnd - contentStart;
 
-                    FlushPendingWrite(destination, readBuffer, contentStart, contentLength, logicalPosition, ref destinationPosition);
+                    WriteData(destination, readBuffer, contentStart, contentLength, logicalPosition, ref destinationPosition);
                     logicalPosition += contentLength;
 
                     int trailingZeroPages = (count - contentEnd) / pageSize;
@@ -123,11 +128,11 @@ namespace Voron.Impl.Backup
                 }
 
                 if (contiguousZeroPages > 0)
-                    HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
+                    HandleContiguousZeroPages(destination, zeroBuffer, contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                 if (subPageTail > 0)
                 {
-                    FlushPendingWrite(destination, readBuffer, subPageTailOffset, subPageTail, logicalPosition, ref destinationPosition);
+                    WriteData(destination, readBuffer, subPageTailOffset, subPageTail, logicalPosition, ref destinationPosition);
                     logicalPosition += subPageTail;
                 }
 
@@ -141,7 +146,7 @@ namespace Voron.Impl.Backup
             }
         }
 
-        private static void FlushPendingWrite(Stream destination, byte[] buffer, int offset, int length,
+        private static void WriteData(Stream destination, byte[] buffer, int offset, int length,
             long logicalOffset, ref long destinationPosition)
         {
             if (destinationPosition != logicalOffset)
@@ -154,34 +159,38 @@ namespace Voron.Impl.Backup
             destinationPosition += length;
         }
 
-        private static void HandleContiguousZeroPages(Stream destination, byte[] zeroBuffer, ref int contiguousZeroPages, long logicalPosition, int pageSize, ref long destinationPosition)
+        private static void HandleContiguousZeroPages(Stream destination, byte[] zeroBuffer, int zeroPageCount, long logicalPosition, int pageSize, ref long destinationPosition)
         {
-            if (contiguousZeroPages is > 0 and < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration)
+            long zeroRegionLength = (long)zeroPageCount * pageSize;
+            long zeroStart = logicalPosition - zeroRegionLength;
+
+            if (zeroPageCount < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration)
             {
-                long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                // write zeros
+
+                if (destinationPosition != zeroStart)
+                {
+                    destination.Seek(zeroStart, SeekOrigin.Begin);
+                    destinationPosition = zeroStart;
+                }
+
+                long remaining = zeroRegionLength;
+                while (remaining > 0)
+                {
+                    int toWrite = (int)Math.Min(remaining, DefaultBufferSize);
+                    destination.Write(zeroBuffer, 0, toWrite);
+                    remaining -= toWrite;
+                }
+
+                destinationPosition += zeroRegionLength;
             }
-
-            contiguousZeroPages = 0;
-        }
-
-        private static void WriteZeros(Stream destination, byte[] zeroBuffer, long logicalOffset, long length, ref long destinationPosition)
-        {
-            if (destinationPosition != logicalOffset)
+            else
             {
-                destination.Seek(logicalOffset, SeekOrigin.Begin);
-                destinationPosition = logicalOffset;
-            }
+                // don't write - the unwritten gap becomes a sparse region on disk
 
-            long remaining = length;
-            while (remaining > 0)
-            {
-                int toWrite = (int)Math.Min(remaining, DefaultBufferSize);
-                destination.Write(zeroBuffer, 0, toWrite);
-                remaining -= toWrite;
+                destination.Seek(logicalPosition, SeekOrigin.Begin);
+                destinationPosition = logicalPosition;
             }
-
-            destinationPosition += length;
         }
 
         public static async Task CopyToAsync(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -40,10 +40,8 @@ namespace Voron.Impl.Backup
         public static void CopyToPreservingSparseRegions(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
             int pageSize = Constants.Storage.PageSize;
-            int minZeroPagesForHole = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
 
-            int bufferSize = DefaultBufferSize;
-            var readBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            var readBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
             var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
             var pageBuffer = ArrayPool<byte>.Shared.Rent(pageSize);
 
@@ -57,7 +55,7 @@ namespace Voron.Impl.Backup
                 int partialPageBytes = 0;
 
                 int count;
-                while ((count = source.Read(readBuffer, 0, bufferSize)) != 0)
+                while ((count = source.Read(readBuffer, 0, DefaultBufferSize)) != 0)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     onProgress?.Invoke(count);
@@ -75,8 +73,7 @@ namespace Voron.Impl.Backup
 
                         if (partialPageBytes == pageSize)
                         {
-                            ProcessPage(destination, pageBuffer, 0, pageSize, ref contiguousZeroPages, minZeroPagesForHole,
-                                zeroBuffer, ref logicalPosition, ref destinationPosition);
+                            ProcessPage(destination, pageBuffer, 0, pageSize, ref contiguousZeroPages, zeroBuffer, ref logicalPosition, ref destinationPosition);
                             partialPageBytes = 0;
                         }
                     }
@@ -98,8 +95,9 @@ namespace Voron.Impl.Backup
                                 if (pendingWriteStart >= 0)
                                 {
                                     int writeLength = pageOffset - pendingWriteStart;
+                                    long writeLogicalStart = logicalPosition - writeLength;
                                     FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
-                                        logicalPosition - (pageOffset - pendingWriteStart), ref destinationPosition);
+                                        writeLogicalStart, ref destinationPosition);
                                     pendingWriteStart = -1;
                                 }
 
@@ -108,15 +106,7 @@ namespace Voron.Impl.Backup
                             else
                             {
                                 if (contiguousZeroPages > 0)
-                                {
-                                    if (contiguousZeroPages < minZeroPagesForHole)
-                                    {
-                                        long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                                        WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
-                                    }
-
-                                    contiguousZeroPages = 0;
-                                }
+                                    HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                                 if (pendingWriteStart < 0)
                                     pendingWriteStart = pageOffset;
@@ -146,25 +136,14 @@ namespace Voron.Impl.Backup
                 if (partialPageBytes > 0)
                 {
                     if (contiguousZeroPages > 0)
-                    {
-                        if (contiguousZeroPages < minZeroPagesForHole)
-                        {
-                            long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                            WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
-                        }
-
-                        contiguousZeroPages = 0;
-                    }
+                        HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                     FlushPendingWrite(destination, pageBuffer, 0, partialPageBytes, logicalPosition, ref destinationPosition);
                     logicalPosition += partialPageBytes;
                 }
 
-                if (contiguousZeroPages > 0 && contiguousZeroPages < minZeroPagesForHole)
-                {
-                    long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                    WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
-                }
+                if (contiguousZeroPages > 0)
+                    HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                 if (logicalPosition > 0)
                 {
@@ -179,8 +158,7 @@ namespace Voron.Impl.Backup
             }
         }
 
-        private static void ProcessPage(Stream destination, byte[] pageBuffer, int offset, int pageSize, ref int contiguousZeroPages,
-            int minZeroPagesForHole, byte[] zeroBuffer, ref long logicalPosition, ref long destinationPosition)
+        private static void ProcessPage(Stream destination, byte[] pageBuffer, int offset, int pageSize, ref int contiguousZeroPages, byte[] zeroBuffer, ref long logicalPosition, ref long destinationPosition)
         {
             bool isZeroPage = new ReadOnlySpan<byte>(pageBuffer, offset, pageSize).ContainsAnyExcept((byte)0) == false;
 
@@ -192,15 +170,7 @@ namespace Voron.Impl.Backup
             }
 
             if (contiguousZeroPages > 0)
-            {
-                if (contiguousZeroPages < minZeroPagesForHole)
-                {
-                    long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                    WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
-                }
-
-                contiguousZeroPages = 0;
-            }
+                HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
             FlushPendingWrite(destination, pageBuffer, offset, pageSize, logicalPosition, ref destinationPosition);
             logicalPosition += pageSize;
@@ -217,6 +187,17 @@ namespace Voron.Impl.Backup
 
             destination.Write(buffer, offset, length);
             destinationPosition += length;
+        }
+
+        private static void HandleContiguousZeroPages(Stream destination, byte[] zeroBuffer, ref int contiguousZeroPages, long logicalPosition, int pageSize, ref long destinationPosition)
+        {
+            if (contiguousZeroPages is > 0 and < FreeSpaceHandling.NumberOfFreePagesForSparseConsideration)
+            {
+                long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+            }
+
+            contiguousZeroPages = 0;
         }
 
         private static void WriteZeros(Stream destination, byte[] zeroBuffer, long logicalOffset, long length, ref long destinationPosition)

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -40,10 +40,10 @@ namespace Voron.Impl.Backup
         public static void CopyToPreservingSparseRegions(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
             int pageSize = Constants.Storage.PageSize;
+            int bufferSize = DefaultBufferSize;
 
-            var readBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            var readBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
             var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
-            var pageBuffer = ArrayPool<byte>.Shared.Rent(pageSize);
 
             try
             {
@@ -52,128 +52,91 @@ namespace Voron.Impl.Backup
                 long logicalPosition = 0;
                 long destinationPosition = 0;
                 int contiguousZeroPages = 0;
-                int partialPageBytes = 0;
 
                 int count;
-                while ((count = source.Read(readBuffer, 0, DefaultBufferSize)) != 0)
+                while ((count = source.ReadAtLeast(readBuffer.AsSpan(0, bufferSize), bufferSize, throwOnEndOfStream: false)) > 0)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     onProgress?.Invoke(count);
 
-                    int offset = 0;
+                    var span = new ReadOnlySpan<byte>(readBuffer, 0, count);
 
-                    if (partialPageBytes > 0)
+                    // Fast path: first and last bytes non-zero means no sparse region can start/end in this buffer
+                    // (max internal zero run is 9 pages, far below the 512-page threshold).
+                    if (count == bufferSize && span[0] != 0 && span[count - 1] != 0)
                     {
-                        int bytesNeeded = pageSize - partialPageBytes;
-                        int bytesToCopy = Math.Min(bytesNeeded, count);
-                        Buffer.BlockCopy(readBuffer, 0, pageBuffer, partialPageBytes, bytesToCopy);
+                        if (contiguousZeroPages > 0)
+                            HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
-                        partialPageBytes += bytesToCopy;
-                        offset += bytesToCopy;
-
-                        if (partialPageBytes == pageSize)
-                        {
-                            ProcessPage(destination, pageBuffer, 0, pageSize, ref contiguousZeroPages, zeroBuffer, ref logicalPosition, ref destinationPosition);
-                            partialPageBytes = 0;
-                        }
+                        FlushPendingWrite(destination, readBuffer, 0, count, logicalPosition, ref destinationPosition);
+                        logicalPosition += count;
+                        continue;
                     }
 
-                    int remaining = count - offset;
-                    int fullPages = remaining / pageSize;
+                    int firstNonZero = span.IndexOfAnyExcept((byte)0);
 
-                    if (fullPages > 0)
+                    if (firstNonZero == -1)
                     {
-                        int pendingWriteStart = -1;
+                        int wholeZeroPages = count / pageSize;
+                        contiguousZeroPages += wholeZeroPages;
+                        logicalPosition += (long)wholeZeroPages * pageSize;
 
-                        for (int i = 0; i < fullPages; i++)
+                        int zeroTail = count - (wholeZeroPages * pageSize);
+                        if (zeroTail > 0)
                         {
-                            int pageOffset = offset + (i * pageSize);
-                            bool isZeroPage = new ReadOnlySpan<byte>(readBuffer, pageOffset, pageSize).ContainsAnyExcept((byte)0) == false;
+                            if (contiguousZeroPages > 0)
+                                HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
-                            if (isZeroPage)
-                            {
-                                if (pendingWriteStart >= 0)
-                                {
-                                    int writeLength = pageOffset - pendingWriteStart;
-                                    long writeLogicalStart = logicalPosition - writeLength;
-                                    FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
-                                        writeLogicalStart, ref destinationPosition);
-                                    pendingWriteStart = -1;
-                                }
-
-                                contiguousZeroPages++;
-                            }
-                            else
-                            {
-                                if (contiguousZeroPages > 0)
-                                    HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
-
-                                if (pendingWriteStart < 0)
-                                    pendingWriteStart = pageOffset;
-                            }
-
-                            logicalPosition += pageSize;
+                            FlushPendingWrite(destination, readBuffer, wholeZeroPages * pageSize, zeroTail, logicalPosition, ref destinationPosition);
+                            logicalPosition += zeroTail;
                         }
-
-                        if (pendingWriteStart >= 0)
-                        {
-                            int writeEnd = offset + (fullPages * pageSize);
-                            int writeLength = writeEnd - pendingWriteStart;
-                            FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
-                                logicalPosition - writeLength, ref destinationPosition);
-                        }
+                        continue;
                     }
 
-                    int remainderOffset = offset + (fullPages * pageSize);
-                    int remainder = count - remainderOffset;
-                    if (remainder > 0)
-                    {
-                        Buffer.BlockCopy(readBuffer, remainderOffset, pageBuffer, partialPageBytes, remainder);
-                        partialPageBytes += remainder;
-                    }
-                }
+                    int lastNonZero = span.LastIndexOfAnyExcept((byte)0);
 
-                if (partialPageBytes > 0)
-                {
+                    int leadingZeroPages = firstNonZero / pageSize;
+                    contiguousZeroPages += leadingZeroPages;
+                    logicalPosition += (long)leadingZeroPages * pageSize;
+
                     if (contiguousZeroPages > 0)
                         HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
-                    FlushPendingWrite(destination, pageBuffer, 0, partialPageBytes, logicalPosition, ref destinationPosition);
-                    logicalPosition += partialPageBytes;
+                    int contentStart = leadingZeroPages * pageSize;
+                    int contentEnd = Math.Min(((lastNonZero / pageSize) + 1) * pageSize, count);
+                    int contentLength = contentEnd - contentStart;
+
+                    FlushPendingWrite(destination, readBuffer, contentStart, contentLength, logicalPosition, ref destinationPosition);
+                    logicalPosition += contentLength;
+
+                    int trailingBytes = count - contentEnd;
+                    int trailingZeroPages = trailingBytes / pageSize;
+                    contiguousZeroPages = trailingZeroPages;
+                    logicalPosition += (long)trailingZeroPages * pageSize;
+
+                    int trailingZeroTail = trailingBytes - (trailingZeroPages * pageSize);
+                    if (trailingZeroTail > 0)
+                    {
+                        if (contiguousZeroPages > 0)
+                            HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
+
+                        int tailStart = contentEnd + (trailingZeroPages * pageSize);
+                        FlushPendingWrite(destination, readBuffer, tailStart, trailingZeroTail, logicalPosition, ref destinationPosition);
+                        logicalPosition += trailingZeroTail;
+                    }
                 }
 
                 if (contiguousZeroPages > 0)
                     HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
 
                 if (logicalPosition > 0)
-                {
                     destination.SetLength(logicalPosition);
-                }
             }
             finally
             {
                 ArrayPool<byte>.Shared.Return(readBuffer);
                 ArrayPool<byte>.Shared.Return(zeroBuffer);
-                ArrayPool<byte>.Shared.Return(pageBuffer);
             }
-        }
-
-        private static void ProcessPage(Stream destination, byte[] pageBuffer, int offset, int pageSize, ref int contiguousZeroPages, byte[] zeroBuffer, ref long logicalPosition, ref long destinationPosition)
-        {
-            bool isZeroPage = new ReadOnlySpan<byte>(pageBuffer, offset, pageSize).ContainsAnyExcept((byte)0) == false;
-
-            if (isZeroPage)
-            {
-                contiguousZeroPages++;
-                logicalPosition += pageSize;
-                return;
-            }
-
-            if (contiguousZeroPages > 0)
-                HandleContiguousZeroPages(destination, zeroBuffer, ref contiguousZeroPages, logicalPosition, pageSize, ref destinationPosition);
-
-            FlushPendingWrite(destination, pageBuffer, offset, pageSize, logicalPosition, ref destinationPosition);
-            logicalPosition += pageSize;
         }
 
         private static void FlushPendingWrite(Stream destination, byte[] buffer, int offset, int length,

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -1,14 +1,21 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Voron.Global;
 
 namespace Voron.Impl.Backup
 {
     public static class StreamExtensions
     {
         private const int DefaultBufferSize = 81920;
+
+        /// <summary>
+        /// Minimum number of contiguous zero pages required to create a sparse hole.
+        /// Matches the threshold in FreeSpaceHandling.GetSparseRegions (128 pages = 1 MB).
+        /// </summary>
+        internal const int MinContiguousZeroPagesForSparse = 128;
 
         public static void CopyTo(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
@@ -27,6 +34,180 @@ namespace Voron.Impl.Backup
             finally
             {
                 ArrayPool<byte>.Shared.Return(readBuffer);
+            }
+        }
+
+        /// <summary>
+        /// Copies from source to destination while detecting contiguous zero-page regions
+        /// and skipping them, creating a sparse file. The destination file must already be
+        /// marked as sparse on Windows (via SparseFileHelper.TryMarkFileAsSparse).
+        /// </summary>
+        /// <remarks>
+        /// Zero regions shorter than MinContiguousZeroPagesForSparse pages (1 MB) are written
+        /// normally to avoid creating fragmented sparse holes with negligible benefit.
+        /// This threshold matches the one used by Voron's flush pipeline in FreeSpaceHandling.GetSparseRegions.
+        /// </remarks>
+        public static void CopyToSparse(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
+        {
+            int pageSize = Constants.Storage.PageSize;
+            int minZeroPagesForHole = MinContiguousZeroPagesForSparse;
+
+            // Use a buffer that is a multiple of page size for aligned zero-detection.
+            // DefaultBufferSize (81920) = 10 pages of 8192 bytes each.
+            int bufferSize = DefaultBufferSize;
+            var readBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+
+            try
+            {
+                long logicalPosition = 0;     // tracks the logical position in the output stream
+                long destinationPosition = 0; // tracks where destination stream is actually positioned
+                int contiguousZeroPages = 0;  // accumulated count of consecutive zero pages across buffer boundaries
+
+                int count;
+                while ((count = source.Read(readBuffer, 0, bufferSize)) != 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    onProgress?.Invoke(count);
+
+                    int fullPages = count / pageSize;
+                    int remainder = count - (fullPages * pageSize);
+
+                    // Process full pages - detect zero pages and batch writes
+                    int pendingWriteStart = -1; // start offset within buffer of pending non-zero data
+
+                    for (int i = 0; i < fullPages; i++)
+                    {
+                        int pageOffset = i * pageSize;
+                        bool isZeroPage = new ReadOnlySpan<byte>(readBuffer, pageOffset, pageSize).ContainsAnyExcept((byte)0) == false;
+
+                        if (isZeroPage)
+                        {
+                            // Flush any pending non-zero data before accumulating zeros
+                            if (pendingWriteStart >= 0)
+                            {
+                                int writeLength = pageOffset - pendingWriteStart;
+                                FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
+                                    logicalPosition - (pageOffset - pendingWriteStart), ref destinationPosition);
+                                pendingWriteStart = -1;
+                            }
+
+                            contiguousZeroPages++;
+                        }
+                        else
+                        {
+                            // Non-zero page encountered - check if we need to flush accumulated zeros
+                            if (contiguousZeroPages > 0)
+                            {
+                                if (contiguousZeroPages < minZeroPagesForHole)
+                                {
+                                    // Small zero run - write it (not worth creating a sparse hole)
+                                    long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                                    WriteZeros(destination, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                                }
+                                // else: large zero run - skip it (creates a sparse hole)
+
+                                contiguousZeroPages = 0;
+                            }
+
+                            if (pendingWriteStart < 0)
+                                pendingWriteStart = pageOffset;
+                        }
+
+                        logicalPosition += pageSize;
+                    }
+
+                    // Flush any pending non-zero writes from this buffer
+                    if (pendingWriteStart >= 0)
+                    {
+                        int writeEnd = fullPages * pageSize;
+                        int writeLength = writeEnd - pendingWriteStart;
+                        FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
+                            logicalPosition - writeLength, ref destinationPosition);
+                        pendingWriteStart = -1;
+                    }
+
+                    // Handle remainder (partial page at end of buffer or end of stream)
+                    // Write partial pages normally without zero-detection
+                    if (remainder > 0)
+                    {
+                        // First, flush any accumulated zeros before the remainder
+                        if (contiguousZeroPages > 0)
+                        {
+                            if (contiguousZeroPages < minZeroPagesForHole)
+                            {
+                                long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                                WriteZeros(destination, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                            }
+                            contiguousZeroPages = 0;
+                        }
+
+                        int remainderOffset = fullPages * pageSize;
+                        FlushPendingWrite(destination, readBuffer, remainderOffset, remainder,
+                            logicalPosition, ref destinationPosition);
+                        logicalPosition += remainder;
+                    }
+                }
+
+                // After all data is read, flush any trailing zeros below threshold
+                if (contiguousZeroPages > 0 && contiguousZeroPages < minZeroPagesForHole)
+                {
+                    long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                    WriteZeros(destination, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                }
+
+                // Set the correct file length (the file may end with a sparse hole)
+                if (logicalPosition > 0)
+                {
+                    destination.SetLength(logicalPosition);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(readBuffer);
+            }
+        }
+
+        private static void FlushPendingWrite(Stream destination, byte[] buffer, int offset, int length,
+            long logicalOffset, ref long destinationPosition)
+        {
+            if (destinationPosition != logicalOffset)
+            {
+                destination.Seek(logicalOffset, SeekOrigin.Begin);
+                destinationPosition = logicalOffset;
+            }
+
+            destination.Write(buffer, offset, length);
+            destinationPosition += length;
+        }
+
+        private static void WriteZeros(Stream destination, long logicalOffset, long length, ref long destinationPosition)
+        {
+            // For small zero runs that don't meet the sparse threshold, we need to actually write them.
+            // Seek to position and write zero bytes.
+            if (destinationPosition != logicalOffset)
+            {
+                destination.Seek(logicalOffset, SeekOrigin.Begin);
+                destinationPosition = logicalOffset;
+            }
+
+            // Write zeros in chunks using a stack-allocated or pooled buffer
+            var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            try
+            {
+                Array.Clear(zeroBuffer, 0, DefaultBufferSize);
+                long remaining = length;
+                while (remaining > 0)
+                {
+                    int toWrite = (int)Math.Min(remaining, DefaultBufferSize);
+                    destination.Write(zeroBuffer, 0, toWrite);
+                    remaining -= toWrite;
+                }
+
+                destinationPosition += length;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(zeroBuffer);
             }
         }
 

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -52,6 +52,7 @@ namespace Voron.Impl.Backup
             int bufferSize = DefaultBufferSize;
             var readBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
             var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+            var pageBuffer = ArrayPool<byte>.Shared.Rent(pageSize);
 
             try
             {
@@ -60,6 +61,7 @@ namespace Voron.Impl.Backup
                 long logicalPosition = 0;     // tracks the logical position in the output stream
                 long destinationPosition = 0; // tracks where destination stream is actually positioned
                 int contiguousZeroPages = 0;  // accumulated count of consecutive zero pages across buffer boundaries
+                int partialPageBytes = 0;     // accumulated bytes of a page that spans multiple reads
 
                 int count;
                 while ((count = source.Read(readBuffer, 0, bufferSize)) != 0)
@@ -67,83 +69,108 @@ namespace Voron.Impl.Backup
                     cancellationToken.ThrowIfCancellationRequested();
                     onProgress?.Invoke(count);
 
-                    int fullPages = count / pageSize;
-                    int remainder = count - (fullPages * pageSize);
+                    int offset = 0;
 
-                    // Process full pages - detect zero pages and batch writes
-                    int pendingWriteStart = -1; // start offset within buffer of pending non-zero data
-
-                    for (int i = 0; i < fullPages; i++)
+                    if (partialPageBytes > 0)
                     {
-                        int pageOffset = i * pageSize;
-                        bool isZeroPage = new ReadOnlySpan<byte>(readBuffer, pageOffset, pageSize).ContainsAnyExcept((byte)0) == false;
+                        int bytesNeeded = pageSize - partialPageBytes;
+                        int bytesToCopy = Math.Min(bytesNeeded, count);
+                        Buffer.BlockCopy(readBuffer, 0, pageBuffer, partialPageBytes, bytesToCopy);
 
-                        if (isZeroPage)
+                        partialPageBytes += bytesToCopy;
+                        offset += bytesToCopy;
+
+                        if (partialPageBytes == pageSize)
                         {
-                            // Flush any pending non-zero data before accumulating zeros
-                            if (pendingWriteStart >= 0)
-                            {
-                                int writeLength = pageOffset - pendingWriteStart;
-                                FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
-                                    logicalPosition - (pageOffset - pendingWriteStart), ref destinationPosition);
-                                pendingWriteStart = -1;
-                            }
-
-                            contiguousZeroPages++;
+                            ProcessPage(destination, pageBuffer, 0, pageSize, ref contiguousZeroPages, minZeroPagesForHole,
+                                zeroBuffer, ref logicalPosition, ref destinationPosition);
+                            partialPageBytes = 0;
                         }
-                        else
+                    }
+
+                    int remaining = count - offset;
+                    int fullPages = remaining / pageSize;
+
+                    if (fullPages > 0)
+                    {
+                        // Process full pages - detect zero pages and batch writes
+                        int pendingWriteStart = -1; // start offset within buffer of pending non-zero data
+
+                        for (int i = 0; i < fullPages; i++)
                         {
-                            // Non-zero page encountered - check if we need to flush accumulated zeros
-                            if (contiguousZeroPages > 0)
+                            int pageOffset = offset + (i * pageSize);
+                            bool isZeroPage = new ReadOnlySpan<byte>(readBuffer, pageOffset, pageSize).ContainsAnyExcept((byte)0) == false;
+
+                            if (isZeroPage)
                             {
-                                if (contiguousZeroPages < minZeroPagesForHole)
+                                // Flush any pending non-zero data before accumulating zeros
+                                if (pendingWriteStart >= 0)
                                 {
-                                    // Small zero run - write it (not worth creating a sparse hole)
-                                    long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                                    WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                                    int writeLength = pageOffset - pendingWriteStart;
+                                    FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
+                                        logicalPosition - (pageOffset - pendingWriteStart), ref destinationPosition);
+                                    pendingWriteStart = -1;
                                 }
-                                // else: large zero run - skip it (creates a sparse hole)
 
-                                contiguousZeroPages = 0;
+                                contiguousZeroPages++;
+                            }
+                            else
+                            {
+                                // Non-zero page encountered - check if we need to flush accumulated zeros
+                                if (contiguousZeroPages > 0)
+                                {
+                                    if (contiguousZeroPages < minZeroPagesForHole)
+                                    {
+                                        // Small zero run - write it (not worth creating a sparse hole)
+                                        long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                                        WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                                    }
+                                    // else: large zero run - skip it (creates a sparse hole)
+
+                                    contiguousZeroPages = 0;
+                                }
+
+                                if (pendingWriteStart < 0)
+                                    pendingWriteStart = pageOffset;
                             }
 
-                            if (pendingWriteStart < 0)
-                                pendingWriteStart = pageOffset;
+                            logicalPosition += pageSize;
                         }
 
-                        logicalPosition += pageSize;
+                        // Flush any pending non-zero writes from this buffer
+                        if (pendingWriteStart >= 0)
+                        {
+                            int writeEnd = offset + (fullPages * pageSize);
+                            int writeLength = writeEnd - pendingWriteStart;
+                            FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
+                                logicalPosition - writeLength, ref destinationPosition);
+                        }
                     }
 
-                    // Flush any pending non-zero writes from this buffer
-                    if (pendingWriteStart >= 0)
-                    {
-                        int writeEnd = fullPages * pageSize;
-                        int writeLength = writeEnd - pendingWriteStart;
-                        FlushPendingWrite(destination, readBuffer, pendingWriteStart, writeLength,
-                            logicalPosition - writeLength, ref destinationPosition);
-                        pendingWriteStart = -1;
-                    }
-
-                    // Handle remainder (partial page at end of buffer or end of stream)
-                    // Write partial pages normally without zero-detection
+                    int remainderOffset = offset + (fullPages * pageSize);
+                    int remainder = count - remainderOffset;
                     if (remainder > 0)
                     {
-                        // First, flush any accumulated zeros before the remainder
-                        if (contiguousZeroPages > 0)
+                        Buffer.BlockCopy(readBuffer, remainderOffset, pageBuffer, partialPageBytes, remainder);
+                        partialPageBytes += remainder;
+                    }
+                }
+
+                if (partialPageBytes > 0)
+                {
+                    if (contiguousZeroPages > 0)
+                    {
+                        if (contiguousZeroPages < minZeroPagesForHole)
                         {
-                            if (contiguousZeroPages < minZeroPagesForHole)
-                            {
-                                long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                                WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
-                            }
-                            contiguousZeroPages = 0;
+                            long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                            WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
                         }
 
-                        int remainderOffset = fullPages * pageSize;
-                        FlushPendingWrite(destination, readBuffer, remainderOffset, remainder,
-                            logicalPosition, ref destinationPosition);
-                        logicalPosition += remainder;
+                        contiguousZeroPages = 0;
                     }
+
+                    FlushPendingWrite(destination, pageBuffer, 0, partialPageBytes, logicalPosition, ref destinationPosition);
+                    logicalPosition += partialPageBytes;
                 }
 
                 // After all data is read, flush any trailing zeros below threshold
@@ -163,7 +190,35 @@ namespace Voron.Impl.Backup
             {
                 ArrayPool<byte>.Shared.Return(readBuffer);
                 ArrayPool<byte>.Shared.Return(zeroBuffer);
+                ArrayPool<byte>.Shared.Return(pageBuffer);
             }
+        }
+
+        private static void ProcessPage(Stream destination, byte[] pageBuffer, int offset, int pageSize, ref int contiguousZeroPages,
+            int minZeroPagesForHole, byte[] zeroBuffer, ref long logicalPosition, ref long destinationPosition)
+        {
+            bool isZeroPage = new ReadOnlySpan<byte>(pageBuffer, offset, pageSize).ContainsAnyExcept((byte)0) == false;
+
+            if (isZeroPage)
+            {
+                contiguousZeroPages++;
+                logicalPosition += pageSize;
+                return;
+            }
+
+            if (contiguousZeroPages > 0)
+            {
+                if (contiguousZeroPages < minZeroPagesForHole)
+                {
+                    long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
+                    WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                }
+
+                contiguousZeroPages = 0;
+            }
+
+            FlushPendingWrite(destination, pageBuffer, offset, pageSize, logicalPosition, ref destinationPosition);
+            logicalPosition += pageSize;
         }
 
         private static void FlushPendingWrite(Stream destination, byte[] buffer, int offset, int length,

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -37,7 +37,7 @@ namespace Voron.Impl.Backup
         /// The destination file must already be marked as sparse on Windows (via <see cref="SparseFileHelper.TryMarkFileAsSparse"/>).
         /// Zero runs shorter than <see cref="FreeSpaceHandling.NumberOfFreePagesForSparseConsideration"/> pages are written normally.
         /// </summary>
-        public static void CopyToPreservingSparseRegions(this Stream source, FileStream destination, Action<int> onProgress, CancellationToken cancellationToken)
+        public static void CopyToPreservingSparseRegions(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
             int pageSize = Constants.Storage.PageSize;
             int minZeroPagesForHole = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -42,7 +42,7 @@ namespace Voron.Impl.Backup
         /// normally to avoid creating fragmented sparse holes with negligible benefit.
         /// This threshold matches the one used by Voron's flush pipeline in FreeSpaceHandling.GetSparseRegions.
         /// </remarks>
-        public static void CopyToSparse(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
+        public static void CopyToPreservingSparseRegions(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
             int pageSize = Constants.Storage.PageSize;
             int minZeroPagesForHole = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;

--- a/src/Voron/Impl/Backup/StreamExtensions.cs
+++ b/src/Voron/Impl/Backup/StreamExtensions.cs
@@ -4,18 +4,13 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Voron.Global;
+using Voron.Impl.FreeSpace;
 
 namespace Voron.Impl.Backup
 {
     public static class StreamExtensions
     {
         private const int DefaultBufferSize = 81920;
-
-        /// <summary>
-        /// Minimum number of contiguous zero pages required to create a sparse hole.
-        /// Matches the threshold in FreeSpaceHandling.GetSparseRegions (128 pages = 1 MB).
-        /// </summary>
-        internal const int MinContiguousZeroPagesForSparse = 128;
 
         public static void CopyTo(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
@@ -43,22 +38,25 @@ namespace Voron.Impl.Backup
         /// marked as sparse on Windows (via SparseFileHelper.TryMarkFileAsSparse).
         /// </summary>
         /// <remarks>
-        /// Zero regions shorter than MinContiguousZeroPagesForSparse pages (1 MB) are written
+        /// Zero regions shorter than FreeSpaceHandling.NumberOfFreePagesForSparseConsideration pages (1 MB) are written
         /// normally to avoid creating fragmented sparse holes with negligible benefit.
         /// This threshold matches the one used by Voron's flush pipeline in FreeSpaceHandling.GetSparseRegions.
         /// </remarks>
         public static void CopyToSparse(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)
         {
             int pageSize = Constants.Storage.PageSize;
-            int minZeroPagesForHole = MinContiguousZeroPagesForSparse;
+            int minZeroPagesForHole = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
 
             // Use a buffer that is a multiple of page size for aligned zero-detection.
             // DefaultBufferSize (81920) = 10 pages of 8192 bytes each.
             int bufferSize = DefaultBufferSize;
             var readBuffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
 
             try
             {
+                Array.Clear(zeroBuffer, 0, DefaultBufferSize);
+
                 long logicalPosition = 0;     // tracks the logical position in the output stream
                 long destinationPosition = 0; // tracks where destination stream is actually positioned
                 int contiguousZeroPages = 0;  // accumulated count of consecutive zero pages across buffer boundaries
@@ -102,7 +100,7 @@ namespace Voron.Impl.Backup
                                 {
                                     // Small zero run - write it (not worth creating a sparse hole)
                                     long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                                    WriteZeros(destination, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                                    WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
                                 }
                                 // else: large zero run - skip it (creates a sparse hole)
 
@@ -136,7 +134,7 @@ namespace Voron.Impl.Backup
                             if (contiguousZeroPages < minZeroPagesForHole)
                             {
                                 long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                                WriteZeros(destination, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                                WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
                             }
                             contiguousZeroPages = 0;
                         }
@@ -152,7 +150,7 @@ namespace Voron.Impl.Backup
                 if (contiguousZeroPages > 0 && contiguousZeroPages < minZeroPagesForHole)
                 {
                     long zeroStart = logicalPosition - ((long)contiguousZeroPages * pageSize);
-                    WriteZeros(destination, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
+                    WriteZeros(destination, zeroBuffer, zeroStart, (long)contiguousZeroPages * pageSize, ref destinationPosition);
                 }
 
                 // Set the correct file length (the file may end with a sparse hole)
@@ -164,6 +162,7 @@ namespace Voron.Impl.Backup
             finally
             {
                 ArrayPool<byte>.Shared.Return(readBuffer);
+                ArrayPool<byte>.Shared.Return(zeroBuffer);
             }
         }
 
@@ -180,7 +179,7 @@ namespace Voron.Impl.Backup
             destinationPosition += length;
         }
 
-        private static void WriteZeros(Stream destination, long logicalOffset, long length, ref long destinationPosition)
+        private static void WriteZeros(Stream destination, byte[] zeroBuffer, long logicalOffset, long length, ref long destinationPosition)
         {
             // For small zero runs that don't meet the sparse threshold, we need to actually write them.
             // Seek to position and write zero bytes.
@@ -190,25 +189,15 @@ namespace Voron.Impl.Backup
                 destinationPosition = logicalOffset;
             }
 
-            // Write zeros in chunks using a stack-allocated or pooled buffer
-            var zeroBuffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
-            try
+            long remaining = length;
+            while (remaining > 0)
             {
-                Array.Clear(zeroBuffer, 0, DefaultBufferSize);
-                long remaining = length;
-                while (remaining > 0)
-                {
-                    int toWrite = (int)Math.Min(remaining, DefaultBufferSize);
-                    destination.Write(zeroBuffer, 0, toWrite);
-                    remaining -= toWrite;
-                }
+                int toWrite = (int)Math.Min(remaining, DefaultBufferSize);
+                destination.Write(zeroBuffer, 0, toWrite);
+                remaining -= toWrite;
+            }
 
-                destinationPosition += length;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(zeroBuffer);
-            }
+            destinationPosition += length;
         }
 
         public static async Task CopyToAsync(this Stream source, Stream destination, Action<int> onProgress, CancellationToken cancellationToken)

--- a/src/Voron/StorageEnvironment.cs
+++ b/src/Voron/StorageEnvironment.cs
@@ -369,9 +369,20 @@ namespace Voron
 
                 if (_options.DisableSparseRegions == false)
                 {
+                    var hasSparseRegions = false;
+
                     foreach (long freeSegment in _freeSpaceHandling.GetCandidatesForSparseRegions(tx))
                     {
                         tx.RecordSparseRangeCandidate(freeSegment);
+                        hasSparseRegions = true;
+                    }
+
+                    if (hasSparseRegions && tx.NumberOfModifiedPages == 0)
+                    {
+                        // When there are no other modified pages the transaction state will not be enqueued to _transactionsToFlush in UpdateStateOnCommit
+                        // meaning sparse region candidates won't reach the flush pipeline and hole-punching won't happen.
+                        // Force a page modification so the transaction is written to the journal hence enqueued to _transactionsToFlush.
+                        tx.ModifyPage(0);
                     }
                 }
 

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -224,7 +224,7 @@ public class RavenDB_26344 : StorageTest
 
         // Restore with sparse regions disabled
         var restoreDir = voronDataDir.Combine("restored-no-sparse");
-        BackupMethods.Full.Restore(backupPath, restoreDir, disableSparseRegions: true);
+        BackupMethods.Full.Restore(backupPath, restoreDir);
 
         var options = StorageEnvironmentOptions.ForPathForTests(restoreDir.FullPath);
         options.MaxLogFileSize = Env.Options.MaxLogFileSize;

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -1,10 +1,16 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.IO;
 using FastTests.Voron;
+using Raven.Client.Documents.Operations.Backups;
 using Sparrow;
+using Sparrow.Backups;
 using Sparrow.Platform;
 using Tests.Infrastructure;
 using Voron;
 using Voron.Global;
+using Voron.Impl.Backup;
+using Voron.Util.Settings;
 using Xunit;
 
 namespace SlowTests.Voron.Issues;
@@ -83,4 +89,255 @@ public class RavenDB_26344 : StorageTest
             $"but allocated={new Size(allocatedAfter, SizeUnit.Bytes)}, physical={new Size(physicalAfter, SizeUnit.Bytes)}");
     }
 
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.BackupExportImport)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd)]
+    public unsafe void SnapshotRestoreShouldPreserveSparsity(SnapshotBackupCompressionAlgorithm compressionAlgorithm)
+    {
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+
+        var pages = new List<long>();
+
+        // 1. Create data: 32 overflow pages of 2MB each = 64MB of data
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                Page allocatePage = txw.LowLevelTransaction.AllocatePage(256);
+                allocatePage.Flags = PageFlags.Overflow | PageFlags.Single;
+                allocatePage.OverflowSize = (256 * Constants.Storage.PageSize) - PageHeader.SizeOf;
+
+                // Write non-zero data so pages are physically allocated
+                Memory.Set(allocatePage.DataPointer, (byte)(i + 1), allocatePage.OverflowSize);
+                pages.Add(allocatePage.PageNumber);
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        // 2. Free most pages (keep first 2 and last 2 so we can verify data integrity after restore)
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 2; i < 30; i++)
+            {
+                for (int j = 0; j < 256; j++)
+                {
+                    txw.LowLevelTransaction.FreePage(pages[i] + j);
+                }
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        // 3. Get the original file sizes for reference
+        (long originalAllocated, long originalPhysical) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
+
+        // The data file should be large (the freed pages are zeroed but still allocated)
+        Assert.True(originalAllocated >= 64 * 1024 * 1024,
+            $"Expected allocated size >= 64MB, but got {new Size(originalAllocated, SizeUnit.Bytes)}");
+
+        // 4. Create a snapshot backup
+        var voronDataDir = new VoronPathSetting(DataDir);
+        var backupPath = voronDataDir.Combine("voron-test.backup");
+
+        BackupMethods.Full.ToFile(Env, backupPath, compressionAlgorithm);
+
+        // 5. Restore with sparse-aware copy (default behavior)
+        var sparseRestoreDir = voronDataDir.Combine("restored-sparse");
+        BackupMethods.Full.Restore(backupPath, sparseRestoreDir);
+
+        // 6. Open restored database and verify sizes
+        var sparseOptions = StorageEnvironmentOptions.ForPathForTests(sparseRestoreDir.FullPath);
+        sparseOptions.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+        using (var restoredEnv = new StorageEnvironment(sparseOptions))
+        {
+            (long restoredAllocated, long restoredPhysical) = restoredEnv.DataPager.GetFileSize(restoredEnv.CurrentStateRecord.DataPagerState);
+
+            // The logical (allocated) size should match the original
+            Assert.Equal(originalAllocated, restoredAllocated);
+
+            if (PlatformDetails.RunningOnMacOsx == false)
+            {
+                // The physical size should be significantly less than allocated
+                // We freed 28 * 2MB = 56MB of data, so physical should be at least 40MB less
+                Assert.True(restoredPhysical < restoredAllocated - (40L * 1024 * 1024),
+                    $"Expected restored physical size to be at least 40MB less than allocated after sparse restore, " +
+                    $"but allocated={new Size(restoredAllocated, SizeUnit.Bytes)}, physical={new Size(restoredPhysical, SizeUnit.Bytes)}");
+            }
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.BackupExportImport)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd)]
+    public unsafe void SnapshotRestoreWithDisabledSparseRegionsShouldNotCreateSparseFile(SnapshotBackupCompressionAlgorithm compressionAlgorithm)
+    {
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+
+        var pages = new List<long>();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                Page allocatePage = txw.LowLevelTransaction.AllocatePage(256);
+                allocatePage.Flags = PageFlags.Overflow | PageFlags.Single;
+                allocatePage.OverflowSize = (256 * Constants.Storage.PageSize) - PageHeader.SizeOf;
+
+                Memory.Set(allocatePage.DataPointer, (byte)(i + 1), allocatePage.OverflowSize);
+                pages.Add(allocatePage.PageNumber);
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 2; i < 30; i++)
+            {
+                for (int j = 0; j < 256; j++)
+                {
+                    txw.LowLevelTransaction.FreePage(pages[i] + j);
+                }
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        (long originalAllocated, _) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
+
+        var voronDataDir = new VoronPathSetting(DataDir);
+        var backupPath = voronDataDir.Combine("voron-test.backup");
+
+        BackupMethods.Full.ToFile(Env, backupPath, compressionAlgorithm);
+
+        // Restore with sparse regions disabled
+        var restoreDir = voronDataDir.Combine("restored-no-sparse");
+        using (var zip = System.IO.Compression.ZipFile.Open(backupPath.FullPath, System.IO.Compression.ZipArchiveMode.Read, System.Text.Encoding.UTF8))
+        {
+            BackupMethods.Full.Restore(
+                zip.Entries,
+                restoreDir,
+                disableSparseRegions: true);
+        }
+
+        var options = StorageEnvironmentOptions.ForPathForTests(restoreDir.FullPath);
+        options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+        using (var restoredEnv = new StorageEnvironment(options))
+        {
+            (long restoredAllocated, long restoredPhysical) = restoredEnv.DataPager.GetFileSize(restoredEnv.CurrentStateRecord.DataPagerState);
+
+            Assert.Equal(originalAllocated, restoredAllocated);
+
+            // When sparse is disabled, physical size should equal allocated size (fully materialized file)
+            Assert.Equal(restoredAllocated, restoredPhysical);
+        }
+    }
+
+    [RavenTheory(RavenTestCategory.Voron | RavenTestCategory.BackupExportImport)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Deflate)]
+    [InlineData(SnapshotBackupCompressionAlgorithm.Zstd)]
+    public unsafe void SnapshotRestoreWithSparseRegionsShouldPreserveDataIntegrity(SnapshotBackupCompressionAlgorithm compressionAlgorithm)
+    {
+        RequireFileBasedPager();
+        Options.ManualFlushing = true;
+
+        // Create a tree with real data that we can verify after restore
+        using (var txw = Env.WriteTransaction())
+        {
+            var tree = txw.CreateTree("test-tree");
+
+            for (int i = 0; i < 100; i++)
+            {
+                var data = new byte[8192];
+                Array.Fill(data, (byte)((i % 255) + 1));
+                tree.Add("items/" + i, new MemoryStream(data));
+            }
+
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        // Create large free space by allocating and freeing overflow pages
+        var pages = new List<long>();
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                Page allocatePage = txw.LowLevelTransaction.AllocatePage(256);
+                allocatePage.Flags = PageFlags.Overflow | PageFlags.Single;
+                allocatePage.OverflowSize = (256 * Constants.Storage.PageSize) - PageHeader.SizeOf;
+
+                Memory.Set(allocatePage.DataPointer, 1, allocatePage.OverflowSize);
+                pages.Add(allocatePage.PageNumber);
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                for (int j = 0; j < 256; j++)
+                {
+                    txw.LowLevelTransaction.FreePage(pages[i] + j);
+                }
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        var voronDataDir = new VoronPathSetting(DataDir);
+        var backupPath = voronDataDir.Combine("voron-test.backup");
+
+        BackupMethods.Full.ToFile(Env, backupPath, compressionAlgorithm);
+
+        // Restore with sparse-aware copy
+        var restoreDir = voronDataDir.Combine("restored-data-integrity");
+        BackupMethods.Full.Restore(backupPath, restoreDir);
+
+        // Verify all data is intact after sparse restore
+        var options = StorageEnvironmentOptions.ForPathForTests(restoreDir.FullPath);
+        options.MaxLogFileSize = Env.Options.MaxLogFileSize;
+
+        using (var restoredEnv = new StorageEnvironment(options))
+        {
+            using (var tx = restoredEnv.ReadTransaction())
+            {
+                var tree = tx.ReadTree("test-tree");
+                Assert.NotNull(tree);
+
+                for (int i = 0; i < 100; i++)
+                {
+                    var readResult = tree.Read("items/" + i);
+                    Assert.NotNull(readResult);
+
+                    byte expectedByte = (byte)((i % 255) + 1);
+                    var reader = readResult.Reader;
+                    var buffer = new byte[reader.Length];
+                    reader.Read(buffer, 0, buffer.Length);
+
+                    for (int b = 0; b < buffer.Length; b++)
+                    {
+                        Assert.True(buffer[b] == expectedByte,
+                            $"Data corruption at item {i}, byte {b}: expected {expectedByte}, got {buffer[b]}");
+                    }
+                }
+            }
+        }
+    }
 }

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using FastTests.Voron;
+using Sparrow;
+using Sparrow.Platform;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Global;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_26344 : StorageTest
+{
+    public RavenDB_26344(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        Options.ManualFlushing = true;
+        Options.ManualSyncing = true;
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public unsafe void ShouldApplySparseRegionsOnDatabaseLoad()
+    {
+        RequireFileBasedPager();
+        Options.DisableSparseRegions = true; // initially disable sparse regions to produce a data file without hole-punching
+
+        var pages = new List<long>();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                Page allocatePage = txw.LowLevelTransaction.AllocatePage(256);
+                allocatePage.Flags = PageFlags.Overflow | PageFlags.Single;
+                allocatePage.OverflowSize = (256 * Constants.Storage.PageSize) - PageHeader.SizeOf;
+
+                Memory.Set(allocatePage.DataPointer, 1, allocatePage.OverflowSize);
+                pages.Add(allocatePage.PageNumber);
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        using (var txw = Env.WriteTransaction())
+        {
+            for (int i = 0; i < 32; i++)
+            {
+                for (int j = 0; j < 256; j++)
+                {
+                    txw.LowLevelTransaction.FreePage(pages[i] + j);
+                }
+            }
+            txw.Commit();
+        }
+
+        Env.FlushLogToDataFile();
+
+        Assert.Null(Env.CurrentStateRecord.SparseRegions);
+
+        (long allocatedBefore, long physicalBefore) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
+        
+        Assert.Equal(allocatedBefore, physicalBefore);
+
+        Options.DisableSparseRegions = false; // enable sparse regions before the restart
+        
+        RestartDatabase();
+
+        Assert.NotNull(Env.CurrentStateRecord.SparseRegions);
+        Assert.NotEmpty(Env.CurrentStateRecord.SparseRegions);
+        Assert.True(Env.HasAdditionalTransactionsToFlush);
+
+        Env.FlushLogToDataFile();
+
+        (long allocatedAfter, long physicalAfter) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
+        Assert.Equal(allocatedBefore, allocatedAfter);
+
+        Assert.True(physicalAfter < allocatedAfter - (32L * 1024 * 1024),
+            $"Expected physical size to drop by at least 32MB after reload, " +
+            $"but allocated={new Size(allocatedAfter, SizeUnit.Bytes)}, physical={new Size(physicalAfter, SizeUnit.Bytes)}");
+    }
+
+}

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using FastTests.Voron;
-using Raven.Client.Documents.Operations.Backups;
 using Sparrow;
 using Sparrow.Backups;
 using Sparrow.Platform;
@@ -224,7 +223,7 @@ public class RavenDB_26344 : StorageTest
 
         // Restore with sparse regions disabled
         var restoreDir = voronDataDir.Combine("restored-no-sparse");
-        BackupMethods.Full.Restore(backupPath, restoreDir);
+        BackupMethods.Full.Restore(backupPath, restoreDir, sparseRegionsSupported: false);
 
         var options = StorageEnvironmentOptions.ForPathForTests(restoreDir.FullPath);
         options.MaxLogFileSize = Env.Options.MaxLogFileSize;

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -163,11 +163,13 @@ public class RavenDB_26344 : StorageTest
 
             if (PlatformDetails.RunningOnMacOsx == false)
             {
-                // The physical size should be significantly less than allocated
-                // We freed 28 * 2MB = 56MB of data, so physical should be at least 40MB less
-                Assert.True(restoredPhysical < restoredAllocated - (40L * 1024 * 1024),
-                    $"Expected restored physical size to be at least 40MB less than allocated after sparse restore, " +
-                    $"but allocated={new Size(restoredAllocated, SizeUnit.Bytes)}, physical={new Size(restoredPhysical, SizeUnit.Bytes)}");
+                Assert.True(originalPhysical < originalAllocated - (40L * 1024 * 1024),
+                    $"Expected source database to be sparse before backup, but allocated={new Size(originalAllocated, SizeUnit.Bytes)}, physical={new Size(originalPhysical, SizeUnit.Bytes)}");
+
+                const long allowedRestoreOverhead = 16L * 1024 * 1024;
+                Assert.True(restoredPhysical <= originalPhysical + allowedRestoreOverhead,
+                    $"Expected restored physical size to stay close to the source sparse file after restore, " +
+                    $"but source physical={new Size(originalPhysical, SizeUnit.Bytes)}, restored physical={new Size(restoredPhysical, SizeUnit.Bytes)}, allocated={new Size(restoredAllocated, SizeUnit.Bytes)}");
             }
         }
     }
@@ -222,13 +224,7 @@ public class RavenDB_26344 : StorageTest
 
         // Restore with sparse regions disabled
         var restoreDir = voronDataDir.Combine("restored-no-sparse");
-        using (var zip = System.IO.Compression.ZipFile.Open(backupPath.FullPath, System.IO.Compression.ZipArchiveMode.Read, System.Text.Encoding.UTF8))
-        {
-            BackupMethods.Full.Restore(
-                zip.Entries,
-                restoreDir,
-                disableSparseRegions: true);
-        }
+        BackupMethods.Full.Restore(backupPath, restoreDir, disableSparseRegions: true);
 
         var options = StorageEnvironmentOptions.ForPathForTests(restoreDir.FullPath);
         options.MaxLogFileSize = Env.Options.MaxLogFileSize;

--- a/test/SlowTests/Voron/Issues/RavenDB_26344.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344.cs
@@ -67,8 +67,9 @@ public class RavenDB_26344 : StorageTest
         Assert.Null(Env.CurrentStateRecord.SparseRegions);
 
         (long allocatedBefore, long physicalBefore) = Env.DataPager.GetFileSize(Env.CurrentStateRecord.DataPagerState);
-        
-        Assert.Equal(allocatedBefore, physicalBefore);
+
+        Assert.True(physicalBefore >= allocatedBefore,
+            $"Expected physical size >= allocated before sparse regions, but allocated={allocatedBefore}, physical={physicalBefore}");
 
         Options.DisableSparseRegions = false; // enable sparse regions before the restart
         

--- a/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
@@ -342,6 +342,46 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
         Assert.Empty(destination.ForwardSeekLengths);
     }
 
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldHandleEntirelyZeroPageAlignedStream()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 20;
+        var source = new byte[sparsePages * pageSize];
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(0, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldCreateHoleForExactThresholdZeroRunFollowedByPartialTail()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
+        int tailLength = 137;
+        var source = new byte[(sparsePages * pageSize) + tailLength];
+
+        // tail is non-zero so we can verify it's written correctly after the hole
+        Fill(source, sparsePages * pageSize, tailLength, 99);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(tailLength, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
     private static void Fill(byte[] buffer, int offset, int length, byte value)
     {
         new Span<byte>(buffer, offset, length).Fill(value);

--- a/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
@@ -14,7 +14,7 @@ namespace SlowTests.Voron.Issues;
 public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) : NoDisposalNeeded(output)
 {
     [RavenFact(RavenTestCategory.Voron)]
-    public void CopyToPreservingSparsity_ShouldCreateHoleForZeroRunSpanningMultipleReadBuffers()
+    public void CopyToPreservingSparseRegions_ShouldCreateHoleForZeroRunSpanningMultipleReadBuffers()
     {
         int pageSize = Constants.Storage.PageSize;
         int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 17;
@@ -35,7 +35,28 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     }
 
     [RavenFact(RavenTestCategory.Voron)]
-    public void CopyToPreservingSparsity_ShouldPreserveTrailingSparseHoleAtEndOfStream()
+    public void CopyToPreservingSparseRegions_ShouldCreateHoleForZeroRunSpanningNonPageAlignedReads()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 17;
+        var source = new byte[(2 + sparsePages) * pageSize];
+
+        Fill(source, 0, pageSize, 11);
+        Fill(source, (1 + sparsePages) * pageSize, pageSize, 12);
+
+        using var input = new ChunkedReadStream(source, pageSize / 2);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal((long)source.Length - (long)sparsePages * pageSize, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldPreserveTrailingSparseHoleAtEndOfStream()
     {
         int pageSize = Constants.Storage.PageSize;
         int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 9;
@@ -55,7 +76,27 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     }
 
     [RavenFact(RavenTestCategory.Voron)]
-    public void CopyToPreservingSparsity_ShouldWriteZeroRunBelowSparseThreshold()
+    public void CopyToPreservingSparseRegions_ShouldPreserveTrailingSparseHoleAtEndOfStreamWithNonPageAlignedReads()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 9;
+        var source = new byte[(1 + sparsePages) * pageSize];
+
+        Fill(source, 0, pageSize, 13);
+
+        using var input = new ChunkedReadStream(source, (pageSize / 2) + 37);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(pageSize, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldWriteZeroRunBelowSparseThreshold()
     {
         int pageSize = Constants.Storage.PageSize;
         int zeroPages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration - 1;
@@ -76,7 +117,49 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
     }
 
     [RavenFact(RavenTestCategory.Voron)]
-    public void CopyToPreservingSparsity_ShouldWritePartialPageTailAfterSparseHole()
+    public void CopyToPreservingSparseRegions_ShouldWriteZeroRunBelowSparseThresholdWithNonPageAlignedReads()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int zeroPages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration - 1;
+        var source = new byte[(2 + zeroPages) * pageSize];
+
+        Fill(source, 0, pageSize, 14);
+        Fill(source, (1 + zeroPages) * pageSize, pageSize, 15);
+
+        using var input = new ChunkedReadStream(source, (pageSize / 3) + 29);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(source.Length, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldCreateHoleForZeroRunAtSparseThreshold()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration;
+        var source = new byte[(2 + sparsePages) * pageSize];
+
+        Fill(source, 0, pageSize, 16);
+        Fill(source, (1 + sparsePages) * pageSize, pageSize, 17);
+
+        using var input = new ChunkedReadStream(source, (pageSize / 4) + 17);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal((long)source.Length - (long)sparsePages * pageSize, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldWritePartialPageTailAfterSparseHole()
     {
         int pageSize = Constants.Storage.PageSize;
         int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 5;
@@ -87,6 +170,28 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
         Fill(source, (1 + sparsePages) * pageSize, tailLength, 7);
 
         using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(pageSize + tailLength, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldWritePartialPageTailAfterSparseHoleWithNonPageAlignedReads()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 5;
+        int tailLength = pageSize / 2;
+        var source = new byte[((1 + sparsePages) * pageSize) + tailLength];
+
+        Fill(source, 0, pageSize, 18);
+        Fill(source, (1 + sparsePages) * pageSize, tailLength, 19);
+
+        using var input = new ChunkedReadStream(source, (pageSize / 2) + 11);
         using var destination = new RecordingSparseDestination();
 
         input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
@@ -164,6 +269,75 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
         {
             TotalBytesWritten += buffer.Length;
             _inner.Write(buffer);
+        }
+    }
+
+    private sealed class ChunkedReadStream : Stream
+    {
+        private readonly MemoryStream _inner;
+        private readonly int _maxReadSize;
+
+        public ChunkedReadStream(byte[] buffer, int maxReadSize)
+        {
+            _inner = new MemoryStream(buffer);
+            _maxReadSize = maxReadSize;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => _inner.CanSeek;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush()
+        {
+            _inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _inner.Read(buffer, offset, Math.Min(count, _maxReadSize));
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            return _inner.Read(buffer[..Math.Min(buffer.Length, _maxReadSize)]);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
@@ -72,7 +72,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
         Assert.Equal(source.Length, destination.Length);
         Assert.Equal(source, destination.ToArray());
         Assert.Equal(pageSize, destination.TotalBytesWritten);
-        Assert.Empty(destination.ForwardSeekLengths);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
     }
 
     [RavenFact(RavenTestCategory.Voron)]
@@ -92,7 +92,7 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
         Assert.Equal(source.Length, destination.Length);
         Assert.Equal(source, destination.ToArray());
         Assert.Equal(pageSize, destination.TotalBytesWritten);
-        Assert.Empty(destination.ForwardSeekLengths);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
     }
 
     [RavenFact(RavenTestCategory.Voron)]

--- a/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
@@ -202,6 +202,146 @@ public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) 
         Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
     }
 
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldUseFastPathForAllNonZeroContent()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int pages = 30;
+        var source = new byte[pages * pageSize];
+
+        for (int i = 0; i < pages; i++)
+            Fill(source, i * pageSize, pageSize, (byte)(i + 1));
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(source.Length, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldPreserveInternalZeroPagesInFastPathBuffer()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int pages = 10;
+        var source = new byte[pages * pageSize];
+
+        Fill(source, 0 * pageSize, pageSize, 1);
+        Fill(source, 1 * pageSize, pageSize, 2);
+        Fill(source, 2 * pageSize, pageSize, 3);
+        // pages 3, 4, 5 left as zeros (below sparse threshold, must be preserved as-is)
+        Fill(source, 6 * pageSize, pageSize, 6);
+        Fill(source, 7 * pageSize, pageSize, 7);
+        Fill(source, 8 * pageSize, pageSize, 8);
+        Fill(source, 9 * pageSize, pageSize, 9);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(source.Length, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldHandleMultipleSparseRegions()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 11;
+        int totalPages = 1 + sparsePages + 1 + sparsePages + 1;
+        var source = new byte[totalPages * pageSize];
+
+        Fill(source, 0, pageSize, 21);
+        Fill(source, (1 + sparsePages) * pageSize, pageSize, 22);
+        Fill(source, (1 + sparsePages + 1 + sparsePages) * pageSize, pageSize, 23);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(3L * pageSize, destination.TotalBytesWritten);
+        Assert.Equal(2, destination.ForwardSeekLengths.Count);
+        Assert.All(destination.ForwardSeekLengths, len => Assert.Equal((long)sparsePages * pageSize, len));
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldHandleAllZeroStreamWithPartialPageTail()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 1;
+        int tailLength = 100;
+        var source = new byte[(sparsePages * pageSize) + tailLength];
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(tailLength, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldHandleSourceSmallerThanOneBuffer()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int pages = 5;
+        var source = new byte[pages * pageSize];
+
+        for (int i = 0; i < pages; i++)
+            Fill(source, i * pageSize, pageSize, (byte)(i + 31));
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(source.Length, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparseRegions_ShouldResolvePendingZeroRunBeforeFastPathWrite()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        const int bufferPages = 10; // must match DefaultBufferSize / pageSize
+        var source = new byte[2 * bufferPages * pageSize];
+
+        // Buffer 1: 3 non-zero pages, then 7 zero pages (below sparse threshold).
+        // First byte non-zero, last byte zero -> slow path, carries 7-page zero run into buffer 2.
+        Fill(source, 0 * pageSize, pageSize, 41);
+        Fill(source, 1 * pageSize, pageSize, 42);
+        Fill(source, 2 * pageSize, pageSize, 43);
+
+        // Buffer 2: 10 non-zero pages -> fast path. Must resolve the 7-page pending zero run first.
+        for (int i = 0; i < bufferPages; i++)
+            Fill(source, (bufferPages + i) * pageSize, pageSize, (byte)(51 + i));
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(source.Length, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
     private static void Fill(byte[] buffer, int offset, int length, byte value)
     {
         new Span<byte>(buffer, offset, length).Fill(value);

--- a/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_26344_StreamExtensionsSparseCopy.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using FastTests;
+using Tests.Infrastructure;
+using Voron.Global;
+using Voron.Impl.Backup;
+using Voron.Impl.FreeSpace;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_26344_StreamExtensionsSparseCopy(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparsity_ShouldCreateHoleForZeroRunSpanningMultipleReadBuffers()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 17;
+        var source = new byte[(2 + sparsePages) * pageSize];
+
+        Fill(source, 0, pageSize, 1);
+        Fill(source, (1 + sparsePages) * pageSize, pageSize, 2);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal((long)source.Length - (long)sparsePages * pageSize, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparsity_ShouldPreserveTrailingSparseHoleAtEndOfStream()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 9;
+        var source = new byte[(1 + sparsePages) * pageSize];
+
+        Fill(source, 0, pageSize, 3);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(pageSize, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparsity_ShouldWriteZeroRunBelowSparseThreshold()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int zeroPages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration - 1;
+        var source = new byte[(2 + zeroPages) * pageSize];
+
+        Fill(source, 0, pageSize, 4);
+        Fill(source, (1 + zeroPages) * pageSize, pageSize, 5);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(source.Length, destination.TotalBytesWritten);
+        Assert.Empty(destination.ForwardSeekLengths);
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void CopyToPreservingSparsity_ShouldWritePartialPageTailAfterSparseHole()
+    {
+        int pageSize = Constants.Storage.PageSize;
+        int sparsePages = FreeSpaceHandling.NumberOfFreePagesForSparseConsideration + 5;
+        int tailLength = pageSize / 2;
+        var source = new byte[((1 + sparsePages) * pageSize) + tailLength];
+
+        Fill(source, 0, pageSize, 6);
+        Fill(source, (1 + sparsePages) * pageSize, tailLength, 7);
+
+        using var input = new MemoryStream(source);
+        using var destination = new RecordingSparseDestination();
+
+        input.CopyToPreservingSparseRegions(destination, onProgress: null, CancellationToken.None);
+
+        Assert.Equal(source.Length, destination.Length);
+        Assert.Equal(source, destination.ToArray());
+        Assert.Equal(pageSize + tailLength, destination.TotalBytesWritten);
+        Assert.Contains((long)sparsePages * pageSize, destination.ForwardSeekLengths);
+    }
+
+    private static void Fill(byte[] buffer, int offset, int length, byte value)
+    {
+        new Span<byte>(buffer, offset, length).Fill(value);
+    }
+
+    private sealed class RecordingSparseDestination : Stream
+    {
+        private readonly MemoryStream _inner = new();
+
+        public List<long> ForwardSeekLengths { get; } = new();
+
+        public long TotalBytesWritten { get; private set; }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => _inner.CanSeek;
+
+        public override bool CanWrite => _inner.CanWrite;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public byte[] ToArray()
+        {
+            return _inner.ToArray();
+        }
+
+        public override void Flush()
+        {
+            _inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _inner.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long current = _inner.Position;
+            long newPosition = _inner.Seek(offset, origin);
+            if (newPosition > current)
+                ForwardSeekLengths.Add(newPosition - current);
+
+            return newPosition;
+        }
+
+        public override void SetLength(long value)
+        {
+            _inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            TotalBytesWritten += count;
+            _inner.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            TotalBytesWritten += buffer.Length;
+            _inner.Write(buffer);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26344

### Additional description

- Database load now applies sparse regions on restart when they weren't previously tracked, fixing cases where a database that should have had sparse regions never got them marked

- Snapshot restore now preserves sparse regions in `Raven.voron` via `CopyToPreservingSparseRegions`, which detects contiguous zero-page runs (≥ 512 pages) during the copy and skips writing them, creating sparse holes in the destination file

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
