### PR TITLE
RavenDB-25833 Set Integrations.PostgreSql.Enabled configuration option to true when enabling experimental features in setup wizard

### DIFF
--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -749,6 +749,8 @@ public static class SettingsZipFileHelper
     private static void AddExperimentalFeaturesToSettingsJson(BlittableJsonReaderObject settingsJson)
     {
         settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Experimental;
+#if !RVN
         settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)] = true;
+#endif
     }
 }

--- a/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
+++ b/src/Raven.Server/Commercial/LetsEncrypt/SettingsZipFileHelper.cs
@@ -116,9 +116,7 @@ public static class SettingsZipFileHelper
                 settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Core.SetupMode)] = parameters.SetupMode.ToString();
 
                 if (parameters.SetupInfo.EnableExperimentalFeatures)
-                {
-                    settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Experimental;
-                }
+                    AddExperimentalFeaturesToSettingsJson(settingsJson);
                 
                 ModifySettingsJson(parameters.SetupInfo, parameters.Progress.SetupActionSteps, ref settingsJson);
 
@@ -330,9 +328,7 @@ public static class SettingsZipFileHelper
                 };
 
                 if (parameters.UnsecuredSetupInfo.EnableExperimentalFeatures)
-                {
-                    settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Experimental;
-                }
+                    AddExperimentalFeaturesToSettingsJson(settingsJson);
                 
                 ModifySettingsJson(parameters.UnsecuredSetupInfo, parameters.Progress.SetupActionSteps, ref settingsJson);
 
@@ -750,4 +746,9 @@ public static class SettingsZipFileHelper
         return url;
     }
 
+    private static void AddExperimentalFeaturesToSettingsJson(BlittableJsonReaderObject settingsJson)
+    {
+        settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)] = FeaturesAvailability.Experimental;
+        settingsJson.Modifications[RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)] = true;
+    }
 }

--- a/test/SlowTests/Issues/RavenDB-25833.cs
+++ b/test/SlowTests/Issues/RavenDB-25833.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Server.Commercial;
+using Raven.Server.Commercial.LetsEncrypt;
+using Raven.Server.Config;
+using Raven.Server.Utils.Features;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_25833 : RavenTestBase
+{
+    public RavenDB_25833(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Setup)]
+    public static async Task UnsecuredSetup_ExperimentalFeaturesEnabled_SetsKeysInSettingsJson()
+    {
+        byte[] zipBytes = await SettingsZipFileHelper.GetSetupZipFileUnsecuredSetup(CreateUnsecuredParameters(enableExperimentalFeatures: true));
+
+        JObject settings = ExtractSettingsJson(zipBytes, "A/settings.json");
+
+        Assert.Equal(nameof(FeaturesAvailability.Experimental), settings[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)]?.Value<string>());
+        Assert.True(settings[RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)]?.Value<bool>());
+    }
+
+    [RavenFact(RavenTestCategory.Setup)]
+    public static async Task UnsecuredSetup_ExperimentalFeaturesDisabled_DoesNotSetKeysInSettingsJson()
+    {
+        byte[] zipBytes = await SettingsZipFileHelper.GetSetupZipFileUnsecuredSetup(CreateUnsecuredParameters(enableExperimentalFeatures: false));
+
+        JObject settings = ExtractSettingsJson(zipBytes, "A/settings.json");
+
+        Assert.Null(settings[RavenConfiguration.GetKey(x => x.Core.FeaturesAvailability)]);
+        Assert.Null(settings[RavenConfiguration.GetKey(x => x.Integrations.PostgreSql.Enabled)]);
+    }
+
+    private static GetSetupZipFileParameters CreateUnsecuredParameters(bool enableExperimentalFeatures)
+    {
+        return new GetSetupZipFileParameters
+        {
+            SetupMode = SetupMode.Unsecured,
+            ZipOnly = true,
+            Progress = new SetupProgressAndResult(_ => { }, SetupMode.Unsecured, zipOnly: true),
+            CompleteClusterConfigurationResult = new CompleteClusterConfigurationResult { PublicServerUrl = "http://localhost:8080" },
+            UnsecuredSetupInfo = new UnsecuredSetupInfo
+            {
+                EnableExperimentalFeatures = enableExperimentalFeatures,
+                ZipOnly = true,
+                LocalNodeTag = "A",
+                NodeSetupInfos = new Dictionary<string, NodeInfo>
+                {
+                    ["A"] = new NodeInfo { Addresses = new List<string>(), Port = 8080, TcpPort = 38888 }
+                }
+            }
+        };
+    }
+
+    private static JObject ExtractSettingsJson(byte[] zipBytes, string entryName)
+    {
+        using MemoryStream ms = new MemoryStream(zipBytes);
+        using ZipArchive archive = new ZipArchive(ms, ZipArchiveMode.Read);
+        ZipArchiveEntry entry = archive.GetEntry(entryName);
+        Assert.NotNull(entry);
+        using StreamReader reader = new StreamReader(entry.Open());
+        return JObject.Parse(reader.ReadToEnd());
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25833/Setup-Wizard-Enabling-PostgreSQL-integration-doesnt-set-all-required-settings

### Additional description


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
