### PR TITLE
RavenDB-24870 Fix artificial doc cleanup on side-by-side index replacement

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexStore.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexStore.cs
@@ -2068,6 +2068,16 @@ namespace Raven.Server.Documents.Indexes
 
                 if (oldIndex != null)
                 {
+                    if (oldIndex is MapReduceIndex oldMapReduceIndex && oldMapReduceIndex.OutputReduceToCollection != null
+                        && newIndex is MapReduceIndex newMapReduceIndex && newMapReduceIndex.OutputReduceToCollection != null)
+                    {
+                        var prefixesOfDocumentsToDelete = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        CollectPrefixesOfDocumentsToDelete(oldMapReduceIndex, ref prefixesOfDocumentsToDelete);
+
+                        if (prefixesOfDocumentsToDelete.Count > 0)
+                            newMapReduceIndex.OutputReduceToCollection.AddPrefixesOfDocumentsToDelete(prefixesOfDocumentsToDelete);
+                    }
+
                     while (true)
                     {
                         try

--- a/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
+++ b/test/SlowTests/Server/Documents/Indexing/MapReduce/OutputReduceToCollectionTests.cs
@@ -213,6 +213,49 @@ namespace SlowTests.Server.Documents.Indexing.MapReduce
         }
 
         [RavenFact(RavenTestCategory.Indexes)]
+        public async Task SideBySideReplacementShouldCleanUpOldArtificialDocuments()
+        {
+            using (var store = GetDocumentStore())
+            {
+                await store.ExecuteIndexAsync(new DailyInvoicesIndex());
+
+                var date = new DateTime(2017, 1, 1);
+
+                using (var session = store.OpenAsyncSession())
+                {
+                    for (int i = 0; i < 30; i++)
+                    {
+                        await session.StoreAsync(new Invoice { Amount = 1, IssuedAt = date.AddHours(i * 6) });
+                    }
+
+                    await session.SaveChangesAsync();
+                }
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                int countBeforeReplacement;
+                using (var session = store.OpenAsyncSession())
+                {
+                    countBeforeReplacement = await session.Query<DailyInvoice>().CountAsync();
+                    Assert.True(countBeforeReplacement > 0);
+                }
+
+                // deploy updated index - triggers side-by-side replacement
+                await store.ExecuteIndexAsync(new Replacement_CountFieldAdded.DailyInvoicesIndex());
+
+                await Indexes.WaitForIndexingAsync(store);
+
+                // after replacement, the artificial document count must remain the same
+                // (old ones deleted, new ones created)
+                using (var session = store.OpenAsyncSession())
+                {
+                    var countAfterReplacement = await session.Query<DailyInvoice>().CountAsync();
+                    Assert.Equal(countBeforeReplacement, countAfterReplacement);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
         public async Task CanUpdateIndexAsSideBySideAndChangingReduceOutputCollection()
         {
             using (var store = GetDocumentStore())


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24870

### Additional description

Backport from v7.2 (PR #22639).

When a map-reduce index with `OutputReduceToCollection` is replaced via side-by-side deployment, the old artificial documents were not being cleaned up. This change transfers the prefixes of documents to delete from the old index to the new one during `ReplaceIndexes`, so the replacement index properly cleans up stale artificial documents.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed