### PR TITLE
RavenDB-26421 HNSW vector search: cache resolved edge indexes in search loops

### DIFF
--- a/src/Corax/Querying/IndexSearcher.cs
+++ b/src/Corax/Querying/IndexSearcher.cs
@@ -35,6 +35,8 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     private Dictionary<string, Slice> _dynamicFieldNameMapping;
 
     private readonly IndexFieldsMapping _fieldMapping;
+    private Dictionary<Slice, Hnsw.SearchState> _vectorSearchStateCache;
+    private Dictionary<Slice, HnswIndexCache> _vectorNodeCaches;
     private HashSet<long> _nullTermsMarkers;
     private HashSet<long> _nonExistingTermsMarkers;
     private long[] _vectorFieldsMarkers;
@@ -480,8 +482,50 @@ public sealed unsafe partial class IndexSearcher : IDisposable
     }
 
     
+    /// <summary>
+    /// Returns a shared SearchState for the given vector field, creating one if needed.
+    /// The SearchState is cached per field name and disposed when the IndexSearcher is disposed.
+    /// This lets multiple vector search operations against the same field share loaded
+    /// node topology and vector pointers. The distance cache is keyed by the query vector
+    /// (see <see cref="Hnsw.SearchState.OnQueryVector"/>): sub-searches with distinct vectors
+    /// see independent caches, while same-vector re-entry (e.g. eF re-expansion in filtered
+    /// search) keeps its cached distances.
+    /// </summary>
+    internal Hnsw.SearchState GetOrCreateVectorSearchState(Slice fieldName)
+    {
+        _vectorSearchStateCache ??= new(SliceComparer.Instance);
+        ref var state = ref CollectionsMarshal.GetValueRefOrAddDefault(_vectorSearchStateCache, fieldName, out bool exists);
+        if (exists == false)
+        {
+            // Look for a shared HnswIndexCache for this field
+            HnswIndexCache nodeCache = null;
+            _vectorNodeCaches?.TryGetValue(fieldName, out nodeCache);
+            state = new Hnsw.SearchState(_transaction.LowLevelTransaction, fieldName, nodeCache);
+        }
+        return state;
+    }
+
+    /// <summary>
+    /// Attach a per-field dictionary of HNSW node caches to this IndexSearcher. Each
+    /// SearchState created by <see cref="GetOrCreateVectorSearchState"/> looks up its field's
+    /// cache here and uses it for node lookups instead of reading them through Voron.
+    /// The dictionary is read by query code only and must not be mutated while the
+    /// IndexSearcher is alive.
+    /// </summary>
+    public void AttachVectorNodeCaches(Dictionary<Slice, HnswIndexCache> caches)
+    {
+        _vectorNodeCaches = caches;
+    }
+
     public void Dispose()
     {
+        if (_vectorSearchStateCache != null)
+        {
+            foreach (var kvp in _vectorSearchStateCache)
+                kvp.Value.Dispose();
+            _vectorSearchStateCache = null;
+        }
+
         if (_ownsTransaction)
             _transaction?.Dispose();
 

--- a/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/MultiVectorSearchMatch.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using Corax.Mappings;
 using Corax.Querying.Matches.Meta;
 using Corax.Utils;
@@ -35,8 +34,9 @@ public struct MultiVectorSearchMatch : IQueryMatch
     private GrowableBuffer<long, Constant<long>> _matches;
     private GrowableBuffer<float, Constant<float>> _distances;
 
-    // Voron VectorSearch Retriever
-    private Hnsw.VectorSearchRetriever[] _vectorsRetrievers;
+    // Reference to the first sub-query's retriever, kept so Score can call its distance-to-score
+    // conversion methods after all retrievers have been disposed.
+    private Hnsw.VectorSearchRetriever _firstRetriever;
     private ContextBoundNativeList<long> _nodesIdsToScan;
     private bool _vectorRetrieverInitialized;
 
@@ -106,25 +106,11 @@ public struct MultiVectorSearchMatch : IQueryMatch
             }
         }
 
-        _vectorsRetrievers = new Hnsw.VectorSearchRetriever[_vectorsToSearch.Length];
-        var llt = _indexSearcher.Transaction.LowLevelTransaction;
-        var allEmpty = true;
-        for (int i = 0; i < _vectorsRetrievers.Length; ++i)
-        {
-            var vector = _vectorsToSearch[i].GetEmbeddingMemory();
-            _vectorsRetrievers[i] = (_isExact) switch
-            {
+        // Obtain the IndexSearcher-scoped SearchState for this field; sub-queries below reuse it
+        // so loaded node data (edges, vectors) is shared across them.
+        var sharedSearchState = _indexSearcher.GetOrCreateVectorSearchState(_metadata.FieldName);
 
-                _ when _scanningQuery => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, false, _nodesIdsToScan),
-                true => Hnsw.ExactNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
-                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt,  _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)), 
-                false => Hnsw.ApproximateNearest(llt, _metadata.FieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            };
-
-            allEmpty &= _vectorsRetrievers[i].IsEmpty;
-        }
-
-        _isEmpty = allEmpty || (_filterQuery != null && _filterResults!.Value.Count == 0);
+        _isEmpty = sharedSearchState.IsEmpty || (_filterQuery != null && _filterResults!.Value.Count == 0);
     }
 
     public int Fill(Span<long> matches)
@@ -155,12 +141,33 @@ public struct MultiVectorSearchMatch : IQueryMatch
         _resultsPersisted = true;
         if (_isEmpty)
             return;
-        
+
+        // Construct and fully consume each retriever before moving to the next; the shared
+        // SearchState has a single pair of priority queues (_candidatesQ, _nearestEdgesQ) that
+        // cannot be interleaved across retrievers.
+        var sharedSearchState = _indexSearcher.GetOrCreateVectorSearchState(_metadata.FieldName);
+
         _matches.Init(_indexSearcher.Allocator, 128);
         _distances.Init(_indexSearcher.Allocator, 128);
-        for (var i = 0; i < _vectorsRetrievers.Length; ++i)
+        for (var i = 0; i < _vectorsToSearch.Length; ++i)
         {
-            ref var vectorSearcher = ref _vectorsRetrievers[i];
+            // Invariant: when a new retriever starts, the shared priority queues on SearchState
+            // must be empty. Violating this causes the new traversal to read leftover entries
+            // from the previous sub-query.
+            sharedSearchState.AssertSharedQueuesClean();
+
+            var vector = _vectorsToSearch[i].GetEmbeddingMemory();
+            var vectorSearcher = (_isExact) switch
+            {
+                _ when _scanningQuery => Hnsw.ExactNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, false, _nodesIdsToScan),
+                true => Hnsw.ExactNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null, null),
+                false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)),
+                false => Hnsw.ApproximateNearest(sharedSearchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            };
+
+            if (i == 0)
+                _firstRetriever = vectorSearcher;
+
             int currentRead = 0;
             do
             {
@@ -168,9 +175,8 @@ public struct MultiVectorSearchMatch : IQueryMatch
                 var distanceBuffer = _distances.GetSpace();
                 Debug.Assert(matchBuffer.Length == distanceBuffer.Length, "matchBuffer.Length == distanceBuffer.Length");
 
-
                 currentRead = vectorSearcher.Fill(matchBuffer, distanceBuffer, _filterResults);
-                
+
                 _matches.AddUsage(currentRead);
                 _distances.AddUsage(currentRead);
                 Count += currentRead;
@@ -234,13 +240,13 @@ public struct MultiVectorSearchMatch : IQueryMatch
                     continue;
 
                 var distance = _distances.Results[pos];
-                scores[i] += boostFactor * _vectorsRetrievers[0].DistanceToScore(distance);
+                scores[i] += boostFactor * _firstRetriever.DistanceToScore(distance);
             }
         }
         else
         {
             _distances.Results[..scores.Length].CopyTo(scores);
-            _vectorsRetrievers[0].DistancesToScores(scores);
+            _firstRetriever.DistancesToScores(scores);
             for (int i = 0; i < scores.Length; ++i)
                 scores[i] *= boostFactor;
         }
@@ -268,7 +274,7 @@ public struct MultiVectorSearchMatch : IQueryMatch
             parameters: new Dictionary<string, string>()
             {
                 { Constants.QueryInspectionNode.FieldName, _metadata.FieldName.ToString() },                
-                { nameof(Hnsw.SimilarityMethod), _vectorsRetrievers.FirstOrDefault().SimilarityMethod?.ToString() ?? "Query not initialized." },
+                { nameof(Hnsw.SimilarityMethod), _firstRetriever.SimilarityMethod?.ToString() ?? "Query not initialized." },
                 { "IsExact", _isExact.ToString() },
                 { "IsScanning", _scanningQuery.ToString() },
                 { "Minimum match", _minimumMatch.ToString(CultureInfo.InvariantCulture) },

--- a/src/Corax/Querying/Matches/VectorSearchMatch.cs
+++ b/src/Corax/Querying/Matches/VectorSearchMatch.cs
@@ -132,12 +132,13 @@ public struct VectorSearchMatch : IQueryMatch
         }
         
         
+        var searchState = _indexSearcher.GetOrCreateVectorSearchState(fieldName);
         _vectorSearchRetriever = _isExact switch
         {
-            _ when _scanningQuery => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
-            true => Hnsw.ExactNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
-            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)), 
-                _ => Hnsw.ApproximateNearest(llt, fieldName, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            _ when _scanningQuery => Hnsw.ExactNearest(searchState, _numberOfCandidates, vector, _minimumMatch, hasFilterMatch: false, nodesIdsToScan),
+            true => Hnsw.ExactNearest(searchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
+            false when _filterQuery != null => Hnsw.ApproximateFilteredNearest(searchState, _numberOfCandidates, vector, _minimumMatch, new IndexSearcher.VectorSearchUtils.RandomNodesFromFilterEnumerator(_indexSearcher, _metadata, _filterResults!.Value, _random)),
+                _ => Hnsw.ApproximateNearest(searchState, _numberOfCandidates, vector, _minimumMatch, _filterQuery != null),
         };
         
 

--- a/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/IndexingConfiguration.cs
@@ -665,6 +665,15 @@ namespace Raven.Server.Config.Categories
         [ConfigurationEntry("Indexing.Corax.VectorSearch.VectorSearchScanningThreshold", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
         public int CoraxVectorSearchScanningThreshold { get; set; }
 
+        [Description("The maximum amount of memory for the HNSW vector search node cache per index. " +
+                     "This cache pre-loads upper-level graph nodes to accelerate vector queries. " +
+                     "Changing this value does not require re-indexing.")]
+        [DefaultValue(1)]
+        [SizeUnit(SizeUnit.Megabytes)]
+        [IndexUpdateType(IndexUpdateType.Refresh)]
+        [ConfigurationEntry("Indexing.Corax.VectorSearch.CacheSizeInMb", ConfigurationEntryScope.ServerWideOrPerDatabaseOrPerIndex)]
+        public Size CoraxVectorSearchCacheSize { get; set; }
+
         [Description("Use default search analyzer for dynamic fields if not set explicitly.")]
         [DefaultValue(false)]
         [IndexUpdateType(IndexUpdateType.Refresh)]

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexPersistence.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Raven.Client.Documents.Indexes;
 using Raven.Client.Exceptions.Corax;
@@ -11,11 +13,13 @@ using Raven.Server.Indexing;
 using Raven.Server.Logging;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
+using Sparrow;
 using Sparrow.Json;
 using Sparrow.Logging;
 using Sparrow.Server.Logging;
 using Voron;
 using Voron.Data.CompactTrees;
+using Voron.Data.Graphs;
 using Voron.Impl;
 using Constants = Raven.Client.Constants;
 
@@ -26,10 +30,24 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
     private const bool DisableDictionaryTraining = false; // [DEBUG ONLY]: disable training.
     private readonly RavenLogger _logger;
     private readonly CoraxDocumentConverterBase _converter;
+
+    // Holds the cache published by the most recent successful commit (or by Initialize). Each new
+    // read transaction snapshots this reference into its ImmutableExternalState (see the
+    // subscription in Initialize), so a query always sees the cache that was current at the
+    // moment its transaction was created.
+    private IndexTransactionCache _currentCache;
+
     public CoraxIndexPersistence(Index index, IIndexReadOperationFactory indexReadOperationFactory) : base(index, indexReadOperationFactory)
     {
         _logger = RavenLogManager.Instance.GetLoggerForIndex<CoraxIndexPersistence>(index);
         _converter = CreateConverter(index);
+    }
+
+    private int GetMaxNodesForVectorCache()
+    {
+        var cacheSizeBytes = _index.Configuration.CoraxVectorSearchCacheSize.GetValue(SizeUnit.Bytes);
+        var bytesPerNode = HnswIndexCache.EstimateBytesPerNode(_index.Configuration.CoraxVectorDefaultNumberOfEdges);
+        return (int)Math.Min(cacheSizeBytes / bytesPerNode, int.MaxValue);
     }
 
     private CoraxDocumentConverterBase CreateConverter(Index index)
@@ -176,23 +194,72 @@ public sealed class CoraxIndexPersistence : IndexPersistenceBase
 
     public override void Initialize(StorageEnvironment environment)
     {
+        // Attach _currentCache to every newly created transaction. _currentCache may be null at
+        // this point; the assignment is still correct because readers treat a null
+        // ImmutableExternalState as "no cache available".
+        environment.NewTransactionCreated += tx => tx.ImmutableExternalState = _currentCache;
+
+        // Seed _currentCache from the current committed state so queries arriving before the
+        // first indexing batch find a populated cache. The build copies everything it needs
+        // into managed memory, so the read transaction can be released immediately.
+        using var roTx = environment.ReadTransaction();
+        _currentCache = BuildVectorCacheSnapshot(roTx);
     }
-    
+
     public override void PublishIndexCacheToNewTransactions(IndexTransactionCache transactionCache)
     {
-        //lucene method
+        // Corax builds and publishes its cache in RecreateSearcher rather than here.
+        // BuildStreamCacheAfterTx returns null, so this method is always invoked with null.
     }
 
     internal override IndexTransactionCache BuildStreamCacheAfterTx(Transaction tx)
     {
-        //lucene method
-
+        // The actual vector cache build runs in RecreateSearcher, which is invoked from the
+        // post-commit hook — only after the commit is durable.
         return null;
     }
 
     internal override void RecreateSearcher(Transaction asOfTx)
     {
-        //lucene method
+        // Invoked from AfterCommitWhenNewTransactionsPrevented: at this point the commit is
+        // durable and no new read transaction can be created until this method returns. Building
+        // and assigning _currentCache here guarantees that the published cache reflects a state
+        // that is already visible on disk, and that every read transaction created afterwards
+        // captures it atomically via the NewTransactionCreated subscription in Initialize.
+        var newCache = BuildVectorCacheSnapshot(asOfTx);
+        if (newCache != null)
+            _currentCache = newCache;
+    }
+
+    private IndexTransactionCache BuildVectorCacheSnapshot(Transaction tx)
+    {
+        var mapping = _converter?.GetKnownFieldsForQuerying();
+        if (mapping is null)
+            return null;
+
+        var maxNodes = GetMaxNodesForVectorCache();
+        if (maxNodes <= 0)
+            return null;
+
+        var llt = tx.LowLevelTransaction;
+        Dictionary<Slice, HnswIndexCache> vectorCaches = null;
+        foreach (var field in mapping)
+        {
+            if (field.VectorOptions is null)
+                continue;
+            var cache = HnswIndexCache.WarmFromScratch(llt, field.FieldName, maxNodes);
+            if (cache is null)
+                continue;
+            vectorCaches ??= new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
+            // FieldName is allocated against _converter's persistent scope; _converter is
+            // disposed only when this CoraxIndexPersistence is disposed, which outlives any cache
+            // reachable from _currentCache or an open read tx's ImmutableExternalState.
+            Debug.Assert(field.FieldName.HasValue && field.FieldName.Size > 0,
+                "Vector field name must be allocated and non-empty for cache keying");
+            vectorCaches[field.FieldName] = cache;
+        }
+
+        return vectorCaches is null ? null : new IndexTransactionCache { VectorNodeCaches = vectorCaches };
     }
 
     internal override void RecreateSuggestionsSearchers(Transaction asOfTx)

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxIndexReadOperation.cs
@@ -26,6 +26,7 @@ using Raven.Server.Documents.Queries.Highlightings;
 using Raven.Server.Documents.Queries.MoreLikeThis.Corax;
 using Raven.Server.Documents.Queries.Results;
 using Raven.Server.Documents.Queries.Timings;
+using Raven.Server.Indexing;
 using Raven.Server.Json;
 using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
@@ -108,7 +109,17 @@ namespace Raven.Server.Documents.Indexes.Persistence.Corax
             {
                 MaxMemoizationSizeInBytes = index.Configuration.MaxMemoizationSize.GetValue(SizeUnit.Bytes),
             };
-            
+
+            // Pick up the per-field HNSW vector node caches that CoraxIndexPersistence attached
+            // to this transaction's ImmutableExternalState at creation time. The transaction
+            // holds the only reference the IndexSearcher needs; once the transaction disposes
+            // and no other transaction is still keeping the cache alive, GC reclaims it.
+            if (readTransaction.LowLevelTransaction.ImmutableExternalState is IndexTransactionCache txCache
+                && txCache.VectorNodeCaches is { Count: > 0 } vectorCaches)
+            {
+                IndexSearcher.AttachVectorNodeCaches(vectorCaches);
+            }
+
             if (index is {_forTestingPurposes: {CoraxConfiguration: not null}})
                 IndexSearcher.SetTestingConfiguration(index._forTestingPurposes.CoraxConfiguration);
             

--- a/src/Raven.Server/Indexing/IndexTransactionCache.cs
+++ b/src/Raven.Server/Indexing/IndexTransactionCache.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using Voron;
 using Voron.Data.BTrees;
+using Voron.Data.Graphs;
 
 namespace Raven.Server.Indexing
 {
@@ -28,5 +30,16 @@ namespace Raven.Server.Indexing
 
         public Dictionary<string, DirectoryFiles> DirectoriesByName = new Dictionary<string, DirectoryFiles>(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, CollectionEtags> Collections = new Dictionary<string, CollectionEtags>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Per-field HNSW vector caches keyed by field name. Populated by Corax indexes only
+        /// (null or empty for Lucene indexes and for Corax indexes without vector fields).
+        /// Attached to a transaction via
+        /// <see cref="Voron.Impl.LowLevelTransaction.ImmutableExternalState"/>, so a read tx
+        /// observes the same cache instance that was current at the moment its transaction was
+        /// created. Each cache instance is long-lived (one per index field) and survives across
+        /// commits; the dictionary only changes when a vector field is added or removed.
+        /// </summary>
+        public Dictionary<Slice, HnswIndexCache> VectorNodeCaches;
     }
 }

--- a/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
+++ b/src/Raven.Studio/typescript/models/database/index/configurationItem.ts
@@ -46,6 +46,7 @@ class configurationItem {
         "Indexing.Corax.MaxAllocationsAtDictionaryTrainingInMb",
         "Indexing.Corax.Static.ComplexFieldIndexingBehavior",
         "Indexing.Corax.UnmanagedAllocationsBatchSizeLimitInMb",
+        "Indexing.Corax.VectorSearch.CacheSizeInMb",
         "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
         "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
         "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",

--- a/src/Sparrow/PortableIntrinsics.cs
+++ b/src/Sparrow/PortableIntrinsics.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+
+#if NET7_0_OR_GREATER
+using System.Runtime.Intrinsics.X86;
+#endif
+#if NET9_0_OR_GREATER
+using System.Runtime.Intrinsics.Arm;
+#endif
+
+namespace Sparrow
+{
+    internal static class PortableIntrinsics
+    {
+        /// <summary>
+        /// JIT-time constant: true when software prefetch is available on this platform.
+        /// Use to guard scan-ahead or range-walk logic that is only worthwhile when
+        /// we can actually issue prefetch instructions.
+        /// </summary>
+        public static bool CanPrefetch
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+#if NET9_0_OR_GREATER
+                if (Sve.IsSupported)
+                    return true;
+#endif
+#if NET7_0_OR_GREATER
+                if (Sse.IsSupported)
+                    return true;
+#endif
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Prefetch a single cache line for temporal read (L1).
+        /// x86: SSE PREFETCHT0.  ARM SVE: PRFM PLDL1KEEP.  Otherwise: no-op.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void PrefetchRead(void* address)
+        {
+#if NET7_0_OR_GREATER
+            if (Sse.IsSupported)
+            {
+                Sse.Prefetch0(address);
+                return;
+            }
+#endif
+#if NET9_0_OR_GREATER
+            if (Sve.IsSupported)
+            {
+                Sve.Prefetch8Bit(Sve.CreateTrueMaskByte(), address, SvePrefetchType.LoadL1Temporal);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Prefetch a contiguous memory range for temporal read at 512-byte intervals.
+        /// The stride primes the hardware sequential prefetcher across page boundaries.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void PrefetchRange(byte* address, int length)
+        {
+            if (CanPrefetch == false)
+                return;
+
+            for (byte* p = address, end = address + length; p < end; p += 512)
+                PrefetchRead(p);
+        }
+    }
+}

--- a/src/Sparrow/Sparrow.csproj
+++ b/src/Sparrow/Sparrow.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);SYSLIB5003</NoWarn> <!-- ARM SVE intrinsics are experimental in .NET 10 -->
     <AssemblyName>Sparrow</AssemblyName>
     <PackageId>Sparrow</PackageId>
     <CodeAnalysisRuleSet>..\..\RavenDB.Client.ruleset</CodeAnalysisRuleSet>

--- a/src/Voron/Data/Graphs/Hnsw.Constants.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Constants.cs
@@ -8,7 +8,7 @@ public partial class Hnsw
 
     internal static readonly Slice VectorContainerStorageSlice;
     internal static readonly Slice VectorsContainerIdSlice;
-    private static readonly Slice NodeIdToLocationSlice;
+    internal static readonly Slice NodeIdToLocationSlice;
     public static readonly Slice NodesByVectorIdSlice;
     public static readonly Slice VectorsIdByHashSlice;
     internal static readonly Slice HnswGlobalConfigSlice;

--- a/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.ExactSearcher.cs
@@ -44,6 +44,12 @@ public partial class Hnsw
 
             public IEnumerable<bool> Search()
             {
+                // Reset the visited set for this traversal and record the query vector so the
+                // per-node QueryDistance cache is either reused (same vector) or invalidated
+                // (different vector) — OnQueryVector decides based on Memory identity.
+                ++_searchState._visitsCounter;
+                _searchState.OnQueryVector(_vector);
+
                 _pq = new PriorityQueue<long, float>();
                 Span<byte> vector = _vector.Span;
                 IEnumerable<long> toScan = _nodesToScan.HasValue ? _nodesToScan.Value.Iterate() : AllNodes();

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Sparrow;
 using Voron.Global;
 using Voron.Util;
 
 namespace Voron.Data.Graphs;
 
-public partial class Hnsw
+public unsafe partial class Hnsw
 {
     public partial class SearchState
     {
@@ -192,6 +194,11 @@ public partial class Hnsw
                             continue; // already checked
                         next.Visited = visitedCounter;
 
+                        // Prefetch the next unvisited neighbor's vector data to overlap
+                        // cache-miss latency with the current distance computation.
+                        // SimilarityCalc is ~65% of query time, ~80% of which is data loading.
+                        PrefetchNextNeighborVector(i + 1, visitedCounter);
+
                         var isDeleted = (next.PostingListId & Constants.Graphs.VectorId.EnsureIsSingleMask) == Constants.Graphs.VectorId.Tombstone
                                         || (_hasFilterMatch && _alreadyReturnedEdges.Contains(nextIndex));
 
@@ -285,6 +292,33 @@ public partial class Hnsw
                 };
                 
                 return _vectorReadCounter < max;
+            }
+
+            /// <summary>
+            /// Finds the next unvisited neighbor starting from <paramref name="startFrom"/> and
+            /// issues software prefetch instructions for its vector data. This overlaps the
+            /// cache-miss latency (~500ns for 6KB from L3) with the current distance computation (~633ns).
+            /// On platforms without software prefetch the JIT eliminates this entirely.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void PrefetchNextNeighborVector(int startFrom, int visitedCounter)
+            {
+                if (PortableIntrinsics.CanPrefetch == false)
+                    return;
+
+                for (int j = startFrom; j < _indexes.Count; j++)
+                {
+                    var idx = _indexes[j];
+                    ref var node = ref _searchState.GetNodeByIndex(idx);
+                    if (node.Visited == visitedCounter)
+                        continue;
+
+                    if (node.TryGetVectorAddress(out byte* address, out int length) == false)
+                        return; // vector not loaded yet, skip prefetch
+
+                    PortableIntrinsics.PrefetchRange(address, length);
+                    return;
+                }
             }
 
             private static int GetPrefetchExtendSize(int numberOfCandidates) => numberOfCandidates switch

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -96,6 +96,7 @@ public partial class Hnsw
 
                 lowerBound = float.MaxValue;
                 visitedCounter = ++_searchState._visitsCounter;
+                _searchState.OnQueryVector(_vector);
 
                 foreach (var nodeIdx in _startingPointIndexes)
                 {
@@ -122,8 +123,9 @@ public partial class Hnsw
                 Debug.Assert(candidatesQ.Count == 0, "_candidatesQ.Count == 0");
                 Debug.Assert(nearestEdgesQ.Count == 0, "_nearestEdgesQ.Count == 0");
 
-                lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
                 visitedCounter = ++_searchState._visitsCounter;
+                _searchState.OnQueryVector(_vector);
+                lowerBound = -_searchState.QueryDistance(_vector.Span, _startingPointIndex, ref _vectorReadCounter);
                 {
                     ref var startingPoint = ref _searchState.GetNodeByIndex(_startingPointIndex);
                     startingPoint.Visited = visitedCounter;
@@ -159,6 +161,12 @@ public partial class Hnsw
                         nearestEdgesQ.Count == _internalNumberOfCandidates)
                     {
                         ProcessResults();
+                        // Drain candidatesQ before yielding. Non-filtered queries consume only
+                        // the first batch and never resume the iterator, so without this clear
+                        // the shared SearchState carries far-from-the-old-vector candidates into
+                        // the next query, polluting its priority queue and forcing the search to
+                        // expand 25-30% more nodes than a fresh state would.
+                        candidatesQ.Clear();
                         yield return true;
                         // If we need to fetch more, we'll start the query again with a higher NumberOfCandidates.
                         // The SearchState keeps its state, so traversal through already visited nodes is I/O-free
@@ -236,17 +244,13 @@ public partial class Hnsw
 
             // Reset the NearestSearcher state; however, it does not clear the data already stored inside SearchState.
             // This is important because it allows us to reduce I/O pressure during over-fetching and when restarting the query.
+            // Node.Visited uses version-based invalidation keyed on SearchState._visitsCounter
+            // (incremented in InitState), and Node.QueryDistanceVersion uses a separate version
+            // keyed on the query vector, so neither needs a per-node reset here.
             private void Reset()
             {
                 _searchState._candidatesQ.Clear();
                 _searchState._nearestEdgesQ.Clear();
-
-                for (int nodeIdx = 0; nodeIdx < _searchState._nodes.Count; nodeIdx++)
-                {
-                    _searchState._nodes[nodeIdx].Visited = 0;
-                }
-
-                _searchState._visitsCounter = 0;
                 _candidates.Clear();
                 _nodeIds.Clear();
                 _indexes.Clear();

--- a/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
+++ b/src/Voron/Data/Graphs/Hnsw.NearestSearcher.cs
@@ -178,13 +178,8 @@ public unsafe partial class Hnsw
                         goto Start;
                     }
 
-                    ref var candidate = ref _searchState.GetNodeByIndex(cur);
-                    candidate.Visited = visitedCounter;
-
-                    ref var edges = ref candidate.EdgesPerLevel[_level];
-
-                    _nodeIds.ResetAndCopyFrom(allocator, edges.ToSpan());
-                    _searchState.LoadNodeIndexes(ref _nodeIds, ref _indexes);
+                    _searchState.GetNodeByIndex(cur).Visited = visitedCounter;
+                    _searchState.ResolveEdgeIndexes(cur, _level, ref _nodeIds, ref _indexes);
 
                     for (int i = 0; i < _indexes.Count; i++)
                     {

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Sparrow;
 using Sparrow.Compression;
 using Sparrow.Server.Utils;
@@ -29,6 +30,25 @@ public partial class Hnsw
         public int QueryDistanceVersion;
 
         public bool VectorLoaded => _vectorSpan.Length > 0;
+
+        /// <summary>
+        /// Returns the vector's memory address and length without triggering I/O.
+        /// Returns false if the vector hasn't been loaded yet.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetVectorAddress(out byte* address, out int length)
+        {
+            if (_vectorSpan.Length > 0)
+            {
+                address = _vectorSpan.Address;
+                length = _vectorSpan.Length;
+                return true;
+            }
+
+            address = null;
+            length = 0;
+            return false;
+        }
 
         public long GetVectorContainerId()
         {

--- a/src/Voron/Data/Graphs/Hnsw.Node.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Node.cs
@@ -19,9 +19,14 @@ public partial class Hnsw
         public long NodeId;
         public NativeList<NativeList<long>> EdgesPerLevel;
         public NativeList<NativeList<int>> EdgesIndexesPerLevel;
-        private UnmanagedSpan _vectorSpan;
+        internal UnmanagedSpan _vectorSpan;
         public int Visited;
-        public float? QueryDistance;
+        // Cached distance between this node and the current query vector. Valid only when
+        // QueryDistanceVersion == SearchState._queryVectorVersion. SearchState bumps that
+        // version whenever the query vector changes (see OnQueryVector), which in turn
+        // invalidates this entry without touching the node.
+        public float QueryDistanceValue;
+        public int QueryDistanceVersion;
 
         public bool VectorLoaded => _vectorSpan.Length > 0;
 
@@ -102,7 +107,7 @@ public partial class Hnsw
             return GetVectorUnmanagedSpan(state).ToSpan();
         }
 
-        internal void SetVector(SearchState searchState, UnmanagedSpan span)
+        internal void SetVector(in Options options, UnmanagedSpan span)
         {
             if ((VectorId & Constants.Graphs.VectorStorage.VectorContainerInternalIndexer) == 0)
             {
@@ -111,8 +116,8 @@ public partial class Hnsw
             }
 
             var count = (byte)(VectorId >> 1);
-            var offset = count * searchState.Options.VectorSizeBytes;
-            _vectorSpan = new UnmanagedSpan(span.Address + offset, searchState.Options.VectorSizeBytes);
+            var offset = count * options.VectorSizeBytes;
+            _vectorSpan = new UnmanagedSpan(span.Address + offset, options.VectorSizeBytes);
         }
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
+++ b/src/Voron/Data/Graphs/Hnsw.SimilarityMethods.cs
@@ -42,7 +42,7 @@ public partial class Hnsw
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static float HammingDistance(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    internal static float HammingDistance(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
     {
         return Functions.HammingBitDistance(a, b);
     }

--- a/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
+++ b/src/Voron/Data/Graphs/Hnsw.VectorSearchRetriever.cs
@@ -20,6 +20,7 @@ public partial class Hnsw
     {
         private int _returnedCandidates;
         private readonly SearchState _searchState;
+        private readonly bool _ownsSearchState;
         private int _currentNode, _currentMatchesIndex;
         private ContextBoundNativeList<long> _postingListResults;
         private FastPForDecoder _pforDecoder;
@@ -43,9 +44,11 @@ public partial class Hnsw
 
         public long CandidatesProcessed => _vectorsSearcher?.CandidatesProcessed ?? 0;
         
-        public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity)
+        public VectorSearchRetriever(SearchState searchState, IHnswSearcher vectorsSearcher, Memory<byte> vector, float minimumSimilarity,
+            bool ownsSearchState = true)
         {
             _searchState = searchState;
+            _ownsSearchState = ownsSearchState;
             _vectorsSearcher = vectorsSearcher;
             _vector = vector;
             _postingListResults = new(_searchState.Llt.Allocator);
@@ -311,7 +314,8 @@ public partial class Hnsw
             _pforDecoder.Dispose();
             _resultsEnumerator?.Dispose();
             _vectorsSearcher?.Dispose();
-            _searchState.Dispose();
+            if (_ownsSearchState)
+                _searchState.Dispose();
         }
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -289,6 +289,31 @@ public unsafe partial class Hnsw
         }
 
         /// <summary>
+        /// Resolves edge indexes for a node at the specified level, caching the result in
+        /// <see cref="Node.EdgesIndexesPerLevel"/>. On cache hit the expensive
+        /// <see cref="LoadNodeIndexes"/> dictionary lookups are skipped entirely.
+        /// May grow the nodes array — callers must re-fetch any outstanding node refs afterward.
+        /// </summary>
+        private void ResolveEdgeIndexes(int nodeIndex, int level, ref NativeList<long> nodeIds, ref NativeList<int> indexes)
+        {
+            ref var node = ref GetNodeByIndex(nodeIndex);
+
+            if (node.EdgesIndexesPerLevel.Count > level &&
+                node.EdgesIndexesPerLevel[level].Count == node.EdgesPerLevel[level].Count)
+            {
+                indexes.ResetAndCopyFrom(Llt.Allocator, node.EdgesIndexesPerLevel[level].ToSpan());
+                return;
+            }
+
+            nodeIds.ResetAndCopyFrom(Llt.Allocator, node.EdgesPerLevel[level].ToSpan());
+            LoadNodeIndexes(ref nodeIds, ref indexes);
+
+            node = ref GetNodeByIndex(nodeIndex);
+            node.EdgesIndexesPerLevel.SetCapacity(Llt.Allocator, level + 1);
+            node.EdgesIndexesPerLevel[level].ResetAndCopyFrom(Llt.Allocator, indexes.ToSpan());
+        }
+
+        /// <summary>
         /// This accepts a list of node ids (mutable, we do destructive updates to it) and translate
         /// that to a list of the indexes in the nodes array. If needed, it will load the nodes
         /// from the disk in a batch oriented manner.
@@ -543,11 +568,8 @@ public unsafe partial class Hnsw
                 do
                 {
                     moved = false;
-                    ref var n = ref GetNodeByIndex(currentNodeIndex);
-                    Debug.Assert(n.EdgesPerLevel.Count > level, "n.EdgesPerLevel.Count > level");
-                    ref var edges = ref n.EdgesPerLevel[level];
-                    nodeIds.ResetAndCopyFrom(Llt.Allocator, edges.ToSpan());
-                    LoadNodeIndexes(ref nodeIds, ref indexes);
+                    Debug.Assert(GetNodeByIndex(currentNodeIndex).EdgesPerLevel.Count > level, "n.EdgesPerLevel.Count > level");
+                    ResolveEdgeIndexes(currentNodeIndex, level, ref nodeIds, ref indexes);
                     for (var i = 0; i < indexes.Count; i++)
                     {
                         var edgeIdx = indexes[i];

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -99,9 +99,17 @@ public unsafe partial class Hnsw
         private readonly Tree _tree;
         private readonly Lookup<Int64LookupKey> _nodeIdToLocations;
         public readonly LowLevelTransaction Llt;
-        private int _visitsCounter;
+        // _visitsCounter versions Node.Visited; every traversal start bumps it so the visited
+        // set is reset in O(1). _queryVectorVersion versions Node.QueryDistanceVersion; it is
+        // bumped by OnQueryVector only when the query vector changes, so a node's cached distance
+        // survives across traversals that reuse the same query vector. Both start at 1 so
+        // freshly-loaded nodes (fields default to 0) never spuriously match.
+        private int _visitsCounter = 1;
+        private int _queryVectorVersion = 1;
+        private Memory<byte> _lastQueryVector;
         public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
         public readonly bool IsEmpty;
+        private readonly HnswIndexCache _nodeCache;
 
         public Span<Node> Nodes => _nodes.ToSpan();
         public Tree Tree => _tree;
@@ -124,9 +132,14 @@ public unsafe partial class Hnsw
         
         public Lookup<Int64LookupKey> NodeIdsByVectorId => _tree.LookupFor<Int64LookupKey>(Hnsw.NodesByVectorIdSlice);
 
-        public SearchState(LowLevelTransaction llt, Slice name)
+        public SearchState(LowLevelTransaction llt, Slice name) : this(llt, name, null)
+        {
+        }
+
+        public SearchState(LowLevelTransaction llt, Slice name, HnswIndexCache nodeCache)
         {
             Llt = llt;
+            _nodeCache = nodeCache;
             _tree = llt.Transaction.ReadTree(name);
 
             if (_tree is null || _tree.TryGetLookupFor(NodeIdToLocationSlice, out _nodeIdToLocations) == false)
@@ -135,15 +148,24 @@ public unsafe partial class Hnsw
                 return;
             }
 
-            var options = _tree.DirectRead(OptionsSlice);
-            Options = Unsafe.Read<Options>(options);
-            SimilarityCalc = Options.SimilarityMethod switch
+            if (_nodeCache != null)
             {
-                SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
-                SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
-                SimilarityMethod.HammingDistance => &HammingDistance,
-                _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
-            };
+                // Use options and similarity calc from the cache (already resolved)
+                Options = _nodeCache.Options;
+                SimilarityCalc = _nodeCache.SimilarityCalc;
+            }
+            else
+            {
+                var options = _tree.DirectRead(OptionsSlice);
+                Options = Unsafe.Read<Options>(options);
+                SimilarityCalc = Options.SimilarityMethod switch
+                {
+                    SimilarityMethod.CosineSimilaritySingles => &CosineDistanceSingles,
+                    SimilarityMethod.CosineSimilarityI8 => &CosineDistanceI8,
+                    SimilarityMethod.HammingDistance => &HammingDistance,
+                    _ => throw new ArgumentOutOfRangeException(nameof(Options.SimilarityMethod), Options.SimilarityMethod, null)
+                };
+            }
         }
 
         public float MinimumSimilarityToDistance(float minimumSimilarity)
@@ -239,6 +261,34 @@ public unsafe partial class Hnsw
         }
 
         /// <summary>
+        /// Populate a local node from the shared HnswIndexCache. Edge slices are copied into
+        /// local <see cref="NativeList{T}"/>s because NativeLists can't be shared across
+        /// allocator boundaries. Vector span is left default — <see cref="Node.GetVectorUnmanagedSpan"/>
+        /// lazily resolves it via <c>Llt</c>, which is consistent with the cache because the
+        /// publication invariant guarantees the cache reflects state visible to this
+        /// transaction's snapshot.
+        /// </summary>
+        private void CopyNodeFromCache(in HnswIndexCache.CachedNodeView cached, ref Node local)
+        {
+            local.NodeId = cached.Header->NodeId;
+            local.PostingListId = cached.Header->PostingListId;
+            local.VectorId = cached.Header->VectorId;
+            // local._vectorSpan and per-query scratch (Visited, QueryDistance*) stay at default.
+
+            int levelCount = cached.Header->LevelCount;
+            local.EdgesPerLevel.EnsureCapacityFor(Llt.Allocator, levelCount);
+            for (int lvl = 0; lvl < levelCount; lvl++)
+            {
+                var src = cached.EdgesAtLevel(lvl);
+                var dst = new NativeList<long>();
+                dst.EnsureCapacityFor(Llt.Allocator, src.Length);
+                for (int e = 0; e < src.Length; e++)
+                    dst.AddUnsafe(src[e]);
+                local.EdgesPerLevel.AddUnsafe(dst);
+            }
+        }
+
+        /// <summary>
         /// This accepts a list of node ids (mutable, we do destructive updates to it) and translate
         /// that to a list of the indexes in the nodes array. If needed, it will load the nodes
         /// from the disk in a batch oriented manner.
@@ -252,6 +302,18 @@ public unsafe partial class Hnsw
                 {
                     indexes.AddUnsafe(index);
                     nodeIds[i] = -1;
+                    continue;
+                }
+
+                // Check the shared HnswIndexCache before going to disk
+                if (_nodeCache != null && _nodeCache.TryGetNode(nodeIds[i], out var cached))
+                {
+                    var localIdx = AllocateNodeIndex(nodeIds[i]);
+                    CopyNodeFromCache(in cached, ref _nodes[localIdx]);
+                    _nodeIdToIdx[nodeIds[i]] = localIdx;
+                    indexes.AddUnsafe(localIdx);
+                    nodeIds[i] = -1;
+                    continue;
                 }
             }
 
@@ -288,6 +350,16 @@ public unsafe partial class Hnsw
             if (exists)
                 return nodeIdx;
 
+            // Check the shared HnswIndexCache for a pre-loaded copy.
+            // Deep-copy edge lists into the local allocator (NativeLists can't cross allocator boundaries).
+            // Vector data is read on demand through this transaction; the cache itself doesn't pin pages.
+            if (_nodeCache != null && _nodeCache.TryGetNode(nodeId, out var cached))
+            {
+                nodeIdx = AllocateNodeIndex(nodeId);
+                CopyNodeFromCache(in cached, ref GetNodeByIndex(nodeIdx));
+                return nodeIdx;
+            }
+
             if (TryGetLocationForNode(nodeId, out var nodeLocation) is false)
                 throw new InvalidOperationException($"Unable to find node id {nodeId}");
 
@@ -318,12 +390,12 @@ public unsafe partial class Hnsw
             }
 
             ref var to = ref GetNodeByIndex(toIdx);
-            if (to.QueryDistance is not null)
-                return to.QueryDistance.Value;
-            
+            if (to.QueryDistanceVersion == _queryVectorVersion)
+                return to.QueryDistanceValue;
+
             Span<byte> v2 = to.GetVector(this);
             var distance = SimilarityCalc(vector, v2);
-            
+
             return distance;
         }
 
@@ -331,17 +403,30 @@ public unsafe partial class Hnsw
         public float QueryDistance(ReadOnlySpan<byte> vector, int toIdx, ref long vectorReadCounter)
         {
             ref var to = ref GetNodeByIndex(toIdx);
-            if (to.QueryDistance is not null)
-            {
-                return to.QueryDistance.Value;
-            }
-            
+            if (to.QueryDistanceVersion == _queryVectorVersion)
+                return to.QueryDistanceValue;
+
             Span<byte> v2 = to.GetVector(this);
             vectorReadCounter++;
             var distance = SimilarityCalc(vector, v2);
-            to.QueryDistance = distance;
-
+            to.QueryDistanceValue = distance;
+            to.QueryDistanceVersion = _queryVectorVersion;
             return distance;
+        }
+
+        /// <summary>
+        /// Records the query vector a searcher is about to use. Bumps <see cref="_queryVectorVersion"/>
+        /// iff the vector differs from the previously recorded one (compared by Memory identity, i.e.
+        /// same underlying buffer and range). A bump invalidates every cached QueryDistance; a no-op
+        /// keeps them valid.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void OnQueryVector(Memory<byte> queryVector)
+        {
+            if (queryVector.Equals(_lastQueryVector))
+                return;
+            _lastQueryVector = queryVector;
+            ++_queryVectorVersion;
         }
 
         public void ReadPostingList(ContainerEntryId rawPostingListId, ref ContextBoundNativeList<long> listBuffer, ref FastPForDecoder pforDecoder, out int postingListSize)
@@ -603,7 +688,7 @@ public unsafe partial class Hnsw
            {
                // note, small vectors (where multiple can fit in a single page), will be 
                // partition inside the SetVector if needed
-               _nodes[nodeIndexes[i]].SetVector(this, spans[i]);
+               _nodes[nodeIndexes[i]].SetVector(Options, spans[i]);
            }
        }
 
@@ -612,14 +697,27 @@ public unsafe partial class Hnsw
            return _nodeIdToIdx.TryGetValue(nodeId, out nodeIndex);
        }
 
+       /// <summary>
+       /// Debug-only check that the candidate and nearest-edges priority queues owned by this
+       /// SearchState are empty. A searcher that reuses a shared SearchState must leave these
+       /// queues empty on Dispose; this method catches a searcher that fails to do so before the
+       /// next one starts.
+       /// </summary>
+       [Conditional("DEBUG")]
+       public void AssertSharedQueuesClean()
+       {
+           Debug.Assert(_candidatesQ.Count == 0, "_candidatesQ must be empty between sub-queries on a shared SearchState");
+           Debug.Assert(_nearestEdgesQ.Count == 0, "_nearestEdgesQ must be empty between sub-queries on a shared SearchState");
+       }
+
        public void Dispose()
        {
            _candidatesQ.Clear();
            _nearestEdgesQ.Clear();
            _newNodes.Dispose(Llt.Allocator);
-           
+
            _nodes.Dispose(Llt.Allocator);
-           
+
        }
     }
 
@@ -1108,6 +1206,68 @@ public unsafe partial class Hnsw
         var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
             SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
         return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity);
+    }
+
+    /// <summary>
+    /// Approximate nearest neighbor search using a caller-owned <see cref="SearchState"/>. The
+    /// caller keeps the SearchState alive across multiple queries and is responsible for
+    /// disposing it; node data loaded by earlier queries remains in SearchState for later ones,
+    /// so repeated traversals avoid the node-index resolution and container reads already paid
+    /// for on the first pass.
+    /// </summary>
+    public static VectorSearchRetriever ApproximateNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch = false)
+    {
+        // Bind the per-node QueryDistance cache to this query vector before SearchNearestAcrossLevels
+        // reads it. Without this, a shared SearchState reuses cached distances from a prior sub-query
+        // and the upper-level descent latches onto the wrong starting point.
+        searchState.OnQueryVector(vector);
+
+        var nearestNodesByLevel = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        nearestNodesByLevel.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
+
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+
+        searchState.SearchNearestAcrossLevels(vector.Span, -1, searchState.Options.MaxLevel, ref nearestNodesByLevel);
+        var nearest = nearestNodesByLevel[0];
+        nearestNodesByLevel.Clear();
+        var nearestEdgesSearch = searchState.NearestSearch(nearest, vector, 0, numberOfCandidates, nearestNodesByLevel,
+            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists, hasFilterMatch);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
+    }
+
+    /// <summary>
+    /// Exact nearest neighbor search using a caller-owned SearchState.
+    /// The caller is responsible for disposing the SearchState.
+    /// </summary>
+    public static VectorSearchRetriever ExactNearest(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, bool hasFilterMatch, ContextBoundNativeList<long>? nodesToScan = null)
+    {
+        searchState.OnQueryVector(vector);
+        var results = searchState.ExactSearch(vector, hasFilterMatch, numberOfCandidates, nodesToScan);
+        return new VectorSearchRetriever(searchState, results, vector, minimumSimilarity, ownsSearchState: false);
+    }
+
+    /// <summary>
+    /// Approximate filtered nearest neighbor search using a caller-owned SearchState.
+    /// The caller is responsible for disposing the SearchState.
+    /// </summary>
+    public static VectorSearchRetriever ApproximateFilteredNearest<TEnumerator>(SearchState searchState, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity, TEnumerator nodesToProbe)
+        where TEnumerator : IEnumerator<long>
+    {
+        searchState.OnQueryVector(vector);
+
+        var startingPointsIndexes = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        var candidates = new ContextBoundNativeList<int>(searchState.Llt.Allocator);
+        candidates.EnsureCapacityFor(searchState.Options.MaxLevel + 1);
+
+        if (searchState.Options.CountOfVectors == 0)
+            return new VectorSearchRetriever(searchState, searchState.EmptySearch(), vector, minimumSimilarity, ownsSearchState: false);
+
+        searchState.SearchFilteredNearest(ref startingPointsIndexes, nodesToProbe, numberOfCandidates, 16);
+        candidates.Clear();
+        var nearestEdgesSearch = searchState.NearestSearch(startingPointsIndexes, vector, 0, numberOfCandidates, candidates,
+            SearchState.NearestEdgesFlags.StartingPointAsEdge | SearchState.NearestEdgesFlags.FilterNodesWithEmptyPostingLists);
+        return new VectorSearchRetriever(searchState, nearestEdgesSearch, vector, minimumSimilarity, ownsSearchState: false);
     }
 
     public static VectorSearchRetriever EmptySearch(LowLevelTransaction llt, Slice name, int numberOfCandidates, Memory<byte> vector, float minimumSimilarity)

--- a/src/Voron/Data/Graphs/HnswIndexCache.cs
+++ b/src/Voron/Data/Graphs/HnswIndexCache.cs
@@ -1,0 +1,471 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Sparrow;
+using Voron.Data.Containers;
+using Voron.Data.Lookups;
+using Voron.Impl;
+using Voron.Util;
+
+namespace Voron.Data.Graphs;
+
+/// <summary>
+/// Per-index in-memory cache of HNSW node topology backed by a single contiguous unmanaged
+/// buffer. Each cached node is laid out as a fixed header followed by per-level offsets and
+/// the flat edge list. Lookups go through a <see cref="ConcurrentDictionary{TKey,TValue}"/>
+/// keyed by node id; the dict is the publication point for newly appended records and
+/// provides the acquire load that lets readers observe the bytes a writer placed before
+/// publishing.
+///
+/// The cache is initially populated by <see cref="WarmFromScratch"/> (BFS from the entry
+/// point through every reachable node up to the configured budget) and incrementally
+/// maintained by <see cref="ApplyCommit"/> after each indexing commit. Capacity is
+/// provisioned at construction time; if the buffer fills, further <see cref="TryAppend"/>
+/// calls fail gracefully and those nodes simply miss the cache.
+/// </summary>
+public sealed unsafe class HnswIndexCache : IDisposable
+{
+    public readonly Hnsw.Options Options;
+    public readonly delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> SimilarityCalc;
+
+    private byte* _buffer;
+    private long _writeHead;
+    private readonly long _capacityBytes;
+    private readonly ConcurrentDictionary<long, NodeRef> _ids;
+    private int _disposed;
+
+    public int Count => _ids.Count;
+    public long CapacityBytes => _capacityBytes;
+    public long UsedBytes => Volatile.Read(ref _writeHead);
+
+    public HnswIndexCache(long capacityBytes, in Hnsw.Options options,
+        delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> similarityCalc)
+    {
+        if (capacityBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacityBytes), capacityBytes, "capacity must be positive");
+
+        _capacityBytes = capacityBytes;
+        _buffer = (byte*)NativeMemory.AlignedAlloc((nuint)capacityBytes, 4096);
+        _ids = new ConcurrentDictionary<long, NodeRef>();
+        Options = options;
+        SimilarityCalc = similarityCalc;
+    }
+
+    ~HnswIndexCache() => DisposeNative();
+
+    public void Dispose()
+    {
+        DisposeNative();
+        GC.SuppressFinalize(this);
+    }
+
+    private void DisposeNative()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        var ptr = _buffer;
+        _buffer = null;
+        if (ptr != null)
+            NativeMemory.AlignedFree(ptr);
+    }
+
+    /// <summary>
+    /// Reserve a 64-byte-aligned region of <paramref name="sizeBytes"/> in the buffer. Lock-free
+    /// CAS on <see cref="_writeHead"/>; fails when the cap is reached.
+    /// </summary>
+    public bool TryAllocate(int sizeBytes, out long offset)
+    {
+        int aligned = AlignUp(sizeBytes, 64);
+        long head, next;
+        do
+        {
+            head = Volatile.Read(ref _writeHead);
+            next = head + aligned;
+            if (next > _capacityBytes)
+            {
+                offset = -1;
+                return false;
+            }
+        } while (Interlocked.CompareExchange(ref _writeHead, next, head) != head);
+        offset = head;
+        return true;
+    }
+
+    /// <summary>
+    /// Append a node record. The bytes are written first; the dict entry publishes them via the
+    /// volatile store at the end of <see cref="ConcurrentDictionary{TKey,TValue}.TryAdd"/>.
+    /// Returns false on capacity exhaustion or duplicate id.
+    /// </summary>
+    public bool TryAppend(long nodeId, in CachedNodeBuilder src)
+    {
+        Debug.Assert(src.LevelOffsets.Length == src.LevelCount + 1, "level offsets length mismatch");
+        Debug.Assert(src.Edges.Length == src.EdgesTotalCount, "edges length mismatch");
+
+        int totalBytes = sizeof(CachedNodeHeader)
+                         + sizeof(int) * (src.LevelCount + 1)
+                         + sizeof(long) * src.EdgesTotalCount;
+
+        if (TryAllocate(totalBytes, out long offset) == false)
+            return false;
+
+        var h = (CachedNodeHeader*)(_buffer + offset);
+        h->NodeId = nodeId;
+        h->PostingListId = src.PostingListId;
+        h->VectorId = src.VectorId;
+        h->LevelCount = src.LevelCount;
+        h->_padding0 = 0;
+        h->_padding1 = 0;
+        h->EdgesTotalCount = src.EdgesTotalCount;
+
+        var offsets = (int*)(h + 1);
+        src.LevelOffsets.CopyTo(new Span<int>(offsets, src.LevelCount + 1));
+
+        var edges = (long*)(offsets + src.LevelCount + 1);
+        src.Edges.CopyTo(new Span<long>(edges, src.EdgesTotalCount));
+
+        // Linearization point: only after the bytes above are written do readers become able to
+        // discover this record. The volatile store inside TryAdd provides the release barrier.
+        return _ids.TryAdd(nodeId, new NodeRef(offset));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetNode(long nodeId, out CachedNodeView view)
+    {
+        if (_ids.TryGetValue(nodeId, out var r) == false)
+        {
+            view = default;
+            return false;
+        }
+        var h = (CachedNodeHeader*)(_buffer + r.Offset);
+        var offs = (int*)(h + 1);
+        var edges = (long*)(offs + h->LevelCount + 1);
+        view = new CachedNodeView(h, offs, edges);
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool ContainsNode(long nodeId) => _ids.ContainsKey(nodeId);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int AlignUp(int v, int align) => (v + align - 1) & ~(align - 1);
+
+    private static delegate*<ReadOnlySpan<byte>, ReadOnlySpan<byte>, float> ResolveSimilarityKernel(in Hnsw.Options options) =>
+        options.SimilarityMethod switch
+        {
+            Hnsw.SimilarityMethod.CosineSimilaritySingles => &Hnsw.CosineDistanceSingles,
+            Hnsw.SimilarityMethod.CosineSimilarityI8 => &Hnsw.CosineDistanceI8,
+            Hnsw.SimilarityMethod.HammingDistance => &Hnsw.HammingDistance,
+            _ => throw new ArgumentOutOfRangeException(nameof(options.SimilarityMethod), options.SimilarityMethod, null)
+        };
+
+    /// <summary>
+    /// Conservative bytes-per-node estimate used to translate a node-count budget into a buffer
+    /// size at construction time. Worst-case node has <c>2*numberOfEdges</c> entries at level 0
+    /// across the flat edge list.
+    /// </summary>
+    public static int EstimateBytesPerNode(int numberOfEdges)
+    {
+        const int AvgLevelCount = 4;
+        return sizeof(CachedNodeHeader)
+               + sizeof(int) * (AvgLevelCount + 1)
+               + sizeof(long) * 2 * numberOfEdges
+               + 64;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    public struct CachedNodeHeader
+    {
+        public long NodeId;
+        public long PostingListId;
+        public long VectorId;
+        public byte LevelCount;
+        public byte _padding0;
+        public short _padding1;
+        public int EdgesTotalCount;
+    }
+
+    public readonly struct CachedNodeView
+    {
+        public readonly CachedNodeHeader* Header;
+        public readonly int* Offsets;
+        public readonly long* Edges;
+
+        public CachedNodeView(CachedNodeHeader* header, int* offsets, long* edges)
+        {
+            Header = header;
+            Offsets = offsets;
+            Edges = edges;
+        }
+
+        public byte LevelCount => Header->LevelCount;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan<long> EdgesAtLevel(int level)
+        {
+            int start = Offsets[level];
+            int end = Offsets[level + 1];
+            return new ReadOnlySpan<long>(Edges + start, end - start);
+        }
+    }
+
+    /// <summary>
+    /// Caller-built view of a node ready to be appended. The spans must remain stable for the
+    /// duration of the <see cref="TryAppend"/> call.
+    /// </summary>
+    public ref struct CachedNodeBuilder
+    {
+        public long PostingListId;
+        public long VectorId;
+        public byte LevelCount;
+        public int EdgesTotalCount;
+        public ReadOnlySpan<int> LevelOffsets;
+        public ReadOnlySpan<long> Edges;
+    }
+
+    private readonly record struct NodeRef(long Offset);
+
+    /// <summary>
+    /// Initial fill: BFS from the entry point. Upper levels (>= 1) are fully connected by HNSW
+    /// construction so a single sweep per level suffices. Level 0 needs full BFS because under
+    /// the standard HNSW level formula most nodes live only at level 0 and many sit &gt;1 hop
+    /// from any upper-level seed, so a single hop would silently miss them. BFS allocation
+    /// order means neighboring nodes become neighboring records in <see cref="_buffer"/>,
+    /// giving Gorder-style locality for free.
+    /// </summary>
+    public static HnswIndexCache WarmFromScratch(LowLevelTransaction llt, Slice fieldName, int maxNodes)
+    {
+        var tree = llt.Transaction.ReadTree(fieldName);
+        if (tree is null || tree.TryGetLookupFor(Hnsw.NodeIdToLocationSlice, out Lookup<Int64LookupKey> locations) == false)
+            return null;
+
+        var options = Unsafe.Read<Hnsw.Options>(tree.DirectRead(Hnsw.OptionsSlice));
+        var simCalc = ResolveSimilarityKernel(options);
+
+        long bytesPerNode = EstimateBytesPerNode(options.NumberOfEdges);
+        long capacityBytes = (long)Math.Max(1, maxNodes) * bytesPerNode * 11 / 10;
+        var cache = new HnswIndexCache(capacityBytes, options, simCalc);
+
+        if (maxNodes <= 0 || locations.TryGetValue(Hnsw.EntryPointId, out _) == false)
+            return cache;
+
+        using var builder = new WarmupBuilder(llt, locations, maxNodes);
+        builder.SeedAndLoad(Hnsw.EntryPointId);
+        if (builder.LoadedCount == 0)
+            return cache;
+
+        int maxLevel = builder.NodeLevelsAt(0) - 1;
+        for (int level = maxLevel; level > 0 && builder.HasBudget; level--)
+            builder.ExpandAtLevel(level);
+
+        // Level 0 needs full BFS, not a single hop: under the standard HNSW level formula
+        // most nodes live only at level 0 and many sit >1 hop from any upper-level seed, so
+        // one ExpandAtLevel(0) call leaves them out.
+        while (builder.HasBudget)
+        {
+            int before = builder.LoadedCount;
+            builder.ExpandAtLevel(0);
+            if (builder.LoadedCount == before)
+                break;
+        }
+
+        builder.AppendAllPromoted(cache);
+        return cache;
+    }
+
+    /// <summary>
+    /// Per-commit incremental update. Loads each dirty node from the just-committed snapshot
+    /// and appends a record. <see cref="TryAppend"/> is a no-op for nodes already present
+    /// (id collision), so re-touched nodes keep their previous cache entry.
+    /// </summary>
+    public void ApplyCommit(LowLevelTransaction llt, Slice fieldName, IEnumerable<long> dirtyNodeIds)
+    {
+        if (dirtyNodeIds is null)
+            return;
+
+        var tree = llt.Transaction.ReadTree(fieldName);
+        if (tree is null || tree.TryGetLookupFor(Hnsw.NodeIdToLocationSlice, out Lookup<Int64LookupKey> locations) == false)
+            return;
+
+        using var builder = new WarmupBuilder(llt, locations, budget: int.MaxValue);
+        foreach (var nodeId in dirtyNodeIds)
+        {
+            if (_ids.ContainsKey(nodeId))
+                continue;
+            builder.SeedAndLoad(nodeId);
+        }
+        builder.AppendAllPromoted(this);
+    }
+
+    /// <summary>
+    /// BFS scratch that owns the temporary <see cref="NativeList"/>s. Emits node records in the
+    /// order they were discovered, so a subsequent bulk append produces a locality-friendly
+    /// layout in the cache buffer.
+    /// </summary>
+    private sealed class WarmupBuilder : IDisposable
+    {
+        private readonly LowLevelTransaction _llt;
+        private readonly Lookup<Int64LookupKey> _locations;
+        private readonly int _budget;
+        private readonly Dictionary<long, int> _nodeIdToIdx = new();
+        private NativeList<Hnsw.Node> _working;
+        private NativeList<long> _batch;
+
+        public bool HasBudget => _nodeIdToIdx.Count < _budget;
+        public int LoadedCount => _nodeIdToIdx.Count;
+        public int NodeLevelsAt(int index) => _working[index].EdgesPerLevel.Count;
+
+        public WarmupBuilder(LowLevelTransaction llt, Lookup<Int64LookupKey> locations, int budget)
+        {
+            _llt = llt;
+            _locations = locations;
+            _budget = budget;
+        }
+
+        public void SeedAndLoad(long nodeId)
+        {
+            if (_nodeIdToIdx.ContainsKey(nodeId))
+                return;
+            _batch.Add(_llt.Allocator, nodeId);
+            Flush();
+        }
+
+        /// <summary>
+        /// Sweep at <paramref name="level"/>: every loaded node whose level-L edge list is
+        /// non-empty contributes its neighbors to the next batch. Multiple passes are required
+        /// because a Flush appends new nodes whose own level-L edges must also be followed
+        /// before we drop down a level.
+        /// </summary>
+        public void ExpandAtLevel(int level)
+        {
+            var seen = new HashSet<long>();
+            int cursor = 0;
+            while (cursor < _working.Count && _nodeIdToIdx.Count + _batch.Count < _budget)
+            {
+                for (int i = cursor; i < _working.Count && _nodeIdToIdx.Count + _batch.Count < _budget; i++)
+                {
+                    ref var node = ref _working[i];
+                    if (node.EdgesPerLevel.Count <= level)
+                        continue;
+
+                    ref var edges = ref node.EdgesPerLevel[level];
+                    for (int e = 0; e < edges.Count; e++)
+                    {
+                        var edgeId = edges[e];
+                        if (_nodeIdToIdx.ContainsKey(edgeId) || seen.Add(edgeId) == false)
+                            continue;
+                        _batch.Add(_llt.Allocator, edgeId);
+                        if (_nodeIdToIdx.Count + _batch.Count >= _budget)
+                            break;
+                    }
+                }
+                cursor = _working.Count;
+
+                if (_batch.Count == 0)
+                    break;
+                Flush();
+            }
+        }
+
+        // Lookup<T>.GetFor walks pages left-to-right and updates LastSearchPosition, so unsorted
+        // keys produce spurious not-found results. Sort here, then map decoded results back to
+        // the original slot order so emit order matches insertion order.
+        private void Flush()
+        {
+            var keys = _batch.ToSpan();
+            int priorCount = _working.Count;
+
+            var targetSlots = new int[keys.Length];
+            _working.EnsureCapacityFor(_llt.Allocator, keys.Length);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                targetSlots[i] = _working.Count;
+                _working.Add(_llt.Allocator, new Hnsw.Node { NodeId = keys[i] });
+            }
+
+            keys.Sort(targetSlots.AsSpan());
+            _locations.GetFor(keys, keys, -1);
+
+            var spans = new UnmanagedSpan[keys.Length];
+            Container.GetAll(_llt, keys, spans.AsSpan(), -1, _llt.PageLocator);
+            for (int i = 0; i < keys.Length; i++)
+            {
+                if (spans[i].Length == 0)
+                {
+                    // The graph references a node that has no container entry; tombstoned nodes
+                    // keep their entry with a marker, so a zero-length span is corruption.
+                    throw new InvalidDataException(
+                        $"HNSW node {_working[targetSlots[i]].NodeId} is referenced as an edge target " +
+                        "but has no container entry; the graph appears to be corrupt.");
+                }
+                Hnsw.Node.Decode(_llt, spans[i].ToSpan()).LoadInto(ref _working[targetSlots[i]]);
+            }
+
+            for (int i = priorCount; i < _working.Count; i++)
+            {
+                ref var node = ref _working[i];
+                int levels = node.EdgesPerLevel.Count;
+                if (levels == 0)
+                    continue; // not decoded (tombstone / missing) — skip
+                if (levels > byte.MaxValue)
+                    throw new InvalidDataException(
+                        $"HNSW node {node.NodeId} reports {levels} levels; graph appears corrupt (max expected ~log2(N))");
+                _nodeIdToIdx[node.NodeId] = i;
+            }
+
+            _batch.Clear();
+        }
+
+        /// <summary>
+        /// Bulk-emit every loaded node into <paramref name="cache"/>. Routers (level &gt;= 1)
+        /// and leaves (level 0 only) are both admitted; the BFS in <see cref="WarmFromScratch"/>
+        /// caps the loaded set at the configured budget, and the goal is the highest cache hit
+        /// rate over the working set rather than a structural slice of the graph.
+        /// </summary>
+        public void AppendAllPromoted(HnswIndexCache cache)
+        {
+            Span<int> levelOffsetsScratch = stackalloc int[byte.MaxValue + 1];
+            var edgesScratch = new List<long>(cache.Options.NumberOfEdges * 4);
+
+            foreach (var (_, idx) in _nodeIdToIdx)
+            {
+                ref var node = ref _working[idx];
+                int levels = node.EdgesPerLevel.Count;
+                if (levels == 0)
+                    continue; // tombstone / missing — skip
+
+                edgesScratch.Clear();
+                levelOffsetsScratch[0] = 0;
+                for (int lvl = 0; lvl < levels; lvl++)
+                {
+                    var src = node.EdgesPerLevel[lvl];
+                    for (int e = 0; e < src.Count; e++)
+                        edgesScratch.Add(src[e]);
+                    levelOffsetsScratch[lvl + 1] = edgesScratch.Count;
+                }
+
+                var builder = new CachedNodeBuilder
+                {
+                    PostingListId = node.PostingListId,
+                    VectorId = node.VectorId,
+                    LevelCount = (byte)levels,
+                    EdgesTotalCount = edgesScratch.Count,
+                    LevelOffsets = levelOffsetsScratch[..(levels + 1)],
+                    Edges = CollectionsMarshal.AsSpan(edgesScratch),
+                };
+                if (cache.TryAppend(node.NodeId, builder) == false)
+                    break; // capacity exhausted: subsequent nodes also fail, stop early
+            }
+        }
+
+        public void Dispose()
+        {
+            _batch.Dispose(_llt.Allocator);
+            _working.Dispose(_llt.Allocator);
+        }
+    }
+}

--- a/test/FastTests/Issues/RavenDB_16590.cs
+++ b/test/FastTests/Issues/RavenDB_16590.cs
@@ -87,6 +87,7 @@ namespace FastTests.Issues
                 "Indexing.Querying.UseSearchAnalyzerForDynamicFieldsIfNotSetExplicitlyInSearchQuery",
                 "Indexing.Querying.Corax.NullFirst",
                 
+                "Indexing.Corax.VectorSearch.CacheSizeInMb",
                 "Indexing.Corax.VectorSearch.DefaultMinimumSimilarity",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfEdges",
                 "Indexing.Corax.VectorSearch.DefaultNumberOfCandidatesForIndexing",

--- a/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
+++ b/test/FastTests/Voron/Graphs/HnswIndexCacheTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+using VectorEmbeddingType = Voron.Data.Graphs.VectorEmbeddingType;
+
+namespace FastTests.Voron.Graphs;
+
+public unsafe class HnswIndexCacheTests(ITestOutputHelper output) : StorageTest(output)
+{
+    private const string TreeName = "test";
+    private const int VectorDimensions = 16;
+    private const int VectorSizeInBytes = VectorDimensions * sizeof(float);
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void EmptyGraphReturnsEmptyCache()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        using (var tx = Env.WriteTransaction())
+        {
+            Hnsw.Create(tx.LowLevelTransaction, treeName, VectorSizeInBytes, 3, 12, VectorEmbeddingType.Single);
+            tx.Commit();
+        }
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 1024);
+            Assert.NotNull(cache);
+            Assert.Equal(0, cache.Count);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void ZeroBudgetReturnsEmptyCache()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 50, seed: 42);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 0);
+            Assert.NotNull(cache);
+            Assert.Equal(0, cache.Count);
+        }
+    }
+
+    // With a budget that exceeds the graph size, BFS from the entry point must reach every
+    // node — including level-0 leaves — and admit it. The cache count therefore equals the
+    // full vector count.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void BudgetLargerThanGraphCachesAllNodes()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        const int vectorCount = 200;
+        BuildGraph(treeName, vectorCount, seed: 42);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 10_000);
+            Assert.Equal(vectorCount, cache.Count);
+        }
+    }
+
+    // When the budget caps below the graph size, BFS must fill the cache exactly to the
+    // budget — no fewer (otherwise we are starving the cache and missing reachable nodes).
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CacheFullyUsesBudgetWhenGraphIsLargerThanBudget()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        const int vectorCount = 1500;
+        const int budget = 400;
+        BuildGraph(treeName, vectorCount, seed: 42);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: budget);
+            Assert.InRange(cache.Count, budget * 9 / 10, budget);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CachedEdgesMatchFreshlyLoadedEdges()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 500, seed: 7);
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 10_000);
+            Assert.True(cache.Count > 0);
+
+            // Load a fresh SearchState for ground-truth edges.
+            using var state = new Hnsw.SearchState(tx.LowLevelTransaction, treeName);
+
+            foreach (var (nodeId, view) in EnumerateCache(cache, 500))
+            {
+                int stateIdx = state.GetNodeIndexById(nodeId);
+                ref var stateNode = ref state.GetNodeByIndex(stateIdx);
+
+                Assert.Equal(stateNode.NodeId, view.Header->NodeId);
+                Assert.Equal(stateNode.VectorId, view.Header->VectorId);
+                Assert.Equal(stateNode.PostingListId, view.Header->PostingListId);
+                Assert.Equal(stateNode.EdgesPerLevel.Count, view.LevelCount);
+
+                for (int lvl = 0; lvl < view.LevelCount; lvl++)
+                {
+                    var cachedEdges = view.EdgesAtLevel(lvl);
+                    var stateEdges = stateNode.EdgesPerLevel[lvl];
+
+                    Assert.Equal(stateEdges.Count, cachedEdges.Length);
+                    for (int e = 0; e < cachedEdges.Length; e++)
+                        Assert.Equal(stateEdges[e], cachedEdges[e]);
+                }
+            }
+        }
+    }
+
+    // The cache reflects the snapshot of the LLT it was built from. A cache built from an older
+    // read tx must not surface nodes that were committed after that snapshot.
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void CacheBuiltFromOlderSnapshotDoesNotIncludeLaterNodes()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 200, seed: 11);
+
+        long countAtSnapshot;
+        using (var readTx = Env.ReadTransaction())
+        {
+            using var state = new Hnsw.SearchState(readTx.LowLevelTransaction, treeName);
+            countAtSnapshot = state.Options.CountOfVectors;
+
+            // Add MORE vectors in a write tx AFTER the read snapshot was opened.
+            AddVectors(treeName, vectorCount: 100, firstId: (int)countAtSnapshot + 1, seed: 22);
+
+            using var cache = HnswIndexCache.WarmFromScratch(readTx.LowLevelTransaction, treeName, maxNodes: 10_000);
+
+            foreach (var (nodeId, _) in EnumerateCache(cache, (int)countAtSnapshot))
+                Assert.InRange(nodeId, 1L, countAtSnapshot);
+        }
+    }
+
+    [RavenFact(RavenTestCategory.Voron | RavenTestCategory.Vector)]
+    public void SearchStateCanQueryUsingACache()
+    {
+        using var _ = Slice.From(Allocator, TreeName, out var treeName);
+        BuildGraph(treeName, vectorCount: 300, seed: 19);
+
+        float[] query = RandomVector(new Random(99));
+        var queryBytes = MemoryMarshal.Cast<float, byte>(query).ToArray();
+
+        using (var tx = Env.ReadTransaction())
+        {
+            using var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, treeName, maxNodes: 10_000);
+            Assert.True(cache.Count > 0);
+
+            using var state = new Hnsw.SearchState(tx.LowLevelTransaction, treeName, cache);
+            using var retriever = Hnsw.ApproximateNearest(state, numberOfCandidates: 32, queryBytes, minimumSimilarity: 0f);
+
+            var scores = new float[32];
+            var docs = new long[32];
+            int total = 0;
+            int read;
+            do
+            {
+                read = retriever.Fill(docs, scores, filter: null);
+                total += read;
+            } while (read != 0);
+
+            Assert.True(total > 0, "search with cache returned no results");
+        }
+    }
+
+    private void BuildGraph(Slice treeName, int vectorCount, int seed)
+    {
+        var random = new Random(seed);
+        using var tx = Env.WriteTransaction();
+        Hnsw.Create(tx.LowLevelTransaction, treeName, VectorSizeInBytes, numberOfEdges: 12,
+            numberOfCandidates: 16, VectorEmbeddingType.Single);
+
+        using (var registration = Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, random))
+        {
+            for (int i = 1; i <= vectorCount; i++)
+            {
+                var v = RandomVector(random);
+                registration.Register(i, MemoryMarshal.Cast<float, byte>(v));
+            }
+            registration.Commit(CancellationToken.None);
+        }
+        tx.Commit();
+    }
+
+    private void AddVectors(Slice treeName, int vectorCount, int firstId, int seed)
+    {
+        var random = new Random(seed);
+        using var tx = Env.WriteTransaction();
+        using (var registration = Hnsw.RegistrationFor(tx.LowLevelTransaction, treeName, random))
+        {
+            for (int i = 0; i < vectorCount; i++)
+            {
+                var v = RandomVector(random);
+                registration.Register(firstId + i, MemoryMarshal.Cast<float, byte>(v));
+            }
+            registration.Commit(CancellationToken.None);
+        }
+        tx.Commit();
+    }
+
+    private static float[] RandomVector(Random random)
+    {
+        var v = new float[VectorDimensions];
+        float sumSq = 0;
+        for (int i = 0; i < VectorDimensions; i++)
+        {
+            v[i] = (float)(random.NextDouble() * 2 - 1);
+            sumSq += v[i] * v[i];
+        }
+        var norm = MathF.Sqrt(sumSq);
+        if (norm > 0)
+        {
+            for (int i = 0; i < VectorDimensions; i++)
+                v[i] /= norm;
+        }
+        return v;
+    }
+
+    /// <summary>
+    /// Probe ids 1..upper and yield those that are present. Iteration order is not part of the
+    /// cache contract, so this iterator works against the public TryGetNode surface.
+    /// </summary>
+    private static unsafe IEnumerable<(long NodeId, HnswIndexCache.CachedNodeView View)> EnumerateCache(HnswIndexCache cache, int upper)
+    {
+        for (long nodeId = 1; nodeId <= upper; nodeId++)
+        {
+            if (cache.TryGetNode(nodeId, out var view))
+                yield return (nodeId, view);
+        }
+    }
+}

--- a/test/SlowTests/Corax/Vectors/VectorSearchWithHnswIndexCache.cs
+++ b/test/SlowTests/Corax/Vectors/VectorSearchWithHnswIndexCache.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Corax;
+using Corax.Indexing;
+using Corax.Mappings;
+using Corax.Querying;
+using Corax.Utils;
+using FastTests.Voron;
+using Nito.Disposables;
+using Raven.Server.Documents.Indexes.VectorSearch;
+using Sparrow.Server;
+using Sparrow.Threading;
+using Tests.Infrastructure;
+using Voron;
+using Voron.Data.Graphs;
+using Xunit;
+
+namespace SlowTests.Corax.Vectors;
+
+public class VectorSearchWithHnswIndexCache(ITestOutputHelper output) : StorageTest(output)
+{
+    // 128-D random unit vectors admit a non-trivial nearest-neighbor graph (at very low
+    // dimensions uniform random vectors become nearly equidistant and HNSW quality collapses).
+    private const int VectorDimensions = 128;
+    private const int VectorByteSize = VectorDimensions * sizeof(float);
+
+    // Queries must return the same matches whether or not a cache is attached, and whether
+    // the cache contains all nodes or just a subset. The partial-cache variant exercises
+    // the mixed code path: cache hits for upper-level nodes, disk loads for the remainder.
+    // Binary is excluded because hamming distance at small dimensions produces many nodes at
+    // equal distance, so which ones land in top-K depends on priority-queue tie-breaking —
+    // an ambiguity that is unrelated to whether the cache is used.
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(VectorEmbeddingType.Single, 10_000)] // cache holds every node
+    [InlineData(VectorEmbeddingType.Single, 50)]     // cache holds only upper-level nodes
+    [InlineData(VectorEmbeddingType.Int8, 10_000)]
+    [InlineData(VectorEmbeddingType.Int8, 50)]
+    public void ResultsAreIdenticalWithAndWithoutCache(VectorEmbeddingType embedding, int cacheBudget)
+        => RunParityCheck(embedding, cacheBudget, baseSeed: 23);
+
+    private void RunParityCheck(VectorEmbeddingType embedding, int cacheBudget, int baseSeed)
+    {
+        using var _ = GetMappings(embedding, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        const int docCount = 500;
+        const int queryCount = 25;
+        const int k = 16;
+
+        BuildIndex(mapping, docCount, seed: 7);
+        var caches = BuildCaches(metadata.FieldName, cacheBudget);
+
+        for (int i = 0; i < queryCount; i++)
+        {
+            long[] uncached, cached;
+            using (var searcher = new IndexSearcher(Env, mapping))
+                uncached = TopK(searcher, metadata, NewQueryVector(bsc, seed: baseSeed + i), k);
+
+            using (var searcher = new IndexSearcher(Env, mapping))
+            {
+                searcher.AttachVectorNodeCaches(caches);
+                cached = TopK(searcher, metadata, NewQueryVector(bsc, seed: baseSeed + i), k);
+            }
+
+            Assert.Equal(uncached, cached);
+        }
+    }
+
+    // When no cache is attached to an IndexSearcher, queries must still work — it's the
+    // happy-path for indexes that have disabled the cache (CoraxVectorSearchCacheSize=0) or
+    // haven't committed yet so no cache exists. Results must also be meaningful: every returned
+    // id must map to a real doc and the top-K must agree with an exact scan on most of its
+    // entries (HNSW is approximate; we require high recall, not byte-identity).
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(17, 71)]
+    [InlineData(null, null)]
+    public void SearchWorksWithNoCacheAttached(int? buildSeed, int? querySeed)
+    {
+        var (bSeed, qSeed) = MaterializeSeeds(buildSeed, querySeed);
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        BuildIndex(mapping, docCount: 200, seed: bSeed);
+
+        long[] truth, returned;
+        using (var searcher = new IndexSearcher(Env, mapping))
+            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16, isExact: true);
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            // Deliberately do NOT call AttachVectorNodeCaches.
+            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16);
+        }
+
+        Assert.Equal(16, returned.Length);
+        Assert.Equal(returned.Distinct().Count(), returned.Length);
+        foreach (var id in returned)
+            Assert.InRange(id, 1L, 200L);
+        // At least one returned id must overlap the exact top-K — lower bound on recall that
+        // catches "the search returned random ids" without being sensitive to approximate-search
+        // jitter on adversarial random seeds.
+        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (buildSeed={bSeed}, querySeed={qSeed})");
+    }
+
+    // When a cache is attached but empty (e.g. the graph has fewer nodes than the cache
+    // budget could hold but none were persisted yet), queries must fall back to disk loads
+    // and still return meaningful results.
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(19, 73)]
+    [InlineData(null, null)]
+    public void SearchWorksWithEmptyCacheDictionaryAttached(int? buildSeed, int? querySeed)
+    {
+        var (bSeed, qSeed) = MaterializeSeeds(buildSeed, querySeed);
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        BuildIndex(mapping, docCount: 200, seed: bSeed);
+
+        long[] truth, returned;
+        using (var searcher = new IndexSearcher(Env, mapping))
+            truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16, isExact: true);
+
+        using (var searcher = new IndexSearcher(Env, mapping))
+        {
+            searcher.AttachVectorNodeCaches(new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance));
+            returned = TopK(searcher, metadata, NewQueryVector(bsc, seed: qSeed), k: 16);
+        }
+
+        Assert.Equal(16, returned.Length);
+        Assert.Equal(returned.Distinct().Count(), returned.Length);
+        foreach (var id in returned)
+            Assert.InRange(id, 1L, 200L);
+        // At least one returned id must overlap the exact top-K — lower bound on recall that
+        // catches "the search returned random ids" without being sensitive to approximate-search
+        // jitter on adversarial random seeds.
+        Assert.True(Recall(truth, returned) > 0, $"no overlap with exact top-K (buildSeed={bSeed}, querySeed={qSeed})");
+    }
+
+    private (int BuildSeed, int QuerySeed) MaterializeSeeds(int? buildSeed, int? querySeed)
+    {
+        if (buildSeed.HasValue && querySeed.HasValue)
+            return (buildSeed.Value, querySeed.Value);
+        var rng = new Random();
+        var b = buildSeed ?? rng.Next();
+        var q = querySeed ?? rng.Next();
+        Output.WriteLine($"Random seeds: buildSeed={b}, querySeed={q} (re-run with fixed seeds to reproduce)");
+        return (b, q);
+    }
+
+    // Randomized variant of the parity theory: picks a fresh seed at test time and logs it
+    // so a regression can be reproduced. Fixed-seed variants cover the deterministic path.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void ResultsAreIdenticalWithAndWithoutCache_RandomSeed()
+    {
+        var seed = unchecked((int)DateTime.UtcNow.Ticks);
+        Output.WriteLine($"Random seed: {seed} (re-run with fixed seed to reproduce)");
+        RunParityCheck(VectorEmbeddingType.Single, cacheBudget: 10_000, baseSeed: seed);
+    }
+
+    // The cached path must agree with the exact scan on most top-K. HNSW params are sized
+    // so intrinsic recall vs exact is high enough (~0.83) that the 0.75 threshold is a
+    // quality gate rather than a "not random ids" sanity check. The parity tests above
+    // cover the aggressive-params path with a tight ef.
+    [RavenTheory(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    [InlineData(10_000)] // cache holds every node
+    [InlineData(50)]     // cache holds only upper-level nodes
+    public void CachedSearchAchievesGoodRecallAgainstExactScan(int cacheBudget)
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping, numberOfEdges: 32, numberOfCandidates: 256);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        const int docCount = 500;
+        const int queryCount = 10;
+        const int k = 16;
+
+        BuildIndex(mapping, docCount, seed: 7);
+        var caches = BuildCaches(metadata.FieldName, cacheBudget);
+
+        double totalRecall = 0;
+        for (int i = 0; i < queryCount; i++)
+        {
+            long[] truth, cached;
+            using (var searcher = new IndexSearcher(Env, mapping))
+                truth = TopK(searcher, metadata, NewQueryVector(bsc, seed: 23 + i), k, isExact: true);
+
+            using (var searcher = new IndexSearcher(Env, mapping))
+            {
+                searcher.AttachVectorNodeCaches(caches);
+                cached = TopK(searcher, metadata, NewQueryVector(bsc, seed: 23 + i), k);
+            }
+
+            totalRecall += Recall(truth, cached);
+        }
+
+        var avgRecall = totalRecall / queryCount;
+        Output.WriteLine($"Average recall@{k} with cacheBudget={cacheBudget}: {avgRecall:F3}");
+        Assert.True(avgRecall >= 0.75, $"HNSW recall@{k} dropped to {avgRecall:F3} (threshold 0.75) with cacheBudget={cacheBudget}");
+    }
+
+    // Multi-vector queries internally share a SearchState across sub-searches. The cache
+    // must interoperate correctly with that reuse path.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void MultiVectorSearchResultsAreIdenticalWithAndWithoutCache()
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+        BuildIndex(mapping, docCount: 400, seed: 13);
+
+        long[] Run(bool withCache)
+        {
+            using var searcher = new IndexSearcher(Env, mapping);
+            if (withCache)
+                searcher.AttachVectorNodeCaches(BuildCaches(metadata.FieldName));
+
+            // Query vectors are allocated per-run because each IndexSearcher disposal
+            // releases the ByteStringContext-backed VectorValue buffers.
+            var queryVectors = new[] { NewQueryVector(bsc, seed: 29), NewQueryVector(bsc, seed: 30), NewQueryVector(bsc, seed: 31) };
+            var match = searcher.MultiVectorSearch(metadata, queryVectors, 0.0f, 16, false, false, filterQuery: null, scanningThreshold: 0);
+            var collected = new List<long>();
+            Span<long> ids = stackalloc long[16];
+            int read;
+            while ((read = match.Fill(ids)) > 0)
+                for (int i = 0; i < read; i++)
+                    collected.Add(ids[i]);
+            collected.Sort();
+            return collected.ToArray();
+        }
+
+        Assert.Equal(Run(withCache: false), Run(withCache: true));
+    }
+
+    // A query opened BEFORE new vectors were committed must see its own snapshot, even when
+    // the HnswIndexCache it was given was built AT OR BEFORE that snapshot. A cache that predates
+    // the query's tx is always valid; the query must never see vectors added after it started.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void QueryAtOlderTxDoesNotSeeVectorsCommittedAfterItStarted()
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+
+        BuildIndex(mapping, docCount: 200, seed: 41);
+        var caches = BuildCaches(metadata.FieldName); // cache reflects the first 200 vectors
+
+        // Take a snapshot by creating the IndexSearcher now. Subsequent writes must be
+        // invisible to queries issued on this searcher.
+        using var snapshotSearcher = new IndexSearcher(Env, mapping);
+        snapshotSearcher.AttachVectorNodeCaches(caches);
+
+        AppendDocuments(mapping, docCount: 200, firstId: 201, seed: 53);
+
+        var q = NewQueryVector(bsc, seed: 61);
+        var ids = TopK(snapshotSearcher, metadata, q, k: 200);
+
+        // Max docId at the snapshot is 200. Anything >= 201 was committed later and must
+        // not be returned.
+        foreach (var id in ids)
+            Assert.InRange(id, 1L, 200L);
+    }
+
+    // A cache built after both commits should yield results equivalent to a fresh searcher
+    // with no cache: the cache sees everything, queries see everything.
+    [RavenFact(RavenTestCategory.Vector | RavenTestCategory.Corax)]
+    public void CacheBuiltAfterAllCommitsAgreesWithUncachedSearcher()
+    {
+        using var _ = GetMappings(VectorEmbeddingType.Single, out var bsc, out var mapping);
+        var metadata = mapping.GetByFieldId(1).Metadata;
+
+        BuildIndex(mapping, docCount: 200, seed: 41);
+        AppendDocuments(mapping, docCount: 200, firstId: 201, seed: 53);
+
+        var caches = BuildCaches(metadata.FieldName);
+
+        long[] cached, uncached;
+        {
+            using var searcher = new IndexSearcher(Env, mapping);
+            searcher.AttachVectorNodeCaches(caches);
+            cached = TopK(searcher, metadata, NewQueryVector(bsc, seed: 61), k: 16);
+        }
+        {
+            using var searcher = new IndexSearcher(Env, mapping);
+            uncached = TopK(searcher, metadata, NewQueryVector(bsc, seed: 61), k: 16);
+        }
+
+        Assert.Equal(uncached, cached);
+    }
+
+    private void BuildIndex(IndexFieldsMapping mapping, int docCount, int seed)
+    {
+        var random = new Random(seed);
+        using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
+        for (int i = 1; i <= docCount; i++)
+        {
+            var id = $"docs/{i}";
+            using var entry = indexWriter.Index(id);
+            entry.Write(0, System.Text.Encoding.UTF8.GetBytes(id));
+            entry.WriteVector(1, "Vector", MemoryMarshal.Cast<float, byte>(RandomVector(random)));
+            entry.EndWriting();
+        }
+        indexWriter.Commit();
+    }
+
+    private void AppendDocuments(IndexFieldsMapping mapping, int docCount, int firstId, int seed)
+    {
+        var random = new Random(seed);
+        using var indexWriter = new IndexWriter(Env, mapping, SupportedFeatures.All);
+        for (int i = 0; i < docCount; i++)
+        {
+            var docId = firstId + i;
+            var id = $"docs/{docId}";
+            using var entry = indexWriter.Index(id);
+            entry.Write(0, System.Text.Encoding.UTF8.GetBytes(id));
+            entry.WriteVector(1, "Vector", MemoryMarshal.Cast<float, byte>(RandomVector(random)));
+            entry.EndWriting();
+        }
+        indexWriter.Commit();
+    }
+
+    private Dictionary<Slice, HnswIndexCache> BuildCaches(Slice fieldName, int maxNodes = 10_000)
+    {
+        using var tx = Env.ReadTransaction();
+        var cache = HnswIndexCache.WarmFromScratch(tx.LowLevelTransaction, fieldName, maxNodes);
+        var dict = new Dictionary<Slice, HnswIndexCache>(SliceComparer.Instance);
+        if (cache != null && cache.Count > 0)
+            dict[fieldName] = cache;
+        return dict;
+    }
+
+    private static VectorValue NewQueryVector(ByteStringContext bsc, int seed)
+    {
+        var v = RandomVector(new Random(seed));
+        var scope = bsc.Allocate(VectorByteSize, out Memory<byte> buffer);
+        MemoryMarshal.Cast<float, byte>(v).CopyTo(buffer.Span);
+        return GenerateEmbeddings.FromArray(bsc, scope, buffer, Raven.Client.Documents.Indexes.Vector.VectorOptions.Default, VectorByteSize);
+    }
+
+    private static long[] TopK(IndexSearcher searcher, FieldMetadata metadata, VectorValue query, int k, bool isExact = false)
+    {
+        var match = searcher.VectorSearch(metadata, query, 0.0f, k, isExact, false);
+        var collected = new List<long>();
+        Span<long> ids = stackalloc long[k];
+        int read;
+        while ((read = match.Fill(ids)) > 0)
+        {
+            for (int i = 0; i < read; i++)
+                collected.Add(ids[i]);
+        }
+        collected.Sort();
+        return collected.ToArray();
+    }
+
+    private static float[] RandomVector(Random random)
+    {
+        var v = new float[VectorDimensions];
+        float sumSq = 0;
+        for (int i = 0; i < VectorDimensions; i++)
+        {
+            v[i] = (float)(random.NextDouble() * 2 - 1);
+            sumSq += v[i] * v[i];
+        }
+        var norm = MathF.Sqrt(sumSq);
+        if (norm > 0)
+        {
+            for (int i = 0; i < VectorDimensions; i++)
+                v[i] /= norm;
+        }
+        return v;
+    }
+
+    private static IDisposable GetMappings(VectorEmbeddingType embedding, out ByteStringContext bsc, out IndexFieldsMapping mapping, int numberOfEdges = 8, int numberOfCandidates = 16)
+    {
+        var bscLocal = new ByteStringContext(SharedMultipleUseFlag.None);
+        var mappingLocal = IndexFieldsMappingBuilder
+            .CreateForWriter(false)
+            .AddBinding(0, "id()")
+            .AddBinding(1, "Vector", vectorOptions: new VectorOptions { NumberOfEdges = numberOfEdges, NumberOfCandidates = numberOfCandidates, VectorEmbeddingType = embedding })
+            .Build();
+
+        bsc = bscLocal;
+        mapping = mappingLocal;
+
+        return Disposable.Create(() =>
+        {
+            bscLocal.Dispose();
+            mappingLocal.Dispose();
+        });
+    }
+
+    private static double Recall(long[] truth, long[] returned)
+    {
+        if (truth.Length == 0)
+            return 1.0;
+        var set = new HashSet<long>(truth);
+        int hits = 0;
+        foreach (var id in returned)
+            if (set.Contains(id))
+                hits++;
+        return (double)hits / truth.Length;
+    }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #22671** (vector prefetch) — merge that first.

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26421

### Additional description

Cache resolved edge indexes (`EdgesIndexesPerLevel`) in `NearestSearcher.Search()` and `SearchNearestAcrossLevels()` to skip repeated `LoadNodeIndexes` dictionary lookups for nodes visited multiple times. `LoadNodeIndexes` resolves node IDs (`long`) to array indexes (`int`) via `_nodeIdToIdx` dictionary lookups and potentially disk I/O — work that is redundant for nodes revisited across queries when the SearchState is reused.

**Changes:**

- **`SearchState.ResolveEdgeIndexes`** (new): checks `EdgesIndexesPerLevel` for cached indexes before falling back to `LoadNodeIndexes`, then caches the result. Matches the existing pattern in `Hnsw.Parallel.cs` (`AfterPreloading`/`RegisterForPreloading`).
- **`NearestSearcher.Search()`**: replaces inline edge resolution with `ResolveEdgeIndexes` call.
- **`SearchNearestAcrossLevels()`**: same replacement.

### Benchmark results (50K vectors, 768D, ef=64, 1000 queries)

| Scenario | Before | After | Delta |
|---|---|---|---|
| No cache | 3,797 QPS | 3,785–4,400 QPS | ~+8% |
| With NodeCache | 5,173 QPS | 5,100–6,891 QPS | ~+17% |
| Full budget (50K) | 7,507 QPS | 8,793–8,868 QPS | **+17–18%** |

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using Documentation Required tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable private)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using QA Required tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using Studio Required tag.
- [x] No UI work is needed