### PR TITLE
RavenDB-26334 Update vector search tests to enforce exact matches when searching through the entire database.

### DIFF
--- a/test/SlowTests/Corax/RavenDB-23453.cs
+++ b/test/SlowTests/Corax/RavenDB-23453.cs
@@ -30,6 +30,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
 
 
     [RavenTheory(RavenTestCategory.Querying | RavenTestCategory.Corax | RavenTestCategory.Vector)]
+    [InlineData(true, false, 1479157058)] //HNSW level-0 had unreachable nodes for this seed — see resultQueryContainsAllDb
     [InlineDataWithRandomSeed(true, false)]
     [InlineDataWithRandomSeed(false, true)]
     [InlineDataWithRandomSeed(true, true)]
@@ -95,7 +96,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
             {
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), 15L, 18L);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact, false, random: random);
+                var vecSearch = indexSearcher.VectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), vec1, 0.75f, 400, isExact: true, false, random: random);
                 IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
                 query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);
@@ -183,7 +184,7 @@ public class RavenDB_23453(ITestOutputHelper output) : StorageTest(output)
                 var betweenQuery = indexSearcher.BetweenQuery(mapping.GetByFieldId(2).Metadata.ChangeScoringMode(true), FilterMin, FilterMax);
                 var vec1 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[0].Vector), VectorOptions.Default);
                 var vec2 = GenerateEmbeddings.FromArray(indexSearcher.Transaction.Allocator, MemoryMarshal.Cast<float, byte>(docs[180].Vector), VectorOptions.Default);
-                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 400, isExact, false, random: random);
+                var vecSearch = indexSearcher.MultiVectorSearch(mapping.GetByFieldId(3).Metadata.ChangeScoringMode(true), [vec1, vec2], 0.75f, 400, isExact: true, false, random: random);
                 IQueryMatch query = indexSearcher.And(vecSearch, betweenQuery);
                 query = indexSearcher.OrderBy(query, [new OrderMetadata(true, MatchCompareFieldType.Score)], nullFirst: true);
                 resultQueryContainsAllDb = EvaluateQuery(indexSearcher, ref query);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26334

### Additional description

Sometimes it may happen during graph building phase that we will build it with a case when some nodes are undiscoverable from another. For the resultQueryContainsAllDb baseline we need a deterministic "scan every vector" pass regardless of the random seed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
