### PR TITLE
RavenDB-26397 Fix v7.2-only test assertions (SchemaValidation, AI agent)

### DIFF
--- a/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
+++ b/test/SlowTests/SchemaValidation/BasicIntegrationSchemaValidationTests.cs
@@ -671,7 +671,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             var changeVector = revisions[1].GetString(Constants.Documents.Metadata.ChangeVector);
             
             var e = await Assert.ThrowsAnyAsync<RavenException>(async () => await store.Operations.SendAsync(new RevertRevisionsByIdOperation(id, changeVector)));
-            Assert.Contains("System.InvalidOperationException: Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
+            Assert.Contains("Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
             
             configuration.Disabled = true;
             await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));
@@ -726,7 +726,7 @@ public class BasicIntegrationSchemaValidationTests : ReplicationTestBase
             var operation = await store.Maintenance.SendAsync(new RevisionsHelper.RevertRevisionsOperation(revisionTime, 1));
             await operation.WaitForCompletionAsync<RevertResult>(TimeSpan.FromSeconds(5));
         });
-        Assert.Contains("System.InvalidOperationException: Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
+        Assert.Contains("Reverting documents to revisions is not allowed when Schema Validation is enabled. Please disable Schema Validation and try again.", e.Message);
         
         configuration.Disabled = true;
         await store.Maintenance.SendAsync(new ConfigureSchemaValidationOperation(configuration));

--- a/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/RavenDB-24887.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FastTests;
 using Newtonsoft.Json;
 using Raven.Client.Documents.AI;
@@ -234,6 +235,6 @@ public class RavenDB_24887(ITestOutputHelper output) : RavenTestBase(output)
         Assert.NotNull(addToCartArgs);
         // and were able to "solve" it properly
         Assert.Equal(AiConversationResult.Done, result.Status);
-        Assert.Contains("added", result.Answer.Message);
+        Assert.Contains("added", result.Answer.Message, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26397

### Additional description

v7.2-only test fixes from https://github.com/ravendb/ravendb/pull/22644 (features not present in v6.2).

- RavenDB-26393: Fix SchemaValidation revert test assertion (remove exception type prefix from assertion string)
- RavenDB-26309: Fix case-sensitive assertion in AI sub-agent action test

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed