### PR TITLE
RavenDB-24450: Bad performance in attachment replication

### DIFF
--- a/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
+++ b/src/Raven.Server/Documents/Replication/Senders/ReplicationDocumentSenderBase.cs
@@ -33,8 +33,8 @@ namespace Raven.Server.Documents.Replication.Senders
         protected readonly Logger Log;
         private long _lastEtag;
 
-        private readonly SortedList<long, ReplicationBatchItem> _orderedReplicaItems = new SortedList<long, ReplicationBatchItem>();
-        private readonly Dictionary<Slice, AttachmentReplicationItem> _replicaAttachmentStreams = new Dictionary<Slice, AttachmentReplicationItem>(SliceComparer.Instance);
+        private readonly SortedList<long, ReplicationBatchItem> _orderedReplicaItems = new();
+        private readonly Dictionary<Slice, AttachmentReplicationItem> _replicaAttachmentStreams = new(SliceComparer.Instance);
         private readonly byte[] _tempBuffer = new byte[32 * 1024];
         private readonly Stream _stream;
         internal readonly DatabaseOutgoingReplicationHandler _parent;
@@ -496,7 +496,12 @@ namespace Raven.Server.Documents.Replication.Senders
             if (item is AttachmentReplicationItem attachment)
             {
                 if (ShouldSendAttachmentStream(attachment))
+                {
                     _replicaAttachmentStreams[attachment.Base64Hash] = attachment;
+
+                    // Add the actual size of the stream sent
+                    state._size += attachment.StreamSize;
+                }
 
                 if (MissingAttachmentsInLastBatch)
                     state.MissingAttachmentBase64Hashes?.Remove(attachment.Base64Hash);

--- a/test/SlowTests/Issues/RavenDB-24450.cs
+++ b/test/SlowTests/Issues/RavenDB-24450.cs
@@ -6,6 +6,7 @@ using Raven.Server.Config;
 using Sparrow;
 using Tests.Infrastructure;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace SlowTests.Issues;
 

--- a/test/SlowTests/Issues/RavenDB-24450.cs
+++ b/test/SlowTests/Issues/RavenDB-24450.cs
@@ -1,0 +1,101 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Server.Config;
+using Sparrow;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_24450(ITestOutputHelper output) : ReplicationTestBase(output)
+{
+    [RavenTheory(RavenTestCategory.Attachments | RavenTestCategory.Replication)]
+    [RavenData(DatabaseMode = RavenDatabaseMode.Single)]
+    public async Task ShouldAccountForAttachmentStreamSizeInReplicationBatchSize(Options options)
+    {
+        const int attachmentSize = 512 * 1024; // 512KB each
+        const int documentCount = 10; // 5MB total in attachment streams
+        const int maxSizeToSendMb = 1; // 1MB per batch
+
+        const long maxSizeToSendBytes = maxSizeToSendMb * 1024L * 1024L;
+
+        using var store1 = GetDocumentStore(new Options(options)
+        {
+            ModifyDatabaseRecord = record =>
+            {
+                record.Settings[RavenConfiguration.GetKey(x => x.Replication.MaxSizeToSend)] = maxSizeToSendMb.ToString();
+                options.ModifyDatabaseRecord?.Invoke(record);
+            }
+        });
+
+        using var store2 = GetDocumentStore(options);
+
+        for (int i = 0; i < documentCount; i++)
+        {
+            byte[] data = GetAttachmentData(attachmentSize, i);
+
+            using var session = store1.OpenAsyncSession();
+            var docId = GetDocId(i);
+            await session.StoreAsync(new { }, docId);
+            session.Advanced.Attachments.Store(docId, GetAttachmentId(i), new MemoryStream(data));
+            await session.SaveChangesAsync();
+        }
+
+        var sourceDb = await GetDocumentDatabaseInstanceForAsync(store1, options.DatabaseMode, GetDocId(0));
+
+        await SetupReplicationAsync(store1, store2);
+        await EnsureReplicatingAsync(store1, store2);
+
+        // Verify all documents and attachments arrived
+        using (var session = store2.OpenAsyncSession())
+        {
+            for (int i = 0; i < documentCount; i++)
+            {
+                var docId = GetDocId(i);
+                var doc = await session.LoadAsync<object>(docId);
+                Assert.NotNull(doc);
+
+                using var attachment = await session.Advanced.Attachments.GetAsync(docId, GetAttachmentId(i));
+                Assert.NotNull(attachment);
+                Assert.Equal(attachmentSize, attachment.Details.Size);
+            }
+        }
+
+        // Use the existing outgoing replication performance stats to verify batch sizes.
+        // BatchSizeInBytes is accumulated from RecordAttachmentOutput, RecordAttachmentStreamOutput,
+        // RecordDocumentOutput, etc. — it reflects the real bytes written per batch.
+        var outgoingHandler = sourceDb.ReplicationLoader.OutgoingHandlers
+            .First(h => h.Destination.Database == store2.Database || h.Destination.Database.StartsWith(store2.Database));
+        var perfStats = outgoingHandler.GetReplicationPerformance();
+        var completedBatches = perfStats.Where(s => s.BatchSizeInBytes.HasValue).ToList();
+
+        Assert.True(completedBatches.Count > 1,
+            $"Expected multiple replication batches due to attachment stream sizes, but got {completedBatches.Count}");
+
+        // The batch size should respect MaxSizeToSend.
+        // It can exceed by at most one item's worth (the item that pushed it over the limit,
+        // plus the "always send at least one item" rule).
+        const long allowedBatchSize = maxSizeToSendBytes + attachmentSize;
+        long maxBatchSize = completedBatches.Max(s => s.BatchSizeInBytes!.Value);
+
+        Assert.True(maxBatchSize <= allowedBatchSize,
+            $"Expected batch size to respect MaxSizeToSend ({new Size(maxSizeToSendBytes, SizeUnit.Bytes)}) " +
+            $"with at most one attachment overshoot ({new Size(attachmentSize, SizeUnit.Bytes)}), " +
+            $"but the largest batch was {new Size(maxBatchSize, SizeUnit.Bytes)}. " +
+            $"Total batches: {completedBatches.Count}");
+        return;
+
+        static string GetDocId(int i) => $"items/{i}";
+        
+        static string GetAttachmentId(int i) => $"attachment-{i}";
+        
+        static byte[] GetAttachmentData(int attachmentSize, int i)
+        {
+            var data = new byte[attachmentSize];
+            new Random(i).NextBytes(data);
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-24450/Bad-performance-in-attachment-replication

### Additional description

This PR addresses the fact that the stream size of the Attachments was not taken into consideration when sending them under the replication scenario. When the traffic was attachment heavy, such as with GenAI, the attachments streams could dominate the batch as their sizes were not added up to the actual payload size. After this PR, when an attachment is replicated, its stream size is properly noticed and added to the batch size.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
