### PR TITLE
RavenDB-26305 ShardedDatabaseContext cleans its connections now

### DIFF
--- a/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
+++ b/src/Raven.Server/Documents/Sharding/ShardedDatabaseContext.cs
@@ -49,7 +49,7 @@ namespace Raven.Server.Documents.Sharding
 
         public readonly RachisLogIndexNotifications RachisLogIndexNotifications;
 
-        public readonly ConcurrentSet<TcpConnectionOptions> RunningTcpConnections = new ConcurrentSet<TcpConnectionOptions>();
+        public readonly ConcurrentSet<TcpConnectionOptions> RunningTcpConnections = new();
 
         public readonly MetricCounters Metrics;
 
@@ -243,6 +243,14 @@ namespace Raven.Server.Documents.Sharding
             var exceptionAggregator = new ExceptionAggregator(_logger, $"Could not dispose {nameof(ShardedDatabaseContext)} {DatabaseName}");
 
             exceptionAggregator.Execute(() => Replication?.Dispose());
+
+            foreach (var connection in RunningTcpConnections)
+            {
+                exceptionAggregator.Execute(() =>
+                {
+                    connection.Dispose();
+                });
+            }
 
             exceptionAggregator.Execute(() => ShardExecutor?.Dispose());
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26305/memdump-Unhandled-exception.-Sparrow.LowMemory.LowMemoryException-Detected-a-leak-on-TcpConnectionOptions

### Additional description

There are two sets of TCO on the sharded side:

1. `ShardedReplicationContext._incoming` drained by `AbstractReplicationLoader.Dispose()` 
2. `ShardedDatabaseContext.RunningTcpConnections`. Never drained on shutdown. 

For the 2nd point, there is no analogue to the `DocumentDatabase` which runs the `RunningTcpConnections` through:

https://github.com/ravendb/ravendb/blob/c35824c364b358dfcc218ad0bb2503c523ec0c9f/src/Raven.Server/Documents/DocumentDatabase.cs#L1003-L1009

In the happy path both are transitively disposed through the `_incoming` drain chain, but any `TCO` that is in `RunningTcpConnections` without being reachable through `_incoming` is orphaned when ShardedDatabaseContext disposes. Mirroring `DocumentDatabase`'s drain pattern closes all of these.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
