### PR TITLE
RavenDB-26336 Throw relevant exception when performing vector search query on static index that uses disabled embeddings generation task

### DIFF
--- a/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
+++ b/src/Raven.Server/Documents/Indexes/IndexFieldsPersistence.cs
@@ -96,23 +96,23 @@ namespace Raven.Server.Documents.Indexes
             return _vectorFieldsDimensions.TryGetValue(fieldName, out dimensions);
         }
 
-        internal bool TryReadEmbeddingsGenerationTaskIdentifier(string fieldName, out string taskName)
+        internal bool TryReadEmbeddingsGenerationTaskIdentifier(string fieldName, out string taskIdentifier)
         {
-            return _embeddingsGenerationTaskIdentifiers.TryGetValue(fieldName, out taskName);
+            return _embeddingsGenerationTaskIdentifiers.TryGetValue(fieldName, out taskIdentifier);
         }
 
         internal void SetEmbeddingsGenerationTaskIdentifier(string fieldName, string taskIdentifier)
         {
-            var isStoredOnDisk = _embeddingsGenerationTaskIdentifiers.TryGetValue(fieldName, out var diskStoredSourceEtlTaskName);
+            var isStoredOnDisk = _embeddingsGenerationTaskIdentifiers.TryGetValue(fieldName, out var diskStoredTaskIdentifier);
 
-            PortableExceptions.ThrowIf<InvalidOperationException>(isStoredOnDisk && diskStoredSourceEtlTaskName != taskIdentifier, $"We are expecting that field {fieldName} has the same Embeddings Generation task as it was before. However, stored task was {diskStoredSourceEtlTaskName} and current one is {taskIdentifier}.");
+            PortableExceptions.ThrowIf<InvalidOperationException>(isStoredOnDisk && diskStoredTaskIdentifier != taskIdentifier, $"We are expecting that field {fieldName} has the same Embeddings Generation task as it was before. However, stored task was {diskStoredTaskIdentifier} and current one is {taskIdentifier}.");
 
             var isStoredInRuntime = false;
             if (_embeddingsGenerationTaskIdentifiersToWrite != null)
             {
-                isStoredInRuntime = _embeddingsGenerationTaskIdentifiersToWrite.TryGetValue(fieldName, out var runtimeStoredSourceEtlTaskName);
-                PortableExceptions.ThrowIf<InvalidOperationException>(isStoredInRuntime && runtimeStoredSourceEtlTaskName != taskIdentifier,
-                    $"We are expecting that field {fieldName} has the same Embeddings Generation task as it was before. However, previous task was {runtimeStoredSourceEtlTaskName} and current one is {taskIdentifier}.");
+                isStoredInRuntime = _embeddingsGenerationTaskIdentifiersToWrite.TryGetValue(fieldName, out var runtimeStoredTaskIdentifier);
+                PortableExceptions.ThrowIf<InvalidOperationException>(isStoredInRuntime && runtimeStoredTaskIdentifier != taskIdentifier,
+                    $"We are expecting that field {fieldName} has the same Embeddings Generation task as it was before. However, previous task was {runtimeStoredTaskIdentifier} and current one is {taskIdentifier}.");
             }
             
             if (isStoredOnDisk || isStoredInRuntime)
@@ -222,11 +222,11 @@ namespace Raven.Server.Documents.Indexes
 
                 if (_embeddingsGenerationTaskIdentifiersToWrite != null)
                 {
-                    var vectorSourceEtlTaskName = new Dictionary<string, string>(_embeddingsGenerationTaskIdentifiers);
-                    foreach (var fieldAiTaskName in _embeddingsGenerationTaskIdentifiersToWrite)
-                        vectorSourceEtlTaskName.Add(fieldAiTaskName.Key, fieldAiTaskName.Value);
-                    
-                    _embeddingsGenerationTaskIdentifiers = vectorSourceEtlTaskName;
+                    var embeddingsGenerationTaskIdentifiers = new Dictionary<string, string>(_embeddingsGenerationTaskIdentifiers);
+                    foreach (var fieldTaskIdentifier in _embeddingsGenerationTaskIdentifiersToWrite)
+                        embeddingsGenerationTaskIdentifiers.Add(fieldTaskIdentifier.Key, fieldTaskIdentifier.Value);
+
+                    _embeddingsGenerationTaskIdentifiers = embeddingsGenerationTaskIdentifiers;
                     _embeddingsGenerationTaskIdentifiersToWrite = null;
                 }
             };

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Corax.Querying.Matches.Meta;
@@ -373,7 +374,21 @@ public static partial class CoraxQueryBuilder
             var embeddingsTaskId = new EmbeddingsGenerationTaskIdentifier(embeddingsGenerationTaskIdentifier);
             
             var embeddingsGenerator = database.EmbeddingsGeneratorQueries;
-            
+
+            if (embeddingsGenerator.EmbeddingTaskExists(embeddingsTaskId) == false)
+            {
+                var taskConfiguration = database.EtlLoader.EmbeddingsGenerationDestinations
+                    .SingleOrDefault(x => x.Identifier == embeddingsGenerationTaskIdentifier);
+
+                if (taskConfiguration is null)
+                    throw new InvalidQueryException(
+                        $"Couldn't find Embeddings Generation task with '{embeddingsGenerationTaskIdentifier}' identifier");
+
+                if (taskConfiguration.Disabled)
+                    throw new InvalidQueryException(
+                        $"Embeddings Generation task with '{embeddingsGenerationTaskIdentifier}' identifier is disabled, and cannot be used for querying");
+            }
+
             var sourceEmbeddingType = embeddingsGenerator.GetQuantizationOf(embeddingsTaskId);
 
             // Quantized dynamic field indicates that the task generated embeddings with different quantization than requested in the index

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -129,7 +129,7 @@ public static partial class CoraxQueryBuilder
 
         (VectorValue? SingleVector, VectorValue[] MultiVector) transformedEmbeddings = (null, null);
         int numberOfDimensions;
-        if (VectorHelpers.TryRetrieveEtlTaskName(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
+        if (VectorHelpers.TryRetrieveEtlTaskIdentifier(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
         {
             var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
             transformedEmbeddings = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueType, value, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
@@ -239,7 +239,7 @@ public static partial class CoraxQueryBuilder
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryRetrieveEtlTaskName(Parameters builderParameters, in string fieldName, out string embeddingsGenerationTaskIdentifier)
+        public static bool TryRetrieveEtlTaskIdentifier(Parameters builderParameters, in string fieldName, out string embeddingsGenerationTaskIdentifier)
         {
             var existsInPersistence =
                 builderParameters.Index.IndexFieldsPersistence.TryReadEmbeddingsGenerationTaskIdentifier(fieldName, out embeddingsGenerationTaskIdentifier);
@@ -247,7 +247,7 @@ public static partial class CoraxQueryBuilder
             if (builderParameters.Metadata.IsDynamic == false)
                 return existsInPersistence;
 
-            if (((builderParameters.FieldsToFetch != null && builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out var indexField)) || (builderParameters.Index.Definition.IndexFields.TryGetValue(fieldName, out indexField))) && indexField.Vector is AutoVectorOptions avo)
+            if (((builderParameters.FieldsToFetch != null && builderParameters.FieldsToFetch.IndexFields.TryGetValue(fieldName, out var indexField)) || builderParameters.Index.Definition.IndexFields.TryGetValue(fieldName, out indexField)) && indexField.Vector is AutoVectorOptions avo)
             {
                 embeddingsGenerationTaskIdentifier = avo.EmbeddingsGenerationTaskIdentifier;
                 return avo.EmbeddingsGenerationTaskIdentifier != null;            

--- a/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Persistence/Corax/CoraxQueryBuilder.VectorSearch.cs
@@ -129,7 +129,7 @@ public static partial class CoraxQueryBuilder
 
         (VectorValue? SingleVector, VectorValue[] MultiVector) transformedEmbeddings = (null, null);
         int numberOfDimensions;
-        if (VectorHelpers.TryRetrieveEtlTaskIdentifier(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
+        if (VectorHelpers.TryRetrieveEmbeddingsGenerationTaskIdentifier(builderParameters, fieldName, out embeddingsGenerationTaskIdentifier))
         {
             var vectorOptions = VectorHelpers.GetExplicitVectorOptions(builderParameters, fieldName, out indexField);
             transformedEmbeddings = VectorHelpers.GetEmbeddingsForQueryParameter(builderParameters, valueType, value, embeddingsGenerationTaskIdentifier, vectorOptions, fieldName);
@@ -239,7 +239,7 @@ public static partial class CoraxQueryBuilder
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryRetrieveEtlTaskIdentifier(Parameters builderParameters, in string fieldName, out string embeddingsGenerationTaskIdentifier)
+        public static bool TryRetrieveEmbeddingsGenerationTaskIdentifier(Parameters builderParameters, in string fieldName, out string embeddingsGenerationTaskIdentifier)
         {
             var existsInPersistence =
                 builderParameters.Index.IndexFieldsPersistence.TryReadEmbeddingsGenerationTaskIdentifier(fieldName, out embeddingsGenerationTaskIdentifier);

--- a/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
+++ b/src/Raven.Server/Documents/Indexes/Static/StaticIndexBase.VectorSearch.cs
@@ -536,16 +536,16 @@ public partial class AbstractStaticIndexBase
         return value is null or DynamicNullObject or DynamicJsNull or JsNull;
     }
 
-    public static object LoadVectorJs(string fieldName, string path, string embeddingGeneratorTaskName, object embeddingSourceDocumentId, string embeddingSourceDocumentCollectionName, out IndexField vectorField)
+    public static object LoadVectorJs(string fieldName, string path, string embeddingGeneratorTaskIdentifier, object embeddingSourceDocumentId, string embeddingSourceDocumentCollectionName, out IndexField vectorField)
     {
         if (IsDictionaryTrainingPhase(CurrentIndexingScope.Current))
         {
             vectorField = null;
             return null;
         }
-        
+
         //todo
-        var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskName, GetStringFromObject(embeddingSourceDocumentId), embeddingSourceDocumentCollectionName, out vectorField);
+        var vectors = ProcessLoadVector(fieldName, path, embeddingGeneratorTaskIdentifier, GetStringFromObject(embeddingSourceDocumentId), embeddingSourceDocumentCollectionName, out vectorField);
 
         // for js indexes we've no choice than create dynamic field, in such cases let's assume it is single. 
         if (vectorField == null)

--- a/test/SlowTests.Issues/Issues/RavenDB-25692.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25692.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Raven.Client.Documents;
+using Raven.Client.Documents.Indexes;
 using Raven.Client.Documents.Operations.AI;
 using Raven.Client.Documents.Operations.OngoingTasks;
 using Raven.Client.Exceptions;
@@ -12,7 +14,7 @@ public class RavenDB_25692(ITestOutputHelper output) : EmbeddingsGenerationTestB
 {
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Vector)]
     [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
-    public async Task QueryingDisabledEmbeddings(Options options)
+    public async Task DynamicQueryOnDisabledEmbeddingsGenerationTask(Options options)
     {
         using (var store = GetDocumentStore(options))
         {
@@ -21,9 +23,9 @@ public class RavenDB_25692(ITestOutputHelper output) : EmbeddingsGenerationTestB
             var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
             Assert.True(queriesWorkerRegistered);
             Assert.True(indexingWorkerRegistered);
-            
+
             var taskInfo = store.Maintenance.Send(new GetOngoingTaskInfoOperation(configuration.Identifier, OngoingTaskType.EmbeddingsGeneration));
-            
+
             var disableOp = new ToggleOngoingTaskStateOperation(taskInfo.TaskId, OngoingTaskType.EmbeddingsGeneration, disable: true);
             store.Maintenance.Send(disableOp);
 
@@ -33,11 +35,68 @@ public class RavenDB_25692(ITestOutputHelper output) : EmbeddingsGenerationTestB
 
                 Assert.Contains($"Embeddings Generation task with '{configuration.Identifier}' identifier is disabled, and cannot be used for querying", ex.Message);
             }
+
+            var indexNames = store.Maintenance.Send(new Raven.Client.Documents.Operations.Indexes.GetIndexNamesOperation(0, 10));
+            Assert.Empty(indexNames);
         }
     }
-    
+
+    [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Vector)]
+    [RavenData(SearchEngineMode = RavenSearchEngineMode.Corax)]
+    public async Task StaticIndexQueryOnDisabledEmbeddingsGenerationTask(Options options)
+    {
+        using (var store = GetDocumentStore(options))
+        {
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Dto { TextualValue = "apple" });
+                session.SaveChanges();
+            }
+
+            var index = new TextualValueIndex();
+            await index.ExecuteAsync(store);
+            await Indexes.WaitForIndexingAsync(store);
+
+            var etlStatus = Etl.WaitForEtlToComplete(store);
+            var (configuration, _) = AddEmbeddingsGenerationTask(store,
+                embeddingsPaths: [new EmbeddingPathConfiguration { Path = "TextualValue", ChunkingOptions = DefaultChunkingOptions }]);
+
+            Assert.True(await etlStatus.WaitAsync(DefaultEtlTimeout));
+            var (queriesWorkerRegistered, indexingWorkerRegistered) = await WaitForEmbeddingsGenerationWorkerToRegisterAsync(store, configuration);
+            Assert.True(queriesWorkerRegistered);
+            Assert.True(indexingWorkerRegistered);
+
+            var taskInfo = store.Maintenance.Send(new GetOngoingTaskInfoOperation(configuration.Identifier, OngoingTaskType.EmbeddingsGeneration));
+
+            var disableOp = new ToggleOngoingTaskStateOperation(taskInfo.TaskId, OngoingTaskType.EmbeddingsGeneration, disable: true);
+            store.Maintenance.Send(disableOp);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var ex = await Assert.ThrowsAsync<InvalidQueryException>(async () =>
+                    await session.Query<Dto, TextualValueIndex>()
+                        .VectorSearch(f => f.WithField(s => s.Vector), v => v.ByText("fruit"), minimumSimilarity: 0.75f)
+                        .ToListAsync());
+
+                Assert.Contains($"Embeddings Generation task with '{configuration.Identifier}' identifier is disabled, and cannot be used for querying", ex.Message);
+            }
+        }
+    }
+
+    private class TextualValueIndex : AbstractIndexCreationTask<Dto>
+    {
+        public TextualValueIndex()
+        {
+            Map = dtos => from dto in dtos
+                select new { Vector = LoadVector("TextualValue", DefaultEmbeddingGenerationTaskName) };
+
+            SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
+        }
+    }
+
     private class Dto
     {
         public string TextualValue { get; set; }
+        public object Vector { get; }
     }
 }

--- a/test/SlowTests.Issues/Issues/RavenDB-25692.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB-25692.cs
@@ -88,7 +88,7 @@ public class RavenDB_25692(ITestOutputHelper output) : EmbeddingsGenerationTestB
         public TextualValueIndex()
         {
             Map = dtos => from dto in dtos
-                select new { Vector = LoadVector("TextualValue", DefaultEmbeddingGenerationTaskName) };
+                select new { Vector = LoadVector("TextualValue", "localaitask") };
 
             SearchEngineType = Raven.Client.Documents.Indexes.SearchEngineType.Corax;
         }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26336/Vector-Search-on-Disabled-AI-Task-Throws-NRE

### Additional description

This PR consists of two changes
1. Additional check whether queried task is disabled in `CoraxQueryBuilder.VectorSearch.GetEmbeddingsForQueryParameter`
2. Multiple renames in places where we use task identifier but named it task name

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
