### PR TITLE
RavenDB-25912 Using proper value of JOBOBJECT_EXTENDED_LIMIT_INFORMATION

### DIFF
--- a/src/Sparrow.Server/LowMemory/MemoryInformation.EarlyOutOfMemory.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.EarlyOutOfMemory.cs
@@ -113,7 +113,7 @@ public static partial class MemoryInformation
 
                 if (limits.JobMemoryLimit != UIntPtr.Zero)
                 {
-                    maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
+                    maxSize = Math.Min(maxSize, (long)limits.JobMemoryLimit);
                 }
 
                 if (maxSize != long.MaxValue)

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.EarlyOutOfMemory.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.EarlyOutOfMemory.cs
@@ -82,49 +82,11 @@ public static partial class MemoryInformation
         long totalPageFile = (long)memoryStatus.ullTotalPageFile;
         long availPageFile = (long)(memoryStatus.ullTotalPageFile - memoryStatus.ullAvailPageFile);
 
+        long availableMemoryForProcessingInBytes = memoryStatusUllAvailPhys;
         if (Win32MemoryMethods.IsProcessInJob(ProcessHandle, IntPtr.Zero, out var isInJob) && isInJob)
         {
-            Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = default;
-            if (Win32MemoryMethods.QueryInformationJobObject(IntPtr.Zero,
-                    Win32MemoryMethods.JOBOBJECTINFOCLASS.ExtendedLimitInformation, (void*)&limits,
-                    sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
-                    out int limitsOutputSize) == false ||
-                limitsOutputSize != sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
-            {
-                if (_reportedQueryJobObjectFailure == false && Logger.IsInfoEnabled)
-                {
-                    _reportedQueryJobObjectFailure = true;
-                    Logger.Info(
-                        $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
-                }
-            }
-            else
-            {
-                long maxSize = long.MaxValue;
-                if (limits.BasicLimitInformation.MaximumWorkingSetSize != UIntPtr.Zero)
-                {
-                    maxSize = (long)limits.BasicLimitInformation.MaximumWorkingSetSize;
-                }
-
-                if (limits.ProcessMemoryLimit != UIntPtr.Zero)
-                {
-                    maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
-                }
-
-                if (limits.JobMemoryLimit != UIntPtr.Zero)
-                {
-                    maxSize = Math.Min(maxSize, (long)limits.JobMemoryLimit);
-                }
-
-                if (maxSize != long.MaxValue)
-                {
-                    (long workingSetInBytes, long _, long? _) = GetProcessMemoryInfoForWindows();
-                    var availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSetInBytes, 0);
-                    availPageFile = Math.Max(maxSize - workingSetInBytes, 0);
-                    totalPageFile = maxSize;
-                    memoryStatusUllAvailPhys = Math.Min(availableMemoryForProcessingInBytes, memoryStatusUllAvailPhys);
-                }
-            }
+            (long workingSet, long _, long? _) = GetProcessMemoryInfoForWindows();
+            TryApplyJobObjectMemoryLimits(workingSet, ref memoryStatusUllAvailPhys, ref totalPageFile, ref availPageFile, ref availableMemoryForProcessingInBytes);
         }
 
         return new LightWeightMemoryInfoResult

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -526,7 +526,7 @@ namespace Sparrow.Server.LowMemory
                 {
                     _reportedQueryJobObjectFailure = true;
                     Logger.Info(
-                        $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
+                        $"Failure when trying to query job object information from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
                 }
                 return false;
             }

--- a/src/Sparrow.Server/LowMemory/MemoryInformation.cs
+++ b/src/Sparrow.Server/LowMemory/MemoryInformation.cs
@@ -512,6 +512,51 @@ namespace Sparrow.Server.LowMemory
 
         private static bool _reportedQueryJobObjectFailure = false;
 
+        private static unsafe bool TryApplyJobObjectMemoryLimits(long workingSet, ref long memoryStatusUllAvailPhys,
+            ref long totalPageFile, ref long availPageFile, ref long availableMemoryForProcessingInBytes)
+        {
+            Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = default;
+            if (Win32MemoryMethods.QueryInformationJobObject(IntPtr.Zero,
+                    Win32MemoryMethods.JOBOBJECTINFOCLASS.ExtendedLimitInformation, (void*)&limits,
+                    sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
+                    out int limitsOutputSize) == false ||
+                limitsOutputSize != sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
+            {
+                if (_reportedQueryJobObjectFailure == false && Logger.IsInfoEnabled)
+                {
+                    _reportedQueryJobObjectFailure = true;
+                    Logger.Info(
+                        $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
+                }
+                return false;
+            }
+
+            long maxSize = long.MaxValue;
+            if (limits.BasicLimitInformation.MaximumWorkingSetSize != UIntPtr.Zero)
+            {
+                maxSize = (long)limits.BasicLimitInformation.MaximumWorkingSetSize;
+            }
+
+            if (limits.ProcessMemoryLimit != UIntPtr.Zero)
+            {
+                maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
+            }
+
+            if (limits.JobMemoryLimit != UIntPtr.Zero)
+            {
+                maxSize = Math.Min(maxSize, (long)limits.JobMemoryLimit);
+            }
+
+            if (maxSize == long.MaxValue)
+                return false;
+
+            availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSet, 0);
+            availPageFile = Math.Max(maxSize - workingSet, 0);
+            totalPageFile = maxSize;
+            memoryStatusUllAvailPhys = Math.Min(availableMemoryForProcessingInBytes, memoryStatusUllAvailPhys);
+            return true;
+        }
+
         private static unsafe MemoryInfoResult GetMemoryInfoWindows()
         {
             // windows
@@ -534,50 +579,9 @@ namespace Sparrow.Server.LowMemory
             var availableMemoryForProcessingInBytes = memoryStatusUllAvailPhys + sharedCleanInBytes;
 
             string remarks = null;
-            if (Win32MemoryMethods.IsProcessInJob(ProcessHandle, IntPtr.Zero, out var isInJob) && isInJob)
-            {
-                Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = default;
-                if (Win32MemoryMethods.QueryInformationJobObject(IntPtr.Zero,
-                        Win32MemoryMethods.JOBOBJECTINFOCLASS.ExtendedLimitInformation, (void*)&limits,
-                        sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION),
-                        out int limitsOutputSize) == false ||
-                    limitsOutputSize != sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION))
-                {
-                    if (_reportedQueryJobObjectFailure == false && Logger.IsInfoEnabled)
-                    {
-                        _reportedQueryJobObjectFailure = true;
-                        Logger.Info(
-                            $"Failure when trying to query job object information info from Windows, error code is: {Marshal.GetLastWin32Error()}. Output size: {limitsOutputSize} instead of {sizeof(Win32MemoryMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION)}!");
-                    }
-                }
-                else
-                {
-                    long maxSize = long.MaxValue;
-                    if (limits.BasicLimitInformation.MaximumWorkingSetSize != UIntPtr.Zero)
-                    {
-                        maxSize = (long)limits.BasicLimitInformation.MaximumWorkingSetSize;
-                    }
-
-                    if (limits.ProcessMemoryLimit != UIntPtr.Zero)
-                    {
-                        maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
-                    }
-
-                    if (limits.JobMemoryLimit != UIntPtr.Zero)
-                    {
-                        maxSize = Math.Min(maxSize, (long)limits.ProcessMemoryLimit);
-                    }
-
-                    if (maxSize != long.MaxValue)
-                    {
-                        availableMemoryForProcessingInBytes = Math.Max(maxSize - workingSet, 0);
-                        availPageFile = Math.Max(maxSize - workingSet, 0);
-                        totalPageFile = maxSize;
-                        memoryStatusUllAvailPhys = Math.Min(availableMemoryForProcessingInBytes, memoryStatusUllAvailPhys);
-                        remarks = "Memory limited by Job Object limits";
-                    }
-                }
-            }
+            if (Win32MemoryMethods.IsProcessInJob(ProcessHandle, IntPtr.Zero, out var isInJob) && isInJob &&
+                TryApplyJobObjectMemoryLimits(workingSet, ref memoryStatusUllAvailPhys, ref totalPageFile, ref availPageFile, ref availableMemoryForProcessingInBytes))
+                remarks = "Memory limited by Job Object limits";
 
             return new MemoryInfoResult
             {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25912

### Additional description

It fixes https://github.com/ravendb/ravendb/pull/22321

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
