### PR TITLE
RavenDB-26456 Fix cgroup v2 memory controller detection on Azure Linux kernel

### DIFF
--- a/src/Sparrow.Server/Platform/Posix/CGroupHelper.cs
+++ b/src/Sparrow.Server/Platform/Posix/CGroupHelper.cs
@@ -191,7 +191,7 @@ public abstract class CGroup
     //memory 0	205	1
     //cpu    2  232 1
     private static readonly Regex FindControllerGroupsAvailability = new Regex(@"^(?<subsys_name>[\w|_]+)\s+(?<hierarchy>\d+)\s+(?<num_cgroups>\d+)\s+(?<enabled>[1|0])$", RegexOptions.Compiled);
-    private bool IsControllerGroupsAvailable(string subsysName)
+    protected virtual bool IsControllerGroupsAvailable(string subsysName)
     {
         foreach (string line in File.ReadLines(PROC_CGROUPS_FILENAME))
         {
@@ -287,8 +287,41 @@ public sealed class CGroupV2 : CGroup
     protected override string MemoryLimitFileName => "memory.max";
     protected override string MemoryUsageFileName => "memory.current";
     protected override string MaxMemoryUsageFileName => "memory.peak";
-    
+
     protected override string FindCGroupPathForMemoryInternal() => FindCGroupPath();
+
+    protected override bool IsControllerGroupsAvailable(string subsysName)
+    {
+        // /proc/cgroups only lists cgroup v1 controllers, which may not include the memory
+        // controller on kernels where memory is managed exclusively by cgroup v2 (e.g. Azure Linux).
+        // For cgroup v2, we check the cgroup.controllers file at the process's cgroup path instead.
+        try
+        {
+            string cgroupPath = FindCGroupPath();
+            if (cgroupPath == null)
+                return false;
+
+            string controllersFilePath = Path.Combine(cgroupPath, "cgroup.controllers");
+            if (File.Exists(controllersFilePath) == false)
+                return false;
+
+            string controllers = File.ReadAllText(controllersFilePath).Trim();
+            foreach (string controller in controllers.Split(' '))
+            {
+                if (controller == subsysName)
+                    return true;
+            }
+
+            return false;
+        }
+        catch (Exception e)
+        {
+            if (Logger.IsInfoEnabled)
+                Logger.Info($"Failed to check cgroup v2 controller availability for '{subsysName}', falling back to /proc/cgroups", e);
+
+            return base.IsControllerGroupsAvailable(subsysName);
+        }
+    }
     
     private static string FindCGroupPath()
     {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26456

### Additional description

When running on kernels where the memory controller is managed exclusively by cgroup v2 (e.g. Azure Linux kernel), RavenDB fails to detect the container memory limit. `IsControllerGroupsAvailable()` reads `/proc/cgroups` which only lists cgroup v1 controllers. On such kernels, the memory controller is absent from `/proc/cgroups`, causing RavenDB to permanently cache a null memory path and report host RAM instead of the container limit.

Fix: Make `IsControllerGroupsAvailable` virtual and override it in `CGroupV2` to read the `cgroup.controllers` file at the process's cgroup v2 path (resolved via `/proc/self/cgroup` and `/proc/self/mountinfo`). Falls back to the base v1 behavior if the v2 check fails.

GitHub issue: https://github.com/ravendb/ravendb/issues/22703

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [x] Yes. Please list the affected platforms.

Linux with cgroup v2 where the kernel does not expose the memory controller in /proc/cgroups (e.g. Azure Linux kernel).

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed