### PR TITLE
RavenDB-26410 Raven ETL load request timeout should be 300 sec by default instead of 12 hours. Also fixing a bug that modification of LoadRequestTimeoutInSec wasn't recognized properly as a task update.

### DIFF
--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -138,7 +138,7 @@ namespace Raven.Client.Documents.Operations.ETL
             return ToJson();
         }
 
-        internal EtlConfigurationCompareDifferences Compare(
+        internal virtual EtlConfigurationCompareDifferences Compare(
             EtlConfiguration<T> config,
             Dictionary<string, T> connectionStrings,
             List<(string TransformationName, EtlConfigurationCompareDifferences Difference)> transformationDiffs = null)

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfigurationCompareDifferences.cs
@@ -18,5 +18,6 @@ namespace Raven.Client.Documents.Operations.ETL
         ConfigurationDisabled = 1 << 10,
         TransformationDocumentIdPostfix = 1 << 11,
         ConnectionString = 1 << 12,
+        ConfigurationOptions = 1 << 13,
     }
 }

--- a/src/Raven.Client/Documents/Operations/ETL/RavenEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/RavenEtlConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ETL
@@ -31,6 +32,19 @@ namespace Raven.Client.Documents.Operations.ETL
         public override string GetDefaultTaskName()
         {
             return $"RavenDB ETL to {ConnectionStringName}";
+        }
+
+        internal override EtlConfigurationCompareDifferences Compare(EtlConfiguration<RavenConnectionString> config, Dictionary<string, RavenConnectionString> connectionStrings, List<(string TransformationName, EtlConfigurationCompareDifferences Difference)> transformationDiffs = null)
+        {
+            var diff = base.Compare(config, connectionStrings, transformationDiffs);
+
+            if (config is RavenEtlConfiguration ravenConfig)
+            {
+                if (ravenConfig.LoadRequestTimeoutInSec != LoadRequestTimeoutInSec)
+                    diff |= EtlConfigurationCompareDifferences.ConfigurationOptions;
+            }
+
+            return diff;
         }
 
         public override DynamicJsonValue ToJson()

--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -8,8 +8,8 @@ namespace Raven.Server.Config.Categories
     [ConfigurationCategory(ConfigurationCategoryType.Etl)]
     public sealed class EtlConfiguration : ConfigurationCategory
     {
-        [Description("Number of seconds after which Raven ETL load request will timeout. Default: 100 seconds. Can be overriden by setting LoadRequestTimeoutInSec property value in Raven ETL configuration.")]
-        [DefaultValue(100)]
+        [Description("Number of seconds after which Raven ETL load request will timeout. Default: 300 seconds. Can be overriden by setting LoadRequestTimeoutInSec property value in Raven ETL configuration.")]
+        [DefaultValue(300)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("ETL.Raven.LoadRequestTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting RavenLoadRequestTimeout { get; set; }

--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -8,6 +8,12 @@ namespace Raven.Server.Config.Categories
     [ConfigurationCategory(ConfigurationCategoryType.Etl)]
     public sealed class EtlConfiguration : ConfigurationCategory
     {
+        [Description("Number of seconds after which Raven ETL load request will timeout. Default: 100 seconds. Can be overriden by setting LoadRequestTimeoutInSec property value in Raven ETL configuration.")]
+        [DefaultValue(100)]
+        [TimeUnit(TimeUnit.Seconds)]
+        [ConfigurationEntry("ETL.Raven.LoadRequestTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
+        public TimeSetting RavenLoadRequestTimeout { get; set; }
+
         [Description("Number of seconds after which SQL command will timeout. Default: null (use provider default). Can be overriden by setting CommandTimeout property value in SQL ETL configuration.")]
         [DefaultValue(null)]
         [TimeUnit(TimeUnit.Seconds)]

--- a/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Raven/RavenEtl.cs
@@ -60,7 +60,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
             Interlocked.Exchange(ref _requestExecutor, newRequestExecutor);
         }
 
-        internal Action<RavenEtl> BeforeActualLoad = null;
+        internal Action<RavenEtl, SingleNodeBatchCommand> BeforeActualLoad = null;
 
         private static RequestExecutor CreateNewRequestExecutor(RavenEtlConfiguration configuration, ServerStore serverStore)
         {
@@ -162,14 +162,14 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
                 }
             }
 
-            BatchOptions options = null;
-            if (Configuration.LoadRequestTimeoutInSec != null)
+            var requestTimeout = Configuration.LoadRequestTimeoutInSec != null
+                ? TimeSpan.FromSeconds(Configuration.LoadRequestTimeoutInSec.Value)
+                : Database.Configuration.Etl.RavenLoadRequestTimeout.AsTimeSpan;
+
+            var options = new BatchOptions
             {
-                options = new BatchOptions
-                {
-                    RequestTimeout = TimeSpan.FromSeconds(Configuration.LoadRequestTimeoutInSec.Value)
-                };
-            }
+                RequestTimeout = requestTimeout
+            };
 
             using (var batchCommand = new SingleNodeBatchCommand(DocumentConventions.DefaultForServer, context, commands, options))
             {
@@ -177,7 +177,7 @@ namespace Raven.Server.Documents.ETL.Providers.Raven
 
                 try
                 {
-                    BeforeActualLoad?.Invoke(this);
+                    BeforeActualLoad?.Invoke(this, batchCommand);
 
                     AsyncHelpers.RunSync(() => _requestExecutor.ExecuteAsync(batchCommand, context, token: CancellationToken));
                     _recentUrl = _requestExecutor.Url;

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
@@ -6,6 +6,7 @@ import getOngoingTaskInfoCommand = require("commands/database/tasks/getOngoingTa
 import eventsCollector = require("common/eventsCollector");
 import getConnectionStringsCommand = require("commands/database/settings/getConnectionStringsCommand");
 import getDatabaseSettingsCommand = require("commands/database/settings/getDatabaseSettingsCommand");
+import { settingsEntry } from "models/database/settings/databaseSettingsModels";
 import configurationConstants = require("configuration");
 import saveEtlTaskCommand = require("commands/database/tasks/saveEtlTaskCommand");
 import generalUtils = require("common/generalUtils");
@@ -294,15 +295,14 @@ class editRavenEtlTask extends shardViewModelBase {
             .execute()
             .done((result: Raven.Server.Config.SettingsResult) => {
                 const key = configurationConstants.etl.ravenLoadRequestTimeout;
-                const entry = result.Settings.find(x => x.Metadata.Keys.includes(key)) as Raven.Server.Config.ConfigurationEntryDatabaseValue;
+                const rawEntry = result.Settings.find(x => x.Metadata.Keys.includes(key));
 
-                if (!entry) {
+                if (!rawEntry) {
                     return;
                 }
 
-                const effectiveValue = entry.DatabaseValues?.[key]?.HasValue ? entry.DatabaseValues[key].Value :
-                    entry.ServerValues?.[key]?.HasValue ? entry.ServerValues[key].Value :
-                    entry.Metadata.DefaultValue;
+                const entry = settingsEntry.getEntry(rawEntry);
+                const effectiveValue = entry.effectiveValue();
 
                 if (effectiveValue) {
                     this.loadRequestTimeoutPlaceholder(`Use database default timeout (${effectiveValue}s)`);

--- a/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
+++ b/src/Raven.Studio/typescript/viewmodels/database/tasks/editRavenEtlTask.ts
@@ -5,6 +5,8 @@ import database = require("models/resources/database");
 import getOngoingTaskInfoCommand = require("commands/database/tasks/getOngoingTaskInfoCommand");
 import eventsCollector = require("common/eventsCollector");
 import getConnectionStringsCommand = require("commands/database/settings/getConnectionStringsCommand");
+import getDatabaseSettingsCommand = require("commands/database/settings/getDatabaseSettingsCommand");
+import configurationConstants = require("configuration");
 import saveEtlTaskCommand = require("commands/database/tasks/saveEtlTaskCommand");
 import generalUtils = require("common/generalUtils");
 import ongoingTaskRavenEtlEditModel = require("models/database/tasks/ongoingTaskRavenEtlEditModel");
@@ -193,6 +195,7 @@ class editRavenEtlTask extends shardViewModelBase {
     ravenEtlConnectionStringsDetails = ko.observableArray<Raven.Client.Documents.Operations.ETL.RavenConnectionString>([]);
 
     possibleMentors = ko.observableArray<string>([]);
+    loadRequestTimeoutPlaceholder = ko.observable<string>("Use database default timeout");
 
     testConnectionResult = ko.observable<Raven.Server.Web.System.NodeConnectionTestResult>();
     
@@ -257,7 +260,7 @@ class editRavenEtlTask extends shardViewModelBase {
             deferred.resolve();
         }
 
-        return $.when<any>(this.getAllConnectionStrings(), deferred)
+        return $.when<any>(this.getAllConnectionStrings(), this.loadDatabaseSettings(), deferred)
             .done(() => {
                 this.initObservables();
             })
@@ -283,6 +286,27 @@ class editRavenEtlTask extends shardViewModelBase {
             .done((result: Raven.Client.Documents.Operations.ConnectionStrings.GetConnectionStringsResult) => {
                 const connectionStrings = Object.values(result.RavenConnectionStrings);
                 this.ravenEtlConnectionStringsDetails(typeUtils.sortBy(connectionStrings, x => x.Name.toUpperCase()));
+            });
+    }
+
+    private loadDatabaseSettings() {
+        return new getDatabaseSettingsCommand(this.db)
+            .execute()
+            .done((result: Raven.Server.Config.SettingsResult) => {
+                const key = configurationConstants.etl.ravenLoadRequestTimeout;
+                const entry = result.Settings.find(x => x.Metadata.Keys.includes(key)) as Raven.Server.Config.ConfigurationEntryDatabaseValue;
+
+                if (!entry) {
+                    return;
+                }
+
+                const effectiveValue = entry.DatabaseValues?.[key]?.HasValue ? entry.DatabaseValues[key].Value :
+                    entry.ServerValues?.[key]?.HasValue ? entry.ServerValues[key].Value :
+                    entry.Metadata.DefaultValue;
+
+                if (effectiveValue) {
+                    this.loadRequestTimeoutPlaceholder(`Use database default timeout (${effectiveValue}s)`);
+                }
             });
     }
 

--- a/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/tasks/editRavenEtlTask.html
@@ -123,7 +123,7 @@
                                     <label for="loadTimeout" class="control-label">Http Request Timeout</label>
                                     <div class="flex-grow">
                                         <div class="input-group">
-                                            <input type="number" min="0" class="form-control" placeholder="Use default timeout (100s)" id="loadTimeout" data-bind="numericInput: loadRequestTimeout">
+                                            <input type="number" min="0" class="form-control" id="loadTimeout" data-bind="numericInput: loadRequestTimeout, attr: { placeholder: $root.loadRequestTimeoutPlaceholder }">
                                             <div class="input-group-addon">seconds</div>
                                         </div>
                                     </div>

--- a/test/SlowTests/Issues/RavenDB_26410.cs
+++ b/test/SlowTests/Issues/RavenDB_26410.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Server.Config;
+using Raven.Server.Documents.ETL.Providers.Raven;
+using Raven.Tests.Core.Utils.Entities;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26410 : RavenTestBase
+    {
+        public RavenDB_26410(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task RavenEtl_uses_database_default_load_request_timeout_when_not_specified()
+        {
+            using (var src = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                    record.Settings[RavenConfiguration.GetKey(x => x.Etl.RavenLoadRequestTimeout)] = "33"
+            }))
+            using (var dest = GetDocumentStore())
+            {
+                Etl.AddEtl(src, dest, new[] { "Users" }, script: "loadToUsers(this);", out var configuration);
+
+                var etlProcess = await GetRavenEtlProcess(src, configuration.Name);
+                Assert.Null(etlProcess.Configuration.LoadRequestTimeoutInSec);
+
+                var database = await GetDocumentDatabaseInstanceFor(src);
+                Assert.Equal(TimeSpan.FromSeconds(33), database.Configuration.Etl.RavenLoadRequestTimeout.AsTimeSpan);
+
+                TimeSpan? actualTimeout = null;
+                var afterRun = new AsyncManualResetEvent();
+
+                etlProcess.BeforeActualLoad += (_, batchCommand) =>
+                {
+                    actualTimeout = batchCommand.Timeout;
+                    afterRun.Set();
+                };
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User { Name = "Test" });
+                    session.SaveChanges();
+                }
+
+                await afterRun.WaitAsync(TimeSpan.FromSeconds(30));
+
+                Assert.Equal(TimeSpan.FromSeconds(33), actualTimeout);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task RavenEtl_explicit_load_request_timeout_overrides_database_default()
+        {
+            using (var src = GetDocumentStore(new Options
+            {
+                ModifyDatabaseRecord = record =>
+                    record.Settings[RavenConfiguration.GetKey(x => x.Etl.RavenLoadRequestTimeout)] = "33"
+            }))
+            using (var dest = GetDocumentStore())
+            {
+                var addResult = Etl.AddEtl(src, dest, new[] { "Users" }, script: "loadToUsers(this);", out var configuration);
+                configuration.LoadRequestTimeoutInSec = 17;
+
+                var updateResult = src.Maintenance.Send(new UpdateEtlOperation<RavenConnectionString>(addResult.TaskId, configuration));
+
+                await Databases.WaitForRaftIndex(src.Database, updateResult.RaftCommandIndex);
+
+                var database = await GetDocumentDatabaseInstanceFor(src);
+
+                // wait to process to get updated configuration
+
+                var timeoutValue = await WaitForValueAsync(async () =>
+                {
+                    var process = await GetRavenEtlProcess(src, configuration.Name);
+                    
+                    return process?.Configuration.LoadRequestTimeoutInSec;
+                }, 17, interval: 333);
+
+                Assert.Equal(17, timeoutValue);
+
+                var etlProcess = await GetRavenEtlProcess(src, configuration.Name);
+                
+                Assert.Equal(17, etlProcess.Configuration.LoadRequestTimeoutInSec);
+
+                Assert.Equal(TimeSpan.FromSeconds(33), database.Configuration.Etl.RavenLoadRequestTimeout.AsTimeSpan);
+
+                TimeSpan? actualTimeout = null;
+                var afterRun = new AsyncManualResetEvent();
+
+                etlProcess.BeforeActualLoad += (_, batchCommand) =>
+                {
+                    actualTimeout = batchCommand.Timeout;
+                    afterRun.Set();
+                };
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User { Name = "Test" });
+                    session.SaveChanges();
+                }
+
+                Assert.True(await afterRun.WaitAsync(TimeSpan.FromSeconds(30)));
+
+                Assert.Equal(TimeSpan.FromSeconds(17), actualTimeout);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Etl)]
+        public async Task RavenEtl_uses_global_default_timeout_when_nothing_is_configured()
+        {
+            using (var src = GetDocumentStore())
+            using (var dest = GetDocumentStore())
+            {
+                Etl.AddEtl(src, dest, new[] { "Users" }, script: "loadToUsers(this);", out var configuration);
+
+                Assert.Null(configuration.LoadRequestTimeoutInSec);
+
+                var etlProcess = await GetRavenEtlProcess(src, configuration.Name);
+                Assert.Null(etlProcess.Configuration.LoadRequestTimeoutInSec);
+
+                var database = await GetDocumentDatabaseInstanceFor(src);
+                Assert.Equal(TimeSpan.FromSeconds(100), database.Configuration.Etl.RavenLoadRequestTimeout.AsTimeSpan);
+
+                TimeSpan? actualTimeout = null;
+                var afterRun = new AsyncManualResetEvent();
+
+                etlProcess.BeforeActualLoad += (_, batchCommand) =>
+                {
+                    actualTimeout = batchCommand.Timeout;
+                    afterRun.Set();
+                };
+
+                using (var session = src.OpenSession())
+                {
+                    session.Store(new User { Name = "Test" });
+                    session.SaveChanges();
+                }
+
+                Assert.True(await afterRun.WaitAsync(TimeSpan.FromSeconds(30)));
+
+                Assert.Equal(TimeSpan.FromSeconds(100), actualTimeout);
+            }
+        }
+
+        private async Task<RavenEtl> GetRavenEtlProcess(DocumentStore store, string configurationName)
+        {
+            var database = await GetDocumentDatabaseInstanceFor(store);
+            return Assert.IsType<RavenEtl>(Assert.Single(database.EtlLoader.Processes, x => x.ConfigurationName == configurationName));
+        }
+    }
+}

--- a/test/SlowTests/Issues/RavenDB_26410.cs
+++ b/test/SlowTests/Issues/RavenDB_26410.cs
@@ -129,7 +129,7 @@ namespace SlowTests.Issues
                 Assert.Null(etlProcess.Configuration.LoadRequestTimeoutInSec);
 
                 var database = await GetDocumentDatabaseInstanceFor(src);
-                Assert.Equal(TimeSpan.FromSeconds(100), database.Configuration.Etl.RavenLoadRequestTimeout.AsTimeSpan);
+                Assert.Equal(TimeSpan.FromSeconds(300), database.Configuration.Etl.RavenLoadRequestTimeout.AsTimeSpan);
 
                 TimeSpan? actualTimeout = null;
                 var afterRun = new AsyncManualResetEvent();
@@ -148,7 +148,7 @@ namespace SlowTests.Issues
 
                 Assert.True(await afterRun.WaitAsync(TimeSpan.FromSeconds(30)));
 
-                Assert.Equal(TimeSpan.FromSeconds(100), actualTimeout);
+                Assert.Equal(TimeSpan.FromSeconds(300), actualTimeout);
             }
         }
 

--- a/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RDBS_85.cs
@@ -34,7 +34,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var afterStop = new AsyncManualResetEvent();
 
-                process.BeforeActualLoad += p =>
+                process.BeforeActualLoad += (p, _) =>
                 {
                     p.Stop("testing");
                     afterStop.Set();
@@ -100,7 +100,7 @@ namespace SlowTests.Server.Documents.ETL.Raven
 
                 var afterLoadError = new AsyncManualResetEvent();
 
-                process.BeforeActualLoad += p =>
+                process.BeforeActualLoad += (p, _) =>
                 {
                     afterLoadError.Set();
                     throw new Exception("Force the failure of the load of docs");


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26410/RavenDB-ETL-load-request-timeout-43200s-applying-commands-has-too-long-of-a-default-value

https://issues.hibernatingrhinos.com/issue/RavenDB-26379/RavenDB-ETL-HTTP-Request-Timeout-placeholder-is-wrong



### Additional description

Previously, when no explicit `LoadRequestTimeoutInSec` was set on the ETL task, no timeout was applied to the batch request at all. This caused it to fall back to the `RequestExecutor` default (12 hours), meaning the 100s timeout shown in the UI was never actually enforced.

EDIT: Eventually the timeout was set to 300 sec

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
