### PR TITLE
Enable hierarchy aware queries OnlyOfType

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1508,10 +1508,17 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     DocumentQuery.Intersect();
                     _chainedWhere = false;
                     break;
-                case nameof(LinqExtensions.WhereClrTypeIs):
+                case nameof(LinqExtensions.OnlyOfType):
+                {
+                    Type onlyOfTypeTarget = expression.Method.GetGenericArguments()[0];
+                    if (expression.Arguments[0].Type.IsGenericType)
+                        DocumentQuery.AddRootType(expression.Arguments[0].Type.GetGenericArguments()[0]);
+                    if (_isSelectArg && expression.Type.IsGenericType)
+                        _ofType = expression.Type.GetGenericArguments()[0];
                     VisitExpression(expression.Arguments[0]);
-                    DocumentQuery.WhereClrTypeIs(expression.Method.GetGenericArguments()[1]);
+                    DocumentQuery.OnlyOfType(onlyOfTypeTarget);
                     break;
+                }
                 case nameof(RavenQueryableExtensions.In):
                     var memberInfo = GetMember(expression.Arguments[0]);
                     var objects = GetValueFromExpression(expression.Arguments[1], GetMemberType(memberInfo));

--- a/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryProviderProcessor.cs
@@ -1508,6 +1508,10 @@ The recommended method is to use full text search (mark the field as Analyzed an
                     DocumentQuery.Intersect();
                     _chainedWhere = false;
                     break;
+                case nameof(LinqExtensions.WhereClrTypeIs):
+                    VisitExpression(expression.Arguments[0]);
+                    DocumentQuery.WhereClrTypeIs(expression.Method.GetGenericArguments()[1]);
+                    break;
                 case nameof(RavenQueryableExtensions.In):
                     var memberInfo = GetMember(expression.Arguments[0]);
                     var objects = GetValueFromExpression(expression.Arguments[1], GetMemberType(memberInfo));

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -621,6 +621,18 @@ namespace Raven.Client.Documents
             return Search(self, fieldSelector, termToSearch, boost, options, @operator);
         }
 
+        /// <inheritdoc cref="IFilterDocumentQueryBase{T, TSelf}.WhereClrTypeIs{TDocument}"/>
+        public static IRavenQueryable<T> WhereClrTypeIs<T, TDocument>(this IQueryable<T> self)
+        {
+            var currentMethod = (MethodInfo)MethodBase.GetCurrentMethod();
+
+            currentMethod = ConvertMethodIfNecessary(currentMethod, new[] { typeof(T), typeof(TDocument) });
+            var expression = ConvertExpressionIfNecessary(self);
+
+            var queryable = self.Provider.CreateQuery(Expression.Call(null, currentMethod, expression));
+            return (IRavenQueryable<T>)queryable;
+        }
+
         /// <inheritdoc cref="IDocumentQueryBase{T, TSelf}.OrderByScore"/>
         public static IOrderedQueryable<T> OrderByScore<T>(this IQueryable<T> self)
         {

--- a/src/Raven.Client/Documents/LinqExtensions.cs
+++ b/src/Raven.Client/Documents/LinqExtensions.cs
@@ -621,16 +621,15 @@ namespace Raven.Client.Documents
             return Search(self, fieldSelector, termToSearch, boost, options, @operator);
         }
 
-        /// <inheritdoc cref="IFilterDocumentQueryBase{T, TSelf}.WhereClrTypeIs{TDocument}"/>
-        public static IRavenQueryable<T> WhereClrTypeIs<T, TDocument>(this IQueryable<T> self)
+        /// <inheritdoc cref="IDocumentQuery{T}.OnlyOfType{TDocument}"/>
+        public static IRavenQueryable<TDocument> OnlyOfType<TDocument>(this IQueryable source)
         {
             var currentMethod = (MethodInfo)MethodBase.GetCurrentMethod();
 
-            currentMethod = ConvertMethodIfNecessary(currentMethod, new[] { typeof(T), typeof(TDocument) });
-            var expression = ConvertExpressionIfNecessary(self);
+            currentMethod = ConvertMethodIfNecessary(currentMethod, typeof(TDocument));
 
-            var queryable = self.Provider.CreateQuery(Expression.Call(null, currentMethod, expression));
-            return (IRavenQueryable<T>)queryable;
+            var queryable = source.Provider.CreateQuery<TDocument>(Expression.Call(null, currentMethod, source.Expression));
+            return (IRavenQueryable<TDocument>)queryable;
         }
 
         /// <inheritdoc cref="IDocumentQueryBase{T, TSelf}.OrderByScore"/>

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -655,6 +655,19 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             tokens.AddLast(whereToken);
         }
 
+        public void WhereClrTypeIs(Type type)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+            var clrTypeName = Conventions.GetClrTypeName(type);
+            WhereEquals(new WhereParams
+            {
+                FieldName = "@metadata." + Constants.Documents.Metadata.RavenClrType,
+                Value = clrTypeName,
+                IsNestedPath = true
+            });
+        }
+
         private bool IfValueIsMethod(WhereOperator op, WhereParams whereParams, LinkedList<QueryToken> tokens)
         {
             if (whereParams.Value is MethodCall mc)

--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -655,7 +655,7 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             tokens.AddLast(whereToken);
         }
 
-        public void WhereClrTypeIs(Type type)
+        public void OnlyOfType(Type type)
         {
             if (type == null)
                 throw new ArgumentNullException(nameof(type));

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -135,10 +135,10 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.WhereClrTypeIs<TDocument>()
+        IAsyncDocumentQuery<TDocument> IAsyncDocumentQuery<T>.OnlyOfType<TDocument>()
         {
-            WhereClrTypeIs(typeof(TDocument));
-            return this;
+            OnlyOfType(typeof(TDocument));
+            return CreateDocumentQueryInternal<TDocument>();
         }
 
         /// <inheritdoc />

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -135,6 +135,13 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
+        IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.WhereClrTypeIs<TDocument>()
+        {
+            WhereClrTypeIs(typeof(TDocument));
+            return this;
+        }
+
+        /// <inheritdoc />
         IAsyncDocumentQuery<T> IFilterDocumentQueryBase<T, IAsyncDocumentQuery<T>>.WhereNotEquals(string fieldName, object value, bool exact)
         {
             WhereNotEquals(fieldName, value, exact);

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -475,6 +475,13 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
+        IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.WhereClrTypeIs<TDocument>()
+        {
+            WhereClrTypeIs(typeof(TDocument));
+            return this;
+        }
+
+        /// <inheritdoc />
         IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.WhereNotEquals(string fieldName, object value, bool exact)
         {
             WhereNotEquals(fieldName, value, exact);

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -475,10 +475,10 @@ namespace Raven.Client.Documents.Session
         }
 
         /// <inheritdoc />
-        IDocumentQuery<T> IFilterDocumentQueryBase<T, IDocumentQuery<T>>.WhereClrTypeIs<TDocument>()
+        IDocumentQuery<TDocument> IDocumentQuery<T>.OnlyOfType<TDocument>()
         {
-            WhereClrTypeIs(typeof(TDocument));
-            return this;
+            OnlyOfType(typeof(TDocument));
+            return CreateDocumentQueryInternal<TDocument>();
         }
 
         /// <inheritdoc />

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
@@ -274,7 +274,7 @@ namespace Raven.Client.Documents.Session
 
         void Intersect();
         void AddRootType(Type type);
-        void WhereClrTypeIs(Type type);
+        void OnlyOfType(Type type);
         void Distinct();
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAbstractDocumentQuery.cs
@@ -274,6 +274,7 @@ namespace Raven.Client.Documents.Session
 
         void Intersect();
         void AddRootType(Type type);
+        void WhereClrTypeIs(Type type);
         void Distinct();
 
         /// <summary>

--- a/src/Raven.Client/Documents/Session/IAsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IAsyncDocumentQuery.cs
@@ -173,6 +173,9 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         IAsyncDocumentQuery<TResult> OfType<TResult>();
 
+        /// <inheritdoc cref="IDocumentQuery{T}.OnlyOfType{TDocument}"/>
+        IAsyncDocumentQuery<TDocument> OnlyOfType<TDocument>();
+
         ///<inheritdoc cref="IDocumentQuery{T}.GroupBy(string,string[])"/>
         IAsyncGroupByDocumentQuery<T> GroupBy(string fieldName, params string[] fieldNames);
 

--- a/src/Raven.Client/Documents/Session/IDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQuery.cs
@@ -172,6 +172,17 @@ namespace Raven.Client.Documents.Session
         /// </summary>
         IDocumentQuery<TResult> OfType<TResult>();
 
+        /// <summary>
+        ///     Filters documents to those whose <c>@metadata.Raven-Clr-Type</c> equals the CLR type name of
+        ///     <typeparamref name="TDocument"/>, as produced by <see cref="Raven.Client.Documents.Conventions.DocumentConventions.FindClrTypeName"/>,
+        ///     and narrows the result element type to <typeparamref name="TDocument"/>.
+        ///     Unlike <c>OfType&lt;T&gt;()</c>, which only switches the client-side result type without filtering, this method
+        ///     emits a WHERE predicate against <c>@metadata.Raven-Clr-Type</c>.
+        ///     Note: when used against a static index, the index must expose <c>@metadata.Raven-Clr-Type</c> directly
+        ///     (via <c>MetadataFor(doc)["Raven-Clr-Type"]</c> without aliasing).
+        /// </summary>
+        IDocumentQuery<TDocument> OnlyOfType<TDocument>();
+
         /// <inheritdoc cref="IAbstractDocumentQuery{T}.GroupBy(string,string[])"/>
         IGroupByDocumentQuery<T> GroupBy(string fieldName, params string[] fieldNames);
 

--- a/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
@@ -196,17 +196,7 @@ namespace Raven.Client.Documents.Session
         /// <param name="whereParams">WhereParams containing query parameters.</param>
         TSelf WhereEquals(WhereParams whereParams);
 
-        /// <summary>
-        ///     Matches documents whose <c>@metadata.Raven-Clr-Type</c> equals the CLR type name of
-        ///     <typeparamref name="TDocument"/>, as produced by <see cref="Raven.Client.Documents.Conventions.DocumentConventions.FindClrTypeName"/>.
-        ///     This is the value stamped by the client when the document was stored.
-        ///     Complementary to <c>OfType&lt;T&gt;()</c>, which only switches the client-side result type without filtering.
-        ///     Note: when used against a static index, the index must expose <c>@metadata.Raven-Clr-Type</c> directly
-        ///     (via <c>MetadataFor(doc)["Raven-Clr-Type"]</c> without aliasing).
-        /// </summary>
-        TSelf WhereClrTypeIs<TDocument>();
-
-        /// <summary>
+/// <summary>
         ///     Matches documents with value of the chosen field different than the specified value.
         /// </summary>
         /// <param name="fieldName">Name of the field to get value from.</param>

--- a/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
+++ b/src/Raven.Client/Documents/Session/IDocumentQueryBase.cs
@@ -197,6 +197,16 @@ namespace Raven.Client.Documents.Session
         TSelf WhereEquals(WhereParams whereParams);
 
         /// <summary>
+        ///     Matches documents whose <c>@metadata.Raven-Clr-Type</c> equals the CLR type name of
+        ///     <typeparamref name="TDocument"/>, as produced by <see cref="Raven.Client.Documents.Conventions.DocumentConventions.FindClrTypeName"/>.
+        ///     This is the value stamped by the client when the document was stored.
+        ///     Complementary to <c>OfType&lt;T&gt;()</c>, which only switches the client-side result type without filtering.
+        ///     Note: when used against a static index, the index must expose <c>@metadata.Raven-Clr-Type</c> directly
+        ///     (via <c>MetadataFor(doc)["Raven-Clr-Type"]</c> without aliasing).
+        /// </summary>
+        TSelf WhereClrTypeIs<TDocument>();
+
+        /// <summary>
         ///     Matches documents with value of the chosen field different than the specified value.
         /// </summary>
         /// <param name="fieldName">Name of the field to get value from.</param>

--- a/test/FastTests/Client/Queries/OnlyOfTypeTests.cs
+++ b/test/FastTests/Client/Queries/OnlyOfTypeTests.cs
@@ -9,6 +9,19 @@ namespace FastTests.Client.Queries
 {
     public class OnlyOfTypeTests(ITestOutputHelper output) : RavenTestBase(output)
     {
+        
+        /// <summary>
+        /// Options assigning both, <see cref="Animal"/> and <see cref="Dog"/> under one
+        /// </summary>
+        private static readonly Options CollectionAwareOptions = new()
+        {
+            ModifyDocumentStore = store =>
+                store.Conventions.FindCollectionName = type =>
+                    typeof(Animal).IsAssignableFrom(type)
+                        ? "Animals"
+                        : DocumentConventions.DefaultGetCollectionName(type)
+        };
+
         private class Animal
         {
             public string Name { get; set; }
@@ -74,16 +87,7 @@ namespace FastTests.Client.Queries
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
         public void EndToEnd_FiltersByClrType()
         {
-            var options = new Options
-            {
-                ModifyDocumentStore = store =>
-                    store.Conventions.FindCollectionName = type =>
-                        typeof(Animal).IsAssignableFrom(type)
-                            ? "Animals"
-                            : DocumentConventions.DefaultGetCollectionName(type)
-            };
-
-            using (var store = GetDocumentStore(options))
+            using (var store = GetDocumentStore(CollectionAwareOptions))
             {
                 using (var session = store.OpenSession())
                 {
@@ -108,16 +112,7 @@ namespace FastTests.Client.Queries
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
         public void EndToEnd_NarrowsElementType()
         {
-            var options = new Options
-            {
-                ModifyDocumentStore = store =>
-                    store.Conventions.FindCollectionName = type =>
-                        typeof(Animal).IsAssignableFrom(type)
-                            ? "Animals"
-                            : DocumentConventions.DefaultGetCollectionName(type)
-            };
-
-            using (var store = GetDocumentStore(options))
+            using (var store = GetDocumentStore(CollectionAwareOptions))
             {
                 using (var session = store.OpenSession())
                 {
@@ -142,16 +137,7 @@ namespace FastTests.Client.Queries
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
         public void EndToEnd_ComposedWithSelect()
         {
-            var options = new Options
-            {
-                ModifyDocumentStore = store =>
-                    store.Conventions.FindCollectionName = type =>
-                        typeof(Animal).IsAssignableFrom(type)
-                            ? "Animals"
-                            : DocumentConventions.DefaultGetCollectionName(type)
-            };
-
-            using (var store = GetDocumentStore(options))
+            using (var store = GetDocumentStore(CollectionAwareOptions))
             {
                 using (var session = store.OpenSession())
                 {

--- a/test/FastTests/Client/Queries/OnlyOfTypeTests.cs
+++ b/test/FastTests/Client/Queries/OnlyOfTypeTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace FastTests.Client.Queries
 {
-    public class WhereClrTypeIsTests(ITestOutputHelper output) : RavenTestBase(output)
+    public class OnlyOfTypeTests(ITestOutputHelper output) : RavenTestBase(output)
     {
         private class Animal
         {
@@ -30,7 +30,7 @@ namespace FastTests.Client.Queries
             using (var store = GetDocumentStore())
             using (var session = store.OpenSession())
             {
-                var query = session.Query<Animal>().WhereClrTypeIs<Animal, Dog>();
+                var query = session.Query<Animal>().OnlyOfType<Dog>();
                 Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", query.ToString());
             }
         }
@@ -41,7 +41,7 @@ namespace FastTests.Client.Queries
             using (var store = GetDocumentStore())
             using (var session = store.OpenSession())
             {
-                var query = session.Advanced.DocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                var query = session.Advanced.DocumentQuery<Animal>().OnlyOfType<Dog>();
                 Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", query.ToString());
             }
         }
@@ -52,7 +52,7 @@ namespace FastTests.Client.Queries
             using (var store = GetDocumentStore())
             using (var session = store.OpenAsyncSession())
             {
-                var query = session.Advanced.AsyncDocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                var query = session.Advanced.AsyncDocumentQuery<Animal>().OnlyOfType<Dog>();
                 Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", query.ToString());
             }
         }
@@ -63,7 +63,7 @@ namespace FastTests.Client.Queries
             using (var store = GetDocumentStore())
             using (var session = store.OpenSession())
             {
-                var query = session.Advanced.DocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                var query = session.Advanced.DocumentQuery<Animal>().OnlyOfType<Dog>();
                 var iq = query.GetIndexQuery();
                 Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", iq.Query);
                 var expectedClrTypeName = store.Conventions.GetClrTypeName(typeof(Dog));
@@ -95,7 +95,7 @@ namespace FastTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var dogs = session.Query<Animal>()
-                        .WhereClrTypeIs<Animal, Dog>()
+                        .OnlyOfType<Dog>()
                         .Customize(x => x.WaitForNonStaleResults())
                         .ToList();
 
@@ -106,7 +106,7 @@ namespace FastTests.Client.Queries
         }
 
         [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
-        public void EndToEnd_ComposedWithOfType()
+        public void EndToEnd_NarrowsElementType()
         {
             var options = new Options
             {
@@ -129,9 +129,8 @@ namespace FastTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var dogs = session.Query<Animal>()
-                        .WhereClrTypeIs<Animal, Dog>()
+                        .OnlyOfType<Dog>()
                         .Customize(x => x.WaitForNonStaleResults())
-                        .OfType<Dog>()
                         .ToList();
 
                     Assert.Equal(1, dogs.Count);
@@ -164,7 +163,7 @@ namespace FastTests.Client.Queries
                 using (var session = store.OpenSession())
                 {
                     var views = session.Query<Animal>()
-                        .WhereClrTypeIs<Animal, Dog>()
+                        .OnlyOfType<Dog>()
                         .Customize(x => x.WaitForNonStaleResults())
                         .Select(x => new AnimalView { Name = x.Name })
                         .ToList();
@@ -198,7 +197,7 @@ namespace FastTests.Client.Queries
             using (var store = GetDocumentStore(options))
             using (var session = store.OpenSession())
             {
-                var query = session.Advanced.DocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                var query = session.Advanced.DocumentQuery<Animal>().OnlyOfType<Dog>();
                 var iq = query.GetIndexQuery();
                 Assert.Equal(customTypeName, iq.QueryParameters["p0"]);
             }

--- a/test/FastTests/Client/Queries/OnlyOfTypeTests.cs
+++ b/test/FastTests/Client/Queries/OnlyOfTypeTests.cs
@@ -9,7 +9,6 @@ namespace FastTests.Client.Queries
 {
     public class OnlyOfTypeTests(ITestOutputHelper output) : RavenTestBase(output)
     {
-        
         /// <summary>
         /// Options assigning both, <see cref="Animal"/> and <see cref="Dog"/> under one
         /// </summary>

--- a/test/FastTests/Client/Queries/WhereClrTypeIsTests.cs
+++ b/test/FastTests/Client/Queries/WhereClrTypeIsTests.cs
@@ -7,12 +7,8 @@ using Xunit;
 
 namespace FastTests.Client.Queries
 {
-    public class WhereClrTypeIsTests : RavenTestBase
+    public class WhereClrTypeIsTests(ITestOutputHelper output) : RavenTestBase(output)
     {
-        public WhereClrTypeIsTests(ITestOutputHelper output) : base(output)
-        {
-        }
-
         private class Animal
         {
             public string Name { get; set; }

--- a/test/FastTests/Client/Queries/WhereClrTypeIsTests.cs
+++ b/test/FastTests/Client/Queries/WhereClrTypeIsTests.cs
@@ -1,0 +1,211 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Conventions;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace FastTests.Client.Queries
+{
+    public class WhereClrTypeIsTests : RavenTestBase
+    {
+        public WhereClrTypeIsTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Animal
+        {
+            public string Name { get; set; }
+        }
+
+        private class Dog : Animal
+        {
+            public string Breed { get; set; }
+        }
+
+        private class AnimalView
+        {
+            public string Name { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void RqlGeneration_LinqForm()
+        {
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                var query = session.Query<Animal>().WhereClrTypeIs<Animal, Dog>();
+                Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", query.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void RqlGeneration_FluentSyncForm()
+        {
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.DocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", query.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public async Task RqlGeneration_FluentAsyncForm()
+        {
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenAsyncSession())
+            {
+                var query = session.Advanced.AsyncDocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", query.ToString());
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void RqlGeneration_ParameterValueMatchesConvention()
+        {
+            using (var store = GetDocumentStore())
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.DocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                var iq = query.GetIndexQuery();
+                Assert.Equal("from 'Animals' where @metadata.Raven-Clr-Type = $p0", iq.Query);
+                var expectedClrTypeName = store.Conventions.GetClrTypeName(typeof(Dog));
+                Assert.Equal(expectedClrTypeName, iq.QueryParameters["p0"]);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void EndToEnd_FiltersByClrType()
+        {
+            var options = new Options
+            {
+                ModifyDocumentStore = store =>
+                    store.Conventions.FindCollectionName = type =>
+                        typeof(Animal).IsAssignableFrom(type)
+                            ? "Animals"
+                            : DocumentConventions.DefaultGetCollectionName(type)
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Animal { Name = "Generic" });
+                    session.Store(new Dog { Name = "Rex", Breed = "Labrador" });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var dogs = session.Query<Animal>()
+                        .WhereClrTypeIs<Animal, Dog>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .ToList();
+
+                    Assert.Equal(1, dogs.Count);
+                    Assert.Equal("Rex", dogs[0].Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void EndToEnd_ComposedWithOfType()
+        {
+            var options = new Options
+            {
+                ModifyDocumentStore = store =>
+                    store.Conventions.FindCollectionName = type =>
+                        typeof(Animal).IsAssignableFrom(type)
+                            ? "Animals"
+                            : DocumentConventions.DefaultGetCollectionName(type)
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Animal { Name = "Generic" });
+                    session.Store(new Dog { Name = "Rex", Breed = "Labrador" });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var dogs = session.Query<Animal>()
+                        .WhereClrTypeIs<Animal, Dog>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .OfType<Dog>()
+                        .ToList();
+
+                    Assert.Equal(1, dogs.Count);
+                    Assert.Equal("Labrador", dogs[0].Breed);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void EndToEnd_ComposedWithSelect()
+        {
+            var options = new Options
+            {
+                ModifyDocumentStore = store =>
+                    store.Conventions.FindCollectionName = type =>
+                        typeof(Animal).IsAssignableFrom(type)
+                            ? "Animals"
+                            : DocumentConventions.DefaultGetCollectionName(type)
+            };
+
+            using (var store = GetDocumentStore(options))
+            {
+                using (var session = store.OpenSession())
+                {
+                    session.Store(new Animal { Name = "Generic" });
+                    session.Store(new Dog { Name = "Rex", Breed = "Labrador" });
+                    session.SaveChanges();
+                }
+
+                using (var session = store.OpenSession())
+                {
+                    var views = session.Query<Animal>()
+                        .WhereClrTypeIs<Animal, Dog>()
+                        .Customize(x => x.WaitForNonStaleResults())
+                        .Select(x => new AnimalView { Name = x.Name })
+                        .ToList();
+
+                    Assert.Equal(1, views.Count);
+                    Assert.Equal("Rex", views[0].Name);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void EndToEnd_ConventionOverride_UsesCustomClrTypeName()
+        {
+            const string customTypeName = "my-custom-dog-type";
+
+            var options = new Options
+            {
+                ModifyDocumentStore = store =>
+                {
+                    store.Conventions.FindCollectionName = type =>
+                        typeof(Animal).IsAssignableFrom(type)
+                            ? "Animals"
+                            : DocumentConventions.DefaultGetCollectionName(type);
+                    store.Conventions.FindClrTypeName = type =>
+                        type == typeof(Dog)
+                            ? customTypeName
+                            : DocumentConventions.DefaultGetCollectionName(type);
+                }
+            };
+
+            using (var store = GetDocumentStore(options))
+            using (var session = store.OpenSession())
+            {
+                var query = session.Advanced.DocumentQuery<Animal>().WhereClrTypeIs<Dog>();
+                var iq = query.GetIndexQuery();
+                Assert.Equal(customTypeName, iq.QueryParameters["p0"]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-...

### Additional description

...Include details of the change made in this Pull Request or additional notes for the solution. Anything that can be useful for reviewers of this PR...

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [ ] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [ ] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
