### PR TITLE
RavenDB-26459 ETL Configuration: fix typo

### DIFF
--- a/src/Raven.Server/Config/Categories/EtlConfiguration.cs
+++ b/src/Raven.Server/Config/Categories/EtlConfiguration.cs
@@ -8,13 +8,13 @@ namespace Raven.Server.Config.Categories
     [ConfigurationCategory(ConfigurationCategoryType.Etl)]
     public sealed class EtlConfiguration : ConfigurationCategory
     {
-        [Description("Number of seconds after which Raven ETL load request will timeout. Default: 300 seconds. Can be overriden by setting LoadRequestTimeoutInSec property value in Raven ETL configuration.")]
+        [Description("Number of seconds after which Raven ETL load request will time out. Default: 300 seconds. Can be overridden by setting the LoadRequestTimeoutInSec property in the Raven ETL configuration.")]
         [DefaultValue(300)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("ETL.Raven.LoadRequestTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]
         public TimeSetting RavenLoadRequestTimeout { get; set; }
 
-        [Description("Number of seconds after which SQL command will timeout. Default: null (use provider default). Can be overriden by setting CommandTimeout property value in SQL ETL configuration.")]
+        [Description("Number of seconds after which SQL command will time out. Default: null (use provider default). Can be overridden by setting the CommandTimeout property in the SQL ETL configuration.")]
         [DefaultValue(null)]
         [TimeUnit(TimeUnit.Seconds)]
         [ConfigurationEntry("ETL.SQL.CommandTimeoutInSec", ConfigurationEntryScope.ServerWideOrPerDatabase)]


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26459/ETL-Configuration-fix-typo

### Additional description
overriden => overridden
will timout => will time out

### Type of change
- [x] Bug fix=> usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
