### PR TITLE
RavenDB-26426 : AiAgent can't send the same image twice

### DIFF
--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -54,7 +54,7 @@ internal class AiConversation : IAiConversationOperations
             throw new ArgumentNullException(nameof(stream));
 
         var attachmentName = name;
-        _attachmentsCommands.Add(new PutAttachmentCommandData("__this__", attachmentName, stream, contentType, changeVector: string.Empty));
+        _attachmentsCommands.Add(new PutAttachmentCommandData("__this__", attachmentName, stream, contentType, changeVector: null));
     }
 
     public void CopyAttachmentFrom(string sourceDocumentId, string fileName)
@@ -63,7 +63,7 @@ internal class AiConversation : IAiConversationOperations
         ValidationMethods.AssertNotNullOrEmpty(fileName, nameof(fileName));
         ValidationMethods.AssertNotNullOrEmpty(sourceDocumentId, nameof(sourceDocumentId));
 
-        _attachmentsCommands.Add(new CopyAttachmentCommandData(sourceDocumentId, fileName, "__this__", fileName, changeVector: string.Empty));
+        _attachmentsCommands.Add(new CopyAttachmentCommandData(sourceDocumentId, fileName, "__this__", fileName, changeVector: null));
     }
 
     public IEnumerable<AiAgentActionRequest> RequiredActions() =>

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26426.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-26426.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class RavenDB_26426 : RavenTestBase
+    {
+        public RavenDB_26426(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenTheory(RavenTestCategory.Ai)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CanSendSameImageTwiceInSeparateTurns(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agent = new AiAgentConfiguration("image-agent", config.ConnectionStringName,
+                "You are a helpful assistant that analyzes images.")
+            {
+                Identifier = "image-agent"
+            };
+
+            await store.AI.CreateAgentAsync(agent, new AiAgentBasics.OutputSchema());
+
+            var chat = store.AI.Conversation(agent.Identifier, "chats/", new AiConversationCreationOptions());
+
+            // First turn: send the image and ask what fruit it is
+            AiAnswer<AiAgentBasics.OutputSchema> result1;
+            await using (var banana1 = GetEmbeddedImgStream("banana.png"))
+            {
+                chat.AddAttachment("banana.png", banana1, "image/png");
+                chat.SetUserPrompt("What fruit is in this image?");
+                result1 = await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+            }
+
+            Assert.Equal(AiConversationResult.Done, result1.Status);
+            Assert.NotNull(result1.Answer);
+            Assert.Contains("banana", result1.Answer.Answer, StringComparison.OrdinalIgnoreCase);
+
+            // Second turn: re-send the same image via a fresh stream and ask a follow-up question
+            AiAnswer<AiAgentBasics.OutputSchema> result2;
+            await using (var banana2 = GetEmbeddedImgStream("banana.png"))
+            {
+                chat.AddAttachment("banana.png", banana2, "image/png");
+                chat.SetUserPrompt("Look at this image again - what color is the fruit?");
+                result2 = await chat.RunAsync<AiAgentBasics.OutputSchema>(CancellationToken.None);
+            }
+
+            Assert.Equal(AiConversationResult.Done, result2.Status);
+            Assert.NotNull(result2.Answer);
+            Assert.Contains("yellow", result2.Answer.Answer, StringComparison.OrdinalIgnoreCase);
+        }
+
+
+        private static Stream GetEmbeddedImgStream(string name)
+        {
+            var asm = typeof(RavenDB_24847).Assembly;
+            var resourceName = "SlowTests.Data.RavenDB_24648." + name;
+
+            var stream = asm.GetManifestResourceStream(resourceName);
+            if (stream == null)
+                throw new FileNotFoundException($"Embedded resource not found: {resourceName}");
+
+            return stream;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26426/AiAgent-cant-send-the-same-image-twice

### Additional description

AiConversation was saving attachments using changeVector: string.Empty. An empty string strictly enforces that the attachment must not already exist. If an AI conversation tried to update or re-add an existing attachment, it threw a ConcurrencyException.

What we did (The Fix): Changed `changeVector: string.Empty` to null in `AiConversation.cs` (`AddAttachment `and `CopyAttachmentFrom`). Passing null correctly bypasses the concurrency check, allowing existing attachments to be updated or overwritten without crashing.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
