### PR TITLE
RavenDB-26218 Sequential read-ahead hint for journal recovery on Linux

### DIFF
--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -14,12 +14,20 @@ namespace Raven.Server.Config.Categories
             // On Windows, DiscardVirtualMemory can result in high CPU usage due to contention on the
             // PTE entry (in Win Server 2016 and Win Server 2019), we want to avoid it by default.
             DiscardVirtualMemory = PlatformDetails.RunningOnPosix;
+
+            // The sequential read-ahead hint relies on posix_fadvise, which exists on Linux but not macOS.
+            UseSequentialReadAheadHintForJournalRecovery = PlatformDetails.RunningOnLinux;
         }
 
         [Description("You can use this setting to specify whether to disable or enable discard virtual memory. By default, on windows, it will be disabled.")]
         [DefaultValue(DefaultValueSetInConstructor)]
         [ConfigurationEntry("Storage.DiscardVirtualMemory", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public bool DiscardVirtualMemory { get; set; }
+
+        [Description("On Linux, hint the kernel (posix_fadvise with POSIX_FADV_SEQUENTIAL) to read journal files ahead aggressively during startup recovery, independent of the device's read_ahead_kb. This speeds up recovery when read_ahead_kb has been tuned low for random-access workloads. Has no effect on Windows or macOS. Set to false to opt out.")]
+        [DefaultValue(DefaultValueSetInConstructor)]
+        [ConfigurationEntry("Storage.UseSequentialReadAheadHintForJournalRecovery", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public bool UseSequentialReadAheadHintForJournalRecovery { get; set; }
         
         [Description("You can use this setting to specify a different path to temporary files. By default it is empty, which means that temporary files will be created at same location as data file.")]
         [DefaultValue(null)]

--- a/src/Raven.Server/Config/Categories/StorageConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/StorageConfiguration.cs
@@ -152,5 +152,11 @@ namespace Raven.Server.Config.Categories
         [MinValue(0)]
         [ConfigurationEntry("Storage.MaxNumberOfRecyclableJournals", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public int MaxNumberOfRecyclableJournals { get; set; }
+
+        [Description("Threshold (in KB) for the block device read_ahead_kb alert raised on server startup on Linux. If any block device's read_ahead_kb exceeds this value, a warning alert is raised. Set to null to disable the check.")]
+        [DefaultValue(128)]
+        [MinValue(0)]
+        [ConfigurationEntry("Storage.ReadAheadKbAlertThresholdInKb", ConfigurationEntryScope.ServerWideOnly)]
+        public int? ReadAheadKbAlertThreshold { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/CompactDatabaseTask.cs
+++ b/src/Raven.Server/Documents/CompactDatabaseTask.cs
@@ -190,6 +190,7 @@ namespace Raven.Server.Documents
             options.ForceUsing32BitsPager = configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = documentDatabase.Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = documentDatabase.Configuration.Storage.DiscardVirtualMemory;
+            options.UseSequentialReadAheadHintForJournalRecovery = documentDatabase.Configuration.Storage.UseSequentialReadAheadHintForJournalRecovery;
             options.OnNonDurableFileSystemError += documentDatabase.HandleNonDurableFileSystemError;
             options.OnRecoverableFailure += documentDatabase.HandleRecoverableFailure;
             options.OnRecoveryError += documentDatabase.HandleOnDatabaseRecoveryError;

--- a/src/Raven.Server/Documents/ConfigurationStorage.cs
+++ b/src/Raven.Server/Documents/ConfigurationStorage.cs
@@ -54,6 +54,7 @@ namespace Raven.Server.Documents
             options.ForceUsing32BitsPager = _db.Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = _db.Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = _db.Configuration.Storage.DiscardVirtualMemory;
+            options.UseSequentialReadAheadHintForJournalRecovery = _db.Configuration.Storage.UseSequentialReadAheadHintForJournalRecovery;
             options.TimeToSyncAfterFlushInSec = (int)_db.Configuration.Storage.TimeToSyncAfterFlush.AsTimeSpan.TotalSeconds;
             options.Encryption.MasterKey = _db.MasterKey?.ToArray();
 

--- a/src/Raven.Server/Documents/DocumentsStorage.cs
+++ b/src/Raven.Server/Documents/DocumentsStorage.cs
@@ -196,6 +196,7 @@ namespace Raven.Server.Documents
             options.ForceUsing32BitsPager = DocumentDatabase.Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = DocumentDatabase.Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = DocumentDatabase.Configuration.Storage.DiscardVirtualMemory;
+            options.UseSequentialReadAheadHintForJournalRecovery = DocumentDatabase.Configuration.Storage.UseSequentialReadAheadHintForJournalRecovery;
             options.TimeToSyncAfterFlushInSec = (int)DocumentDatabase.Configuration.Storage.TimeToSyncAfterFlush.AsTimeSpan.TotalSeconds;
             options.AddToInitLog = _addToInitLog;
             options.Encryption.MasterKey = DocumentDatabase.MasterKey?.ToArray();

--- a/src/Raven.Server/Documents/Indexes/Index.cs
+++ b/src/Raven.Server/Documents/Indexes/Index.cs
@@ -737,6 +737,7 @@ namespace Raven.Server.Documents.Indexes
             options.ForceUsing32BitsPager = documentDatabase.Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = documentDatabase.Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = documentDatabase.Configuration.Storage.DiscardVirtualMemory;
+            options.UseSequentialReadAheadHintForJournalRecovery = documentDatabase.Configuration.Storage.UseSequentialReadAheadHintForJournalRecovery;
             options.TimeToSyncAfterFlushInSec = (int)documentDatabase.Configuration.Storage.TimeToSyncAfterFlush.AsTimeSpan.TotalSeconds;
             options.Encryption.MasterKey = documentDatabase.MasterKey?.ToArray(); //clone
             options.Encryption.RegisterForJournalCompressionHandler();

--- a/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/AlertType.cs
@@ -51,6 +51,7 @@ namespace Raven.Server.NotificationCenter.Notifications
         ClusterTopologyWarning,
         DatabaseTopologyWarning,
         SwappingHddInsteadOfSsd,
+        HighReadAheadKb,
 
         RevisionsConfigurationNotValid,
         ArchivalConfigurationNotValid,

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -792,6 +792,33 @@ namespace Raven.Server.ServerWide
                     Logger.Info("An error occurred while trying to determine Is Swapping On Hdd Instead Of Ssd", e);
             }
 
+            try
+            {
+                var highReadAheadDevices = PlatformSpecific.MemoryInformation.GetBlockDevicesWithHighReadAhead();
+                if (highReadAheadDevices != null)
+                {
+                    var deviceList = string.Join(", ", highReadAheadDevices.Select(x => $"{x.DeviceName} ({x.ReadAheadValue})"));
+                    var alert = AlertRaised.Create(
+                        null,
+                        "High read_ahead_kb Detected",
+                        $"One or more block devices have read_ahead_kb set above 128 KB: {deviceList}. " +
+                        "This can cause excessive I/O during random-access workloads. " +
+                        "Consider lowering it. Please follow the documentation for guidance.",
+                        AlertType.HighReadAheadKb,
+                        NotificationSeverity.Warning);
+                    if (NotificationCenter.IsInitialized)
+                        NotificationCenter.Add(alert);
+                    else
+                        _storeAlertForLateRaise.Add(alert);
+                }
+            }
+            catch (Exception e)
+            {
+                // the above should not throw, but we mask it in case it does (as it reads IO parameters) - this alert is just a nice-to-have warning
+                if (Logger.IsInfoEnabled)
+                    Logger.Info("An error occurred while trying to check read_ahead_kb values for block devices", e);
+            }
+
             options.SchemaVersion = SchemaUpgrader.CurrentVersion.ServerVersion;
             options.SchemaUpgrader = SchemaUpgrader.Upgrader(SchemaUpgrader.StorageType.Server, null, null, this);
             options.BeforeSchemaUpgrade = _server.BeforeSchemaUpgrade;

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -830,6 +830,7 @@ namespace Raven.Server.ServerWide
             options.ForceUsing32BitsPager = Configuration.Storage.ForceUsing32BitsPager;
             options.EnablePrefetching = Configuration.Storage.EnablePrefetching;
             options.DiscardVirtualMemory = Configuration.Storage.DiscardVirtualMemory;
+            options.UseSequentialReadAheadHintForJournalRecovery = Configuration.Storage.UseSequentialReadAheadHintForJournalRecovery;
 
             if (Configuration.Storage.MaxScratchBufferSize.HasValue)
                 options.MaxScratchBufferSize = Configuration.Storage.MaxScratchBufferSize.Value.GetValue(SizeUnit.Bytes);

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -800,7 +800,7 @@ namespace Raven.Server.ServerWide
                 if (thresholdKb != null)
                 {
                     var highReadAheadDevices = PlatformSpecific.MemoryInformation.GetBlockDevicesWithHighReadAhead(thresholdKb.Value);
-                    if (highReadAheadDevices != null)
+                    if (highReadAheadDevices is { Count: > 0 })
                     {
                         var deviceList = string.Join(", ", highReadAheadDevices.Select(x => $"{x.DeviceName} ({x.ReadAheadValue})"));
                         var alert = AlertRaised.Create(
@@ -816,7 +816,7 @@ namespace Raven.Server.ServerWide
                         else
                             _storeAlertForLateRaise.Add(alert);
                     }
-                    else
+                    else if (highReadAheadDevices != null)
                     {
                         _dismissHighReadAheadAlert = true;
                     }
@@ -824,7 +824,6 @@ namespace Raven.Server.ServerWide
             }
             catch (Exception e)
             {
-                // the above should not throw, but we mask it in case it does (as it reads IO parameters) - this alert is just a nice-to-have warning
                 if (Logger.IsInfoEnabled)
                     Logger.Info("An error occurred while trying to check read_ahead_kb values for block devices", e);
             }

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -165,6 +165,8 @@ namespace Raven.Server.ServerWide
 
         private readonly List<AlertRaised> _storeAlertForLateRaise;
 
+        private bool _dismissHighReadAheadAlert;
+
         public ServerStore(RavenConfiguration configuration, RavenServer server)
         {
             // we want our servers to be robust get early errors about such issues
@@ -814,6 +816,10 @@ namespace Raven.Server.ServerWide
                         else
                             _storeAlertForLateRaise.Add(alert);
                     }
+                    else
+                    {
+                        _dismissHighReadAheadAlert = true;
+                    }
                 }
             }
             catch (Exception e)
@@ -905,6 +911,9 @@ namespace Raven.Server.ServerWide
             {
                 NotificationCenter.Add(alertRaised);
             }
+
+            if (_dismissHighReadAheadAlert)
+                NotificationCenter.Dismiss(AlertRaised.GetKey(AlertType.HighReadAheadKb, null), sendNotificationEvenIfDoesntExist: false);
 
             CheckSwapOrPageFileAndRaiseNotification();
             _storeAlertForLateRaise.Clear();

--- a/src/Raven.Server/ServerWide/ServerStore.cs
+++ b/src/Raven.Server/ServerWide/ServerStore.cs
@@ -794,22 +794,26 @@ namespace Raven.Server.ServerWide
 
             try
             {
-                var highReadAheadDevices = PlatformSpecific.MemoryInformation.GetBlockDevicesWithHighReadAhead();
-                if (highReadAheadDevices != null)
+                var thresholdKb = Configuration.Storage.ReadAheadKbAlertThreshold;
+                if (thresholdKb != null)
                 {
-                    var deviceList = string.Join(", ", highReadAheadDevices.Select(x => $"{x.DeviceName} ({x.ReadAheadValue})"));
-                    var alert = AlertRaised.Create(
-                        null,
-                        "High read_ahead_kb Detected",
-                        $"One or more block devices have read_ahead_kb set above 128 KB: {deviceList}. " +
-                        "This can cause excessive I/O during random-access workloads. " +
-                        "Consider lowering it. Please follow the documentation for guidance.",
-                        AlertType.HighReadAheadKb,
-                        NotificationSeverity.Warning);
-                    if (NotificationCenter.IsInitialized)
-                        NotificationCenter.Add(alert);
-                    else
-                        _storeAlertForLateRaise.Add(alert);
+                    var highReadAheadDevices = PlatformSpecific.MemoryInformation.GetBlockDevicesWithHighReadAhead(thresholdKb.Value);
+                    if (highReadAheadDevices != null)
+                    {
+                        var deviceList = string.Join(", ", highReadAheadDevices.Select(x => $"{x.DeviceName} ({x.ReadAheadValue})"));
+                        var alert = AlertRaised.Create(
+                            null,
+                            "High read_ahead_kb Detected",
+                            $"One or more block devices have read_ahead_kb set above {thresholdKb.Value} KB: {deviceList}. " +
+                            "This can cause excessive I/O during random-access workloads. " +
+                            "Consider lowering it. Please follow the documentation for guidance.",
+                            AlertType.HighReadAheadKb,
+                            NotificationSeverity.Warning);
+                        if (NotificationCenter.IsInitialized)
+                            NotificationCenter.Add(alert);
+                        else
+                            _storeAlertForLateRaise.Add(alert);
+                    }
                 }
             }
             catch (Exception e)

--- a/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
+++ b/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
@@ -25,16 +25,18 @@ namespace Sparrow.Server.LowMemory
         /// Only meaningful on Linux; callers should guard with
         /// <c>PlatformDetails.RunningOnPosix &amp;&amp; !PlatformDetails.RunningOnMacOsx</c>.
         /// </summary>
-        public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead(int thresholdKb)
+        /// <param name="thresholdKb">Devices with read_ahead_kb above this are returned.</param>
+        /// <param name="sysBlockPath">Root of the sysfs block-device tree. Defaults to /sys/block/; overridable for testing.</param>
+        public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead(int thresholdKb, string sysBlockPath = SysBlockPath)
         {
             try
             {
-                if (Directory.Exists(SysBlockPath) == false)
+                if (Directory.Exists(sysBlockPath) == false)
                     return null;
 
                 List<(string, Size)> result = null;
 
-                foreach (var blockDir in Directory.GetDirectories(SysBlockPath))
+                foreach (var blockDir in Directory.GetDirectories(sysBlockPath))
                 {
                     var deviceName = Path.GetFileName(blockDir);
 

--- a/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
+++ b/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Sparrow;
+using Sparrow.Logging;
+using Sparrow.Server.Platform.Posix;
+
+namespace Sparrow.Server.LowMemory
+{
+    public static class CheckBlockDeviceKernelSettings
+    {
+        private static readonly Logger Log = LoggingSource.Instance.GetLogger("Server", typeof(CheckBlockDeviceKernelSettings).FullName);
+
+        private const string SysBlockPath = "/sys/block/";
+        private const int ReadAheadKbThreshold = 128;
+
+        /// <summary>
+        /// Returns a list of block devices whose read_ahead_kb value exceeds
+        /// <see cref="ReadAheadKbThreshold"/> KB, or null if no devices are above the
+        /// threshold or if the check cannot be performed.
+        /// <para>
+        /// A high read_ahead_kb causes the kernel to issue large sequential read-ahead
+        /// I/Os on every page fault, which wastes I/O bandwidth and can cause 100% IO wait
+        /// under the random-access patterns of a running database.
+        /// </para>
+        /// Only meaningful on Linux; callers should guard with
+        /// <c>PlatformDetails.RunningOnPosix &amp;&amp; !PlatformDetails.RunningOnMacOsx</c>.
+        /// </summary>
+        public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead()
+        {
+            try
+            {
+                if (Directory.Exists(SysBlockPath) == false)
+                    return null;
+
+                List<(string, Size)> result = null;
+
+                foreach (var blockDir in Directory.GetDirectories(SysBlockPath))
+                {
+                    var deviceName = Path.GetFileName(blockDir);
+
+                    // loop devices are virtual and always report a high read_ahead_kb — skip them
+                    if (deviceName.StartsWith("loop", StringComparison.Ordinal))
+                        continue;
+
+                    var readAheadFile = Path.Combine(blockDir, "queue", "read_ahead_kb");
+                    if (File.Exists(readAheadFile) == false)
+                        continue;
+
+                    var readAheadKb = KernelVirtualFileSystemUtils.ReadNumberFromFile(readAheadFile);
+                    if (readAheadKb == long.MaxValue) // ReadNumberFromFile returns long.MaxValue on error
+                        continue;
+
+                    if (readAheadKb > ReadAheadKbThreshold)
+                    {
+                        result ??= new List<(string, Size)>();
+                        result.Add((deviceName, new Size(readAheadKb, SizeUnit.Kilobytes)));
+                    }
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                if (Log.IsInfoEnabled)
+                    Log.Info("Error while trying to determine read_ahead_kb values for block devices, ignoring this check", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
+++ b/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
@@ -13,10 +13,10 @@ namespace Sparrow.Server.LowMemory
         private const string SysBlockPath = "/sys/block/";
 
         /// <summary>
-        /// Returns a list of block devices whose read_ahead_kb value exceeds
-        /// <paramref name="thresholdKb"/>, or null if no devices are above the threshold
-        /// or if the check cannot be performed (returns null in both cases — the caller
-        /// only needs to know whether an alert should be raised).
+        /// Returns the block devices whose read_ahead_kb exceeds <paramref name="thresholdKb"/>,
+        /// or an empty list if the check ran but found none. Returns <c>null</c> only when the check
+        /// could not be performed (sysfs tree missing, or an error reading it); callers must treat
+        /// null as "unknown", never as "all clear", so a failed check cannot clear a real warning.
         /// <para>
         /// A high read_ahead_kb causes the kernel to issue large sequential read-ahead
         /// I/Os on every page fault, which wastes I/O bandwidth and can cause 100% IO wait
@@ -34,7 +34,7 @@ namespace Sparrow.Server.LowMemory
                 if (Directory.Exists(sysBlockPath) == false)
                     return null;
 
-                List<(string, Size)> result = null;
+                var result = new List<(string, Size)>();
 
                 foreach (var blockDir in Directory.GetDirectories(sysBlockPath))
                 {
@@ -53,10 +53,7 @@ namespace Sparrow.Server.LowMemory
                         continue;
 
                     if (readAheadKb > thresholdKb)
-                    {
-                        result ??= new List<(string, Size)>();
                         result.Add((deviceName, new Size(readAheadKb, SizeUnit.Kilobytes)));
-                    }
                 }
 
                 return result;

--- a/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
+++ b/src/Sparrow.Server/LowMemory/CheckBlockDeviceKernelSettings.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Sparrow;
 using Sparrow.Logging;
 using Sparrow.Server.Platform.Posix;
 
@@ -12,12 +11,12 @@ namespace Sparrow.Server.LowMemory
         private static readonly Logger Log = LoggingSource.Instance.GetLogger("Server", typeof(CheckBlockDeviceKernelSettings).FullName);
 
         private const string SysBlockPath = "/sys/block/";
-        private const int ReadAheadKbThreshold = 128;
 
         /// <summary>
         /// Returns a list of block devices whose read_ahead_kb value exceeds
-        /// <see cref="ReadAheadKbThreshold"/> KB, or null if no devices are above the
-        /// threshold or if the check cannot be performed.
+        /// <paramref name="thresholdKb"/>, or null if no devices are above the threshold
+        /// or if the check cannot be performed (returns null in both cases — the caller
+        /// only needs to know whether an alert should be raised).
         /// <para>
         /// A high read_ahead_kb causes the kernel to issue large sequential read-ahead
         /// I/Os on every page fault, which wastes I/O bandwidth and can cause 100% IO wait
@@ -26,7 +25,7 @@ namespace Sparrow.Server.LowMemory
         /// Only meaningful on Linux; callers should guard with
         /// <c>PlatformDetails.RunningOnPosix &amp;&amp; !PlatformDetails.RunningOnMacOsx</c>.
         /// </summary>
-        public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead()
+        public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead(int thresholdKb)
         {
             try
             {
@@ -51,7 +50,7 @@ namespace Sparrow.Server.LowMemory
                     if (readAheadKb == long.MaxValue) // ReadNumberFromFile returns long.MaxValue on error
                         continue;
 
-                    if (readAheadKb > ReadAheadKbThreshold)
+                    if (readAheadKb > thresholdKb)
                     {
                         result ??= new List<(string, Size)>();
                         result.Add((deviceName, new Size(readAheadKb, SizeUnit.Kilobytes)));

--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -24,11 +24,11 @@ namespace Sparrow.Server.Platform
                 return CheckPageFileOnHdd.WindowsIsSwappingOnHddInsteadOfSsd();
             }
 
-            public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead()
+            public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead(int thresholdKb)
             {
                 if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
                     return null;
-                return CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead();
+                return CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead(thresholdKb);
             }
         }
 

--- a/src/Sparrow.Server/Platform/PlatformSpecific.cs
+++ b/src/Sparrow.Server/Platform/PlatformSpecific.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -21,6 +22,13 @@ namespace Sparrow.Server.Platform
                 if (PlatformDetails.RunningOnPosix)
                     return CheckPageFileOnHdd.PosixIsSwappingOnHddInsteadOfSsd();
                 return CheckPageFileOnHdd.WindowsIsSwappingOnHddInsteadOfSsd();
+            }
+
+            public static List<(string DeviceName, Size ReadAheadValue)> GetBlockDevicesWithHighReadAhead()
+            {
+                if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
+                    return null;
+                return CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead();
             }
         }
 

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -244,14 +244,8 @@ namespace Voron.Impl.Journal
             DiscardProcessedTransactionPages(transactionSizeIn4Kb);
         }
 
-        // Release each processed tx's fully-contained journal pages via madvise(MADV_DONTNEED)
-        // (DiscardPages): unmaps them so the resident set stays bounded and the unmapped pages
-        // become reclaimable page cache, instead of the whole journal staying mapped while many
-        // DBs recover. (MADV_DONTNEED does not evict the cache outright - it just drops the
-        // mapping; the clean pages are then reclaimed under pressure.) Whole pages only - recovery
-        // is forward-only, so the page shared with the next tx survives. RvnMemoryMapPager only:
-        // it is file-backed, so DONTNEED just re-reads from the file - never zeroes pages the way
-        // it would for an anonymous in-memory pager.
+        // Release each processed transaction's fully-contained pages via madvise(MADV_DONTNEED) (DiscardPages)
+        // to keep the resident set bounded while many databases do the startup recovery
         private void DiscardProcessedTransactionPages(long transactionSizeIn4Kb)
         {
             if (_journalPager is not RvnMemoryMapPager rvnJournalPager)
@@ -264,7 +258,7 @@ namespace Voron.Impl.Journal
             var firstFullPage = (txStartOffset + Constants.Storage.PageSize - 1) / Constants.Storage.PageSize;
             var lastFullPageExclusive = txEndOffset / Constants.Storage.PageSize;
             if (lastFullPageExclusive <= firstFullPage)
-                return; // transaction smaller than a page boundary - nothing whole to discard
+                return;
 
             rvnJournalPager.DiscardPages(firstFullPage, (int)(lastFullPageExclusive - firstFullPage));
         }
@@ -794,9 +788,6 @@ namespace Voron.Impl.Journal
                 BeforeCommitFinalization?.Invoke(this);
             }
             OnDispose?.Invoke(this);
-
-            // No whole-file discard here: WriteAheadJournal.RecoverDatabase disposes the journal
-            // pager (munmap) before this runs, which already unmaps the whole journal.
         }
 
         private static int GetNumberOfPagesFor(long size)

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -219,16 +219,7 @@ namespace Voron.Impl.Journal
 
             LastTransactionHeader = current;
 
-            // Release the just-processed transaction's pages from the kernel page cache.
-            // Combined with FADV_SEQUENTIAL's adaptive look-ahead this creates a sliding
-            // window that keeps only ~1-2 transactions resident at a time - critical when
-            // many databases recover simultaneously and page cache pressure is a concern.
-            if (_journalPager is RvnMemoryMapPager rvnJournalPager)
-            {
-                var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * 4 * Constants.Size.Kilobyte;
-                var txLength = transactionSizeIn4Kb * 4 * Constants.Size.Kilobyte;
-                rvnJournalPager.TryDropFromPageCacheHint(txStartOffset, txLength);
-            }
+            DropProcessedTxFromPageCache(transactionSizeIn4Kb);
 
             return true;
         }
@@ -250,14 +241,22 @@ namespace Voron.Impl.Journal
             else
                 _lastSkippedTx = current->TransactionId;
 
-            // Already-synced transactions are skipped but their journal pages should still
-            // be evicted from the page cache - same sliding-window benefit as applied transactions.
-            if (_journalPager is RvnMemoryMapPager rvnJournalPager)
-            {
-                var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * 4 * Constants.Size.Kilobyte;
-                var txLength = transactionSizeIn4Kb * 4 * Constants.Size.Kilobyte;
-                rvnJournalPager.TryDropFromPageCacheHint(txStartOffset, txLength);
-            }
+            DropProcessedTxFromPageCache(transactionSizeIn4Kb);
+        }
+
+        // Release the just-processed transaction's pages from the kernel page cache.
+        // Combined with FADV_SEQUENTIAL's adaptive look-ahead this creates a sliding
+        // window that keeps only ~1-2 transactions resident at a time - critical when
+        // many databases recover simultaneously and page cache pressure is a concern.
+        // Applies to both applied and skipped (already-synced) transactions.
+        private void DropProcessedTxFromPageCache(long transactionSizeIn4Kb)
+        {
+            if (_journalPager is not RvnMemoryMapPager rvnJournalPager)
+                return;
+
+            var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * 4L * Constants.Size.Kilobyte;
+            var txLength = transactionSizeIn4Kb * 4L * Constants.Size.Kilobyte;
+            rvnJournalPager.TryDropFromPageCacheHint(txStartOffset, txLength);
         }
 
         private bool IsAlreadySyncTransaction(TransactionHeader* current)
@@ -786,6 +785,9 @@ namespace Voron.Impl.Journal
             }
             OnDispose?.Invoke(this);
 
+            // Drop the entire journal file from the page cache now that recovery is done.
+            // offset=0, length=0 tells posix_fadvise(FADV_DONTNEED) to apply to the whole file
+            // (the kernel interprets len=0 as "to end of file").
             if (_journalPager is RvnMemoryMapPager rvnPager)
                 rvnPager.TryDropFromPageCacheHint();
         }

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -219,7 +219,7 @@ namespace Voron.Impl.Journal
 
             LastTransactionHeader = current;
 
-            DropProcessedTxFromPageCache(transactionSizeIn4Kb);
+            DiscardProcessedTransactionPages(transactionSizeIn4Kb);
 
             return true;
         }
@@ -241,22 +241,32 @@ namespace Voron.Impl.Journal
             else
                 _lastSkippedTx = current->TransactionId;
 
-            DropProcessedTxFromPageCache(transactionSizeIn4Kb);
+            DiscardProcessedTransactionPages(transactionSizeIn4Kb);
         }
 
-        // Release the just-processed transaction's pages from the kernel page cache.
-        // Combined with FADV_SEQUENTIAL's adaptive look-ahead this creates a sliding
-        // window that keeps only ~1-2 transactions resident at a time - critical when
-        // many databases recover simultaneously and page cache pressure is a concern.
-        // Applies to both applied and skipped (already-synced) transactions.
-        private void DropProcessedTxFromPageCache(long transactionSizeIn4Kb)
+        // Release each processed tx's fully-contained journal pages via madvise(MADV_DONTNEED)
+        // (DiscardPages): unmaps them so the resident set stays bounded and the unmapped pages
+        // become reclaimable page cache, instead of the whole journal staying mapped while many
+        // DBs recover. (MADV_DONTNEED does not evict the cache outright - it just drops the
+        // mapping; the clean pages are then reclaimed under pressure.) Whole pages only - recovery
+        // is forward-only, so the page shared with the next tx survives. RvnMemoryMapPager only:
+        // it is file-backed, so DONTNEED just re-reads from the file - never zeroes pages the way
+        // it would for an anonymous in-memory pager.
+        private void DiscardProcessedTransactionPages(long transactionSizeIn4Kb)
         {
             if (_journalPager is not RvnMemoryMapPager rvnJournalPager)
                 return;
 
-            var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * 4L * Constants.Size.Kilobyte;
-            var txLength = transactionSizeIn4Kb * 4L * Constants.Size.Kilobyte;
-            rvnJournalPager.TryDropFromPageCacheHint(txStartOffset, txLength);
+            const long fourKb = 4L * Constants.Size.Kilobyte;
+            var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * fourKb;
+            var txEndOffset = _readAt4Kb * fourKb; // exclusive
+
+            var firstFullPage = (txStartOffset + Constants.Storage.PageSize - 1) / Constants.Storage.PageSize;
+            var lastFullPageExclusive = txEndOffset / Constants.Storage.PageSize;
+            if (lastFullPageExclusive <= firstFullPage)
+                return; // transaction smaller than a page boundary - nothing whole to discard
+
+            rvnJournalPager.DiscardPages(firstFullPage, (int)(lastFullPageExclusive - firstFullPage));
         }
 
         private bool IsAlreadySyncTransaction(TransactionHeader* current)
@@ -785,11 +795,8 @@ namespace Voron.Impl.Journal
             }
             OnDispose?.Invoke(this);
 
-            // Drop the entire journal file from the page cache now that recovery is done.
-            // offset=0, length=0 tells posix_fadvise(FADV_DONTNEED) to apply to the whole file
-            // (the kernel interprets len=0 as "to end of file").
-            if (_journalPager is RvnMemoryMapPager rvnPager)
-                rvnPager.TryDropFromPageCacheHint();
+            // No whole-file discard here: WriteAheadJournal.RecoverDatabase disposes the journal
+            // pager (munmap) before this runs, which already unmaps the whole journal.
         }
 
         private static int GetNumberOfPagesFor(long size)

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -83,12 +83,6 @@ namespace Voron.Impl.Journal
 
             _readAt4Kb += transactionSizeIn4Kb;
 
-            // Issue a forward-looking prefetch on the journal pager so the OS loads the
-            // next chunk into the page cache while we process the current transaction.
-            // This decouples journal recovery throughput from the kernel's read_ahead_kb
-            // setting (which may be tuned very low for random-access production workloads).
-            //PrefetchJournalAhead();
-            
             TransactionHeaderPageInfo* pageInfoPtr;
             byte* outputPage;
             if (performDecompression)
@@ -225,6 +219,17 @@ namespace Voron.Impl.Journal
 
             LastTransactionHeader = current;
 
+            // Release the just-processed transaction's pages from the kernel page cache.
+            // Combined with FADV_SEQUENTIAL's adaptive look-ahead this creates a sliding
+            // window that keeps only ~1-2 transactions resident at a time - critical when
+            // many databases recover simultaneously and page cache pressure is a concern.
+            if (_journalPager is RvnMemoryMapPager rvnJournalPager)
+            {
+                var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * 4 * Constants.Size.Kilobyte;
+                var txLength = transactionSizeIn4Kb * 4 * Constants.Size.Kilobyte;
+                rvnJournalPager.TryDropFromPageCacheHint(txStartOffset, txLength);
+            }
+
             return true;
         }
 
@@ -244,6 +249,15 @@ namespace Voron.Impl.Journal
                 _firstSkippedTx = current->TransactionId;
             else
                 _lastSkippedTx = current->TransactionId;
+
+            // Already-synced transactions are skipped but their journal pages should still
+            // be evicted from the page cache - same sliding-window benefit as applied transactions.
+            if (_journalPager is RvnMemoryMapPager rvnJournalPager)
+            {
+                var txStartOffset = (_readAt4Kb - transactionSizeIn4Kb) * 4 * Constants.Size.Kilobyte;
+                var txLength = transactionSizeIn4Kb * 4 * Constants.Size.Kilobyte;
+                rvnJournalPager.TryDropFromPageCacheHint(txStartOffset, txLength);
+            }
         }
 
         private bool IsAlreadySyncTransaction(TransactionHeader* current)
@@ -784,31 +798,6 @@ namespace Voron.Impl.Journal
         private static long GetNumberOf4KbFor(long size)
         {
             return checked(size / (4 * Constants.Size.Kilobyte) + (size % (4 * Constants.Size.Kilobyte) == 0 ? 0 : 1));
-        }
-
-        /// <summary>
-        /// Prefetch the next 1 MB of journal data ahead of the current read position using
-        /// madvise(MADV_WILLNEED). This tells the OS to asynchronously load upcoming journal
-        /// pages into the page cache while we process the current transaction, ensuring that
-        /// sequential journal recovery throughput is not constrained by a low read_ahead_kb
-        /// kernel setting (which may be tuned for random-access production workloads).
-        /// </summary>
-        private void PrefetchJournalAhead()
-        {
-            const int pageTo4KbRatio = Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte);
-            // 1 MB look-ahead expressed in 8 KB Voron pages
-            const int prefetchAheadPages = (1 * Constants.Size.Megabyte) / Constants.Storage.PageSize;
-
-            var remaining4Kb = _journalPagerNumberOfAllocated4Kb - _readAt4Kb;
-            if (remaining4Kb <= 0)
-                return;
-
-            var pageNumber = _readAt4Kb / pageTo4KbRatio;
-            var pagesToPrefetch = (int)Math.Min(prefetchAheadPages, remaining4Kb / pageTo4KbRatio);
-            if (pagesToPrefetch <= 0)
-                return;
-
-            _journalPager.MaybePrefetchMemory(pageNumber, pagesToPrefetch);
         }
 
         Dictionary<AbstractPager, TransactionState> IPagerLevelTransactionState.PagerTransactionState32Bits { get; set; }

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -1,4 +1,4 @@
-﻿using Sparrow;
+using Sparrow;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -82,6 +82,12 @@ namespace Voron.Impl.Journal
             var transactionSizeIn4Kb = GetTransactionSizeIn4Kb(current);
 
             _readAt4Kb += transactionSizeIn4Kb;
+
+            // Issue a forward-looking prefetch on the journal pager so the OS loads the
+            // next chunk into the page cache while we process the current transaction.
+            // This decouples journal recovery throughput from the kernel's read_ahead_kb
+            // setting (which may be tuned very low for random-access production workloads).
+            PrefetchJournalAhead();
             
             TransactionHeaderPageInfo* pageInfoPtr;
             byte* outputPage;
@@ -775,6 +781,31 @@ namespace Voron.Impl.Journal
         private static long GetNumberOf4KbFor(long size)
         {
             return checked(size / (4 * Constants.Size.Kilobyte) + (size % (4 * Constants.Size.Kilobyte) == 0 ? 0 : 1));
+        }
+
+        /// <summary>
+        /// Prefetch the next 1 MB of journal data ahead of the current read position using
+        /// madvise(MADV_WILLNEED). This tells the OS to asynchronously load upcoming journal
+        /// pages into the page cache while we process the current transaction, ensuring that
+        /// sequential journal recovery throughput is not constrained by a low read_ahead_kb
+        /// kernel setting (which may be tuned for random-access production workloads).
+        /// </summary>
+        private void PrefetchJournalAhead()
+        {
+            const int pageTo4KbRatio = Constants.Storage.PageSize / (4 * Constants.Size.Kilobyte);
+            // 1 MB look-ahead expressed in 8 KB Voron pages
+            const int prefetchAheadPages = (1 * Constants.Size.Megabyte) / Constants.Storage.PageSize;
+
+            var remaining4Kb = _journalPagerNumberOfAllocated4Kb - _readAt4Kb;
+            if (remaining4Kb <= 0)
+                return;
+
+            var pageNumber = _readAt4Kb / pageTo4KbRatio;
+            var pagesToPrefetch = (int)Math.Min(prefetchAheadPages, remaining4Kb / pageTo4KbRatio);
+            if (pagesToPrefetch <= 0)
+                return;
+
+            _journalPager.MaybePrefetchMemory(pageNumber, pagesToPrefetch);
         }
 
         Dictionary<AbstractPager, TransactionState> IPagerLevelTransactionState.PagerTransactionState32Bits { get; set; }

--- a/src/Voron/Impl/Journal/JournalReader.cs
+++ b/src/Voron/Impl/Journal/JournalReader.cs
@@ -87,7 +87,7 @@ namespace Voron.Impl.Journal
             // next chunk into the page cache while we process the current transaction.
             // This decouples journal recovery throughput from the kernel's read_ahead_kb
             // setting (which may be tuned very low for random-access production workloads).
-            PrefetchJournalAhead();
+            //PrefetchJournalAhead();
             
             TransactionHeaderPageInfo* pageInfoPtr;
             byte* outputPage;
@@ -771,6 +771,9 @@ namespace Voron.Impl.Journal
                 BeforeCommitFinalization?.Invoke(this);
             }
             OnDispose?.Invoke(this);
+
+            if (_journalPager is RvnMemoryMapPager rvnPager)
+                rvnPager.TryDropFromPageCacheHint();
         }
 
         private static int GetNumberOfPagesFor(long size)

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -289,7 +289,15 @@ namespace Voron.Impl.Paging
 
         private const int PosixFadviseSequential = 2; // POSIX_FADV_SEQUENTIAL, same on all Linux arches
 
-        public void TryDropFromPageCacheHint()
+        /// <summary>
+        /// Calls posix_fadvise(POSIX_FADV_DONTNEED) on the specified byte range of the file,
+        /// releasing those clean pages from the page cache immediately.
+        /// Pass <paramref name="offset"/>=0 and <paramref name="length"/>=0 to advise the
+        /// entire file (kernel interprets len=0 as "to end of file").
+        /// Journal pages are always clean (read-only from the pager's perspective), so the
+        /// kernel always honours this hint. Errors are silently ignored — best-effort only.
+        /// </summary>
+        public void TryDropFromPageCacheHint(long offset = 0, long length = 0)
         {
             if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
                 return;
@@ -301,7 +309,7 @@ namespace Voron.Impl.Paging
             if (fd < 0)
                 return;
 
-            PosixFadvise(fd, 0, 0, PosixFadviseDoNotNeed);
+            PosixFadvise(fd, offset, length, PosixFadviseDoNotNeed);
         }
 
         private const int PosixFadviseDoNotNeed = 4; // POSIX_FADV_DONTNEED, same on all Linux arches

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -1,18 +1,20 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using Sparrow;
 using Sparrow.Logging;
+using Sparrow.Platform;
 using Sparrow.Server.Exceptions;
 using Sparrow.Server.Meters;
 using Sparrow.Server.Platform;
 using Sparrow.Server.Utils;
-using Sparrow.Utils;
 using Voron.Global;
 using Voron.Util.Settings;
 using static Sparrow.Server.Platform.Pal;
 using static Sparrow.Server.Platform.PalDefinitions;
 using static Sparrow.Server.Platform.PalFlags;
+using NativeMemory = Sparrow.Utils.NativeMemory;
 
 namespace Voron.Impl.Paging
 {
@@ -249,5 +251,59 @@ namespace Voron.Impl.Paging
             if (_logger.IsInfoEnabled)
                 _logger.Info($"Unable to un-protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Unprotect, errorCode={errorCode}");
         }
+
+        /// <summary>
+        /// Calls posix_fadvise(POSIX_FADV_SEQUENTIAL) on the underlying mmap file descriptor.
+        /// This sets a per-fd, adaptively-growing read-ahead window in the kernel that is
+        /// NOT bounded by the global read_ahead_kb device parameter.  During journal recovery
+        /// (a fully sequential read) the kernel will issue progressively larger I/Os instead
+        /// of being capped at read_ahead_kb bytes per request — reducing IOPS without touching
+        /// any global tuning knobs.
+        ///
+        /// The fd is read directly from the PAL-internal map_file_handle struct:
+        ///     struct map_file_handle { int fd; const char* path; int flags; }
+        /// fd is at offset 0, so *(int*)handle gives the descriptor.
+        ///
+        /// Only meaningful on Linux; macOS lacks posix_fadvise and is not affected by
+        /// read_ahead_kb.  Errors are silently ignored — this is a best-effort hint.
+        /// </summary>
+        public void TrySetSequentialScanHint()
+        {
+            if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
+                return;
+
+            if (_handle.IsInvalid || _handle.IsClosed)
+                return;
+
+            // fd is the first field of map_file_handle at offset 0.
+            var fd = *(int*)_handle.DangerousGetHandle();
+            if (fd < 0)
+                return;
+
+            PosixFadvise(fd, 0, 0, PosixFadviseSequential);
+        }
+
+        // posix_fadvise(2): returns errno directly on error — SetLastError = false is correct.
+        [DllImport("libc", EntryPoint = "posix_fadvise", SetLastError = false)]
+        private static extern int PosixFadvise(int fd, long offset, long len, int advice);
+
+        private const int PosixFadviseSequential = 2; // POSIX_FADV_SEQUENTIAL, same on all Linux arches
+
+        public void TryDropFromPageCacheHint()
+        {
+            if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
+                return;
+
+            if (_handle.IsInvalid || _handle.IsClosed)
+                return;
+
+            var fd = *(int*)_handle.DangerousGetHandle();
+            if (fd < 0)
+                return;
+
+            PosixFadvise(fd, 0, 0, PosixFadviseDoNotNeed);
+        }
+
+        private const int PosixFadviseDoNotNeed = 4; // POSIX_FADV_DONTNEED, same on all Linux arches
     }
 }

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -253,9 +253,9 @@ namespace Voron.Impl.Paging
         }
 
         /// <summary>
-        /// posix_fadvise(POSIX_FADV_SEQUENTIAL) on the journal's mmap fd raises the per-fd kernel
-        /// read-ahead window independently of the device's read_ahead_kb, so sequential recovery
-        /// isn't throttled when read_ahead_kb is tuned low. Linux only, best-effort.
+        /// posix_fadvise(POSIX_FADV_SEQUENTIAL) on the journal's mmap fd enlarges the per-fd kernel
+        /// read-ahead window for recovery (on tested kernels ~2x the device's read_ahead_kb), so a low
+        /// read_ahead_kb tuned for the random-access workload throttles recovery less. Linux only, best-effort.
         /// </summary>
         public void TrySetSequentialScanHint()
         {

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -253,29 +253,19 @@ namespace Voron.Impl.Paging
         }
 
         /// <summary>
-        /// Calls posix_fadvise(POSIX_FADV_SEQUENTIAL) on the underlying mmap file descriptor.
-        /// This sets a per-fd, adaptively-growing read-ahead window in the kernel that is
-        /// NOT bounded by the global read_ahead_kb device parameter.  During journal recovery
-        /// (a fully sequential read) the kernel will issue progressively larger I/Os instead
-        /// of being capped at read_ahead_kb bytes per request — reducing IOPS without touching
-        /// any global tuning knobs.
-        ///
-        /// The fd is read directly from the PAL-internal map_file_handle struct:
-        ///     struct map_file_handle { int fd; const char* path; int flags; }
-        /// fd is at offset 0, so *(int*)handle gives the descriptor.
-        ///
-        /// Only meaningful on Linux; macOS lacks posix_fadvise and is not affected by
-        /// read_ahead_kb.  Errors are silently ignored — this is a best-effort hint.
+        /// posix_fadvise(POSIX_FADV_SEQUENTIAL) on the journal's mmap fd raises the per-fd kernel
+        /// read-ahead window independently of the device's read_ahead_kb, so sequential recovery
+        /// isn't throttled when read_ahead_kb is tuned low. Linux only, best-effort.
         /// </summary>
         public void TrySetSequentialScanHint()
         {
-            if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
+            if (PlatformDetails.RunningOnLinux == false)
                 return;
 
             if (_handle.IsInvalid || _handle.IsClosed)
                 return;
 
-            // fd is the first field of map_file_handle at offset 0.
+            // fd is field 0 of the PAL's map_file_handle (posix/mapping.c).
             var fd = *(int*)_handle.DangerousGetHandle();
             if (fd < 0)
                 return;
@@ -288,30 +278,5 @@ namespace Voron.Impl.Paging
         private static extern int PosixFadvise(int fd, long offset, long len, int advice);
 
         private const int PosixFadviseSequential = 2; // POSIX_FADV_SEQUENTIAL, same on all Linux arches
-
-        /// <summary>
-        /// Calls posix_fadvise(POSIX_FADV_DONTNEED) on the specified byte range of the file,
-        /// releasing those clean pages from the page cache immediately.
-        /// Pass <paramref name="offset"/>=0 and <paramref name="length"/>=0 to advise the
-        /// entire file (kernel interprets len=0 as "to end of file").
-        /// Journal pages are always clean (read-only from the pager's perspective), so the
-        /// kernel always honours this hint. Errors are silently ignored — best-effort only.
-        /// </summary>
-        public void TryDropFromPageCacheHint(long offset = 0, long length = 0)
-        {
-            if (PlatformDetails.RunningOnPosix == false || PlatformDetails.RunningOnMacOsx)
-                return;
-
-            if (_handle.IsInvalid || _handle.IsClosed)
-                return;
-
-            var fd = *(int*)_handle.DangerousGetHandle();
-            if (fd < 0)
-                return;
-
-            PosixFadvise(fd, offset, length, PosixFadviseDoNotNeed);
-        }
-
-        private const int PosixFadviseDoNotNeed = 4; // POSIX_FADV_DONTNEED, same on all Linux arches
     }
 }

--- a/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
+++ b/src/Voron/Impl/Paging/RvnMemoryMapPager.cs
@@ -252,11 +252,6 @@ namespace Voron.Impl.Paging
                 _logger.Info($"Unable to un-protect page range for '{FileName.FullPath}'. start={new IntPtr(start).ToInt64():X}, size={size}, ProtectRange = Unprotect, errorCode={errorCode}");
         }
 
-        /// <summary>
-        /// posix_fadvise(POSIX_FADV_SEQUENTIAL) on the journal's mmap fd enlarges the per-fd kernel
-        /// read-ahead window for recovery (on tested kernels ~2x the device's read_ahead_kb), so a low
-        /// read_ahead_kb tuned for the random-access workload throttles recovery less. Linux only, best-effort.
-        /// </summary>
         public void TrySetSequentialScanHint()
         {
             if (PlatformDetails.RunningOnLinux == false)
@@ -265,18 +260,16 @@ namespace Voron.Impl.Paging
             if (_handle.IsInvalid || _handle.IsClosed)
                 return;
 
-            // fd is field 0 of the PAL's map_file_handle (posix/mapping.c).
             var fd = *(int*)_handle.DangerousGetHandle();
             if (fd < 0)
                 return;
 
-            PosixFadvise(fd, 0, 0, PosixFadviseSequential);
+            PosixFadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
         }
 
-        // posix_fadvise(2): returns errno directly on error — SetLastError = false is correct.
         [DllImport("libc", EntryPoint = "posix_fadvise", SetLastError = false)]
         private static extern int PosixFadvise(int fd, long offset, long len, int advice);
 
-        private const int PosixFadviseSequential = 2; // POSIX_FADV_SEQUENTIAL, same on all Linux arches
+        private const int POSIX_FADV_SEQUENTIAL = 2;
     }
 }

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -928,7 +928,8 @@ namespace Voron
                         return new Posix32BitsMemoryMapPager(this, path);
 
                     var posixJournalPager = new RvnMemoryMapPager(this, path);
-                    posixJournalPager.TrySetSequentialScanHint();
+                    if (UseSequentialReadAheadHintForJournalRecovery)
+                        posixJournalPager.TrySetSequentialScanHint();
                     return posixJournalPager;
                 }
 
@@ -1279,6 +1280,7 @@ namespace Voron
 
         public int MaxNumberOfRecyclableJournals { get; set; } = 32;
         public bool DiscardVirtualMemory { get; set; } = true;
+        public bool UseSequentialReadAheadHintForJournalRecovery { get; set; } = true;
         
         private readonly Logger _log;
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -926,7 +926,14 @@ namespace Voron
                 {
                     if (RunningOn32Bits)
                         return new Posix32BitsMemoryMapPager(this, path);
-                    return new RvnMemoryMapPager(this, path);
+
+                    // We know we'll be reading the entire journal sequentially during recovery.
+                    // Prefetch the whole file upfront so the OS loads it into page cache
+                    // regardless of the read_ahead_kb kernel setting (which may be tuned low
+                    // for random-access production workloads).
+                    var posixJournalPager = new RvnMemoryMapPager(this, path);
+                    posixJournalPager.TryPrefetchingWholeFile();
+                    return posixJournalPager;
                 }
 
                 if (RunningOn32Bits)

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -927,13 +927,8 @@ namespace Voron
                     if (RunningOn32Bits)
                         return new Posix32BitsMemoryMapPager(this, path);
 
-                    // We know we'll be reading the entire journal sequentially during recovery.
-                    // Prefetch the whole file upfront so the OS loads it into page cache
-                    // regardless of the read_ahead_kb kernel setting (which may be tuned low
-                    // for random-access production workloads).
                     var posixJournalPager = new RvnMemoryMapPager(this, path);
                     posixJournalPager.TrySetSequentialScanHint();
-                    //posixJournalPager.TryPrefetchingWholeFile();
                     return posixJournalPager;
                 }
 

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -932,7 +932,8 @@ namespace Voron
                     // regardless of the read_ahead_kb kernel setting (which may be tuned low
                     // for random-access production workloads).
                     var posixJournalPager = new RvnMemoryMapPager(this, path);
-                    posixJournalPager.TryPrefetchingWholeFile();
+                    posixJournalPager.TrySetSequentialScanHint();
+                    //posixJournalPager.TryPrefetchingWholeFile();
                     return posixJournalPager;
                 }
 

--- a/test/SlowTests/Issues/RavenDB_26218.cs
+++ b/test/SlowTests/Issues/RavenDB_26218.cs
@@ -38,13 +38,15 @@ namespace SlowTests.Issues
         }
 
         [RavenFact(RavenTestCategory.Voron)]
-        public void GetBlockDevicesWithHighReadAhead_ReturnsNull_WhenNothingAboveThreshold()
+        public void GetBlockDevicesWithHighReadAhead_ReturnsEmpty_WhenNothingAboveThreshold()
         {
             var sysBlock = NewDataPath(forceCreateDir: true);
             WriteReadAheadKb(sysBlock, "sda", "128");
             WriteReadAheadKb(sysBlock, "sdb", "64");
 
-            Assert.Null(CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead(thresholdKb: 128, sysBlockPath: sysBlock));
+            var result = CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead(thresholdKb: 128, sysBlockPath: sysBlock);
+            Assert.NotNull(result);
+            Assert.Empty(result);
         }
 
         [RavenFact(RavenTestCategory.Voron)]

--- a/test/SlowTests/Issues/RavenDB_26218.cs
+++ b/test/SlowTests/Issues/RavenDB_26218.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using System.Linq;
+using FastTests;
+using Sparrow;
+using Sparrow.Server.LowMemory;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26218 : RavenTestBase
+    {
+        public RavenDB_26218(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void GetBlockDevicesWithHighReadAhead_ReportsOnlyDevicesAboveThreshold()
+        {
+            var sysBlock = NewDataPath(forceCreateDir: true);
+
+            WriteReadAheadKb(sysBlock, "sda", "4096");          // above threshold -> reported
+            WriteReadAheadKb(sysBlock, "sdb", "128");           // equal to threshold -> not reported
+            WriteReadAheadKb(sysBlock, "nvme0n1", "256");       // above threshold -> reported
+            WriteReadAheadKb(sysBlock, "loop0", "8192");        // loop device -> skipped despite being high
+            WriteReadAheadKb(sysBlock, "dm-0", "not-a-number"); // malformed value -> skipped
+            Directory.CreateDirectory(Path.Combine(sysBlock, "sdc")); // no queue/read_ahead_kb -> skipped
+
+            var result = CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead(thresholdKb: 128, sysBlockPath: sysBlock);
+
+            Assert.NotNull(result);
+            var byName = result.ToDictionary(x => x.DeviceName, x => x.ReadAheadValue);
+
+            Assert.Equal(2, byName.Count);
+            Assert.Equal(4096, byName["sda"].GetValue(SizeUnit.Kilobytes));
+            Assert.Equal(256, byName["nvme0n1"].GetValue(SizeUnit.Kilobytes));
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void GetBlockDevicesWithHighReadAhead_ReturnsNull_WhenNothingAboveThreshold()
+        {
+            var sysBlock = NewDataPath(forceCreateDir: true);
+            WriteReadAheadKb(sysBlock, "sda", "128");
+            WriteReadAheadKb(sysBlock, "sdb", "64");
+
+            Assert.Null(CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead(thresholdKb: 128, sysBlockPath: sysBlock));
+        }
+
+        [RavenFact(RavenTestCategory.Voron)]
+        public void GetBlockDevicesWithHighReadAhead_ReturnsNull_WhenSysBlockPathMissing()
+        {
+            var missing = Path.Combine(NewDataPath(forceCreateDir: true), "does-not-exist");
+
+            Assert.Null(CheckBlockDeviceKernelSettings.GetBlockDevicesWithHighReadAhead(thresholdKb: 128, sysBlockPath: missing));
+        }
+
+        private static void WriteReadAheadKb(string sysBlockRoot, string device, string content)
+        {
+            var queueDir = Path.Combine(sysBlockRoot, device, "queue");
+            Directory.CreateDirectory(queueDir);
+            File.WriteAllText(Path.Combine(queueDir, "read_ahead_kb"), content);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26218

### Additional description

Speeding up Voron journal recovery on Linux when the block device's `read_ahead_kb` has been lowered for random-access database workloads.

### Problem

When `read_ahead_kb` is reduced on the journal device (this is still being checked and validated as part of RavenDB-26218 task), startup recovery - which is a purely sequential read of the journal - becomes I/O-bound because the kernel caps each readahead I/O at `read_ahead_kb` bytes. On hosts with low `read_ahead_kb`, database startup time is dominated by this. See [RavenDB-26218 comment](https://issues.hibernatingrhinos.com/issue/RavenDB-26218/Benchmark-and-tune-readaheadkbrotational-and-scheduler-disk-settings-for-on-Linux#focus=Comments-67-1077281.0-0) for the motivation and [this comment](https://issues.hibernatingrhinos.com/issue/RavenDB-26218/Benchmark-and-tune-readaheadkbrotational-and-scheduler-disk-settings-for-on-Linux#focus=Comments-67-1077731.0-0) for the initial measurements showing the speedup.

#### Approach

  - **Per-fd sequential read-ahead hint.** When a journal is opened for recovery, `posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL)` is issued on its memory-mapped fd. This enlarges the kernel's read-ahead window for the recovery read. Measured on Linux: roughly 2x the device's `read_ahead_kb`. Configurable per server/database via `Storage.UseSequentialReadAheadHintForJournalRecovery` (default on, Linux only).

  - **Rolling release of processed journal pages.** After each transaction is applied (or skipped), its journal pages are released with `madvise(MADV_DONTNEED)` via the pager's existing `DiscardPages`. This unmaps them, so the process's resident set stays bounded during recovery and the pages become reclaimable clean cache - relevant when many databases recover at once. Gated by the existing `Storage.DiscardVirtualMemory`.

  - **`read_ahead_kb` startup alert.** A warning is raised if any block device reports `read_ahead_kb` above `Storage.ReadAheadKbAlertThresholdInKb` (default 128 KB; set to `null` to disable).

  ## Testing

  **Correctness.** Every run recovered all databases byte-exact (integrity checked each run). `strace` confirmed `posix_fadvise`/`madvise` target the real `.journal` fds (0 errors, 0 non-zero returns).

  **`kill -9`.** We crashed the server rather than shutting it down cleanly because a hard crash leaves unsynced transactions in the journals, forcing the startup journal replay these hints target.

  ### 1. Fast local disk (Linux VM) - recovery is op-bound

  64-databases recovery, cold cache, identical snapshot per run (61 loaded DBs + 3 empty):

  | read_ahead_kb | hint | read ops | avg KB/op | db-recovery |
  |--:|:--|--:|--:|--:|
  | 16 | ON | 137,825 | ~37 KB | 3.56 s |
  | 16 | OFF | 258,365 | ~20 KB | 5.36 s |
  | 32 | ON | 69,977 | ~72 KB | 2.53 s |
  | 32 | OFF | 129,801 | ~39 KB | 3.44 s |
  | 64 | ON | 37,080 | ~137 KB | 2.01 s |
  | 64 | OFF | 67,047 | ~76 KB | 2.54 s |
  | 128 | ON | 21,161 | ~240 KB | 1.82 s |
  | 128 | OFF | 35,743 | ~142 KB | 1.98 s |

  - The hint cuts read operations ~41-47% at low/default readahead (it ~doubles the average read size).
  - It is equivalent to one doubling of `read_ahead_kb`, in both op count and recovery time:
    - hint-ON@16 ≈ OFF@32 (3.56 s ≈ 3.44 s),
    - ON@32 ≈ OFF@64 (2.53 s ≈ 2.54 s),
    - ON@64 ≈ OFF@128 (2.01 s ≈ 1.98 s).
  - Benefit grows with database count (time saved at `read_ahead_kb=16`): 0.36 s @ 6 DBs → 1.35 s @ 40 → 1.80 s @ 61.

 This disk is fast (~1 GB/s), so recovery is short and bound by per-operation overhead - which is why the read-op reduction shows up directly in wall-time here. 

  ### 2. Real-hardware testing (RavenDB Cloud Dev tier)

  Read I/O measured from `/proc/diskstats`.

  #### 2.1 Premium SSD at native limits (instance cap 6400 IOPS / 145 MB/s) - throughput-bound, wall-time flat

  64-databases recovery:

  | read_ahead_kb | hint | read ops | avg KB/op | io-busy% | db-recovery |
  |---:|:--|---:|---:|---:|---:|
  | 16  | ON  | 124,910 | ~41 KB  | 79% | 26.8 s |
  | 16  | OFF | 225,779 | ~23 KB  | 79% | 27.1 s |
  | 32  | ON  | 63,702  | ~80 KB  | 80% | 26.8 s |
  | 32  | OFF | 111,764 | ~45 KB  | 79% | 26.3 s |
  | 64  | ON  | 33,963  | ~149 KB | 79% | 26.5 s |
  | 64  | OFF | 56,537  | ~87 KB  | 80% | 26.0 s |
  | 128 | ON  | 21,913  | ~258 KB | 80% | 28.2 s |
  | 128 | OFF | 36,774  | ~158 KB | 80% | 30.3 s |

  The hint cuts read operations **~40–45%** at every setting (and ~doubles the average read size). But recovery time stays flat ~26 s: the disk is ~80% busy moving ~7 GB (≈5 GB read + ≈1.9 GB write-back) per run - it's **bound by bytes moved, not by operation count**, so  fewer-but-larger reads don't shorten it.

 Note: §1's local disk (~1 GB/s) is faster than this volume, so there recovery is short and op-bound -  hence wall-time improved. Here it's throughput-bound, so the identical ~44% read-op cut doesn't move the clock.

  #### 2.2 IOPS-bound disk (read-IOPS capped at 2,000) - the hint speeds up startup

 Same 64-DBs recovery, with the device's **read IOPS throttled to 2,000** (cgroup `io.max`) to emulate an IOPS-provisioned/metered cloud volume:

  | read_ahead_kb | hint | read ops | io-busy% | db-recovery | Δ recovery |
  |---:|:--|---:|---:|---:|---:|
  | 16  | ON  | 123,110 | 24% | 66.4 s  | **−43%** |
  | 16  | OFF | 220,877 | 15% | 116.4 s |          |
  | 32  | ON  | 63,928  | 50% | 38.1 s  | **−38%** |
  | 32  | OFF | 112,417 | 25% | 61.5 s  |          |
  | 64  | ON  | 34,921  | 80% | 26.9 s  | **−26%** |
  | 64  | OFF | 59,124  | 57% | 36.5 s  |          |
  | 128 | ON  | 20,694  | 80% | 25.6 s  | **−8%**  |
  | 128 | OFF | 37,974  | 80% | 27.9 s  |          |

 Read operations drop **~41–46%** at every setting. The wall-time win tracks how IOPS-bound recovery is: largest at low `read_ahead_kb`, where there are the most operations to save (−43% @16), and fading toward neutral as readahead rises - fewer, larger reads let the device (throughput) become the bottleneck again (`io-busy%` climbs to ~80%, −8% @128). The "hint ≈ one doubling of `read_ahead_kb`" relationship holds in wall-time too: ON@16 (66 s) ≈ OFF@32 (62 s), ON@32 (38 s) ≈ OFF@64 (37 s), ON@64 (27 s) ≈ OFF@128 (28 s).

## Testing Conclusion

 Most Linux hosts run with `read_ahead_kb = 128 KB`. Journal recovery is a **purely sequential scan** - so `POSIX_FADV_SEQUENTIAL` does nothing more than declare the access pattern the recovery already has. It is the setting that  should always have been in place. On Windows we open journals with `SequentialScan`:
 https://github.com/ravendb/ravendb/blob/be3bfe847c5cd239b16c3d8b94862b6e0f1045be/src/Voron/StorageEnvironmentOptions.cs#L936-L937
So  this change closes that gap on Linux.

  **It always cuts journal-recovery read I/O.** Across every run and every `read_ahead_kb` value (16 → 128), on both local and cloud disks, the hint reduced read **operations ~40–46%** - issuing half as many reads, each roughly twice as large. This is the robust,  hardware-independent result, and it follows directly from the access pattern being sequential.

  **Why it matters for users.** Because startup recovery no longer pays the full price of a small `read_ahead_kb`, operators can now tune `read_ahead_kb` **down** to optimize for random-access (OLTP) workloads - the common database case - without trading away database startup time. 

 **Where it's neutral - and never harmful.** On throughput- or write-bound disks, or where `read_ahead_kb` is already high, wall-time is unchanged - but read I/O still drops ~44%, easing IOPS cost and contention, and recovery is never slower.




### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms. - Linux
- [ ] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
