### PR TITLE
RavenDB-26152 Prevent HNSW node from discovering itself during concurrent placement

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -248,10 +248,12 @@ public partial class Hnsw
                     insertedVector = n.GetVectorUnmanagedSpan(_searchState);
                     AddEdgesFromInFlightNodes(ref n, createdNodeIndex);
                 }
-                foreach(var item in SearchNearestAcrossLevels(insertedVector, currentMaxLevel))
+                
+                foreach(var item in SearchNearestAcrossLevels(insertedVector, currentMaxLevel, currentNodeIndex))
                 {
                     yield return item;
                 }
+                
                 for (int level = nodeRandomLevel; level >= 0; level--)
                 {
                     int startingPointIndex = _nearestIndexes[level];
@@ -331,9 +333,10 @@ public partial class Hnsw
 
             private IEnumerable<WorkItem> NearestEdges(int startingPointIndex, int currentNodeIndex, UnmanagedSpan vector, int level)
             {
-                Debug.Assert(_candidatesQ.Count == 0, "_candidatesQ.Count == 0");
-                Debug.Assert(_nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
-
+                Debug.Assert(_candidatesQ.Count == 0);
+                Debug.Assert(_nearestEdgesQ.Count == 0);
+                Debug.Assert(startingPointIndex != currentNodeIndex);
+                
                 float lowerBound = float.MaxValue;
                 ClearVisited();
                 MarkVisited(currentNodeIndex); // we can't have an edge to itself
@@ -498,10 +501,11 @@ public partial class Hnsw
                 
             }
 
-            private IEnumerable<WorkItem> SearchNearestAcrossLevels(UnmanagedSpan from, int maxLevel)
+            private IEnumerable<WorkItem> SearchNearestAcrossLevels(UnmanagedSpan from, int maxLevel, int insertedNodeIndex)
             {
                 _nearestIndexes.Clear();
                 ClearVisited();
+                MarkVisited(insertedNodeIndex);
                 var currentNodeIndex = _searchState.GetNodeIndexById(EntryPointId);
                 var level = maxLevel;
                 var distance = float.MaxValue;

--- a/test/SlowTests/Voron/Graphs/HnswSearch.cs
+++ b/test/SlowTests/Voron/Graphs/HnswSearch.cs
@@ -186,4 +186,38 @@ public class HnswSearch(ITestOutputHelper output) : StorageTest(output)
 
         float GetNextDim() => random.NextSingle() * (random.Next() % 2 == 0 ? 1 : -1);
     }
+
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineDataWithRandomSeed]
+    public void ConcurrentNodePlacementDoesNotFailWhenNodeDiscoversItself(int seed)
+    {
+        const int vectorSize = 1536;
+        const int vectorSizeInBytes = vectorSize * sizeof(float);
+        using var _ = Slice.From(Allocator, $"test", out var treeName);
+        var random = new Random(seed);
+
+        const int numberOfEntries = 1024;
+        var vectors = new float[numberOfEntries][];
+        for (int i = 0; i < numberOfEntries; i++)
+        {
+            vectors[i] = new float[vectorSize];
+            for (int j = 0; j < vectorSize; j++)
+                vectors[i][j] = random.NextSingle() * (random.Next() % 2 == 0 ? 1 : -1);
+        }
+
+        using (var wTx = Env.WriteTransaction())
+        {
+            Hnsw.Create(wTx.LowLevelTransaction, treeName, vectorSizeInBytes, 3, 16, VectorEmbeddingType.Single);
+
+            using (var registration = Hnsw.RegistrationFor(wTx.LowLevelTransaction, treeName, random))
+            {
+                for (int i = 0; i < numberOfEntries; i++)
+                    registration.Register(i + 1, MemoryMarshal.Cast<float, byte>(vectors[i]));
+
+                registration.Commit(CancellationToken.None);
+            }
+
+            wTx.Commit();
+        }
+    }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26152

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
