### PR TITLE
RavenDB-26397 Backport transient test and stability fixes to v6.2

### DIFF
--- a/src/Raven.Server/Rachis/RachisConsensus.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.cs
@@ -304,7 +304,7 @@ namespace Raven.Server.Rachis
 
                 ContextPool = new ClusterContextPool(changes, _persistentState, configuration.Memory.MaxContextSizeToKeep);
                 TxMerger = new ClusterTransactionOperationsMerger(configuration, time, shutdown);
-                TxMerger.Initialize(ContextPool, IsEncrypted, PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager);
+                TxMerger.Initialize(ContextPool, IsEncrypted, PlatformDetails.Is32Bits || configuration.Storage.ForceUsing32BitsPager || env.Options.ForceUsing32BitsPager);
                 TxMerger.Start();
 
                 ClusterTopology topology;

--- a/src/Raven.Server/RavenServer.cs
+++ b/src/Raven.Server/RavenServer.cs
@@ -3274,7 +3274,7 @@ namespace Raven.Server
                 ea.Execute(() => AdminConsolePipe?.Dispose());
                 ea.Execute(() => LogStreamPipe?.Dispose());
                 ea.Execute(() => _redirectingWebHost?.Dispose());
-                ea.Execute(() => _webHost?.Dispose());
+                ea.Execute(() => DisposeWebHost());
                 ea.Execute(() => _tcpContextPool?.Dispose());
                 if (_tcpListenerStatus != null)
                 {
@@ -3311,6 +3311,36 @@ namespace Raven.Server
 
                 ea.ThrowIfNeeded();
             }
+        }
+
+        private void DisposeWebHost()
+        {
+            try
+            {
+                _webHost?.Dispose();
+            }
+            catch (Exception e) when (IsExpectedShutdownException(e))
+            {
+                // During shutdown, active HTTP connections may throw I/O exceptions
+                // (broken pipe, connection reset) as they are torn down. This is expected.
+                if (_tcpLogger.IsInfoEnabled)
+                    _tcpLogger.Info("Ignoring expected I/O error during web host shutdown", e);
+            }
+        }
+
+        private static bool IsExpectedShutdownException(Exception e)
+        {
+            if (e is IOException or SocketException)
+                return true;
+
+            if (e is AggregateException ae)
+            {
+                AggregateException flattened = ae.Flatten();
+                return flattened.InnerExceptions.Count > 0 &&
+                       flattened.InnerExceptions.All(ie => ie is IOException or SocketException);
+            }
+
+            return false;
         }
 
         private void CloseTcpListeners(List<TcpListener> listeners)

--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -776,7 +776,26 @@ namespace Voron
 
                 foreach (var file in Directory.GetFiles(TempPath.FullPath).Where(x => x.EndsWith(BuffersFileExtension, StringComparison.OrdinalIgnoreCase) || x.EndsWith(TempFileExtension, StringComparison.OrdinalIgnoreCase)))
                 {
-                    File.Delete(file);
+                    DeleteTempFile(file);
+                }
+            }
+
+            private static void DeleteTempFile(string file)
+            {
+                const int retries = 5;
+                for (int i = 0; i < retries; i++)
+                {
+                    try
+                    {
+                        File.Delete(file);
+                        return;
+                    }
+                    catch (Exception e) when (i < retries - 1 && e is UnauthorizedAccessException or IOException)
+                    {
+                        // On Windows, memory-mapped file handles may not be fully released by
+                        // the kernel yet even after the pager is disposed. Retry after a brief delay.
+                        Thread.Sleep(50);
+                    }
                 }
             }
 

--- a/test/SlowTests/Client/ClientConfigurationTests.cs
+++ b/test/SlowTests/Client/ClientConfigurationTests.cs
@@ -220,6 +220,7 @@ namespace SlowTests.Client
             await AssertWaitForClientConfiguration(origin);
 
             await store.Maintenance.SendAsync(new PutClientConfigurationOperation(GetClientConfiguration(101)));
+            await AssertWaitForClientConfiguration(101);
             await store.Maintenance.Server.SendAsync(new PutServerWideClientConfigurationOperation(GetClientConfiguration(102)));
             await AssertWaitForClientConfiguration(101);
 

--- a/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
+++ b/test/SlowTests/Server/Documents/Indexing/Auto/RavenDB_8713.cs
@@ -120,7 +120,10 @@ namespace SlowTests.Server.Documents.Indexing.Auto
 
                     session.SaveChanges();
 
-                    var results = session.Query<Item>().Statistics(out var stats).GroupBy(x => new {x.name, x.Name}).Select(g => new
+                    var results = session.Query<Item>()
+                        .Statistics(out var stats)
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .GroupBy(x => new {x.name, x.Name}).Select(g => new
                     {
                         g.Key.name,
                         g.Key.Name,

--- a/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
+++ b/test/SlowTests/Server/Replication/ReplicationCleanTombstones.cs
@@ -65,9 +65,11 @@ namespace SlowTests.Server.Replication
 
                 await EnsureReplicatingAsync(store1, store2);
 
-                await storage1.TombstoneCleaner.ExecuteCleanup();
-
-                Assert.Equal(0, WaitForValue(() => WaitUntilHasTombstones(store1, 0).Count, 0));
+                Assert.Equal(0, await WaitForValueAsync(async () =>
+                {
+                    await storage1.TombstoneCleaner.ExecuteCleanup();
+                    return WaitUntilHasTombstones(store1, 0).Count;
+                }, 0));
             }
         }
 

--- a/test/SlowTests/Sharding/ShardingTopologyTests.cs
+++ b/test/SlowTests/Sharding/ShardingTopologyTests.cs
@@ -115,6 +115,12 @@ namespace SlowTests.Sharding
                 var res = store.Maintenance.Server.Send(new AddDatabaseShardOperation(store.Database, replicationFactor: 1));
                 await Cluster.WaitForRaftIndexToBeAppliedInClusterAsync(res.RaftCommandIndex);
 
+                await AssertWaitForValueAsync(async () =>
+                {
+                    var s = await Sharding.GetShardingConfigurationAsync(store);
+                    return s.Shards.Count;
+                }, 3);
+
                 var sharding = await Sharding.GetShardingConfigurationAsync(store);
                 var nodeToInstanceCount = new Dictionary<string, int>();
 
@@ -317,10 +323,17 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                DatabaseRecord record = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    var firstShard = record.Sharding.Shards.Values.FirstOrDefault();
+                    return firstShard?.AllNodes.Count() ?? 0;
+                }, 1);
+
                 var chosenShard = record.Sharding.Shards.Keys.First();
                 var shardTopology = record.Sharding.Shards[chosenShard];
-                Assert.Equal(1, shardTopology.AllNodes.Count());
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(1, shardTopology.ReplicationFactor);
 
@@ -511,9 +524,15 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                DatabaseRecord record = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
                 var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 
@@ -574,9 +593,16 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
+                DatabaseRecord record = null;
+                DatabaseTopology shardTopology = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
+                shardTopology = record.Sharding.Shards[0];
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 
@@ -624,9 +650,16 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
+                DatabaseRecord record = null;
+                DatabaseTopology shardTopology = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
+                shardTopology = record.Sharding.Shards[0];
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 
@@ -669,9 +702,16 @@ namespace SlowTests.Sharding
 
             using (var store = GetDocumentStore(options))
             {
-                var record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
-                var shardTopology = record.Sharding.Shards[0];
-                Assert.Equal(2, shardTopology.Members.Count);
+                DatabaseRecord record = null;
+                DatabaseTopology shardTopology = null;
+
+                await AssertWaitForValueAsync(async () =>
+                {
+                    record = await store.Maintenance.Server.SendAsync(new GetDatabaseRecordOperation(store.Database));
+                    return record.Sharding.Shards[0].Members.Count;
+                }, 2);
+
+                shardTopology = record.Sharding.Shards[0];
                 Assert.Equal(0, shardTopology.Promotables.Count);
                 Assert.Equal(2, shardTopology.ReplicationFactor);
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26397

### Additional description

Backport of applicable fixes from https://github.com/ravendb/ravendb/pull/22644 to v6.2.

**Production code fixes:**
- RavenDB-26397: Suppress expected I/O errors during web host disposal
- RavenDB-26317: Fix 32-bit async commit guard in RachisConsensus
- RavenDB-26076: Retry temp file deletion for Windows memory-mapped handles

**Test stability fixes:**
- RavenDB-26177: Fix race in ChangeClientConfiguration test
- RavenDB-26033: Fix race in ShardingTopology tests for shard member count
- RavenDB-26310: Fix race in CleanTombstones replication test
- RavenDB-25784: Add WaitForNonStaleResults to case-sensitive GroupBy test

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed