### PR TITLE
RavenDB-26302 Wrap system collections into a category

### DIFF
--- a/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
+++ b/src/Raven.Studio/typescript/common/helpers/database/collectionsTracker.ts
@@ -21,6 +21,32 @@ class collectionsTracker {
 
     conflictsCount = ko.observable<number>();
 
+    systemCollectionsExpanded = ko.observable<boolean>(true);
+
+    systemCollections = ko.pureComputed<collection[]>(() => {
+        return this.collections().filter(x => x.isSystem);
+    });
+
+    userCollections = ko.pureComputed<collection[]>(() => {
+        return this.collections().filter(x => !x.isAllDocuments && !x.isSystem);
+    });
+
+    systemCollectionsDocumentCount = ko.pureComputed<number>(() => {
+        return this.systemCollections().reduce((total, c) => total + c.documentCount(), 0);
+    });
+
+    systemCollectionsCountPrefix = ko.pureComputed<string>(() => {
+        return generalUtils.getCountPrefix(this.systemCollectionsDocumentCount());
+    });
+
+    systemCollectionsSizeClass = ko.pureComputed<string>(() => {
+        return generalUtils.getSizeClass(this.systemCollectionsDocumentCount());
+    });
+
+    toggleSystemCollections() {
+        this.systemCollectionsExpanded(!this.systemCollectionsExpanded());
+    }
+
     private db: database;
 
     private events = {

--- a/src/Raven.Studio/typescript/components/common/shell/collectionsTrackerSlice.ts
+++ b/src/Raven.Studio/typescript/components/common/shell/collectionsTrackerSlice.ts
@@ -52,7 +52,7 @@ const selectCollectionNames = createSelector(
 );
 
 const selectUserCollectionNames = createSelector(selectCollectionNames, (collections) =>
-    collections.filter((name) => name !== collectionNames.empty && name !== collectionNames.hilo)
+    collections.filter((name) => !String(name).startsWith("@"))
 );
 
 export const collectionsTrackerSelectors = {

--- a/src/Raven.Studio/typescript/models/database/documents/collection.ts
+++ b/src/Raven.Studio/typescript/models/database/documents/collection.ts
@@ -51,6 +51,10 @@ class collection {
         return this.name === collection.revisionsBinCollectionName;
     }
 
+    get isSystem() {
+        return this.name.startsWith('@');
+    }
+
     get collectionNameForQuery() {
         return this.isAllDocuments ? "@all_docs" : this.name;
     }

--- a/src/Raven.Studio/wwwroot/App/views/shell.html
+++ b/src/Raven.Studio/wwwroot/App/views/shell.html
@@ -88,12 +88,40 @@
         </h3>
         <li class="scroll collections-list">
             <ul>
-                <!-- ko foreach: $root.collectionsTracker.collections -->
+                <!-- ko if: $root.collectionsTracker.systemCollections().length > 0 -->
+                <li class="system-collections-group">
+                    <a class="system-group-header" data-bind="click: $root.collectionsTracker.toggleSystemCollections.bind($root.collectionsTracker)">
+                        <i data-bind="css: $root.collectionsTracker.systemCollectionsExpanded() ? 'icon-arrow-filled-down' : 'icon-arrow-filled-right'"></i>
+                        <span>@system</span>
+                        <div class="collection-count">
+                            <div class="value label label-default" data-bind="text: $root.collectionsTracker.systemCollectionsCountPrefix"></div>
+                            <div data-bind="attr: { class: $root.collectionsTracker.systemCollectionsSizeClass }"></div>
+                        </div>
+                    </a>
+                    <!-- ko if: $root.collectionsTracker.systemCollectionsExpanded -->
+                    <ul class="system-collection-items">
+                        <!-- ko foreach: $root.collectionsTracker.systemCollections -->
+                        <li>
+                            <a data-bind="click: $parent.menu.navigate.bind($parent.menu), attr: { href: $root.urlForCollection($data), title: name },
+                                          css: { 'active': $parent.item.isOpen($parent.menu.activeItem, $data) }">
+                                <span data-bind="text: name"></span>
+                                <div class="collection-count" data-bind="attr: {title: documentCount().toLocaleString()}, css: { 'bounce': hasBounceClass }">
+                                    <div class="value label label-default" data-bind="text: countPrefix"></div>
+                                    <div data-bind="attr: { class: sizeClass }"></div>
+                                </div>
+                            </a>
+                        </li>
+                        <!-- /ko -->
+                    </ul>
+                    <!-- /ko -->
+                </li>
+                <!-- /ko -->
+                <!-- ko foreach: $root.collectionsTracker.userCollections -->
                 <li>
                     <a data-bind="click: $parent.menu.navigate.bind($parent.menu), attr: { href: $root.urlForCollection($data), title: name },
-                                  css: { 'active': $parent.item.isOpen($parent.menu.activeItem, $data) }, visible: !isAllDocuments">
+                                  css: { 'active': $parent.item.isOpen($parent.menu.activeItem, $data) }">
                         <span data-bind="text: name"></span>
-                        <div class="collection-count" data-bind="attr: {title: documentCount().toLocaleString()}, css: { 'bounce' : hasBounceClass }">
+                        <div class="collection-count" data-bind="attr: {title: documentCount().toLocaleString()}, css: { 'bounce': hasBounceClass }">
                             <div class="value label label-default" data-bind="text: countPrefix"></div>
                             <div data-bind="attr: { class: sizeClass }"></div>
                         </div>

--- a/src/Raven.Studio/wwwroot/Content/scss/_main-menu.scss
+++ b/src/Raven.Studio/wwwroot/Content/scss/_main-menu.scss
@@ -37,7 +37,7 @@ $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
         display: inline;
     }
     h2 {
-        padding: 0 $gutter-sm;
+        padding: 0 $gutter-xs;
         color: $text-color-var;
         margin: 0;
         font-size: 18px;
@@ -241,6 +241,16 @@ $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
             -webkit-transform-origin: 0 0;
             transform-origin: 0 0;
         }
+        li {
+            a {
+                padding: $gutter-xxs;
+                margin: $gutter-xxxs;
+                border-radius: $gutter-xxxs;
+            }
+        }
+        h3 {
+            padding-left: $gutter-xs;
+        }
         a {
             &:hover {
                 background-color: $base-panel-bg-2;
@@ -250,6 +260,51 @@ $menu-transition-ease: 0.4s cubic-bezier(0.21, 0.88, 0.35, 1);
     .collections-list {
         a {
             padding: $gutter-xxs $gutter-sm;
+        }
+        .system-group-header {
+            cursor: pointer;
+            color: $text-muted-var;
+
+            i {
+                font-size: 10px;
+                margin-right: $gutter-xxxs;
+                flex-shrink: 0;
+            }
+        }
+        .system-collection-items {
+            --tree-spacing: #{$gutter-sm};
+            --tree-radius: #{$gutter-xxxs};
+            --tree-line-color: #{$border-color-light-var};
+            list-style: none;
+            padding-left: 0;
+            margin: 0;
+            margin-left: calc(#{$gutter-xs} + 3px);
+
+            li {
+                position: relative;
+                border-left: 2px solid var(--tree-line-color);
+
+                &:last-child {
+                    border-color: transparent;
+                }
+
+                &::before {
+                    content: "";
+                    display: block;
+                    position: absolute;
+                    top: calc(var(--tree-spacing) / -4);
+                    left: -2px;
+                    width: calc(var(--tree-spacing) + 2px);
+                    height: calc(var(--tree-spacing) + 3px);
+                    border: solid var(--tree-line-color);
+                    border-width: 0 0 2px 2px;
+                    border-bottom-left-radius: var(--tree-radius);
+                }
+
+                a {
+                    margin-left: var(--tree-spacing);
+                }
+            }
         }
     }
     // Document Collections


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26302

### Additional description

All the collections starting with `@` will be wrapped into a `@system` dropdown category.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
