### PR TITLE
RavenDB-26424 Kafka ETL - expose transactional ID in better place

### DIFF
--- a/src/Raven.Studio/typescript/components/common/LocationDistribution.scss
+++ b/src/Raven.Studio/typescript/components/common/LocationDistribution.scss
@@ -33,10 +33,6 @@
                 border-top: sizes.$border-width solid colors.$border-color-light-var;
             }
 
-            & + div.no-top-border {
-                border-top: none;
-            }
-
             &:first-of-type {
                 height: 50px;
             }

--- a/src/Raven.Studio/typescript/components/common/LocationDistribution.scss
+++ b/src/Raven.Studio/typescript/components/common/LocationDistribution.scss
@@ -33,6 +33,10 @@
                 border-top: sizes.$border-width solid colors.$border-color-light-var;
             }
 
+            & + div.no-top-border {
+                border-top: none;
+            }
+
             &:first-of-type {
                 height: 50px;
             }

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskDistribution.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { DistributionItem, DistributionLegend, LocationDistribution } from "components/common/LocationDistribution";
 import classNames from "classnames";
 import { AnyEtlOngoingTaskInfo, OngoingEtlTaskNodeInfo, OngoingTaskInfo } from "components/models/tasks";
@@ -16,90 +16,127 @@ interface OngoingEtlTaskDistributionProps {
     showPreview: (transformationName: string) => void;
 }
 
+interface TxIdLayout {
+    scripts: string[];
+    singleScript: boolean;
+}
+
 interface ItemWithTooltipProps {
     nodeInfo: OngoingEtlTaskNodeInfo;
     sharded: boolean;
     task: AnyEtlOngoingTaskInfo;
     showPreview: (transformationName: string) => void;
-    expectsTxId: boolean;
-    txIdScripts: string[];
-    singleScript: boolean;
+    txIdLayout: TxIdLayout | null;
 }
 
-function buildTxIdCells(
-    expectsTxId: boolean,
-    txIdScripts: string[],
-    singleScript: boolean,
-    nodeInfo: OngoingEtlTaskNodeInfo
-): React.JSX.Element[] {
-    if (!expectsTxId) {
-        return [];
-    }
+interface TransactionalIdCellProps {
+    txId: string | undefined;
+    hasProgress: boolean;
+    noTopBorder?: boolean;
+}
 
-    const hasProgress = !!nodeInfo.etlProgress?.length;
+function TransactionalIdCell({ txId, hasProgress, noTopBorder = false }: TransactionalIdCellProps) {
+    const borderClass = noTopBorder ? "border-top-0" : undefined;
 
-    const loadingDiv = (key: string) => (
-        <div key={key} className="d-flex align-items-center justify-content-center gap-1 text-muted">
-            <Spinner animation="border" size="sm" />
-            <small>Loading...</small>
-        </div>
-    );
-
-    const txIdDiv = (key: string, txId: string | undefined, noTopBorder = false) => {
-        const borderClass = noTopBorder ? "no-top-border" : undefined;
-        if (!txId) {
-            return hasProgress ? (
-                <div key={key} className={borderClass}>
-                    -
-                </div>
-            ) : (
-                loadingDiv(key)
-            );
-        }
-        return (
-            <div
-                key={key}
-                className={classNames(
-                    "d-flex align-items-center justify-content-center gap-1 overflow-hidden",
-                    borderClass
-                )}
-            >
-                <span className="text-truncate" title={txId}>
-                    {txId}
-                </span>
-                <Button
-                    variant="link"
-                    size="xs"
-                    className="p-0 flex-shrink-0"
-                    onClick={() => copyToClipboard.copy(txId, "Transactional Id was copied to clipboard.")}
-                    title="Copy to clipboard"
-                >
-                    <Icon icon="copy" margin="m-0" />
-                </Button>
+    if (!txId) {
+        return hasProgress ? (
+            <div className={borderClass}>-</div>
+        ) : (
+            <div className="d-flex align-items-center justify-content-center gap-1 text-muted">
+                <Spinner animation="border" size="sm" />
+                <small>Loading...</small>
             </div>
         );
-    };
+    }
 
-    if (txIdScripts.length === 0) {
-        return [loadingDiv("txid-loading")];
+    return (
+        <div
+            className={classNames(
+                "d-flex align-items-center justify-content-center gap-1 overflow-hidden",
+                borderClass
+            )}
+        >
+            <span className="text-truncate" title={txId}>
+                {txId}
+            </span>
+            <Button
+                variant="link"
+                size="xs"
+                className="p-0 flex-shrink-0"
+                onClick={() => copyToClipboard.copy(txId, "Transactional Id was copied to clipboard.")}
+                title="Copy to clipboard"
+            >
+                <Icon icon="copy" margin="m-0" />
+            </Button>
+        </div>
+    );
+}
+
+interface TransactionalIdCellsProps {
+    txIdLayout: TxIdLayout;
+    nodeInfo: OngoingEtlTaskNodeInfo;
+}
+
+function TransactionalIdCells({ txIdLayout, nodeInfo }: TransactionalIdCellsProps) {
+    const { scripts, singleScript } = txIdLayout;
+    const hasProgress = !!nodeInfo.etlProgress?.length;
+
+    if (scripts.length === 0) {
+        return (
+            <div className="d-flex align-items-center justify-content-center gap-1 text-muted">
+                <Spinner animation="border" size="sm" />
+                <small>Loading...</small>
+            </div>
+        );
     }
 
     if (singleScript) {
-        const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === txIdScripts[0])?.transactionalId;
-        return [txIdDiv(`txid-${txIdScripts[0]}`, txId)];
+        const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === scripts[0])?.transactionalId;
+        return <TransactionalIdCell txId={txId} hasProgress={hasProgress} />;
     }
 
-    return [
-        <div key="txid-header"></div>,
-        ...txIdScripts.map((script) => {
-            const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === script)?.transactionalId;
-            return txIdDiv(`txid-${script}`, txId, true);
-        }),
-    ];
+    return (
+        <>
+            <div />
+            {scripts.map((script) => {
+                const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === script)?.transactionalId;
+                return <TransactionalIdCell key={script} txId={txId} hasProgress={hasProgress} noTopBorder />;
+            })}
+        </>
+    );
+}
+
+interface TransactionalIdLegendProps {
+    txIdLayout: TxIdLayout;
+}
+
+function TransactionalIdLegend({ txIdLayout }: TransactionalIdLegendProps) {
+    const { scripts } = txIdLayout;
+
+    if (scripts.length <= 1) {
+        return (
+            <div className="pe-1">
+                <Icon icon="identities" /> Transactional ID
+            </div>
+        );
+    }
+
+    return (
+        <>
+            <div className="pe-1">
+                <Icon icon="identities" /> Transactional IDs
+            </div>
+            {scripts.map((script) => (
+                <div key={script} className="border-top-0 ps-3">
+                    {script}
+                </div>
+            ))}
+        </>
+    );
 }
 
 function ItemWithTooltip(props: ItemWithTooltipProps) {
-    const { nodeInfo, sharded, task, showPreview, expectsTxId, txIdScripts, singleScript } = props;
+    const { nodeInfo, sharded, task, showPreview, txIdLayout } = props;
 
     const shard = (
         <div className="top shard">
@@ -122,15 +159,12 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
     const hasError = !!nodeInfo.details?.error;
     const [node, setNode] = useState<HTMLDivElement>();
 
-    const txIdCells = buildTxIdCells(expectsTxId, txIdScripts, singleScript, nodeInfo);
-
     return (
         <div ref={setNode}>
             <DistributionItem loading={nodeInfo.status === "loading" || nodeInfo.status === "idle"} key={key}>
                 {sharded && shard}
                 <div className={classNames("node", { top: !sharded })}>
                     {!sharded && <Icon icon="node" />}
-
                     {nodeInfo.location.nodeTag}
                 </div>
                 <div>{nodeInfo.status === "success" ? nodeInfo.details.taskConnectionStatus : ""}</div>
@@ -143,7 +177,7 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                         "-"
                     )}
                 </div>
-                {txIdCells}
+                {txIdLayout && <TransactionalIdCells txIdLayout={txIdLayout} nodeInfo={nodeInfo} />}
                 <OngoingEtlTaskProgress task={task} nodeInfo={nodeInfo} />
             </DistributionItem>
             {node &&
@@ -187,7 +221,9 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
           )
         : [];
 
-    const singleScript = txIdScripts.length === 1;
+    const txIdLayout: TxIdLayout | null = expectsTxId
+        ? { scripts: txIdScripts, singleScript: txIdScripts.length === 1 }
+        : null;
 
     const items = visibleNodes.map((nodeInfo) => {
         const key = taskNodeInfoKey(nodeInfo);
@@ -199,9 +235,7 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
                 sharded={sharded}
                 showPreview={showPreview}
                 task={task}
-                expectsTxId={expectsTxId}
-                txIdScripts={txIdScripts}
-                singleScript={singleScript}
+                txIdLayout={txIdLayout}
             />
         );
     });
@@ -222,23 +256,7 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
                     <div>
                         <Icon icon="warning" /> Error
                     </div>
-                    {expectsTxId && txIdScripts.length <= 1 && (
-                        <div className="pe-1">
-                            <Icon icon="identities" /> Transactional ID
-                        </div>
-                    )}
-                    {expectsTxId && txIdScripts.length > 1 && (
-                        <>
-                            <div className="pe-1">
-                                <Icon icon="identities" /> Transactional IDs
-                            </div>
-                            {txIdScripts.map((script) => (
-                                <div key={script} className="no-top-border ps-3">
-                                    {script}
-                                </div>
-                            ))}
-                        </>
-                    )}
+                    {txIdLayout && <TransactionalIdLegend txIdLayout={txIdLayout} />}
                     <div>
                         <Icon icon="changes" /> State
                     </div>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskDistribution.tsx
@@ -18,7 +18,7 @@ interface OngoingEtlTaskDistributionProps {
 
 interface TxIdLayout {
     scripts: string[];
-    singleScript: boolean;
+    isSingleScript: boolean;
 }
 
 interface ItemWithTooltipProps {
@@ -78,7 +78,7 @@ interface TransactionalIdCellsProps {
 }
 
 function TransactionalIdCells({ txIdLayout, nodeInfo }: TransactionalIdCellsProps) {
-    const { scripts, singleScript } = txIdLayout;
+    const { scripts, isSingleScript } = txIdLayout;
     const hasProgress = !!nodeInfo.etlProgress?.length;
 
     if (scripts.length === 0) {
@@ -90,7 +90,7 @@ function TransactionalIdCells({ txIdLayout, nodeInfo }: TransactionalIdCellsProp
         );
     }
 
-    if (singleScript) {
+    if (isSingleScript) {
         const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === scripts[0])?.transactionalId;
         return <TransactionalIdCell txId={txId} hasProgress={hasProgress} />;
     }
@@ -197,6 +197,25 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
     );
 }
 
+function getTxIdLayout(task: AnyEtlOngoingTaskInfo, visibleNodes: OngoingEtlTaskNodeInfo[]): TxIdLayout | null {
+    if (task.shared.taskType !== "KafkaQueueEtl") {
+        return null;
+    }
+
+    const scripts = Array.from(
+        visibleNodes.reduce((acc, nodeInfo) => {
+            nodeInfo.etlProgress?.forEach((ep) => {
+                if (ep.transactionalId) {
+                    acc.add(ep.transformationName);
+                }
+            });
+            return acc;
+        }, new Set<string>())
+    );
+
+    return { scripts, isSingleScript: scripts.length === 1 };
+}
+
 export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProps) {
     const { task, showPreview } = props;
     const sharded = task.nodesInfo.some((x) => x.location.shardNumber != null);
@@ -206,24 +225,7 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
             nodeInfo.details && task.responsibleLocations.find((l) => databaseLocationComparator(l, nodeInfo.location))
     );
 
-    const expectsTxId = task.shared.taskType === "KafkaQueueEtl";
-
-    const txIdScripts: string[] = expectsTxId
-        ? Array.from(
-              visibleNodes.reduce((acc, nodeInfo) => {
-                  nodeInfo.etlProgress?.forEach((ep) => {
-                      if (ep.transactionalId) {
-                          acc.add(ep.transformationName);
-                      }
-                  });
-                  return acc;
-              }, new Set<string>())
-          )
-        : [];
-
-    const txIdLayout: TxIdLayout | null = expectsTxId
-        ? { scripts: txIdScripts, singleScript: txIdScripts.length === 1 }
-        : null;
+    const txIdLayout = getTxIdLayout(task, visibleNodes);
 
     const items = visibleNodes.map((nodeInfo) => {
         const key = taskNodeInfoKey(nodeInfo);

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskDistribution.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/partials/OngoingEtlTaskDistribution.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useState } from "react";
+import React, { useState } from "react";
 import { DistributionItem, DistributionLegend, LocationDistribution } from "components/common/LocationDistribution";
 import classNames from "classnames";
 import { AnyEtlOngoingTaskInfo, OngoingEtlTaskNodeInfo, OngoingTaskInfo } from "components/models/tasks";
@@ -7,6 +7,9 @@ import { OngoingEtlTaskProgressTooltip } from "../partials/OngoingEtlTaskProgres
 import { Icon } from "components/common/Icon";
 import { databaseLocationComparator, withPreventDefault } from "components/utils/common";
 import { ErrorModal } from "components/pages/database/tasks/ongoingTasks/partials/ErrorModal";
+import Button from "react-bootstrap/Button";
+import Spinner from "react-bootstrap/Spinner";
+import copyToClipboard from "common/copyToClipboard";
 
 interface OngoingEtlTaskDistributionProps {
     task: AnyEtlOngoingTaskInfo;
@@ -18,10 +21,85 @@ interface ItemWithTooltipProps {
     sharded: boolean;
     task: AnyEtlOngoingTaskInfo;
     showPreview: (transformationName: string) => void;
+    expectsTxId: boolean;
+    txIdScripts: string[];
+    singleScript: boolean;
+}
+
+function buildTxIdCells(
+    expectsTxId: boolean,
+    txIdScripts: string[],
+    singleScript: boolean,
+    nodeInfo: OngoingEtlTaskNodeInfo
+): React.JSX.Element[] {
+    if (!expectsTxId) {
+        return [];
+    }
+
+    const hasProgress = !!nodeInfo.etlProgress?.length;
+
+    const loadingDiv = (key: string) => (
+        <div key={key} className="d-flex align-items-center justify-content-center gap-1 text-muted">
+            <Spinner animation="border" size="sm" />
+            <small>Loading...</small>
+        </div>
+    );
+
+    const txIdDiv = (key: string, txId: string | undefined, noTopBorder = false) => {
+        const borderClass = noTopBorder ? "no-top-border" : undefined;
+        if (!txId) {
+            return hasProgress ? (
+                <div key={key} className={borderClass}>
+                    -
+                </div>
+            ) : (
+                loadingDiv(key)
+            );
+        }
+        return (
+            <div
+                key={key}
+                className={classNames(
+                    "d-flex align-items-center justify-content-center gap-1 overflow-hidden",
+                    borderClass
+                )}
+            >
+                <span className="text-truncate" title={txId}>
+                    {txId}
+                </span>
+                <Button
+                    variant="link"
+                    size="xs"
+                    className="p-0 flex-shrink-0"
+                    onClick={() => copyToClipboard.copy(txId, "Transactional Id was copied to clipboard.")}
+                    title="Copy to clipboard"
+                >
+                    <Icon icon="copy" margin="m-0" />
+                </Button>
+            </div>
+        );
+    };
+
+    if (txIdScripts.length === 0) {
+        return [loadingDiv("txid-loading")];
+    }
+
+    if (singleScript) {
+        const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === txIdScripts[0])?.transactionalId;
+        return [txIdDiv(`txid-${txIdScripts[0]}`, txId)];
+    }
+
+    return [
+        <div key="txid-header"></div>,
+        ...txIdScripts.map((script) => {
+            const txId = nodeInfo.etlProgress?.find((ep) => ep.transformationName === script)?.transactionalId;
+            return txIdDiv(`txid-${script}`, txId, true);
+        }),
+    ];
 }
 
 function ItemWithTooltip(props: ItemWithTooltipProps) {
-    const { nodeInfo, sharded, task, showPreview } = props;
+    const { nodeInfo, sharded, task, showPreview, expectsTxId, txIdScripts, singleScript } = props;
 
     const shard = (
         <div className="top shard">
@@ -44,6 +122,8 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
     const hasError = !!nodeInfo.details?.error;
     const [node, setNode] = useState<HTMLDivElement>();
 
+    const txIdCells = buildTxIdCells(expectsTxId, txIdScripts, singleScript, nodeInfo);
+
     return (
         <div ref={setNode}>
             <DistributionItem loading={nodeInfo.status === "loading" || nodeInfo.status === "idle"} key={key}>
@@ -63,6 +143,7 @@ function ItemWithTooltip(props: ItemWithTooltipProps) {
                         "-"
                     )}
                 </div>
+                {txIdCells}
                 <OngoingEtlTaskProgress task={task} nodeInfo={nodeInfo} />
             </DistributionItem>
             {node &&
@@ -91,11 +172,37 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
             nodeInfo.details && task.responsibleLocations.find((l) => databaseLocationComparator(l, nodeInfo.location))
     );
 
+    const expectsTxId = task.shared.taskType === "KafkaQueueEtl";
+
+    const txIdScripts: string[] = expectsTxId
+        ? Array.from(
+              visibleNodes.reduce((acc, nodeInfo) => {
+                  nodeInfo.etlProgress?.forEach((ep) => {
+                      if (ep.transactionalId) {
+                          acc.add(ep.transformationName);
+                      }
+                  });
+                  return acc;
+              }, new Set<string>())
+          )
+        : [];
+
+    const singleScript = txIdScripts.length === 1;
+
     const items = visibleNodes.map((nodeInfo) => {
         const key = taskNodeInfoKey(nodeInfo);
 
         return (
-            <ItemWithTooltip key={key} nodeInfo={nodeInfo} sharded={sharded} showPreview={showPreview} task={task} />
+            <ItemWithTooltip
+                key={key}
+                nodeInfo={nodeInfo}
+                sharded={sharded}
+                showPreview={showPreview}
+                task={task}
+                expectsTxId={expectsTxId}
+                txIdScripts={txIdScripts}
+                singleScript={singleScript}
+            />
         );
     });
 
@@ -115,6 +222,23 @@ export function OngoingEtlTaskDistribution(props: OngoingEtlTaskDistributionProp
                     <div>
                         <Icon icon="warning" /> Error
                     </div>
+                    {expectsTxId && txIdScripts.length <= 1 && (
+                        <div className="pe-1">
+                            <Icon icon="identities" /> Transactional ID
+                        </div>
+                    )}
+                    {expectsTxId && txIdScripts.length > 1 && (
+                        <>
+                            <div className="pe-1">
+                                <Icon icon="identities" /> Transactional IDs
+                            </div>
+                            {txIdScripts.map((script) => (
+                                <div key={script} className="no-top-border ps-3">
+                                    {script}
+                                </div>
+                            ))}
+                        </>
+                    )}
                     <div>
                         <Icon icon="changes" /> State
                     </div>

--- a/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/stories/KafkaEtl.stories.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/tasks/ongoingTasks/stories/KafkaEtl.stories.tsx
@@ -23,6 +23,7 @@ interface KafkaProps {
     runtimeError: boolean;
     loadError: boolean;
     databaseType: "sharded" | "cluster" | "singleNode";
+    multipleScripts: boolean;
 }
 
 export const Default: StoryObj<KafkaProps> = {
@@ -52,7 +53,34 @@ export const Default: StoryObj<KafkaProps> = {
             tasksService.withGetTasks(mockedValue);
         }
 
-        mockEtlProgress(tasksService, args.completed, args.disabled, args.emptyScript);
+        if (args.multipleScripts) {
+            tasksService.withGetEtlProgress((dto) => {
+                const kafkaTask = dto.Results.find((x) => x.TaskName === TasksStubs.getKafkaEtl().TaskName);
+                if (kafkaTask) {
+                    const base = kafkaTask.ProcessesProgress[0];
+                    kafkaTask.ProcessesProgress = [
+                        {
+                            ...base,
+                            TransformationName: "Script #1",
+                            TransactionalId: "bVhBBojWnEOKrsszfuQ+Yg-tst-kafka_Script #1",
+                            Disabled: args.disabled,
+                            Completed: args.completed,
+                            NumberOfDocumentsToProcess: args.completed ? 0 : base.NumberOfDocumentsToProcess,
+                        },
+                        {
+                            ...base,
+                            TransformationName: "Script #2",
+                            TransactionalId: "cXiCCpkXoFPLttttgvR+Zh-tst-kafka_Script #2",
+                            Disabled: args.disabled,
+                            Completed: args.completed,
+                            NumberOfDocumentsToProcess: args.completed ? 0 : base.NumberOfDocumentsToProcess,
+                        },
+                    ];
+                }
+            });
+        } else {
+            mockEtlProgress(tasksService, args.completed, args.disabled, args.emptyScript);
+        }
 
         return <OngoingTasksPage />;
     },
@@ -62,6 +90,7 @@ export const Default: StoryObj<KafkaProps> = {
         runtimeError: false,
         loadError: false,
         emptyScript: false,
+        multipleScripts: false,
         customizeTask: undefined,
         databaseType: "sharded",
     },


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26424

### Additional description

I've added additional option to see and copy transactional ID in distribution panel. 

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
