### PR TITLE
RavenDB-26440 - Detect deeply chained LINQ methods at index compile time to prevent `StackOverflowException`

### DIFF
--- a/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/IndexCompiler.cs
@@ -27,6 +27,7 @@ using Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters.Counters;
 using Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters.ReduceIndex;
 using Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters.TimeSeries;
 using Sparrow.Logging;
+using Sparrow.Platform;
 
 namespace Raven.Server.Documents.Indexes.Static
 {
@@ -53,6 +54,8 @@ namespace Raven.Server.Documents.Indexes.Static
 
         [ThreadStatic]
         private static bool DisableMatchingAdditionalAssembliesByNameValue;
+
+        private static readonly int MaxChainDepth = PlatformDetails.Is32Bits ? 64 : 16;
 
         static IndexCompiler()
         {
@@ -545,7 +548,7 @@ namespace Raven.Server.Documents.Indexes.Static
                 var map = maps[i];
                 statements.AddRange(HandleMap(definition.SourceType, map, fieldNamesValidator, methodDetector, stackDepthRetriever, ref members));
                 
-                maxDepthInRecursiveLinqQuery = Math.Max(maxDepthInRecursiveLinqQuery, stackDepthRetriever.StackSize);
+                maxDepthInRecursiveLinqQuery = Math.Max(maxDepthInRecursiveLinqQuery, stackDepthRetriever.StackSizeLetCounter);
                 stackDepthRetriever.Clear();
             }
 
@@ -559,7 +562,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
                 statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.GroupByFields)).Assign(groupByFieldsArray).AsExpressionStatement());
                 
-                maxDepthInRecursiveLinqQuery = Math.Max(maxDepthInRecursiveLinqQuery, stackDepthRetriever.StackSize);
+                maxDepthInRecursiveLinqQuery = Math.Max(maxDepthInRecursiveLinqQuery, stackDepthRetriever.StackSizeLetCounter);
             }
 
             var fields = GetIndexedFields(definition, fieldNamesValidator);
@@ -572,7 +575,7 @@ namespace Raven.Server.Documents.Indexes.Static
 
             var methods = methodDetector.Methods;
 
-            statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.StackSizeInSelectClause)).Assign(SyntaxFactory.ParseExpression($"{maxDepthInRecursiveLinqQuery}")).AsExpressionStatement());
+            statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.LetClausesDepth)).Assign(SyntaxFactory.ParseExpression($"{maxDepthInRecursiveLinqQuery}")).AsExpressionStatement());
             
             if (methods.HasCreateField)
                 statements.Add(RoslynHelper.This(nameof(AbstractStaticIndexBase.HasDynamicFields)).Assign(SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)).AsExpressionStatement());
@@ -647,7 +650,21 @@ namespace Raven.Server.Documents.Indexes.Static
                 
                 stackDepthRetriever.Visit(expression);
                 stackDepthRetriever.VisitMethodQuery(map);
-                
+
+                if (stackDepthRetriever.LinqChainDepth > MaxChainDepth)
+                {
+                    throw new IndexCompilationException(
+                        $"Index map contains a deeply chained sequence of LINQ method calls ({stackDepthRetriever.LinqChainDepth} levels deep). " +
+                        $"This will cause a StackOverflowException at indexing time because each chained call (Concat, Where, Select, etc.) " +
+                        $"creates a nested iterator that recurses on MoveNext(). " +
+                        $"Replace chained calls with a flat array + SelectMany, e.g.: " +
+                        $"new[] {{ col1, col2, col3 }}.Where(x => x != null).SelectMany(x => x).ToArray()")
+                    {
+                        IndexDefinitionProperty = nameof(IndexDefinition.Maps),
+                        ProblematicText = map
+                    };
+                }
+
                 var queryExpression = expression as QueryExpressionSyntax;
                 if (queryExpression != null)
                 {

--- a/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/StackDepthRetriever.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/Roslyn/Rewriters/StackDepthRetriever.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -7,16 +8,27 @@ namespace Raven.Server.Documents.Indexes.Static.Roslyn.Rewriters;
 
 public sealed class StackDepthRetriever : CSharpSyntaxRewriter
 {
+    private static readonly HashSet<string> ChainableLinqMethods = new()
+    {
+            "Concat", "Select", "SelectMany", "Where", "Skip", "Take",
+            "SkipWhile", "TakeWhile", "OrderBy", "OrderByDescending",
+            "ThenBy", "ThenByDescending", "Reverse", "Distinct",
+            "Union", "Intersect", "Except", "Zip", "DefaultIfEmpty"
+        };
+
     private int _letCounter;
-
     private int _selectDepth;
+    private int _linqChainDepth;
 
-    public int StackSize => _letCounter + _selectDepth;
+    public int LinqChainDepth => _linqChainDepth;
+
+    public int StackSizeLetCounter => _letCounter + _selectDepth;
 
     public void Clear()
     {
         _letCounter = 0;
         _selectDepth = 0;
+        _linqChainDepth = 0;
     }
 
     public void VisitMethodQuery(string cSharpCode)
@@ -36,10 +48,45 @@ public sealed class StackDepthRetriever : CSharpSyntaxRewriter
             }
         }
     }
-    
+
     public override SyntaxNode VisitLetClause(LetClauseSyntax queryLetClause)
     {
         _letCounter++;
         return base.VisitLetClause(queryLetClause);
+    }
+
+    public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (node.Expression is MemberAccessExpressionSyntax memberAccess &&
+            ChainableLinqMethods.Contains(memberAccess.Name.Identifier.Text))
+        {
+            int depth = CountChainDepth(node);
+            if (depth > _linqChainDepth)
+                _linqChainDepth = depth;
+        }
+
+        return base.VisitInvocationExpression(node);
+    }
+
+    private static int CountChainDepth(InvocationExpressionSyntax node)
+    {
+        int depth = 0;
+        SyntaxNode current = node;
+
+        while (current is InvocationExpressionSyntax invocation &&
+               invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+               ChainableLinqMethods.Contains(memberAccess.Name.Identifier.Text))
+        {
+            depth++;
+            current = memberAccess.Expression;
+
+            // unwrap further invocations on the left side
+            if (current is InvocationExpressionSyntax)
+                continue;
+
+            break;
+        }
+
+        return depth;
     }
 }

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.cs
@@ -186,7 +186,7 @@ namespace Raven.Server.Documents.Indexes.Static
         protected static Logger Log = LoggingSource.Instance.GetLogger<AbstractStaticIndexBase>("Server");
 
         
-        public int StackSizeInSelectClause { get; set; }
+        public int LetClausesDepth { get; set; }
         
         public bool HasDynamicFields { get; set; }
 
@@ -243,18 +243,18 @@ namespace Raven.Server.Documents.Indexes.Static
         internal void CheckDepthOfStackInOutputMap(IndexDefinition indexMetadata, DocumentDatabase documentDatabase)
         {
             var performanceHintConfig = documentDatabase.Configuration.PerformanceHints;
-            if (StackSizeInSelectClause > performanceHintConfig.MaxDepthOfRecursionInLinqSelect)
+            if (LetClausesDepth > performanceHintConfig.MaxDepthOfRecursionInLinqSelect)
             {
                 documentDatabase.NotificationCenter.Add(PerformanceHint.Create(
                     documentDatabase.Name,
-                    $"Index '{indexMetadata.Name}' contains {StackSizeInSelectClause} `let` clauses.",
+                    $"Index '{indexMetadata.Name}' contains {LetClausesDepth} `let` clauses.",
                     $"We have detected that your index contains many `let` clauses. This can be not optimal approach because it might cause to allocate a lot of stack-based memory. Please consider to simplify your index definition. We suggest not to exceed {performanceHintConfig.MaxDepthOfRecursionInLinqSelect} `let` statements.",
                     PerformanceHintType.Indexing,
                     NotificationSeverity.Info,
                     nameof(IndexCompiler)));
-                
+
                 if (Log.IsOperationsEnabled)
-                    Log.Operations($"Index '{indexMetadata.Name}' contains a lot of `let` clauses. Stack size is {StackSizeInSelectClause}.");
+                    Log.Operations($"Index '{indexMetadata.Name}' contains a lot of `let` clauses. Stack size is {LetClausesDepth}.");
             }
         }
         

--- a/test/SlowTests/Issues/RavenDB-26440.cs
+++ b/test/SlowTests/Issues/RavenDB-26440.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents.Indexes;
+using Raven.Client.Exceptions.Documents.Compilation;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26440 : RavenTestBase
+    {
+        public RavenDB_26440(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Indexes)]
+        public void Index_With_Deeply_Chained_Linq_Should_Fail_Compilation()
+        {
+            using (var store = GetDocumentStore())
+            {
+                var concatChain = string.Join("",
+                    Enumerable.Range(0, 150).Select(_ => ".Concat(doc.Tags ?? Enumerable.Empty<string>())"));
+
+                var map = $@"from doc in docs.Users
+select new
+{{
+    Values = (doc.Tags ?? Enumerable.Empty<string>()){concatChain}.ToArray()
+}}";
+
+                var indexDefinition = new IndexDefinition
+                {
+                    Name = "DeepConcatIndex",
+                    Maps = { map }
+                };
+
+                var ex = Assert.Throws<IndexCompilationException>(() =>
+                    store.Maintenance.Send(new Raven.Client.Documents.Operations.Indexes.PutIndexesOperation(indexDefinition)));
+                Assert.Contains("deeply chained", ex.Message, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26440/StackOverflowException-when-indexing-a-map-with-deeply-chained-LINQ-calls

### Additional description

Detect the problem **at compile time** in `HandleMap` using `StackDepthRetriever`, which now
counts chained LINQ method invocations (`Concat`, `Where`, `Select`, `SelectMany`, etc.).
If the chain depth exceeds `MaxChainDepth`, an `IndexCompilationException` is thrown with a
clear message pointing the user to use `SelectMany` over a flat array instead.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
