### PR TITLE
RavenDB-26413 Stabilize ObserverShouldRespectTombstoneCleanupIntervalAfterMultiBatchCleanup

### DIFF
--- a/test/SlowTests/Issues/RavenDB_26367.cs
+++ b/test/SlowTests/Issues/RavenDB_26367.cs
@@ -99,12 +99,12 @@ public class RavenDB_26367 : ClusterTestBase
         // iterations (i.e., at least one multi-batch result).
         Assert.True(tombstonesBefore > 8192, $"Expected more than 8192 tombstones in place before cleanup, got {tombstonesBefore}.");
 
-        // Force the next observer iteration to run the tombstone cleanup immediately.
-        leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks = 0;
-
-        // Wait for all tombstones to drain (requires >= 2 cleanup iterations).
+        // Reset the tick on every poll: the cluster-wide transaction bump propagates to the
+        // observer via heartbeat, so a single reset races that heartbeat and can close the
+        // gate before any cleanup runs.
         var allDrained = await WaitForValueAsync(() =>
         {
+            leader.ServerStore.Observer._lastTombstonesCleanupTimeInTicks = 0;
             using (leader.ServerStore.Engine.ContextPool.AllocateOperationContext(out ClusterOperationContext context))
             using (context.OpenReadTransaction())
             {
@@ -113,6 +113,10 @@ public class RavenDB_26367 : ClusterTestBase
         }, expectedVal: true, timeout: 60_000, interval: 250);
 
         Assert.True(allDrained, "Expected all compare-exchange tombstones to be drained by the observer.");
+
+        // Give the observer one cycle to advance the tick naturally now that the queue is empty,
+        // before we start counting attempts below.
+        await Task.Delay(2_000);
 
         // Now count how many times the observer attempts tombstone cleanup during a short
         // observation window. With the configured interval of `cleanupIntervalInMin` minutes,


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26413

### Additional description

The observer only learns about the cluster-wide transaction bump through heartbeats, so resetting the cleanup gate just once let it run too early - it saw no work to do, legitimately shut the gate for 10 minutes, and the drain never happened.

### Type of change

- [x] Test fix
- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
