### PR TITLE
RavenDB-23264 Fix scratch buffer double-free during journal flush retry

### DIFF
--- a/src/Voron/Impl/Journal/WriteAheadJournal.cs
+++ b/src/Voron/Impl/Journal/WriteAheadJournal.cs
@@ -1074,15 +1074,17 @@ namespace Voron.Impl.Journal
                 var minScratchNumber = int.MaxValue;
                 var maxScratchNumber = int.MinValue;
 #endif
-
-                foreach (var pageFromScratchBuffer in bufferOfPageFromScratchBuffersToFree)
+                
+                for (var i = 0; i < bufferOfPageFromScratchBuffersToFree.Count; i++)
                 {
+                    var pageFromScratchBuffer = bufferOfPageFromScratchBuffersToFree[i];
                     if (pageFromScratchBuffer == null)
-                        throw new ArgumentNullException(nameof(pageFromScratchBuffer));
+                        continue; // it could be already freed in a previous (partial) execution of this action
                     if (pageFromScratchBuffer.File == null)
                         throw new ArgumentNullException(nameof(pageFromScratchBuffer.File));
 
                     scratchBufferPool.Free(txw, pageFromScratchBuffer.File.Number, pageFromScratchBuffer.PositionInScratchBuffer);
+                    bufferOfPageFromScratchBuffersToFree[i] = null;
 
 #if DEBUG
                     freedUpToTx = long.Max(freedUpToTx, pageFromScratchBuffer.AllocatedInTransaction);

--- a/test/SlowTests/Voron/Issues/RavenDB_23264.cs
+++ b/test/SlowTests/Voron/Issues/RavenDB_23264.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Threading;
+using FastTests.Voron;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Voron.Issues;
+
+public class RavenDB_23264 : StorageTest
+{
+    public RavenDB_23264(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override void Configure(StorageEnvironmentOptions options)
+    {
+        base.Configure(options);
+
+        options.ManualFlushing = true;
+        options.ManualSyncing = true;
+    }
+    
+    [RavenFact(RavenTestCategory.Voron)]
+    public void Piggybacking_tx_failure_after_flush_action_should_not_cause_double_free_on_retry()
+    {
+        // RavenDB-23264: This test validates that if the _updateJournalStateAfterFlush action
+        // is invoked by a piggybacking write tx that then fails to commit, the flush thread's
+        // retry succeeds because the free loop is idempotent (entries are nulled after freeing).
+
+        long p1, p2, p3;
+
+        // Step 1: Create initial pages and commit
+        using (var txw = Env.WriteTransaction())
+        {
+            p1 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+            p2 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+            p3 = txw.LowLevelTransaction.AllocatePage(1).PageNumber;
+            txw.LowLevelTransaction.ModifyPage(p1);
+            txw.LowLevelTransaction.ModifyPage(p2);
+            txw.LowLevelTransaction.ModifyPage(p3);
+            txw.Commit();
+        }
+
+        // Step 2: Flush to data file (so scratch pages from step 1 can be freed in next flush)
+        Env.FlushLogToDataFile();
+
+        // Step 3: Create more committed txs that modify the same pages.
+        // These modifications create new scratch entries; the OLD scratch entries
+        // (from step 1) will be in the next flush's bufferOfPageFromScratchBuffersToFree.
+        using (var txw = Env.WriteTransaction())
+        {
+            txw.LowLevelTransaction.ModifyPage(p1);
+            txw.LowLevelTransaction.ModifyPage(p2);
+            txw.LowLevelTransaction.ModifyPage(p3);
+            txw.Commit();
+        }
+
+        // Step 4: Create an empty write tx that holds the write lock.
+        // This blocks the flush thread from getting the lock.
+        var txBlocker = Env.WriteTransaction();
+
+        // Step 5: Set up BeforeCommitFinalization to throw AFTER the flush action completes
+        // but BEFORE CommitStage3 sets Committed = true. This simulates a piggybacking tx
+        // that successfully invokes the flush action but fails to commit.
+        txBlocker.LowLevelTransaction.BeforeCommitFinalization += _ =>
+        {
+            throw new InvalidOperationException("Simulated failure after flush action completed");
+        };
+
+        // Step 6: Set up synchronization to know when the flush sets the action
+        var actionSetEvent = new ManualResetEventSlim(false);
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush += () =>
+        {
+            actionSetEvent.Set();
+        };
+
+        // Step 7: Start flush on a background thread.
+        // The flush will prepare the state, write to data file, then try to get the write lock.
+        // Since txBlocker holds the lock, the flush thread will set _updateJournalStateAfterFlush
+        // and wait.
+        Exception flushException = null;
+        var flushThread = new Thread(() =>
+        {
+            try
+            {
+                Env.FlushLogToDataFile();
+            }
+            catch (Exception e)
+            {
+                flushException = e;
+            }
+        });
+        flushThread.Start();
+
+        // Step 8: Wait for the flush to set the action
+        Assert.True(actionSetEvent.Wait(TimeSpan.FromSeconds(30)), "Timed out waiting for flush to set _updateJournalStateAfterFlush");
+
+        // Step 9: Commit txBlocker. This triggers CommitStage1 → OnTransactionCommitted,
+        // which invokes the _updateJournalStateAfterFlush action. The action frees scratch
+        // pages from the buffer. Then BeforeCommitFinalization throws, so the tx is NOT
+        // committed and the action is NOT cleared.
+        try
+        {
+            txBlocker.Commit();
+            Assert.Fail("Expected InvalidOperationException from BeforeCommitFinalization");
+        }
+        catch (InvalidOperationException e) when (e.Message.Contains("Simulated failure"))
+        {
+            // Expected - the simulated failure prevents the tx from committing
+        }
+
+        // Step 10: Dispose txBlocker → releases write lock.
+        // OnTransactionCompleted will NOT clear the action because Committed = false.
+        txBlocker.Dispose();
+
+        // Step 11: Flush thread wakes up, creates its own tx, Commit() →
+        // CommitStage1 → OnTransactionCommitted → action invoked AGAIN.
+        // With the fix (idempotent free loop): entries are null → skip → success.
+        // Without the fix: double-free → crash.
+        flushThread.Join(TimeSpan.FromSeconds(30));
+
+        // Step 12: Verify no exception from flush thread
+        Assert.Null(flushException);
+
+        // Clean up
+        Env.Journal.Applicator.ForTestingPurposesOnly().OnWaitForJournalStateToBeUpdated_AfterAssigning_updateJournalStateAfterFlush = null;
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-23264

### Additional description

The _updateJournalStateAfterFlush piggybacking mechanism allows any write tx to invoke the flush action during CommitStage1. If that tx fails to commit, the action is not cleared and gets re-invoked by the flush thread, causing double-free of already-freed scratch pages.

Replace the foreach loop in UpdateJournalStateUnderWriteTransactionLock with an indexed for loop that nulls out entries after freeing, making the operation idempotent on retry.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
