### PR TITLE
RavenDB-14562 Order of items in the document title area

### DIFF
--- a/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/documents/editDocument.html
@@ -1,8 +1,8 @@
 <form data-bind="submit: saveDocument, css: { 'diff': inDiffMode }" class="edit-document" autocomplete="off">
     <div class="docEditor flex-window flex-grow content-margin" data-bind="style: { 'z-index': isFullScreenEditor() ? 1084 : undefined }">
         <div class="flex-window-head">
-            <div class="flex-horizontal copy-area">
-                <div class="flex-grow">
+            <div class="flex-horizontal copy-area gap-3 margin-bottom margin-bottom-xs">
+                <div class="left-header">
                     <div class="documentId">
                         <div data-bind="if: isCreatingNewDocument() && !isFullScreenEditor()">
                             <div class="input-group" data-bind="validationElement: userSpecifiedId">
@@ -14,40 +14,42 @@
                                        data-bind="textInput: userSpecifiedId, disable: $root.isBusy, hasFocus: userIdHasFocus()">
                             </div>
                         </div>
-                        <div class="flex-horizontal" data-bind="if: !isCreatingNewDocument()">
+                        <div class="flex-horizontal gap-2" data-bind="if: !isCreatingNewDocument()">
                             <!-- todo: bring back the star when doing issue RavenDB-8110 (vNext) -->
                             <!--<a class="reset-color btn-toggle markFavourite" data-bind="click: connectedDocuments.toggleStar">-->
                                 <!--<span data-bind="attr: { class: connectedDocuments.currentDocumentIsStarred()?'icon-star-filled favorite':'icon-star' }"></span>-->
                             <!--</a>-->
                             <span class="obj-name on-base-background" data-bind="text: userSpecifiedId, attr: { title: userSpecifiedId }"></span>
-                            <a href="#" class="inherit-position" title="Copy document Id" data-bind="click: copyDocumentIdToClipboard"><i class="icon-copy"></i></a>
                             <span data-bind="visible: revisionText(), text: revisionText()" class="text-primary revision flex-shrink-0"></span>
                             <span data-bind="visible: archivedText(), text: archivedText()" class="text-primary archived flex-shrink-0"></span>
-                            <a target="_blank" href="#" title="Click to view the raw content of the document" class="flex-shrink-0 margin-left margin-left-sm"
-                               data-bind="attr: { href: rawJsonUrl }, visible: !isDeleteRevision()"><i class="icon-json"></i>
-                            </a>
+                            <a href="#" class="inherit-position" title="Copy document Id" data-bind="click: copyDocumentIdToClipboard"><i class="icon-copy"></i></a>
                         </div>
                     </div>
                 </div>
-                <div class="flex-shrink-0" data-bind="visible: !inDiffMode()">
-                    <p class="pull-right-md text-right-md padding padding-xs on-base-background" data-bind="if: displayLastModifiedDate()">
-                        <i class="icon-recent"></i>
-                        <small>Last modified <span data-bind="text: $root.lastModifiedAsAgo"></span></small>
-                    </p>
-                    <p class="pull-right-md bg-warning padding padding-xs" data-bind="visible: displayDocumentChange() && !displayDocumentDeleted()">
-                        <small>
-                            <i class="icon-warning"></i>
-                            <span>This document has been modified outside of Studio.</span>
-                            <a href="#" data-bind="click: refreshDocument">Click here to refresh.</a>
-                        </small>
-                    </p>
-                    <p class="pull-right-md bg-warning padding padding-xs" data-bind="visible: displayDocumentDeleted">
-                        <small>
-                            <i class="icon-warning"></i>
-                            <span>This document has been deleted outside of Studio.</span>
-                            <a href="#" data-bind="click: navigateAfterExternalDelete">Go to recent document.</a>
-                        </small>
-                    </p>
+                <div class="flex-horizontal flex-shrink-0 gap-2">
+                    <a target="_blank" href="#" title="Click to view the raw content of the document" class="flex-shrink-0"
+                       data-bind="attr: { href: rawJsonUrl }, visible: !isCreatingNewDocument() && !isDeleteRevision()"><i class="icon-json"></i>
+                    </a>
+                    <div class="flex-shrink-0" data-bind="visible: !inDiffMode()">
+                        <p class="pull-right-md text-right-md padding padding-xs on-base-background" data-bind="if: displayLastModifiedDate()">
+                            <i class="icon-recent"></i>
+                            <small>Last modified <span data-bind="text: $root.lastModifiedAsAgo"></span></small>
+                        </p>
+                        <p class="pull-right-md bg-warning padding padding-xs" data-bind="visible: displayDocumentChange() && !displayDocumentDeleted()">
+                            <small>
+                                <i class="icon-warning"></i>
+                                <span>This document has been modified outside of Studio.</span>
+                                <a href="#" data-bind="click: refreshDocument">Click here to refresh.</a>
+                            </small>
+                        </p>
+                        <p class="pull-right-md bg-warning padding padding-xs" data-bind="visible: displayDocumentDeleted">
+                            <small>
+                                <i class="icon-warning"></i>
+                                <span>This document has been deleted outside of Studio.</span>
+                                <a href="#" data-bind="click: navigateAfterExternalDelete">Go to recent document.</a>
+                            </small>
+                        </p>
+                    </div>
                 </div>
             </div>
             <div class="btn-bar toolbar">

--- a/src/Raven.Studio/wwwroot/Content/css/pages/documents-edit.less
+++ b/src/Raven.Studio/wwwroot/Content/css/pages/documents-edit.less
@@ -13,6 +13,7 @@
 
     .docEditor {
         flex-grow: 1;
+        min-width: 0;
     }
 
     .differences_summary {
@@ -74,9 +75,30 @@
         overflow-x: hidden;
     }
 
+    .copy-area {
+        > .left-header {
+            flex: 1;
+            min-width: 0;
+            overflow: hidden;
+        }
+
+        .icon-copy, .icon-json {
+            font-size: 20px;
+        }
+
+        a.inherit-position, a.flex-shrink-0 {
+            display: inline-flex;
+            align-items: center;
+        }
+
+        p.on-base-background {
+            margin-bottom: 0;
+        }
+    }
+
     .documentId {
         font-size: 25px;
-        margin-bottom: 8px;
+        overflow: hidden;
 
         .fav-object {
             position: relative;
@@ -85,11 +107,12 @@
         }
 
         span.obj-name {
-            flex-shrink: 1;
-            flex-grow: 1;
+            flex: 0 1 auto;
+            min-width: 0;
+            max-width: 35vw;
             overflow: hidden;
             text-overflow: ellipsis;
-            width: 100px;
+            white-space: nowrap;
         }
 
         @obj-name-placeholder-color: darken(@gray,10%);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-14562

### Additional description

Fixed the order and spacing between elements in Edit documents header. 

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
