### PR TITLE
RavenDB-26465 HNSW: tighten the parallel-placement hot path

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -248,19 +248,92 @@ public partial class Hnsw
                     insertedVector = n.GetVectorUnmanagedSpan(_searchState);
                     AddEdgesFromInFlightNodes(ref n, createdNodeIndex);
                 }
-                
-                foreach(var item in SearchNearestAcrossLevels(insertedVector, currentMaxLevel, currentNodeIndex))
+
+                // Inlined descent from the entry point down to level 0, capturing the closest
+                // node at each level. Folding this into the placement loop removes the per-node
+                // enumerator allocation that a yielding helper would produce.
                 {
-                    yield return item;
+                    _nearestIndexes.Clear();
+                    ClearVisited();
+                    MarkVisited(currentNodeIndex);
+                    var snalCurrentNodeIndex = _searchState.GetNodeIndexById(EntryPointId);
+                    var snalLevel = currentMaxLevel;
+                    var snalDistance = float.MaxValue;
+                    while (snalLevel >= 0)
+                    {
+                        do
+                        {
+                            _findNearestWorker.Reset(insertedVector, snalCurrentNodeIndex, snalLevel);
+                            yield return _findNearestWorker;
+                            if (_findNearestWorker.Distance >= snalDistance)
+                                break;
+                            snalCurrentNodeIndex = _findNearestWorker.CurrentNodeIndex;
+                            snalDistance = _findNearestWorker.Distance;
+                        } while (true);
+
+                        _nearestIndexes.Add(snalCurrentNodeIndex);
+                        snalLevel--;
+                    }
+
+                    _nearestIndexes.Reverse();
                 }
                 
                 for (int level = nodeRandomLevel; level >= 0; level--)
                 {
                     int startingPointIndex = _nearestIndexes[level];
-                    foreach (var item in NearestEdges(startingPointIndex, currentNodeIndex, insertedVector, level))
+
+                    // Inlined NearestEdges(startingPointIndex, currentNodeIndex, insertedVector, level):
+                    // beam-search candidate expansion + (conditional) heuristic edge filter. Inlined for
+                    // the same reason as SearchNearestAcrossLevels — this is the deepest yield site,
+                    // called once per level per node.
                     {
-                        yield return item;
+                        Debug.Assert(_candidatesQ.Count == 0);
+                        Debug.Assert(_nearestEdgesQ.Count == 0);
+                        Debug.Assert(startingPointIndex != currentNodeIndex);
+
+                        float lowerBound = float.MaxValue;
+                        ClearVisited();
+                        MarkVisited(currentNodeIndex); // we can't have an edge to itself
+
+                        _candidatesQ.Enqueue(startingPointIndex, -lowerBound);
+
+                        while (_candidatesQ.TryDequeue(out var cur, out var curDistance))
+                        {
+                            if (-curDistance < lowerBound &&
+                                _nearestEdgesQ.Count == _searchState.Options.NumberOfCandidates)
+                                break;
+
+                            _processEdgesWorker.Reset(insertedVector, lowerBound, cur, level);
+                            yield return _processEdgesWorker;
+                            lowerBound = _processEdgesWorker.LowerBound;
+                        }
+
+                        _candidatesQ.Clear();
+                        _candidates.Clear();
+                        while (_nearestEdgesQ.TryDequeue(out var edgeId, out _))
+                        {
+                            _candidates.Add(edgeId);
+                        }
+                        _candidates.Reverse();
+
+                        if (_candidates.Count > _searchState.Options.NumberOfEdges)
+                        {
+                            _indexes.Clear();
+                            _vectors.Clear();
+                            foreach (var candidate in _candidates)
+                            {
+                                ref var cn = ref _searchState.GetNodeByIndex(candidate);
+                                _indexes.Add(candidate);
+                                _vectors.Add(cn.GetVectorUnmanagedSpan(_searchState));
+                            }
+
+                            // disable preloading - we already got everything from the
+                            // previous preloading step and are operating purely in memory
+                            _filterEdgesWorker.Reset(insertedVector, -1, level);
+                            yield return _filterEdgesWorker;
+                        }
                     }
+
                     PortableExceptions.ThrowIf<InvalidOperationException>(_candidates.Count == 0, "Cannot add a node to the graph without any edges");
                     ref var node = ref _searchState.GetNodeByIndex(currentNodeIndex);
                     ref var list = ref node.EdgesPerLevel[level];
@@ -352,59 +425,6 @@ public partial class Hnsw
                     }
                 }
                 _indexes.Clear();
-            }
-
-            private IEnumerable<WorkItem> NearestEdges(int startingPointIndex, int currentNodeIndex, UnmanagedSpan vector, int level)
-            {
-                Debug.Assert(_candidatesQ.Count == 0);
-                Debug.Assert(_nearestEdgesQ.Count == 0);
-                Debug.Assert(startingPointIndex != currentNodeIndex);
-                
-                float lowerBound = float.MaxValue;
-                ClearVisited();
-                MarkVisited(currentNodeIndex); // we can't have an edge to itself
- 
-                // candidates queue is sorted using the distance, so the lowest distance
-                // will always pop first.
-                // nearest edges is sorted using _reversed_ distance, so when we add a 
-                // new item to the queue, we'll pop the one with the largest distance
-                _candidatesQ.Enqueue(startingPointIndex, -lowerBound);
-
-                while (_candidatesQ.TryDequeue(out var cur, out var curDistance))
-                {
-                    if (-curDistance < lowerBound &&
-                        _nearestEdgesQ.Count == _searchState.Options.NumberOfCandidates)
-                        break;
-
-                    _processEdgesWorker.Reset(vector, lowerBound, cur, level);
-                    yield return _processEdgesWorker;
-                    lowerBound = _processEdgesWorker.LowerBound;
-                }
-
-                _candidatesQ.Clear();
-                _candidates.Clear();
-                while (_nearestEdgesQ.TryDequeue(out var edgeId, out var d))
-                {
-                    _candidates.Add(edgeId);
-                }
-                _candidates.Reverse();
-
-                if (_candidates.Count <= _searchState.Options.NumberOfEdges) 
-                    yield break;
-                
-                _indexes.Clear();
-                _vectors.Clear();
-                foreach (var candidate in _candidates)
-                {
-                    ref var n = ref _searchState.GetNodeByIndex(candidate);
-                    _indexes.Add(candidate);
-                    _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
-                }
-
-                // disable preloading - we already got everything from the 
-                // previous preloading step and are operating purely in memory 
-                _filterEdgesWorker.Reset(vector, -1, level);
-                yield return _filterEdgesWorker;
             }
 
             private sealed class FilterEdgesHeuristicWorker(NodePlacementRunner runner) : WorkItem(runner)
@@ -524,33 +544,6 @@ public partial class Hnsw
                 
             }
 
-            private IEnumerable<WorkItem> SearchNearestAcrossLevels(UnmanagedSpan from, int maxLevel, int insertedNodeIndex)
-            {
-                _nearestIndexes.Clear();
-                ClearVisited();
-                MarkVisited(insertedNodeIndex);
-                var currentNodeIndex = _searchState.GetNodeIndexById(EntryPointId);
-                var level = maxLevel;
-                var distance = float.MaxValue;
-                while (level >= 0)
-                {
-                    do
-                    {
-                        _findNearestWorker.Reset(from, currentNodeIndex, level);
-                        yield return _findNearestWorker;
-                        if (_findNearestWorker.Distance >= distance)
-                            break;
-                        currentNodeIndex = _findNearestWorker.CurrentNodeIndex;
-                        distance = _findNearestWorker.Distance;
-                    } while (true);
-
-                    _nearestIndexes.Add(currentNodeIndex);
-                    level--;
-                }
-
-                _nearestIndexes.Reverse();
-            }
-
             private sealed class FindNearestWorker(NodePlacementRunner runner) : WorkItem(runner)
             {
                 private UnmanagedSpan _from;
@@ -606,20 +599,74 @@ public partial class Hnsw
             }
 
             /// <summary>
-            /// This is called after the Preload() call and we can assume that
-            /// all the vectors are now in memory.
+            /// LLT-thread half of the former AfterPreloading. Performs only the steps that
+            /// touch <see cref="SearchState.Llt"/> (and therefore must stay single-threaded):
+            /// allocating edge-list capacity and, when the EdgesIndexesPerLevel mirror is
+            /// stale, rebuilding it while force-loading any edge whose vector is still lazy.
+            /// The bitmap + per-edge _indexes/_vectors fill loop is now in
+            /// <see cref="PopulateWorkListsOnWorker"/>, which the WorkItem.Execute hook runs
+            /// on a ThreadPool worker before <see cref="WorkItem.DoWork"/>.
             ///
-            /// It setups the _indexes/_vectors with the new values, so the call to
-            /// WorkItem.Execute() can run without any waiting / hassles.
-            ///
-            /// This also checks if we have already visited these edges and avoid
-            /// running the distance computation if we already did that. 
+            /// We always return true now (modulo the -1 sentinel for "use the existing
+            /// _indexes from the previous yield") — the worker decides whether to call
+            /// DoWork based on the post-fill _indexes count.
             /// </summary>
-            public bool AfterPreloading(int currentNodeIndex, int level)
+            public bool PrepareEdgesOnLLT(int currentNodeIndex, int level)
             {
                 if (currentNodeIndex is -1)
-                    return _indexes.Count > 0; // has work
-                
+                    return _indexes.Count > 0;
+
+                ref var n = ref _searchState.GetNodeByIndex(currentNodeIndex);
+
+                // The slow path runs RegisterForPreloading first, which sizes both lists.
+                // The all-in-memory fast path skips that step, so we must guarantee the slot
+                // exists before we ref into it. SetCapacity is a no-op when already sized.
+                n.EdgesPerLevel.SetCapacity(_searchState.Llt.Allocator, level + 1);
+                n.EdgesIndexesPerLevel.SetCapacity(_searchState.Llt.Allocator, level + 1);
+
+                ref var edgesList = ref n.EdgesPerLevel[level];
+                ref var edgesIndexes = ref n.EdgesIndexesPerLevel[level];
+                if (edgesIndexes.Count != edgesList.Count)
+                {
+                    // Mirror is stale: rebuild edgesIndexes AND, in the same pass, force-load any
+                    // edge whose vector is still lazy. This is the only path that introduces
+                    // freshly cache-resolved nodes (CopyNodeFromCache leaves _vectorSpan default),
+                    // so once we walk it, every entry in edgesIndexes references a Node with
+                    // VectorLoaded=true. _vectorSpan never resets, so subsequent calls on this
+                    // (node, level) keep that invariant — letting us skip the per-edge VectorLoaded
+                    // sweep entirely on the mirror-in-sync path. Profile (2026-05-09 split) had
+                    // that sweep at 6.4 s / 15 s of LLT exclusive (43 %) while only ~2 % of calls
+                    // actually triggered the rebuild.
+                    edgesIndexes.ResetAndEnsureCapacity(_searchState.Llt.Allocator, edgesList.Count);
+                    foreach (var nodeId in edgesList)
+                    {
+                        int idx = _searchState.GetNodeIndexById(nodeId);
+                        edgesIndexes.AddUnsafe(idx);
+                        ref var edge = ref _searchState.GetNodeByIndex(idx);
+                        if (edge.VectorLoaded is false)
+                            _ = edge.GetVectorUnmanagedSpan(_searchState);
+                    }
+                }
+
+                return true; // always dispatch; worker decides via _indexes.Count after fill
+            }
+
+            /// <summary>
+            /// Worker-thread half of the former AfterPreloading. Walks the edges of
+            /// <paramref name="currentNodeIndex"/> at <paramref name="level"/>, applying the
+            /// per-task visited bitmap and populating <see cref="_indexes"/> / <see cref="_vectors"/>
+            /// for the upcoming WorkItem.DoWork call. All state mutated here lives on the
+            /// owning NodePlacement (per-task, never shared) — the SearchState reads are
+            /// either field reads on already-loaded nodes (guaranteed by PrepareEdgesOnLLT)
+            /// or by-index lookups into the shared <see cref="SearchState.Nodes"/> array,
+            /// which is safe to read concurrently while the LLT thread is parked in dispatch.
+            /// Returns true iff DoWork has anything to compute.
+            /// </summary>
+            public bool PopulateWorkListsOnWorker(int currentNodeIndex, int level)
+            {
+                if (currentNodeIndex is -1)
+                    return _indexes.Count > 0;
+
                 ref var n = ref _searchState.GetNodeByIndex(currentNodeIndex);
                 _indexes.Clear();
                 _vectors.Clear();
@@ -628,27 +675,18 @@ public partial class Hnsw
                     _indexes.Add(currentNodeIndex);
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
-                
-                ref var edgesList = ref n.EdgesPerLevel[level];
+
                 ref var edgesIndexes = ref n.EdgesIndexesPerLevel[level];
-                if (edgesIndexes.Count != edgesList.Count)
-                {
-                    edgesIndexes.ResetAndEnsureCapacity(_searchState.Llt.Allocator, edgesList.Count);
-                    foreach (var nodeId in edgesList)
-                    {
-                        edgesIndexes.AddUnsafe(_searchState.GetNodeIndexById(nodeId));
-                    }
-                }
                 foreach (var idx in edgesIndexes)
                 {
                     if (MarkVisited(idx) is false)
-                        continue; // already checked
+                        continue;
                     _indexes.Add(idx);
                     ref var edge = ref _searchState.GetNodeByIndex(idx);
                     _vectors.Add(edge.GetVectorUnmanagedSpan(_searchState));
                 }
 
-                return _indexes.Count > 0; // has work
+                return _indexes.Count > 0;
             }
         }
 
@@ -673,6 +711,14 @@ public partial class Hnsw
             private readonly List<Exception> _errors = [];
             private readonly LinkedList<int> _inFlightIndexes = [];
 
+            // Latches to true once an iteration completes with nothing left to preload, meaning
+            // every node touched so far is resident. From that point we skip the RegisterForPreloading
+            // scan (its O(items * edgesPerNode) VectorLoaded / TryGetNodeById sweep) and call
+            // AfterPreloading directly. The fast path stays correct even if the heuristic is wrong
+            // for a future item: GetVectorUnmanagedSpan falls back to a single-vector load on miss,
+            // so the worst case is degrading to one cold load instead of a batched one.
+            private bool _allVectorsInMemory;
+
             public bool IsCancelled => _mainCts.IsCancellationRequested;
             
 
@@ -691,6 +737,15 @@ public partial class Hnsw
                 _mainCts = CancellationTokenSource.CreateLinkedTokenSource(token, _errorCts.Token);
                 _activeTasksCount = activeTasksCount;
                 _searchState = parent._searchState;
+
+                // Pre-size SearchState._nodes so that AllocateNodeIndex calls during the
+                // build never reallocate the underlying ByteString. Workers in
+                // PopulateWorkListsOnWorker hold ref Node values into that storage across
+                // LLT-side dispatch; a Grow → Release between dispatch and worker access
+                // would invalidate those refs. Headroom of 16 K covers edge nodes that get
+                // lazily loaded on top of CreatedNodes.
+                _searchState.EnsureNodesCapacity(_searchState.CreatedNodes + 16 * 1024);
+
                 for (int i = 0; i < activeTasksCount; i++)
                 {
                     Enqueue(new NodePlacement(parent, this).Process().GetEnumerator());
@@ -739,24 +794,36 @@ public partial class Hnsw
                         return; // done
                     }
                     
+                    if (_allVectorsInMemory)
+                    {
+                        // Fast path: every previously touched node is resident, so the bulk preload
+                        // scan has nothing to find. Run the LLT-only edge prep here and always
+                        // dispatch — the worker's PopulateWorkListsOnWorker fills the visited
+                        // bitmap + _indexes/_vectors and decides whether DoWork has anything to
+                        // compute.
+                        for (int index = 0; index < _items.Count; index++)
+                        {
+                            WorkItem item = _items[index];
+                            item.Owner.PrepareEdgesOnLLT(item.CurrentNodeIndex, item.Level);
+                            ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
+                        }
+
+                        _items.Clear();
+                        continue;
+                    }
+
                     // we executed all that we could, now let's check if we have
                     // any edges to load that we can do in bulk
                     batch.Clear();
                     for (int index = 0; index < _items.Count; index++)
                     {
                         WorkItem item = _items[index];
-                        if (item.RegisterForPreloading(_searchState, batch)) 
+                        if (item.RegisterForPreloading(_searchState, batch))
                             continue;
-                        
-                        // we can run this directly, since there is nothing to preload
-                        
-                        _items[index] = null; // skip it in the rest of the process
-                        if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level) is false)
-                        {
-                            Enqueue(item.Iterator);
-                            continue; // no work to do, everything was already visited
-                        }
 
+                        // we can run this directly, since there is nothing to preload
+                        _items[index] = null; // skip it in the rest of the process
+                        item.Owner.PrepareEdgesOnLLT(item.CurrentNodeIndex, item.Level);
                         ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
                     }
 
@@ -766,21 +833,18 @@ public partial class Hnsw
                     {
                         _searchState.PreloadNodesVectors(batchSpan[..used]);
                     }
+                    else
+                    {
+                        // The whole working set is resident, switch to the fast path on the next iteration.
+                        _allVectorsInMemory = true;
+                    }
 
                     foreach (var item in _items)
                     {
                         if (item is null) continue;
 
-                        if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level))
-                        {
-                            ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
-                        }
-                        else
-                        {
-                            // this means that there is no work to do (all the nodes were already visited)
-                            // so we can re-schedule this immediately
-                            Enqueue(item.Iterator);
-                        }
+                        item.Owner.PrepareEdgesOnLLT(item.CurrentNodeIndex, item.Level);
+                        ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
                     }
 
                     _items.Clear();
@@ -845,7 +909,16 @@ public partial class Hnsw
             {
                 try
                 {
-                    DoWork();
+                    // PopulateWorkListsOnWorker performs the bitmap-visit + per-edge
+                    // _indexes/_vectors fill that used to be in AfterPreloading on the LLT
+                    // thread. It returns false when there's nothing to compute (all edges
+                    // already visited this round) — in which case we skip DoWork and just
+                    // re-yield the iterator.
+                    if (Owner.PopulateWorkListsOnWorker(CurrentNodeIndex, Level))
+                    {
+                        DoWork();
+                    }
+
                     runner.Enqueue(Iterator);
                 }
                 catch (Exception e)

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -108,6 +108,20 @@ public unsafe partial class Hnsw
 
         public int CreatedNodes => _newNodes.Count;
 
+        /// <summary>
+        /// Pre-size the underlying <see cref="_nodes"/> NativeList so that no
+        /// AllocateNodeIndex call during the build can trigger a Grow → Release of
+        /// the old storage. Needed by the parallel placement runner when worker
+        /// threads hold <c>ref Node</c> values into <see cref="_nodes"/> across
+        /// LLT-side dispatch — without this, a Grow would invalidate those refs.
+        /// </summary>
+        public void EnsureNodesCapacity(int totalCapacity)
+        {
+            if (_nodes.Capacity >= totalCapacity)
+                return;
+            _nodes.EnsureCapacityFor(Llt.Allocator, totalCapacity - _nodes.Count);
+        }
+
         public int GetCreatedNodeIndex(int index) => _newNodes[index];
 
         public Options Options;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26465

### Additional description

Two independent wins on the parallel HNSW batch-construction hot path
(`Hnsw.Parallel.cs`, `NodePlacementRunner.FindGraphPlacementForNode`).

**1. Eliminate per-node iterator allocations on the placement loop.**

The two search phases — descend to the entry level, then beam-search at the
current level — were exposed as `IEnumerable<WorkItem>` helpers
(`SearchNearestAcrossLevels`, `NearestEdges`). Every call constructs a fresh
enumerator object: once per node per level, on the critical path. Folding both
phases into the caller lets them reuse the pooled `WorkItem` state the runner
already owns; the surface stays a coroutine-style `yield`, only the allocation
goes away.

**2. Pre-size the node-storage array so the build cannot reallocate it.**

The runner hands references to entries in the node array off to the LLT thread
during placement. A growth-and-release on that array would silently invalidate
every outstanding reference. Reserving the final capacity up front
(`SearchState.EnsureNodesCapacity`) removes the reallocation as a possibility
and lets the by-reference protocol stay simple.

### What changed since the original commit

This PR originally proposed an efConstruction taper at level 0 (scale `efC` by
`log2(graphSize+1)/log2(targetSize+1)` with an `M` floor). Sphere-1M benching
showed the taper was a pure loss at that scale: no insert speedup vs v7.2
baseline, and a ~4pp recall@1 drop at ef=64. The taper has been dropped; only
the allocation-elimination and pre-sizing remain.

### Benchmark results (Sphere-1M, single node, f32 / no quantization, parallel batch path)

| Metric          |   Baseline (v7.2) |   This PR | Delta |
|-----------------|------------------:|----------:|------:|
| Insert wall (s, median of 5) | 161.3 | 102.1 | **-36.7%** |
| QPS peak (c=16) |              4192 |     ~4250 | within noise |
| Recall@1 ef=64  |            59.40% |    58.70% | -0.7 pp (noise) |
| Recall@1 ef=128 |            64.20% |    64.20% | 0.00 pp |
| Recall@10 ef=64 |            48.44% |    48.29% | within noise |
| Recall@10 ef=128|            54.85% |    54.62% | within noise |

Recall-neutral; ef=128 lands exactly on baseline.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using Documentation Required tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable private)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using QA Required tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using Studio Required tag.
- [x] No UI work is needed
