### PR TITLE
RavenDB-26110 MemoizationMatch - memory managment 

### DIFF
--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -130,8 +130,13 @@ namespace Corax.Querying.Matches
                     inner += " - DebugView failure " + e.Message;
                 }
 
+                var configuredLimit = new Size(_indexSearcher.MaxMemoizationSizeInBytes, SizeUnit.Bytes);
+                var reason = _buffer.MaxAllocationInBytes < _indexSearcher.MaxMemoizationSizeInBytes
+                    ? $"which exceeds the internal allocation maximum ('Indexing.Corax.MaxMemoizationSizeInMb' is configured to: {configuredLimit})"
+                    : $"but 'Indexing.Corax.MaxMemoizationSizeInMb' is set to: {configuredLimit}";
+
                 throw new InvalidOperationException(
-                    $"Memoization clause needs more than {new Size(_buffer.MaxAllocationInBytes, SizeUnit.Bytes)} to fit its results, but 'Indexing.Corax.MaxMemoizationSizeInMb' is set to: {new Size(_indexSearcher.MaxMemoizationSizeInBytes, SizeUnit.Bytes)}, in query: {inner}");
+                    $"Memoization clause needs more than {new Size(_buffer.MaxAllocationInBytes, SizeUnit.Bytes)} to fit its results, {reason}, in query: {inner}");
             }
         }
 

--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using Corax.Querying.Matches.Meta;
 using Sparrow;
 using Sparrow.Server;
@@ -20,18 +19,13 @@ namespace Corax.Querying.Matches
         private readonly Querying.IndexSearcher _indexSearcher;
         private TInner _inner;
 
-        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
-        
         public bool IsBoosting => _inner.IsBoosting;
         public long Count => _inner.Count;
         public QueryCountConfidence Confidence => _inner.Confidence;
 
-        public Span<long> Buffer => MemoryMarshal.Cast<byte, long>(_bufferHolder.ToSpan());
-
         private int _bufferEndIdx;
-        private ByteString _bufferHolder;
-        private ByteStringContext<ByteStringMemoryCache>.InternalScope _bufferScope;
-        
+        private GrowableBuffer<Progressive> _buffer;
+
         private SortMode _sortMode;
 
         private enum SortMode
@@ -40,7 +34,7 @@ namespace Corax.Querying.Matches
             Required,
             Skip
         }
-        
+
         public void SortingRequired()
         {
             _sortMode = SortMode.Required;
@@ -51,14 +45,13 @@ namespace Corax.Querying.Matches
             _sortMode = SortMode.Skip;
         }
 
-        public MemoizationMatchProvider(Querying.IndexSearcher indexSearcher, in TInner inner)
+        public MemoizationMatchProvider(IndexSearcher indexSearcher, in TInner inner)
         {
             _indexSearcher = indexSearcher;
             _ctx = indexSearcher.Allocator;
             _inner = inner;
             _replayCounter = 0;
-            _bufferHolder = default;
-            _bufferScope = default;
+            _buffer = new GrowableBuffer<Progressive>();
             _bufferEndIdx = -1;
         }
 
@@ -76,52 +69,38 @@ namespace Corax.Querying.Matches
             if (_bufferEndIdx == 0)
                 return Span<long>.Empty;
 
-            return Buffer[.._bufferEndIdx];
+            return _buffer.Results[.._bufferEndIdx];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal int Fill(Span<long> matches) => _inner.Fill(matches);
-        
+
         private void InitializeInner()
         {
-            // We rent a buffer size. 
-            int bufferSize = 4 * Math.Min(Math.Max(Voron.Global.Constants.Size.Kilobyte, (int)_inner.Count), 16 * Voron.Global.Constants.Size.Kilobyte);
-            _bufferScope.Dispose();
-            _bufferScope = _ctx.Allocate(bufferSize * sizeof(long), out _bufferHolder);
+            _buffer.Init(_ctx, _inner.Count, _indexSearcher.MaxMemoizationSizeInBytes);
 
-            var bufferState = Buffer;
-            
-            int count = 0;
             while (true)
             {
-                var read = _inner.Fill(bufferState);
+                if (_buffer.TryGetSpace(out var space) == false)
+                    ThrowExceededMemoizationSize();
+
+                var read = _inner.Fill(space);
                 if (read == 0)
-                    goto End;
+                    break;
 
-                // We haven't finished and probably we will need to expand the temporary buffer.
-                int bufferUsedItems = count + read;
-                if (bufferUsedItems > Buffer.Length * 3 / 4)
-                {
-                    UnlikelyGrowBuffer(bufferUsedItems);
-                    bufferState = Buffer[count..];
-                }
-
-                // Every time this is called we will store in a growable temporary buffer all the matches to be used in the AndNot later.
-                bufferState = bufferState[read..];
-                count += read;
+                _buffer.AddUsage(read);
             }
 
-            End:
             // The problem is that multiple Fill calls do not ensure that we will get a sequence of ordered
             // values, therefore we must ensure that we get a 'sorted' sequence ensuring those happen.
             SetSortingMode();
             if (_sortMode == SortMode.Required)
             {
                 // We need to sort and remove duplicates.
-                count = Sorting.SortAndRemoveDuplicates(Buffer[..count]);
+                _buffer.Truncate(Sorting.SortAndRemoveDuplicates(_buffer.Results));
             }
 
-            _bufferEndIdx = count;
+            _bufferEndIdx = _buffer.Count;
 
             void SetSortingMode()
             {
@@ -137,37 +116,6 @@ namespace Corax.Querying.Matches
                     };
                 }
             }
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void UnlikelyGrowBuffer(int currentlyUsed)
-        {
-            // Calculate the new size. 
-            int currentLength = Buffer.Length;
-            int size;
-            if (currentLength > 16 * Voron.Global.Constants.Size.Megabyte)
-            {
-                size = (int)(currentLength * 1.5);
-            }
-            else
-            {
-                // we increase by 3, because we just consumed all the size
-                // we want to _add_ twice as much as we already consumed
-                size = currentLength * 3;
-            }
-
-            var sizeInBytes = size * sizeof(long);
-
-            if (sizeInBytes > _indexSearcher.MaxMemoizationSizeInBytes) ThrowExceededMemoizationSize();
-
-            // Allocate the new buffer
-            var newBufferScope = _ctx.Allocate(sizeInBytes, out var newBufferHolder);
-
-            // Ensure we copy the content and then switch the buffers. 
-            Buffer[..currentlyUsed].CopyTo(MemoryMarshal.Cast<byte,long>(newBufferHolder.ToSpan()));
-            _bufferScope.Dispose();
-            _bufferHolder = newBufferHolder;
-            _bufferScope = newBufferScope;
 
             void ThrowExceededMemoizationSize()
             {
@@ -181,9 +129,9 @@ namespace Corax.Querying.Matches
                     // we are protecting from an error in DebugView during error handling here
                     inner += " - DebugView failure " + e.Message;
                 }
-                
+
                 throw new InvalidOperationException(
-                    $"Memoization clause need to allocation {new Size(sizeInBytes, SizeUnit.Bytes)} but 'Indexing.Corax.MaxMemoizationSizeInMb' is set to: {new Size(_indexSearcher.MaxMemoizationSizeInBytes, SizeUnit.Bytes)}, in query: {inner}");
+                    $"Memoization clause needs more than {new Size(_buffer.MaxAllocationInBytes, SizeUnit.Bytes)} to fit its results, but 'Indexing.Corax.MaxMemoizationSizeInMb' is set to: {new Size(_indexSearcher.MaxMemoizationSizeInBytes, SizeUnit.Bytes)}, in query: {inner}");
             }
         }
 
@@ -197,12 +145,12 @@ namespace Corax.Querying.Matches
             return _inner.Inspect();
         }
         string DebugView => Inspect().ToString();
-        
+
         public void InnerRetriever(out TInner inner) => inner = _inner;
 
         public void Dispose()
         {
-            _bufferScope.Dispose();
+            _buffer.Dispose();
         }
     }
 }

--- a/src/Sparrow.Server/Utils/GrowableBuffer.cs
+++ b/src/Sparrow.Server/Utils/GrowableBuffer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using Sparrow.Platform;
 
 namespace Sparrow.Server.Utils;
@@ -11,19 +10,26 @@ public interface IBufferGrowth
     public bool GrowingThresholdExceed(in int count, in int sizeInBytes);
 }
 
-public readonly struct Progressive : IBufferGrowth
+public readonly unsafe struct Progressive : IBufferGrowth
 {
+    public static readonly int MaxBufferSizeInBytes = int.MaxValue - sizeof(ByteStringStorage);
+
     public int GetNewSize(in int currentSizeInBytes)
     {
         // Slower growth on 32-bit platforms
         float platformScalar = PlatformDetails.Is32Bits ? 1.1f : 1.5f;
-        
-        var size = currentSizeInBytes > 16 * Sparrow.Global.Constants.Size.Megabyte
-            ? (int)(currentSizeInBytes * platformScalar)
-            : currentSizeInBytes * 2;
+
+        long size = currentSizeInBytes > 16 * Sparrow.Global.Constants.Size.Megabyte
+            ? (long)(currentSizeInBytes * platformScalar)
+            : (long)currentSizeInBytes * 2;
+
+        if (size > MaxBufferSizeInBytes)
+            size = MaxBufferSizeInBytes;
+
+        int truncated = (int)size;
 
         // Represent array as N*sizeof(long)
-        return size - (size % sizeof(long));
+        return truncated - (truncated % sizeof(long));
     }
 
     public bool GrowingThresholdExceed(in int count, in int sizeInBytes)
@@ -35,16 +41,15 @@ public readonly struct Progressive : IBufferGrowth
 
     public int GetInitialSize(in long initialSize)
     {
-        Debug.Assert(initialSize < int.MaxValue, "initialSize < int.MaxValue");
-        var size = 4 * Math.Min(Math.Max(Sparrow.Global.Constants.Size.Kilobyte, (int)initialSize), 16 * Sparrow.Global.Constants.Size.Kilobyte);
-        if (size < initialSize)
-        {
-            Debug.Assert(size % sizeof(long) == 0, "size % sizeof(long) == 0");
-            return (int)initialSize;
-        }
-        
+        long suggested = 4 * Math.Min(Math.Max(Sparrow.Global.Constants.Size.Kilobyte, initialSize), 16 * Sparrow.Global.Constants.Size.Kilobyte);
+        long size = Math.Max(suggested, initialSize);
+        if (size > MaxBufferSizeInBytes)
+            size = MaxBufferSizeInBytes;
+
+        int truncated = (int)size;
+
         // Represent array as N*sizeof(long)
-        return size - (size % sizeof(long));
+        return truncated - (truncated % sizeof(long));
     }
 }
 
@@ -55,6 +60,7 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
     private ByteStringContext _context;
     private ByteString _buffer;
     private int _count;
+    private int _maxAllocationInBytes;
     public int Count => _count;
     public bool IsInitialized;
 
@@ -63,12 +69,34 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
         if (_growthCalculator.GrowingThresholdExceed(_count, _buffer.Length))
             Grow();
 
-        return _buffer.ToSpan<long>().Slice(_count);
+        var space = _buffer.ToSpan<long>().Slice(_count);
+        if (space.IsEmpty)
+            ThrowCannotGrowAnyFurther();
+        return space;
+    }
+
+    public bool TryGetSpace(out Span<long> space)
+    {
+        if (_growthCalculator.GrowingThresholdExceed(_count, _buffer.Length))
+            Grow();
+
+        space = _buffer.ToSpan<long>().Slice(_count);
+        return space.IsEmpty == false;
+    }
+
+    private void ThrowCannotGrowAnyFurther()
+    {
+        throw new InvalidOperationException(
+            $"GrowableBuffer cannot allocate more space. The buffer is full ({_count} items) and has reached its maximum allocation of {_maxAllocationInBytes} bytes.");
     }
 
     public Span<long> Results => _buffer.ToSpan<long>().Slice(0, _count);
 
     public bool HasEmptySpace => _buffer.Length == (_count * sizeof(long));
+
+    public int AllocatedSizeInBytes => _buffer.Length;
+
+    public int MaxAllocationInBytes => _maxAllocationInBytes;
 
     public GrowableBuffer()
     {
@@ -77,23 +105,37 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
     public void AddUsage(in int count) => _count += count;
 
     public void Truncate(in int newCount) => _count = newCount;
-    
-    public void Init(ByteStringContext context, in long initialSize)
+
+    public void Init(ByteStringContext context, in long initialSize, long maxAllocationInBytes = long.MaxValue)
     {
         _context = context;
-        _context.Allocate(_growthCalculator.GetInitialSize(initialSize * sizeof(long)), out _buffer);
+        _maxAllocationInBytes = maxAllocationInBytes > Progressive.MaxBufferSizeInBytes
+            ? Progressive.MaxBufferSizeInBytes
+            : (int)Math.Max(0, maxAllocationInBytes);
+
+        var initial = _growthCalculator.GetInitialSize(initialSize * sizeof(long));
+        if (initial > _maxAllocationInBytes)
+            initial = _maxAllocationInBytes;
+
+        _context.Allocate(initial, out _buffer);
         IsInitialized = true;
     }
 
     private void Grow()
     {
         var newSize = _growthCalculator.GetNewSize(_buffer.Length);
+        if (newSize > _maxAllocationInBytes)
+            newSize = _maxAllocationInBytes;
+
+        if (newSize <= _buffer.Length)
+            return;
+
         _context.Allocate(newSize, out ByteString newBuffer);
         new Span<long>(_buffer.Ptr, _count).CopyTo(new Span<long>(newBuffer.Ptr, _count));
         _context.Release(ref _buffer);
         _buffer = newBuffer;
     }
-    
+
     public void Dispose()
     {
         _context.Release(ref _buffer);

--- a/src/Sparrow.Server/Utils/GrowableBuffer.cs
+++ b/src/Sparrow.Server/Utils/GrowableBuffer.cs
@@ -109,11 +109,15 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
     public void Init(ByteStringContext context, in long initialSize, long maxAllocationInBytes = long.MaxValue)
     {
         _context = context;
-        _maxAllocationInBytes = maxAllocationInBytes > Progressive.MaxBufferSizeInBytes
-            ? Progressive.MaxBufferSizeInBytes
-            : (int)Math.Max(0, maxAllocationInBytes);
 
-        var initial = _growthCalculator.GetInitialSize(initialSize * sizeof(long));
+        long clampedMax = Math.Min(Math.Max(0, maxAllocationInBytes), Progressive.MaxBufferSizeInBytes);
+        _maxAllocationInBytes = (int)(clampedMax - (clampedMax % sizeof(long)));
+
+        long initialSizeInBytes = initialSize >= Progressive.MaxBufferSizeInBytes / sizeof(long)
+            ? Progressive.MaxBufferSizeInBytes
+            : initialSize * sizeof(long);
+
+        var initial = _growthCalculator.GetInitialSize(initialSizeInBytes);
         if (initial > _maxAllocationInBytes)
             initial = _maxAllocationInBytes;
 

--- a/test/SlowTests/Issues/RavenDB-26110.cs
+++ b/test/SlowTests/Issues/RavenDB-26110.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using Corax.Mappings;
+using Corax.Querying.Matches.Meta;
+using FastTests.Voron;
+using Sparrow.Server;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+using Xunit.Abstractions;
+using IndexSearcher = Corax.Querying.IndexSearcher;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
+{
+    [RavenMultiplatformFact(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    public void MemoizationMatchProviderCanMemoizeLargeResultSet()
+    {
+        using var fields = CreateFields(Allocator);
+        using var searcher = new IndexSearcher(Env, fields);
+
+        searcher.MaxMemoizationSizeInBytes = long.MaxValue;
+
+        var mock = new DummyBigMatch();
+        var memoizer = searcher.Memoize(mock).Replay();
+        var results = memoizer.FillAndRetrieve();
+        Assert.True(results.Length > 1_000_000);
+        for (int i = 1; i < Math.Min(1000, results.Length); i++)
+        {
+            Assert.True(results[i] > results[i - 1]);
+        }
+    }
+
+    private static IndexFieldsMapping CreateFields(ByteStringContext bsc)
+    {
+        Slice.From(bsc, "Id", ByteStringType.Immutable, out var idSlice);
+
+        using var builder = IndexFieldsMappingBuilder.CreateForWriter(false)
+            .AddBinding(0, idSlice);
+
+        return builder.Build();
+    }
+
+    private struct DummyBigMatch : IQueryMatch
+    {
+        private int _fillCallCount;
+        private bool _completed;
+
+        public long Count => int.MaxValue;
+        public QueryCountConfidence Confidence => QueryCountConfidence.High;
+        public bool IsBoosting => false;
+        public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
+
+        public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.WillSkipSorting;
+
+        public int Fill(Span<long> matches)
+        {
+            if (_completed) return 0;
+
+            _fillCallCount++;
+
+            var fillCount = Math.Min(matches.Length - 1, 90_000_000);
+
+            long baseId = (_fillCallCount - 1L) * fillCount + 1;
+            for (int i = 0; i < fillCount; i++)
+            {
+                matches[i] = baseId + i;
+            }
+
+            if (_fillCallCount >= 20)
+            {
+                _completed = true;
+                return fillCount / 2;
+            }
+
+            return fillCount;
+        }
+
+        public int AndWith(Span<long> buffer, int matches) => matches;
+
+        public void Score(Span<long> matches, Span<float> scores, float boostFactor)
+        {
+        }
+
+        public QueryInspectionNode Inspect() => new(nameof(DummyBigMatch),
+            parameters: new Dictionary<string, string>
+            {
+                { "FillCallCount", _fillCallCount.ToString() },
+                { "Count", Count.ToString() }
+            });
+    }
+}

--- a/test/SlowTests/Issues/RavenDB-26110.cs
+++ b/test/SlowTests/Issues/RavenDB-26110.cs
@@ -25,11 +25,24 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
         var mock = new DummyBigMatch();
         var memoizer = searcher.Memoize(mock).Replay();
         var results = memoizer.FillAndRetrieve();
-        Assert.True(results.Length > 1_000_000);
+        Assert.Equal(DummyBigMatch.TotalItemsToProduce, results.Length);
         for (int i = 1; i < Math.Min(1000, results.Length); i++)
         {
             Assert.True(results[i] > results[i - 1]);
         }
+    }
+
+    [RavenMultiplatformFact(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    public void MemoizationMatchProviderThrowsWhenResultSetExceedsBuffer()
+    {
+        using var fields = CreateFields(Allocator);
+        using var searcher = new IndexSearcher(Env, fields);
+
+        searcher.MaxMemoizationSizeInBytes = 16 * 1024 * 1024;
+
+        var mock = new DummyBigMatch();
+        var memoizer = searcher.Memoize(mock).Replay();
+        Assert.Throws<InvalidOperationException>(() => memoizer.FillAndRetrieve());
     }
 
     private static IndexFieldsMapping CreateFields(ByteStringContext bsc)
@@ -44,10 +57,12 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
 
     private struct DummyBigMatch : IQueryMatch
     {
-        private int _fillCallCount;
+        public const int TotalItemsToProduce = 200_000_000;
+
+        private long _totalGenerated;
         private bool _completed;
 
-        public long Count => int.MaxValue;
+        public long Count => 1000;
         public QueryCountConfidence Confidence => QueryCountConfidence.High;
         public bool IsBoosting => false;
         public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
@@ -58,21 +73,17 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
         {
             if (_completed) return 0;
 
-            _fillCallCount++;
+            int fillCount = (int)Math.Min(Math.Min(matches.Length, 10_000_000), TotalItemsToProduce - _totalGenerated);
 
-            var fillCount = Math.Min(matches.Length - 1, 90_000_000);
-
-            long baseId = (_fillCallCount - 1L) * fillCount + 1;
+            long baseId = _totalGenerated + 1;
             for (int i = 0; i < fillCount; i++)
             {
                 matches[i] = baseId + i;
             }
 
-            if (_fillCallCount >= 20)
-            {
+            _totalGenerated += fillCount;
+            if (_totalGenerated >= TotalItemsToProduce)
                 _completed = true;
-                return fillCount / 2;
-            }
 
             return fillCount;
         }
@@ -86,7 +97,7 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
         public QueryInspectionNode Inspect() => new(nameof(DummyBigMatch),
             parameters: new Dictionary<string, string>
             {
-                { "FillCallCount", _fillCallCount.ToString() },
+                { "TotalGenerated", _totalGenerated.ToString() },
                 { "Count", Count.ToString() }
             });
     }

--- a/test/SlowTests/Issues/RavenDB-26110.cs
+++ b/test/SlowTests/Issues/RavenDB-26110.cs
@@ -15,24 +15,6 @@ namespace SlowTests.Issues;
 public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
 {
     [RavenMultiplatformFact(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
-    public void MemoizationMatchProviderCanMemoizeLargeResultSet()
-    {
-        using var fields = CreateFields(Allocator);
-        using var searcher = new IndexSearcher(Env, fields);
-
-        searcher.MaxMemoizationSizeInBytes = long.MaxValue;
-
-        var mock = new DummyBigMatch();
-        var memoizer = searcher.Memoize(mock).Replay();
-        var results = memoizer.FillAndRetrieve();
-        Assert.Equal(DummyBigMatch.TotalItemsToProduce, results.Length);
-        for (int i = 1; i < Math.Min(1000, results.Length); i++)
-        {
-            Assert.True(results[i] > results[i - 1]);
-        }
-    }
-
-    [RavenMultiplatformFact(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     public void MemoizationMatchProviderThrowsWhenResultSetExceedsBuffer()
     {
         using var fields = CreateFields(Allocator);
@@ -45,7 +27,7 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
         Assert.Throws<InvalidOperationException>(() => memoizer.FillAndRetrieve());
     }
 
-    private static IndexFieldsMapping CreateFields(ByteStringContext bsc)
+    protected static IndexFieldsMapping CreateFields(ByteStringContext bsc)
     {
         Slice.From(bsc, "Id", ByteStringType.Immutable, out var idSlice);
 
@@ -55,7 +37,7 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
         return builder.Build();
     }
 
-    private struct DummyBigMatch : IQueryMatch
+    protected struct DummyBigMatch : IQueryMatch
     {
         public const int TotalItemsToProduce = 200_000_000;
 
@@ -63,11 +45,11 @@ public class RavenDB_26110(ITestOutputHelper output) : StorageTest(output)
         private bool _completed;
 
         public long Count => 1000;
-        public QueryCountConfidence Confidence => QueryCountConfidence.High;
+        public QueryCountConfidence Confidence => QueryCountConfidence.Low;
         public bool IsBoosting => false;
         public DuplicatesOccurrence DuplicatesOccurrenceStatus => DuplicatesOccurrence.NotPossible;
 
-        public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.WillSkipSorting;
+        public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.ResultsNativelySorted;
 
         public int Fill(Span<long> matches)
         {

--- a/test/StressTests/Issues/RavenDB-26110.cs
+++ b/test/StressTests/Issues/RavenDB-26110.cs
@@ -1,0 +1,28 @@
+using System;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+using IndexSearcher = Corax.Querying.IndexSearcher;
+
+namespace StressTests.Issues;
+
+public class RavenDB_26110(ITestOutputHelper output) : SlowTests.Issues.RavenDB_26110(output)
+{
+    [RavenMultiplatformFact(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
+    public void MemoizationMatchProviderCanMemoizeLargeResultSet()
+    {
+        using var fields = CreateFields(Allocator);
+        using var searcher = new IndexSearcher(Env, fields);
+
+        searcher.MaxMemoizationSizeInBytes = long.MaxValue;
+
+        var mock = new DummyBigMatch();
+        var memoizer = searcher.Memoize(mock).Replay();
+        var results = memoizer.FillAndRetrieve();
+        Assert.Equal(DummyBigMatch.TotalItemsToProduce, results.Length);
+        for (int i = 1; i < Math.Min(1000, results.Length); i++)
+        {
+            Assert.True(results[i] > results[i - 1]);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26110

### Additional description

Fixes an int-overflow crash when memoization buffers grow past ~1 GB by switching MemoizationMatchProvider to
  GrowableBuffer<Progressive> and throwing a clear error instead when the configured size is exceeded.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
