### PR TITLE
RavenDB-23376 Fix same flaky ETL test race in Raven and Elasticsearch variants

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_23376.cs
+++ b/test/SlowTests/Server/Documents/ETL/Elasticsearch/RavenDB_23376.cs
@@ -150,8 +150,6 @@
                  var count = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(ProductsByCategoriesIndexName)));
                  Assert.Equal(2, count.Count);
 
-                 etlDone.Reset();
-
                  await new ProductsByCategoryUpdated().ExecuteAsync(store);
 
                  await Indexes.WaitForIndexingAsync(store);
@@ -161,15 +159,14 @@
                      WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, 0, interval: 500);
                  }
 
-                 etlDone.Wait(TimeSpan.FromMinutes(1));
-
-                 await client.Indices.RefreshAsync(ProductsByCategoriesIndexName);
-                 
+                 // poll destination directly - the ETL may need multiple batches to process both
+                 // the new artificial docs (inserts) and old artificial doc tombstones (deletes)
                  var countAfterUpdate = await WaitForValueAsync(async () =>
                  {
+                     await client.Indices.RefreshAsync(ProductsByCategoriesIndexName);
                      var count = await client.CountAsync<object>(descriptor => descriptor.Indices(Indices.Index(ProductsByCategoriesIndexName)));
                      return (int)count.Count;
-                 }, 2, interval: 500);
+                 }, 2, timeout: 60_000, interval: 500);
                  
                  Assert.Equal(2, countAfterUpdate);
 

--- a/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_23376.cs
+++ b/test/SlowTests/Server/Documents/ETL/Raven/RavenDB_23376.cs
@@ -122,19 +122,25 @@ namespace SlowTests.Server.Documents.ETL.Raven
                     Assert.Equal(2, categorySummaries.Count);
                 }
 
-                etlDone.Reset();
-
                 // Update the index definition - this will cause artificial document IDs to be regenerated
                 await new ProductsByCategoryUpdated().ExecuteAsync(src);
 
                 await Indexes.WaitForIndexingAsync(src);
-                
+
                 using (var session = src.OpenSession())
                 {
                     WaitForValue(() => session.Query<ProductsByCategories>().Count(), 2, 0, interval: 500);
                 }
 
-                etlDone.Wait(TimeSpan.FromMinutes(1));
+                // poll destination directly - the ETL may need multiple batches to process both
+                // the new artificial docs (inserts) and old artificial doc tombstones (deletes)
+                WaitForValue(() =>
+                {
+                    using (var session = dest.OpenSession())
+                    {
+                        return session.Query<ProductsByCategories>().Count();
+                    }
+                }, 2, timeout: 60_000, interval: 500);
 
                 using (var session = dest.OpenAsyncSession())
                 {


### PR DESCRIPTION
### Issue link

  https://issues.hibernatingrhinos.com/issue/RavenDB-23376

  ### Additional description

  Applies the same flaky test fix from RavenDB-26307 (SQL ETL) to the Raven ETL and Elasticsearch
  ETL variants of `ShouldPropagateDeletionsOfArtificialDocuments_IndexUpdateScenario`.

Continues: https://github.com/ravendb/ravendb/pull/22625

  The race: `etlDone.Reset()` was called before deploying the updated index. During side-by-side
  replacement, the ETL could process the new artificial docs (inserts) and signal `etlDone` before
  the old docs were cleaned up (tombstones). `etlDone.Wait()` would return immediately, and the
  assertion would find double the expected count.

  Fix: remove the `etlDone` signaling from the post-update section and poll the destination directly
   instead, which correctly waits for the ETL to process both inserts and tombstone deletes
  regardless of batch timing.

  ### Type of change

  - [x] Bug fix
  - [ ] Regression bug fix
  - [ ] Optimization
  - [ ] New feature

  ### How risky is the change?

  - [x] Low
  - [ ] Moderate
  - [ ] High
  - [ ] Not relevant

  ### Backward compatibility

  - [ ] Non breaking change
  - [ ] Ensured. Please explain how has it been implemented?
  - [ ] Breaking change
  - [x] Not relevant

  ### Is it platform specific issue?

  - [ ] Yes. Please list the affected platforms.
  - [x] No

  ### Documentation update

  - [ ] This change requires a documentation update. Please mark the issue on YouTrack using
  `Documentation Required` tag.
  - [x] No documentation update is needed

  ### Testing by Contributor

  - [ ] Tests have been added that prove the fix is effective or that the feature works
  - [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the
  lowest possible access modifier (preferable `private`)
  - [x] It has been verified by manual testing

  ### Testing by RavenDB QA team

  - [ ] This change requires a special QA testing due to possible performance or resources usage
  implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
  - [x] No special testing by RavenDB QA team is needed

  ### Is there any existing behavior change of other features due to this change?

  - [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
  - [x] No

  ### UI work

  - [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio
  Required` tag.
  - [x] No UI work is needed