### PR TITLE
RavenDB-26452 Snapshot & fork AI Conversations

### DIFF
--- a/src/Raven.Client/Documents/AI/AiAnswer.cs
+++ b/src/Raven.Client/Documents/AI/AiAnswer.cs
@@ -29,4 +29,25 @@ public class AiAnswer<TAnswer>
     /// The total time elapsed to produce the answer(measured from the server's request to the LLM until the response was received).
     /// </summary>
     public TimeSpan Elapsed;
+
+    /// <summary>
+    /// An opaque token that captures the conversation state <em>before</em> the current turn was processed.
+    /// Pass this token to <see cref="AiOperations.ForkConversationAsync"/> to create a new conversation
+    /// that branches from this point — the forked conversation will contain all messages up to (but not
+    /// including) the prompt that produced this answer.
+    ///
+    /// <para>
+    /// This property is only populated when the conversation was opened with
+    /// <see cref="AiConversationCreationOptions.SnapshotBeforeRunning"/> set to <c>true</c>.
+    /// It is <c>null</c> when snapshots are disabled or when the conversation is brand-new
+    /// (no prior state to snapshot).
+    /// </para>
+    ///
+    /// <para>
+    /// The token references document revisions. If those revisions are purged (by the revisions
+    /// retention policy or by <see cref="AiOperations.PurgeConversationSnapshotsAsync"/>),
+    /// the token becomes invalid and <see cref="AiOperations.ForkConversationAsync"/> will fail.
+    /// </para>
+    /// </summary>
+    public string SnapshotToken;
 }

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -100,7 +100,21 @@ internal class AiConversation : IAiConversationOperations
             return _conversationId;
         }
     }
-    
+
+    public async Task<AiConversationSnapshot> CreateSnapshotAsync(CancellationToken token = default)
+    {
+        var snapshot = await _aiOperations.CreateSnapshotAsync(Id, token).ConfigureAwait(false);
+
+        // Snapshot creation advances the conversation's change vector on the server; adopt it as the
+        // new baseline so a subsequent RunAsync on this same instance doesn't fail with a false conflict.
+        if (string.IsNullOrEmpty(snapshot.ChangeVector) == false)
+            _changeVector = snapshot.ChangeVector;
+
+        return snapshot;
+    }
+
+    public AiConversationSnapshot CreateSnapshot() => AsyncHelpers.RunSync(() => CreateSnapshotAsync());
+
     public void AddArtificialActionWithResponse(string toolId, string actionResponse)
     {
         ValidationMethods.AssertNotNullOrEmpty(toolId, nameof(toolId));

--- a/src/Raven.Client/Documents/AI/AiConversation.cs
+++ b/src/Raven.Client/Documents/AI/AiConversation.cs
@@ -460,7 +460,8 @@ internal class AiConversation : IAiConversationOperations
                 Answer = r.Response,
                 Status = _actionRequests.Count > 0 ? AiConversationResult.ActionRequired : AiConversationResult.Done,
                 Usage = r.Usage,
-                Elapsed = r.Elapsed
+                Elapsed = r.Elapsed,
+                SnapshotToken = r.SnapshotToken
             };
         }
         catch (ConcurrencyException e)

--- a/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationCreationOptions.cs
@@ -26,6 +26,37 @@ public class AiConversationCreationOptions : IDynamicJson
     public int? ExpirationInSec { get; set; }
     public int? MaxModelIterationsPerCall { get; set; }
 
+    /// <summary>
+    /// When set to <c>true</c>, the server creates a snapshot of the conversation document
+    /// and all sub-conversation documents <em>before</em> processing each user prompt.
+    /// The snapshot is returned as <see cref="AiAnswer{TAnswer}.SnapshotToken"/>,
+    /// which can later be passed to <see cref="AiOperations.ForkConversationAsync"/> to create
+    /// a new conversation that starts from that earlier state.
+    ///
+    /// <para>
+    /// This does not apply when handling action responses — only for user prompts and attachments.
+    /// Action responses are considered part of the previous <c>RunAsync</c> turn.
+    /// </para>
+    ///
+    /// <para>
+    /// This is functionally equivalent to calling <see cref="AiOperations.CreateSnapshotAsync"/> followed
+    /// by <see cref="IAiConversationOperations.RunAsync{TAnswer}"/>, but in a single server roundtrip.
+    /// </para>
+    ///
+    /// <para>
+    /// <strong>Important:</strong> Snapshots are stored as document revisions. To control how many snapshots
+    /// are retained (and to prevent unbounded growth), configure a <c>RevisionsConfiguration</c> for the
+    /// <c>@conversations</c> collection with appropriate <c>MinimumRevisionsToKeep</c> or
+    /// <c>MinimumRevisionAgeToKeep</c> values. Without a revisions policy, snapshots accumulate indefinitely.
+    /// If revisions are purged (by policy or by <see cref="AiOperations.PurgeConversationSnapshotsAsync"/>),
+    /// any <see cref="AiAnswer{TAnswer}.SnapshotToken"/> referencing those revisions becomes invalid
+    /// and <see cref="AiOperations.ForkConversationAsync"/> will fail.
+    /// </para>
+    ///
+    /// Default is <c>false</c>.
+    /// </summary>
+    public bool SnapshotBeforeRunning { get; set; }
+
     public AiConversationCreationOptions()
     {
     }
@@ -64,6 +95,7 @@ public class AiConversationCreationOptions : IDynamicJson
         {
             [nameof(ExpirationInSec)] = ExpirationInSec,
             [nameof(MaxModelIterationsPerCall)] = MaxModelIterationsPerCall,
+            [nameof(SnapshotBeforeRunning)] = SnapshotBeforeRunning,
             [nameof(Parameters)] = Parameters != null ? DynamicJsonValue.Convert(Parameters) : null,
         };
     }

--- a/src/Raven.Client/Documents/AI/AiConversationSnapshot.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationSnapshot.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Raven.Client.Documents.AI;
+
+/// <summary>
+/// Describes a single conversation snapshot available for forking.
+/// </summary>
+public sealed class AiConversationSnapshot
+{
+    /// <summary>
+    /// The opaque token to pass to <see cref="AiOperations.ForkConversationAsync"/>.
+    /// </summary>
+    public string Token { get; set; }
+
+    /// <summary>
+    /// The date and time (UTC) when this snapshot was created, taken from the root
+    /// conversation revision's timestamp.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Raven.Client/Documents/AI/AiConversationSnapshot.cs
+++ b/src/Raven.Client/Documents/AI/AiConversationSnapshot.cs
@@ -17,4 +17,12 @@ public sealed class AiConversationSnapshot
     /// conversation revision's timestamp.
     /// </summary>
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// The change vector of the conversation document after the snapshot was created.
+    /// Creating a snapshot force-creates a revision, which advances the document's change
+    /// vector; this is the resulting value, used to re-baseline a conversation's cached
+    /// change vector so a subsequent turn does not fail with a concurrency conflict.
+    /// </summary>
+    public string ChangeVector { get; set; }
 }

--- a/src/Raven.Client/Documents/AI/AiOperations.cs
+++ b/src/Raven.Client/Documents/AI/AiOperations.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -187,5 +188,181 @@ public class AiOperations
     public AiConversationMessagesResult GetConversationMessages(GetConversationMessagesOptions parameters)
     {
         return AsyncHelpers.RunSync(() => GetConversationMessagesAsync(parameters));
+    }
+
+    /// <summary>
+    /// Creates a new conversation by forking from a previously captured snapshot token.
+    /// The forked conversation contains all messages and state up to the point where the
+    /// snapshot was taken.
+    ///
+    /// <para>
+    /// Sub-conversation documents (including nested sub-conversations) are forked from their
+    /// revisions and linked to the new parent. Existing history documents are shared between
+    /// the original and forked conversations.
+    /// </para>
+    ///
+    /// <para>
+    /// If <paramref name="newConversationId"/> resolves to an ID that already exists (whether
+    /// the original conversation or a different one), the existing document is overwritten
+    /// with the forked state. Any sub-conversations tracked by the overwritten document that
+    /// do not exist in the fork are deleted.
+    /// </para>
+    ///
+    /// <para>
+    /// <strong>Important:</strong> This operation requires that the revisions referenced by the
+    /// snapshot token still exist. If they have been purged by the revisions retention policy
+    /// or by <see cref="PurgeConversationSnapshotsAsync"/>, this operation will fail.
+    /// </para>
+    /// </summary>
+    /// <param name="snapshotToken">
+    /// The opaque token obtained from <see cref="AiAnswer{TAnswer}.SnapshotToken"/>
+    /// or <see cref="GetConversationSnapshotsAsync"/>.
+    /// </param>
+    /// <param name="newConversationId">
+    /// The document ID for the forked conversation. Follows the same conventions as
+    /// <see cref="Conversation"/>:
+    /// <list type="bullet">
+    ///   <item>An explicit ID (e.g. <c>"chats/42"</c>) creates a document with that exact ID.</item>
+    ///   <item>A prefix ending with <c>"/"</c> (e.g. <c>"chats/"</c>) auto-generates a numeric suffix.</item>
+    ///   <item>A prefix ending with <c>"|"</c> (e.g. <c>"chats|"</c>) uses cluster-wide identity generation.</item>
+    ///   <item>When <c>null</c>, the server generates a GUID-based ID.</item>
+    /// </list>
+    /// </param>
+    /// <param name="expectedChangeVector">
+    /// Optional concurrency guard for the target conversation document. When non-null, the server
+    /// verifies it against the existing document's change vector before overwriting. Pass an empty
+    /// string to assert that the target document does not yet exist. This check applies only to the
+    /// root conversation document, not to its sub-conversations.
+    /// </param>
+    /// <param name="token">A cancellation token.</param>
+    /// <returns>
+    /// An <see cref="AiForkConversationResult"/> containing the forked conversation's ID
+    /// and change vector. Use these to open the forked conversation via <see cref="Conversation"/>.
+    /// </returns>
+    public Task<AiForkConversationResult> ForkConversationAsync(
+        string snapshotToken,
+        string newConversationId = null,
+        string expectedChangeVector = null,
+        CancellationToken token = default)
+    {
+        return _executor.SendAsync(new ForkConversationOperation(snapshotToken, newConversationId, expectedChangeVector), token);
+    }
+
+    /// <inheritdoc cref="ForkConversationAsync"/>
+    public AiForkConversationResult ForkConversation(
+        string snapshotToken,
+        string newConversationId = null,
+        string expectedChangeVector = null)
+    {
+        return AsyncHelpers.RunSync(() => ForkConversationAsync(snapshotToken, newConversationId, expectedChangeVector));
+    }
+
+    /// <summary>
+    /// Creates a snapshot of the current conversation state without running a conversation turn.
+    /// Returns a snapshot token that can be passed to <see cref="ForkConversationAsync"/>.
+    ///
+    /// <para>
+    /// This is useful when you want to capture the current state for potential forking
+    /// without sending a new prompt to the model.
+    /// </para>
+    ///
+    /// <para>
+    /// If the conversation has pending actions (open tool calls awaiting user responses),
+    /// they remain open in the forked conversation and need to be resolved separately.
+    /// </para>
+    /// </summary>
+    /// <param name="conversationId">The conversation document ID to snapshot.</param>
+    /// <param name="token">A cancellation token.</param>
+    /// <returns>
+    /// An <see cref="AiConversationSnapshot"/> containing the token and creation timestamp.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">Thrown when the conversation does not exist.</exception>
+    public Task<AiConversationSnapshot> CreateSnapshotAsync(string conversationId, CancellationToken token = default)
+    {
+        return _executor.SendAsync(new CreateConversationSnapshotOperation(conversationId), token);
+    }
+
+    /// <inheritdoc cref="CreateSnapshotAsync"/>
+    public AiConversationSnapshot CreateSnapshot(string conversationId)
+    {
+        return AsyncHelpers.RunSync(() => CreateSnapshotAsync(conversationId));
+    }
+
+    /// <summary>
+    /// Returns available snapshots for a conversation, ordered by creation time (newest first).
+    /// Each entry contains a snapshot token and the date it was captured.
+    /// Supports cursor-based paging via <paramref name="before"/>.
+    ///
+    /// <para>
+    /// Only snapshots whose revisions still exist are returned. Snapshots whose revisions
+    /// have been purged by the retention policy are excluded.
+    /// </para>
+    /// </summary>
+    /// <param name="conversationId">The conversation document ID.</param>
+    /// <param name="before">
+    /// When specified, only returns snapshots created before this date (exclusive).
+    /// Use the <see cref="AiConversationSnapshot.CreatedAt"/> of the last item in a previous
+    /// page to fetch the next page of older snapshots.
+    /// When <c>null</c>, returns the most recent snapshots.
+    /// </param>
+    /// <param name="pageSize">Maximum number of snapshots to return. Default is 25.</param>
+    /// <param name="token">A cancellation token.</param>
+    /// <returns>A list of available snapshots, or an empty list if none exist.</returns>
+    public Task<List<AiConversationSnapshot>> GetConversationSnapshotsAsync(
+        string conversationId,
+        DateTime? before = null,
+        int pageSize = 25,
+        CancellationToken token = default)
+    {
+        return _executor.SendAsync(new GetConversationSnapshotsOperation(conversationId, before, pageSize), token);
+    }
+
+    /// <inheritdoc cref="GetConversationSnapshotsAsync"/>
+    public List<AiConversationSnapshot> GetConversationSnapshots(
+        string conversationId,
+        DateTime? before = null,
+        int pageSize = 25)
+    {
+        return AsyncHelpers.RunSync(() => GetConversationSnapshotsAsync(conversationId, before, pageSize));
+    }
+
+    /// <summary>
+    /// Deletes all snapshots for the specified conversation,
+    /// invalidating any outstanding snapshot tokens. The conversation itself is not affected.
+    ///
+    /// <para>
+    /// Use this when the conversation has no more need to fork its snapshots,
+    /// or to reclaim storage used by accumulated snapshots.
+    /// </para>
+    /// </summary>
+    /// <param name="conversationId">The conversation whose snapshots should be purged.</param>
+    /// <param name="token">A cancellation token.</param>
+    public Task PurgeConversationSnapshotsAsync(string conversationId, CancellationToken token = default)
+    {
+        return _executor.SendAsync(new PurgeConversationSnapshotsOperation(conversationId), token);
+    }
+
+    /// <summary>
+    /// Deletes all snapshots for the specified conversation that were created strictly before the given date,
+    /// invalidating the corresponding snapshot tokens. The conversation itself is not affected.
+    /// </summary>
+    /// <param name="conversationId">The conversation whose snapshots should be purged.</param>
+    /// <param name="before">Only snapshots created strictly before this date (UTC, exclusive) will be deleted.</param>
+    /// <param name="token">A cancellation token.</param>
+    public Task PurgeConversationSnapshotsAsync(string conversationId, DateTime before, CancellationToken token = default)
+    {
+        return _executor.SendAsync(new PurgeConversationSnapshotsOperation(conversationId, before), token);
+    }
+
+    /// <inheritdoc cref="PurgeConversationSnapshotsAsync(string, CancellationToken)"/>
+    public void PurgeConversationSnapshots(string conversationId)
+    {
+        AsyncHelpers.RunSync(() => PurgeConversationSnapshotsAsync(conversationId));
+    }
+
+    /// <inheritdoc cref="PurgeConversationSnapshotsAsync(string, DateTime, CancellationToken)"/>
+    public void PurgeConversationSnapshots(string conversationId, DateTime before)
+    {
+        AsyncHelpers.RunSync(() => PurgeConversationSnapshotsAsync(conversationId, before));
     }
 }

--- a/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
+++ b/src/Raven.Client/Documents/AI/IAiConversationOperations.cs
@@ -329,10 +329,24 @@ public interface IAiConversationOperations
     string Id { get; }
 
     /// <summary>
-    /// The current RavenDB change vector for this conversation document,  
+    /// The current RavenDB change vector for this conversation document,
     /// used to detect concurrent modifications.
     /// </summary>
     string ChangeVector { get; }
+
+    /// <summary>
+    /// Creates a snapshot of the current conversation state (and its sub-conversations) without
+    /// running a turn, returning a token that can later be passed to
+    /// <see cref="AiOperations.ForkConversationAsync"/>. The conversation's cached change vector
+    /// baseline is updated from the snapshot result, so a subsequent <see cref="RunAsync{TAnswer}"/>
+    /// on this same instance does not fail because the snapshot advanced the server-side change vector.
+    /// </summary>
+    /// <param name="token">A <see cref="CancellationToken"/> used to cancel the operation.</param>
+    /// <returns>An <see cref="AiConversationSnapshot"/> containing the token and creation timestamp.</returns>
+    Task<AiConversationSnapshot> CreateSnapshotAsync(CancellationToken token = default);
+
+    /// <inheritdoc cref="CreateSnapshotAsync"/>
+    AiConversationSnapshot CreateSnapshot();
 
     /// <summary>
     /// Retrieves the list of action-tool requests  

--- a/src/Raven.Client/Documents/Operations/AI/Agents/AiForkConversationResult.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/AiForkConversationResult.cs
@@ -1,0 +1,35 @@
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.AI.Agents;
+
+/// <summary>
+/// The result of a <see cref="ForkConversationOperation"/>.
+/// </summary>
+public sealed class AiForkConversationResult
+{
+    /// <summary>
+    /// When the server generated the ID (because <c>newConversationId</c> was <c>null</c>,
+    /// or ended with <c>"/"</c> or <c>"|"</c>), this contains the server-assigned ID.
+    /// Otherwise, this is the same as the <c>newConversationId</c> that was passed.
+    /// </summary>
+    public string ConversationId { get; set; }
+
+    /// <summary>
+    /// The change vector of the forked conversation document.
+    /// Pass this to <see cref="AI.AiOperations.Conversation"/> for optimistic concurrency control
+    /// on the first turn after forking.
+    /// </summary>
+    public string ChangeVector { get; set; }
+
+    internal static AiForkConversationResult Convert(BlittableJsonReaderObject response)
+    {
+        response.TryGet(nameof(ConversationId), out string conversationId);
+        response.TryGet(nameof(ChangeVector), out string changeVector);
+
+        return new AiForkConversationResult
+        {
+            ConversationId = conversationId,
+            ChangeVector = changeVector
+        };
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/Agents/ConversationResult.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/ConversationResult.cs
@@ -36,6 +36,13 @@ public class ConversationResult<TAnswer>
     public List<AiAgentActionRequest> ActionRequests { get; set; }
     internal int ToolsIterations { get; set; }
 
+    /// <summary>
+    /// Opaque snapshot token returned by the server when
+    /// <see cref="AI.AiConversationCreationOptions.SnapshotBeforeRunning"/> is enabled.
+    /// Encodes the revision change vectors captured before this turn was processed.
+    /// </summary>
+    public string SnapshotToken { get; set; }
+
     internal static ConversationResult<TAnswer> Convert(BlittableJsonReaderObject response, DocumentConventions conventions)
     {
         response.TryGet(nameof(TotalUsage), out BlittableJsonReaderObject totalUsage);
@@ -43,6 +50,7 @@ public class ConversationResult<TAnswer>
         response.TryGet(nameof(ChangeVector), out string changeVector);
         response.TryGet(nameof(Usage), out BlittableJsonReaderObject usage);
         response.TryGet(nameof(Elapsed), out TimeSpan elapsedStr);
+        response.TryGet(nameof(SnapshotToken), out string snapshotToken);
 
         List<AiAgentActionRequest> requests = null;
         if (response.TryGet(nameof(ActionRequests), out BlittableJsonReaderArray actionRequests) && actionRequests != null)
@@ -75,7 +83,8 @@ public class ConversationResult<TAnswer>
             TotalUsage = JsonDeserializationClient.AiUsage(totalUsage),
             Response = responseValue,
             Usage = JsonDeserializationClient.AiUsage(usage),
-            Elapsed = elapsedStr
+            Elapsed = elapsedStr,
+            SnapshotToken = snapshotToken
         };
     }
 }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/CreateConversationSnapshotOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/CreateConversationSnapshotOperation.cs
@@ -56,11 +56,13 @@ public class CreateConversationSnapshotOperation : IMaintenanceOperation<AiConve
 
             response.TryGet(nameof(AiConversationSnapshot.Token), out string token);
             response.TryGet(nameof(AiConversationSnapshot.CreatedAt), out DateTime createdAt);
+            response.TryGet(nameof(AiConversationSnapshot.ChangeVector), out string changeVector);
 
             Result = new AiConversationSnapshot
             {
                 Token = token,
-                CreatedAt = createdAt
+                CreatedAt = createdAt,
+                ChangeVector = changeVector
             };
         }
     }

--- a/src/Raven.Client/Documents/Operations/AI/Agents/CreateConversationSnapshotOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/CreateConversationSnapshotOperation.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Net.Http;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.AI.Agents;
+
+/// <summary>
+/// Creates a snapshot of the current conversation state without running a conversation turn.
+/// Returns a snapshot token that can later be passed to <see cref="ForkConversationOperation"/>.
+/// Throws if the conversation does not exist.
+/// </summary>
+public class CreateConversationSnapshotOperation : IMaintenanceOperation<AiConversationSnapshot>
+{
+    private readonly string _conversationId;
+
+    public CreateConversationSnapshotOperation(string conversationId)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
+        _conversationId = conversationId;
+    }
+
+    public RavenCommand<AiConversationSnapshot> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new CreateConversationSnapshotCommand(_conversationId);
+    }
+
+    private sealed class CreateConversationSnapshotCommand : RavenCommand<AiConversationSnapshot>
+    {
+        private readonly string _conversationId;
+
+        public CreateConversationSnapshotCommand(string conversationId)
+        {
+            _conversationId = conversationId;
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/snapshots?conversationId={Uri.EscapeDataString(_conversationId)}";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Post
+            };
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                throw new InvalidOperationException($"Cannot create snapshot for conversation '{_conversationId}' because the conversation does not exist.");
+
+            response.TryGet(nameof(AiConversationSnapshot.Token), out string token);
+            response.TryGet(nameof(AiConversationSnapshot.CreatedAt), out DateTime createdAt);
+
+            Result = new AiConversationSnapshot
+            {
+                Token = token,
+                CreatedAt = createdAt
+            };
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/Agents/ForkConversationOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/ForkConversationOperation.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Json;
+using Raven.Client.Util;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.AI.Agents;
+
+/// <summary>
+/// Creates a new conversation by forking from a previously captured snapshot token.
+/// The forked conversation contains all messages and state up to the point where the
+/// snapshot was taken, and receives a new document ID.
+///
+/// <para>
+/// Sub-conversation documents (including nested sub-conversations) are also forked from their
+/// revisions and linked to the new parent with adjusted IDs. Existing history documents are
+/// shared (not duplicated) between the original and forked conversations.
+/// </para>
+///
+/// <para>
+/// If <c>newConversationId</c> resolves to an ID where a conversation document
+/// already exists (whether the original conversation or a different one), the existing document
+/// is overwritten with the forked state. Any sub-conversations tracked by the overwritten
+/// document that do not exist in the fork are deleted.
+/// </para>
+///
+/// <para>
+/// <strong>Important:</strong> This operation requires that the revisions referenced by the
+/// snapshot token still exist. If they have been purged by the revisions retention policy
+/// or by <see cref="AiOperations.PurgeConversationSnapshotsAsync"/>, this operation will
+/// fail with an error identifying the missing revision.
+/// </para>
+/// </summary>
+public class ForkConversationOperation : IMaintenanceOperation<AiForkConversationResult>
+{
+    private readonly string _snapshotToken;
+    private readonly string _newConversationId;
+    private readonly string _expectedChangeVector;
+
+    public ForkConversationOperation(string snapshotToken, string newConversationId = null, string expectedChangeVector = null)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(snapshotToken, nameof(snapshotToken));
+        _snapshotToken = snapshotToken;
+        _newConversationId = newConversationId;
+        _expectedChangeVector = expectedChangeVector;
+    }
+
+    public RavenCommand<AiForkConversationResult> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new ForkConversationCommand(_snapshotToken, _newConversationId, _expectedChangeVector, conventions);
+    }
+
+    private sealed class ForkConversationCommand : RavenCommand<AiForkConversationResult>, IRaftCommand
+    {
+        private readonly string _snapshotToken;
+        private readonly string _newConversationId;
+        private readonly string _expectedChangeVector;
+        private readonly DocumentConventions _conventions;
+
+        public ForkConversationCommand(string snapshotToken, string newConversationId, string expectedChangeVector, DocumentConventions conventions)
+        {
+            _snapshotToken = snapshotToken;
+            _newConversationId = newConversationId;
+            _expectedChangeVector = expectedChangeVector;
+            _conventions = conventions;
+
+            if (_newConversationId?.EndsWith("|") == true)
+            {
+                _raftId = Guid.NewGuid().ToString();
+            }
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/fork";
+
+            var body = new DynamicJsonValue
+            {
+                ["SnapshotToken"] = _snapshotToken,
+                ["NewConversationId"] = _newConversationId,
+                ["ExpectedChangeVector"] = _expectedChangeVector
+            };
+
+            var request = new HttpRequestMessage
+            {
+                Method = HttpMethod.Post,
+                Content = new BlittableJsonContent(async stream =>
+                {
+                    await ctx.WriteAsync(stream, ctx.ReadObject(body, "fork-conversation")).ConfigureAwait(false);
+                }, _conventions)
+            };
+
+            return request;
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            if (response == null)
+                ThrowInvalidResponse();
+
+            Result = AiForkConversationResult.Convert(response);
+        }
+
+        private string _raftId = string.Empty;
+        public string RaftUniqueRequestId => _raftId;
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/Agents/GetConversationSnapshotsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/GetConversationSnapshotsOperation.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Sparrow.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.AI.Agents;
+
+/// <summary>
+/// Returns available snapshots for a conversation, ordered by creation time (newest first).
+/// Supports cursor-based paging via a <c>before</c> timestamp.
+/// </summary>
+public class GetConversationSnapshotsOperation : IMaintenanceOperation<List<AiConversationSnapshot>>
+{
+    private readonly string _conversationId;
+    private readonly DateTime? _before;
+    private readonly int _pageSize;
+
+    public GetConversationSnapshotsOperation(string conversationId, DateTime? before = null, int pageSize = 25)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
+        _conversationId = conversationId;
+        _before = before;
+        _pageSize = pageSize;
+    }
+
+    public RavenCommand<List<AiConversationSnapshot>> GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new GetConversationSnapshotsCommand(_conversationId, _before, _pageSize);
+    }
+
+    private sealed class GetConversationSnapshotsCommand : RavenCommand<List<AiConversationSnapshot>>
+    {
+        private readonly string _conversationId;
+        private readonly DateTime? _before;
+        private readonly int _pageSize;
+
+        public GetConversationSnapshotsCommand(string conversationId, DateTime? before, int pageSize)
+        {
+            _conversationId = conversationId;
+            _before = before;
+            _pageSize = pageSize;
+        }
+
+        public override bool IsReadRequest => true;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/snapshots?conversationId={Uri.EscapeDataString(_conversationId)}&pageSize={_pageSize}";
+
+            if (_before.HasValue)
+                url += $"&before={_before.Value.GetDefaultRavenFormat()}";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Get
+            };
+        }
+
+        public override void SetResponse(JsonOperationContext context, BlittableJsonReaderObject response, bool fromCache)
+        {
+            Result = [];
+
+            if (response == null)
+                return;
+
+            if (response.TryGet("Snapshots", out BlittableJsonReaderArray snapshots) == false || snapshots == null)
+                return;
+
+            foreach (BlittableJsonReaderObject item in snapshots)
+            {
+                item.TryGet(nameof(AiConversationSnapshot.Token), out string token);
+                item.TryGet(nameof(AiConversationSnapshot.CreatedAt), out DateTime createdAt);
+
+                Result.Add(new AiConversationSnapshot
+                {
+                    Token = token,
+                    CreatedAt = createdAt
+                });
+            }
+        }
+    }
+}

--- a/src/Raven.Client/Documents/Operations/AI/Agents/PurgeConversationSnapshotsOperation.cs
+++ b/src/Raven.Client/Documents/Operations/AI/Agents/PurgeConversationSnapshotsOperation.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Net.Http;
+using Raven.Client.Documents.Conventions;
+using Raven.Client.Http;
+using Raven.Client.Util;
+using Sparrow.Extensions;
+using Sparrow.Json;
+
+namespace Raven.Client.Documents.Operations.AI.Agents;
+
+/// <summary>
+/// Deletes snapshots for the specified conversation, invalidating corresponding snapshot tokens.
+/// The conversation itself is not affected.
+/// </summary>
+public class PurgeConversationSnapshotsOperation : IMaintenanceOperation
+{
+    private readonly string _conversationId;
+    private readonly DateTime? _before;
+
+    public PurgeConversationSnapshotsOperation(string conversationId)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
+        _conversationId = conversationId;
+    }
+
+    public PurgeConversationSnapshotsOperation(string conversationId, DateTime before)
+    {
+        ValidationMethods.AssertNotNullOrEmpty(conversationId, nameof(conversationId));
+        _conversationId = conversationId;
+        _before = before;
+    }
+
+    public RavenCommand GetCommand(DocumentConventions conventions, JsonOperationContext context)
+    {
+        return new PurgeConversationSnapshotsCommand(_conversationId, _before);
+    }
+
+    private sealed class PurgeConversationSnapshotsCommand : RavenCommand
+    {
+        private readonly string _conversationId;
+        private readonly DateTime? _before;
+
+        public PurgeConversationSnapshotsCommand(string conversationId, DateTime? before)
+        {
+            _conversationId = conversationId;
+            _before = before;
+        }
+
+        public override bool IsReadRequest => false;
+
+        public override HttpRequestMessage CreateRequest(JsonOperationContext ctx, ServerNode node, out string url)
+        {
+            url = $"{node.Url}/databases/{node.Database}/ai/agent/snapshots?conversationId={Uri.EscapeDataString(_conversationId)}";
+
+            if (_before.HasValue)
+                url += $"&before={_before.Value.GetDefaultRavenFormat()}";
+
+            return new HttpRequestMessage
+            {
+                Method = HttpMethod.Delete
+            };
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AbstractAiAgentProcessor.cs
@@ -125,11 +125,13 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject parameters);
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.ExpirationInSec), out int? conversationExpirationInSec);
             optionsBlittable.TryGet(nameof(AiConversationCreationOptions.MaxModelIterationsPerCall), out int? maxModelIterationsPerCall);
+            optionsBlittable.TryGet(nameof(AiConversationCreationOptions.SnapshotBeforeRunning), out bool snapshotBeforeRunning);
 
             var options = new AiConversationCreationOptions
             {
                 ExpirationInSec = conversationExpirationInSec,
-                MaxModelIterationsPerCall = maxModelIterationsPerCall
+                MaxModelIterationsPerCall = maxModelIterationsPerCall,
+                SnapshotBeforeRunning = snapshotBeforeRunning
             };
 
             var request = new RequestBody

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentHandler.cs
@@ -69,4 +69,40 @@ public class AiAgentHandler : DatabaseRequestHandler
             await processor.ExecuteAsync();
         }
     }
+
+    [RavenAction("/databases/*/ai/agent/fork", "POST", AuthorizationStatus.ValidUser, EndpointType.Write)]
+    public async Task ForkConversation()
+    {
+        using (var processor = new AiAgentProcessorForForkConversation(this))
+        {
+            await processor.ExecuteAsync();
+        }
+    }
+
+    [RavenAction("/databases/*/ai/agent/snapshots", "POST", AuthorizationStatus.ValidUser, EndpointType.Write)]
+    public async Task CreateConversationSnapshot()
+    {
+        using (var processor = new AiAgentProcessorForCreateConversationSnapshot(this))
+        {
+            await processor.ExecuteAsync();
+        }
+    }
+
+    [RavenAction("/databases/*/ai/agent/snapshots", "GET", AuthorizationStatus.ValidUser, EndpointType.Read)]
+    public async Task GetConversationSnapshots()
+    {
+        using (var processor = new AiAgentProcessorForGetConversationSnapshots(this))
+        {
+            await processor.ExecuteAsync();
+        }
+    }
+
+    [RavenAction("/databases/*/ai/agent/snapshots", "DELETE", AuthorizationStatus.ValidUser, EndpointType.Write)]
+    public async Task PurgeConversationSnapshots()
+    {
+        using (var processor = new AiAgentProcessorForPurgeConversationSnapshots(this))
+        {
+            await processor.ExecuteAsync();
+        }
+    }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForCreateConversationSnapshot.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForCreateConversationSnapshot.cs
@@ -20,7 +20,7 @@ internal sealed class AiAgentProcessorForCreateConversationSnapshot : AbstractDa
     {
         var conversationId = RequestHandler.GetStringQueryString("conversationId");
 
-        var (snapshotToken, createdAt, _) = await ConversationHandler.CreateSnapshotForConversationAsync(RequestHandler.Database, conversationId);
+        var (snapshotToken, createdAt, changeVector) = await ConversationHandler.CreateSnapshotForConversationAsync(RequestHandler.Database, conversationId);
 
         if (snapshotToken == null)
         {
@@ -39,6 +39,10 @@ internal sealed class AiAgentProcessorForCreateConversationSnapshot : AbstractDa
             writer.WriteComma();
             writer.WritePropertyName(nameof(AiConversationSnapshot.CreatedAt));
             writer.WriteDateTime(createdAt, isUtc: true);
+
+            writer.WriteComma();
+            writer.WritePropertyName(nameof(AiConversationSnapshot.ChangeVector));
+            writer.WriteString(changeVector);
 
             writer.WriteEndObject();
         }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForCreateConversationSnapshot.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForCreateConversationSnapshot.cs
@@ -20,7 +20,7 @@ internal sealed class AiAgentProcessorForCreateConversationSnapshot : AbstractDa
     {
         var conversationId = RequestHandler.GetStringQueryString("conversationId");
 
-        var (snapshotToken, createdAt) = await ConversationHandler.CreateSnapshotForConversationAsync(RequestHandler.Database, conversationId);
+        var (snapshotToken, createdAt, _) = await ConversationHandler.CreateSnapshotForConversationAsync(RequestHandler.Database, conversationId);
 
         if (snapshotToken == null)
         {

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForCreateConversationSnapshot.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForCreateConversationSnapshot.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.AI;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+/// <summary>
+/// Processor for POST /ai/agent/snapshots — creates a snapshot of the current conversation state.
+/// </summary>
+internal sealed class AiAgentProcessorForCreateConversationSnapshot : AbstractDatabaseHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public AiAgentProcessorForCreateConversationSnapshot([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        var conversationId = RequestHandler.GetStringQueryString("conversationId");
+
+        var (snapshotToken, createdAt) = await ConversationHandler.CreateSnapshotForConversationAsync(RequestHandler.Database, conversationId);
+
+        if (snapshotToken == null)
+        {
+            RequestHandler.HttpContext.Response.StatusCode = (int)System.Net.HttpStatusCode.NotFound;
+            return;
+        }
+
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+        {
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(nameof(AiConversationSnapshot.Token));
+            writer.WriteString(snapshotToken);
+
+            writer.WriteComma();
+            writer.WritePropertyName(nameof(AiConversationSnapshot.CreatedAt));
+            writer.WriteDateTime(createdAt, isUtc: true);
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForForkConversation.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForForkConversation.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+internal sealed class AiAgentProcessorForForkConversation : AbstractDatabaseHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public AiAgentProcessorForForkConversation([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        {
+            var body = await context.ReadForMemoryAsync(RequestHandler.RequestBodyStream(), "fork-conversation");
+
+            body.TryGet("SnapshotToken", out string snapshotToken);
+            body.TryGet("NewConversationId", out string newConversationId);
+            body.TryGet("ExpectedChangeVector", out string expectedChangeVector);
+
+            if (string.IsNullOrEmpty(snapshotToken))
+                throw new ArgumentException("SnapshotToken is required.");
+
+            // Parse the token using the DTO
+            var dto = SnapshotTokenDto.Parse(context, snapshotToken);
+
+            // Resolve cluster identity before entering the transaction
+            if (newConversationId?.EndsWith("|") == true)
+            {
+                var r = await RequestHandler.ServerStore.GenerateClusterIdentityAsync(
+                    newConversationId,
+                    RequestHandler.Database.IdentityPartsSeparator,
+                    RequestHandler.Database.Name,
+                    RequestHandler.GetRaftRequestIdFromQuery());
+                newConversationId = r.ClusterId;
+            }
+
+            // Execute the fork
+            var cmd = new ForkConversationCommand(RequestHandler.Database, dto.ConversationId, newConversationId, dto.Revisions, expectedChangeVector);
+            await RequestHandler.Database.TxMerger.Enqueue(cmd);
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+
+                writer.WritePropertyName(nameof(AiForkConversationResult.ConversationId));
+                writer.WriteString(cmd.ResultConversationId);
+
+                writer.WriteComma();
+                writer.WritePropertyName(nameof(AiForkConversationResult.ChangeVector));
+                writer.WriteString(cmd.ResultChangeVector);
+
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForGetConversationSnapshots.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForGetConversationSnapshots.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Client.Documents.AI;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+/// <summary>
+/// Processor for GET /ai/agent/snapshots — lists available snapshots for a conversation.
+/// </summary>
+internal sealed class AiAgentProcessorForGetConversationSnapshots : AbstractDatabaseHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public AiAgentProcessorForGetConversationSnapshots([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        var conversationId = RequestHandler.GetStringQueryString("conversationId");
+        var pageSize = RequestHandler.GetPageSize(25);
+        var before = RequestHandler.GetDateTimeQueryString("before", required: false);
+
+        using (ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+        using (context.OpenReadTransaction())
+        {
+            var revisionsStorage = RequestHandler.Database.DocumentsStorage.RevisionsStorage;
+
+            var snapshots = new List<(string Token, DateTime CreatedAt)>();
+
+            // We return all revisions, not just force-created snapshots. Users may also
+            // have collection-level revisions configured, and those are equally valid fork points.
+            foreach (var revision in revisionsStorage.GetRevisionsByDate(context, conversationId, take: pageSize, before: before))
+            {
+                using (revision)
+                {
+                    var revisionEntries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        [conversationId] = revision.ChangeVector
+                    };
+
+                    // Recursively collect sub-conversation revisions (handles nested sub-agents).
+                    // Missing sub-conversation revisions are skipped, producing a partial token.
+                    CollectSubConversationRevisions(context, revisionsStorage, revision, revisionEntries);
+
+                    var token = SnapshotTokenDto.Build(context, conversationId, revision.LastModified, revisionEntries);
+                    snapshots.Add((token, revision.LastModified));
+                }
+            }
+
+            await using (var writer = new AsyncBlittableJsonTextWriter(context, RequestHandler.ResponseBodyStream()))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("Snapshots");
+                writer.WriteStartArray();
+
+                bool first = true;
+                foreach (var (token, createdAt) in snapshots)
+                {
+                    if (first == false)
+                        writer.WriteComma();
+                    first = false;
+
+                    writer.WriteStartObject();
+                    writer.WritePropertyName(nameof(AiConversationSnapshot.Token));
+                    writer.WriteString(token);
+                    writer.WriteComma();
+                    writer.WritePropertyName(nameof(AiConversationSnapshot.CreatedAt));
+                    writer.WriteDateTime(createdAt, isUtc: true);
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Recursively collects sub-conversation revisions from a revision's SubConversationIds.
+    /// Sub-conversations whose revision is not found are skipped — the resulting token will
+    /// be partial but still usable for forking the sub-conversations that are available.
+    /// </summary>
+    private static void CollectSubConversationRevisions(
+        DocumentsOperationContext context,
+        Raven.Server.Documents.Revisions.RevisionsStorage revisionsStorage,
+        Document revision,
+        Dictionary<string, string> revisionEntries)
+    {
+        System.Runtime.CompilerServices.RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        if (revision.Data.TryGet(nameof(ConversationDocument.SubConversationIds), out BlittableJsonReaderArray subIds) == false || subIds == null)
+            return;
+
+        foreach (var subIdValue in subIds)
+        {
+            var subId = subIdValue.ToString();
+            if (revisionEntries.ContainsKey(subId))
+                continue;
+
+            using var subRevision = revisionsStorage.GetRevisionBefore(context, subId, revision.LastModified.AddTicks(1));
+            if (subRevision == null)
+                continue; // skip this sub-conversation, collect the rest
+
+            revisionEntries[subId] = subRevision.ChangeVector;
+
+            CollectSubConversationRevisions(context, revisionsStorage, subRevision, revisionEntries);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForPurgeConversationSnapshots.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiAgentProcessorForPurgeConversationSnapshots.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Raven.Server.Documents.Handlers.Processors;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+/// <summary>
+/// Processor for DELETE /ai/agent/snapshots — purges revisions for a conversation.
+/// </summary>
+internal sealed class AiAgentProcessorForPurgeConversationSnapshots : AbstractDatabaseHandlerProcessor<DatabaseRequestHandler, DocumentsOperationContext>
+{
+    public AiAgentProcessorForPurgeConversationSnapshots([NotNull] DatabaseRequestHandler requestHandler) : base(requestHandler)
+    {
+    }
+
+    public override async ValueTask ExecuteAsync()
+    {
+        var conversationId = RequestHandler.GetStringQueryString("conversationId");
+        var before = RequestHandler.GetDateTimeQueryString("before", required: false);
+
+        var cmd = new PurgeConversationSnapshotsCommand(RequestHandler.Database, conversationId, before);
+        await RequestHandler.Database.TxMerger.Enqueue(cmd);
+
+        RequestHandler.NoContentStatus();
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/AiInternalConversationResult.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/AiInternalConversationResult.cs
@@ -10,5 +10,6 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         public object Response { get; set; }
         public AiUsage Usage { get; set; }
         public int ToolsIterations { get; set; }
+        public string SnapshotToken { get; set; }
     }
 }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.MessagesList.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.MessagesList.cs
@@ -130,7 +130,7 @@ public partial class ConversationDocument
         /// </summary>
         internal object AsSerializable() => (object)_messagesList ?? _messagesArray;
 
-        private List<BlittableJsonReaderObject> Materialize()
+        internal List<BlittableJsonReaderObject> Materialize()
         {
             if (_messagesList != null)
                 return _messagesList;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationDocument.cs
@@ -324,6 +324,11 @@ public partial class ConversationDocument([NotNull] string agent, BlittableJsonR
             conversation.SubConversationIds = subConversationIds.Items.Select(m => ((LazyStringValue)m).ToString(CultureInfo.InvariantCulture)).ToHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
+        // Eagerly materialize messages to decouple from the original document's
+        // underlying memory, which may be backed by a read transaction that will be
+        // disposed before the messages are mutated (AddMessage, RemoveRange, etc.).
+        conversation.Messages.Materialize();
+
         return conversation;
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -943,11 +943,11 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     }
 
 
-    internal static async Task<(string Token, DateTime CreatedAt)> CreateSnapshotForConversationAsync(DocumentDatabase db, string conversationId)
+    internal static async Task<(string Token, DateTime CreatedAt, string RootChangeVector)> CreateSnapshotForConversationAsync(DocumentDatabase db, string conversationId)
     {
         var cmd = new CreateConversationSnapshotCommand(db, conversationId);
         await db.TxMerger.Enqueue(cmd);
-        return (cmd.SnapshotToken, cmd.CreatedAt);
+        return (cmd.SnapshotToken, cmd.CreatedAt, cmd.RootChangeVector);
     }
 
     private async Task CreateSnapshotIfRequiredAsync()
@@ -955,8 +955,12 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         if (_requireSnapshot == false)
             return;
 
-        var (token, _) = await CreateSnapshotForConversationAsync(database, _document.Id);
+        var (token, _, rootCv) = await CreateSnapshotForConversationAsync(database, _document.Id);
         _snapshotToken = token;
+
+        // Snapshot creation advances the document CV; use the resulting CV as the new baseline to avoid a false concurrency conflict.
+        if (rootCv != null)
+            _document.ChangeVector = rootCv;
     }
 
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -55,6 +55,9 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
     private bool _cancelPendingActionTools;
     protected int _maxModelIterationsPerCall;
     internal List<string> _persistedAttachmentsNames;
+    private string _snapshotToken;
+    private bool _isNewConversation;
+    private bool _requireSnapshot;
     private string _schema;
     public string Schema => _schema;
     public required RavenServer.AuthenticateConnection Authentication;
@@ -116,6 +119,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             }
 
             ValidateParameterValues(_request.Parameters);
+            _isNewConversation = true;
             _document = new ConversationDocument(agentId, _request.Parameters);
             _document.Id = await GetDocumentIdAsync();
 
@@ -154,6 +158,18 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
                 _document.ChangeVector = conversation.ChangeVector;
             }
+
+            // Determine whether we need a snapshot, but defer creation until after
+            // TryHandleActionResponses validates the request (so invalid requests
+            // such as ActionResponses + user prompt don't create revisions).
+            bool hasUserPrompt = RequestBody.HasUserPrompt(_request.Content) ||
+                                 _request.Attachments is { Count: > 0 } ||
+                                 _request.AttachmentCommands?.ParsedCommands is { Count: > 0 } ||
+                                 _request.ArtificialActions is { Length: > 0 };
+
+            _requireSnapshot = _request.CreationOptions?.SnapshotBeforeRunning == true &&
+                               _isNewConversation == false &&
+                               hasUserPrompt;
         }
 
         if (_debugOverride.HasValue)
@@ -446,6 +462,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
                 {
                     AddMessageWithAttachmentsName(context, isFirstIteration);
                 }
+
                 isFirstIteration = false;
 
                 bool isNoSchema = r.Type is AiResponseType.Result && _schema == null;
@@ -521,6 +538,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             Response = r.Result,
             Usage = talker.AiUsage,
             ToolsIterations = toolsIterations,
+            SnapshotToken = _snapshotToken
         };
     }
 
@@ -924,6 +942,22 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         }
     }
 
+
+    internal static async Task<(string Token, DateTime CreatedAt)> CreateSnapshotForConversationAsync(DocumentDatabase db, string conversationId)
+    {
+        var cmd = new CreateConversationSnapshotCommand(db, conversationId);
+        await db.TxMerger.Enqueue(cmd);
+        return (cmd.SnapshotToken, cmd.CreatedAt);
+    }
+
+    private async Task CreateSnapshotIfRequiredAsync()
+    {
+        if (_requireSnapshot == false)
+            return;
+
+        var (token, _) = await CreateSnapshotForConversationAsync(database, _document.Id);
+        _snapshotToken = token;
+    }
 
     protected virtual async Task<string> TryPersistAsync(JsonOperationContext context, List<BlittableJsonReaderObject> historyDocs)
     {
@@ -1337,6 +1371,8 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
         if (await TryHandleActionResponsesAsync(context, token) is false)
             return AiInternalConversationResult.Default;
 
+        await CreateSnapshotIfRequiredAsync();
+
         return await TalkAsync(context, token: token);
     }
 
@@ -1350,7 +1386,9 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
         if (await TryHandleActionResponsesAsync(context, token) is false)
             return AiInternalConversationResult.Default;
-        
+
+        await CreateSnapshotIfRequiredAsync();
+
         await using var writer = new AsyncBlittableJsonTextWriter(context, outputStream);
         return await StreamingTalkAsync(context, streamPropertyPath, async (data) =>
         {
@@ -1390,7 +1428,7 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
 
     public virtual DynamicJsonValue GetConversationResponse(JsonOperationContext context, object response, int toolsIterations)
     {
-        return new DynamicJsonValue
+        var result = new DynamicJsonValue
         {
             [nameof(ConversationResult<object>.ConversationId)] = _conversationId,
             [nameof(ConversationResult<object>.ChangeVector)] = _document.ChangeVector,
@@ -1401,6 +1439,11 @@ public partial class ConversationHandler(ServerStore server, DocumentDatabase da
             [nameof(ConversationResult<object>.Elapsed)] = _elapsed,
             [nameof(ConversationResult<object>.ToolsIterations)] = toolsIterations
         };
+
+        if (_snapshotToken != null)
+            result[nameof(ConversationResult<object>.SnapshotToken)] = _snapshotToken;
+
+        return result;
     }
 
     private IEnumerable<DynamicJsonValue> GetUserActions()

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/CreateConversationSnapshotCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/CreateConversationSnapshotCommand.cs
@@ -20,6 +20,7 @@ internal sealed class CreateConversationSnapshotCommand : MergedTransactionComma
 
     public string SnapshotToken { get; private set; }
     public DateTime CreatedAt { get; private set; }
+    public string RootChangeVector { get; private set; }
 
     public CreateConversationSnapshotCommand(DocumentDatabase database, string conversationId)
     {
@@ -41,6 +42,7 @@ internal sealed class CreateConversationSnapshotCommand : MergedTransactionComma
 
         using var rootRevision = _database.DocumentsStorage.RevisionsStorage.GetRevision(context, rootCv);
         CreatedAt = rootRevision?.LastModified ?? _database.Time.GetUtcNow();
+        RootChangeVector = rootCv;
 
         SnapshotToken = SnapshotTokenDto.Build(context, _conversationId, CreatedAt, revisions);
         return 1;

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/CreateConversationSnapshotCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/CreateConversationSnapshotCommand.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+using Sparrow.Server.Json.Sync;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+/// <summary>
+/// Transaction merger command that creates revisions (snapshots) for a conversation
+/// and all its sub-conversations recursively, then builds a JSON snapshot token.
+/// </summary>
+internal sealed class CreateConversationSnapshotCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+{
+    private readonly DocumentDatabase _database;
+    private readonly string _conversationId;
+
+    public string SnapshotToken { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+
+    public CreateConversationSnapshotCommand(DocumentDatabase database, string conversationId)
+    {
+        _database = database;
+        _conversationId = conversationId;
+    }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        var revisions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        CollectRevisionsRecursive(context, _conversationId, revisions);
+
+        if (revisions.Count == 0)
+            return 0;
+
+        if (revisions.TryGetValue(_conversationId, out var rootCv) == false)
+            throw new InvalidOperationException($"Root conversation '{_conversationId}' was not found in collected revisions.");
+
+        using var rootRevision = _database.DocumentsStorage.RevisionsStorage.GetRevision(context, rootCv);
+        CreatedAt = rootRevision?.LastModified ?? _database.Time.GetUtcNow();
+
+        SnapshotToken = SnapshotTokenDto.Build(context, _conversationId, CreatedAt, revisions);
+        return 1;
+    }
+
+    /// <summary>
+    /// Recursively force-creates a revision for the given document and all its sub-conversations.
+    /// </summary>
+    private void CollectRevisionsRecursive(DocumentsOperationContext context, string documentId, Dictionary<string, string> revisions)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        if (revisions.ContainsKey(documentId))
+            return;
+
+        var cv = _database.DocumentsStorage.RevisionsStorage.ForceCreateRevision(context, documentId);
+        if (cv == null)
+            return;
+
+        revisions[documentId] = cv;
+
+        List<string> subConversationIds = null;
+        using (var document = _database.DocumentsStorage.Get(context, documentId))
+        {
+            if (document?.Data.TryGet(nameof(ConversationDocument.SubConversationIds), out BlittableJsonReaderArray subIds) == true && subIds != null)
+            {
+                subConversationIds = new List<string>(subIds.Length);
+                foreach (var subId in subIds)
+                {
+                    subConversationIds.Add(subId.ToString());
+                }
+            }
+        }
+
+        if (subConversationIds != null)
+        {
+            foreach (var subId in subConversationIds)
+            {
+                CollectRevisionsRecursive(context, subId, revisions);
+            }
+        }
+    }
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+    {
+        return new CreateConversationSnapshotCommandDto { ConversationId = _conversationId };
+    }
+
+    internal class CreateConversationSnapshotCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, CreateConversationSnapshotCommand>
+    {
+        public string ConversationId;
+
+        public CreateConversationSnapshotCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new CreateConversationSnapshotCommand(database, ConversationId);
+        }
+    }
+}
+
+internal sealed class SnapshotTokenDto : IDynamicJson
+{
+    public string ConversationId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public List<SnapshotRevisionEntry> Revisions { get; set; }
+
+    public DynamicJsonValue ToJson()
+    {
+        var revisionArray = new DynamicJsonArray();
+        foreach (var rev in Revisions)
+            revisionArray.Add(rev.ToJson());
+
+        return new DynamicJsonValue
+        {
+            [nameof(ConversationId)] = ConversationId,
+            [nameof(CreatedAt)] = CreatedAt,
+            [nameof(Revisions)] = revisionArray
+        };
+    }
+
+    public static string Build(JsonOperationContext context, string conversationId, DateTime createdAt, Dictionary<string, string> revisions)
+    {
+        var dto = new SnapshotTokenDto
+        {
+            ConversationId = conversationId,
+            CreatedAt = createdAt,
+            Revisions = new List<SnapshotRevisionEntry>(revisions.Count)
+        };
+
+        // Root conversation first, then sub-conversations
+        if (revisions.Remove(conversationId, out var rootCv))
+            dto.Revisions.Add(new SnapshotRevisionEntry { Id = conversationId, ChangeVector = rootCv });
+
+        foreach (var (id, cv) in revisions)
+            dto.Revisions.Add(new SnapshotRevisionEntry { Id = id, ChangeVector = cv });
+
+        using var blittable = context.ReadObject(dto.ToJson(), "snapshot-token");
+        return blittable.ToString();
+    }
+
+    public static SnapshotTokenDto Parse(JsonOperationContext context, string token)
+    {
+        if (string.IsNullOrEmpty(token))
+            throw new InvalidOperationException("Snapshot token is empty.");
+
+        string Truncated() => token.Length > 200 ? token[..200] + "..." : token;
+
+        SnapshotTokenDto dto;
+        try
+        {
+            using var obj = context.Sync.ReadForMemory(token, "snapshot-token");
+            dto = Raven.Server.Json.JsonDeserializationServer.SnapshotTokenDto(obj);
+        }
+        catch (Exception e)
+        {
+            throw new InvalidOperationException($"Invalid snapshot token format. Expected a valid JSON string, but got: '{Truncated()}'", e);
+        }
+
+        if (string.IsNullOrEmpty(dto.ConversationId))
+            throw new InvalidOperationException($"Invalid snapshot token: missing ConversationId. Token: '{Truncated()}'");
+
+        if (dto.Revisions == null || dto.Revisions.Count == 0)
+            throw new InvalidOperationException($"Invalid snapshot token: Revisions array is missing or empty. At least one revision (the main conversation) is required. Token: '{Truncated()}'");
+
+        foreach (var rev in dto.Revisions)
+        {
+            if (string.IsNullOrEmpty(rev.Id) || string.IsNullOrEmpty(rev.ChangeVector))
+                throw new InvalidOperationException($"Invalid snapshot token: each revision must have an Id and ChangeVector. Token: '{Truncated()}'");
+        }
+
+        return dto;
+    }
+}
+
+internal sealed class SnapshotRevisionEntry : IDynamicJson
+{
+    public string Id { get; set; }
+    public string ChangeVector { get; set; }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(Id)] = Id,
+            [nameof(ChangeVector)] = ChangeVector
+        };
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ForkConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ForkConversationCommand.cs
@@ -317,7 +317,6 @@ internal sealed class ForkConversationCommand : MergedTransactionCommand<Documen
         // Adjust OpenActionCalls — entries with SubConversationId need their IDs updated
         if (data.TryGet(nameof(ConversationDocument.OpenActionCalls), out BlittableJsonReaderObject openCalls) && openCalls != null && openCalls.Count > 0)
         {
-            var adjustedCalls = new DynamicJsonValue(openCalls);
             bool callsModified = false;
 
             foreach (var callId in openCalls.GetPropertyNames())
@@ -329,9 +328,13 @@ internal sealed class ForkConversationCommand : MergedTransactionCommand<Documen
                     var adjustedSubConvId = AdjustId(subConvId, sourcePrefix, targetPrefix);
                     if (adjustedSubConvId != subConvId)
                     {
-                        var adjustedCall = new DynamicJsonValue(callObj);
-                        adjustedCall["SubConversationId"] = adjustedSubConvId;
-                        adjustedCalls[callId] = adjustedCall;
+                        // Modify the child blittable in place and store it in the parent, since nesting a source-backed DynamicJsonValue is invalid.
+                        callObj.Modifications = new DynamicJsonValue(callObj)
+                        {
+                            ["SubConversationId"] = adjustedSubConvId
+                        };
+                        openCalls.Modifications ??= new DynamicJsonValue(openCalls);
+                        openCalls.Modifications[callId] = callObj;
                         callsModified = true;
                     }
                 }
@@ -339,7 +342,7 @@ internal sealed class ForkConversationCommand : MergedTransactionCommand<Documen
 
             if (callsModified)
             {
-                data.Modifications[nameof(ConversationDocument.OpenActionCalls)] = adjustedCalls;
+                data.Modifications[nameof(ConversationDocument.OpenActionCalls)] = openCalls;
                 modified = true;
             }
         }
@@ -358,10 +361,16 @@ internal sealed class ForkConversationCommand : MergedTransactionCommand<Documen
         if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false || metadata == null)
             return data;
 
+        // Set modifications on the metadata blittable and place the blittable itself in the parent.
+        // Nesting a DynamicJsonValue that carries a source as a value is invalid (asserted in
+        // ObjectJsonParser) — only a blittable's own .Modifications may carry a source.
+        metadata.Modifications = new DynamicJsonValue(metadata)
+        {
+            [Constants.Documents.Metadata.Expires] = now.Add(expires.Value)
+        };
+
         data.Modifications ??= new DynamicJsonValue(data);
-        var metadataMod = new DynamicJsonValue(metadata);
-        metadataMod[Constants.Documents.Metadata.Expires] = now.Add(expires.Value);
-        data.Modifications[Constants.Documents.Metadata.Key] = metadataMod;
+        data.Modifications[Constants.Documents.Metadata.Key] = metadata;
 
         return context.ReadObject(data, "refreshed-expiration");
     }

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ForkConversationCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ForkConversationCommand.cs
@@ -1,0 +1,392 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Raven.Client;
+using Raven.Client.Documents.Attachments;
+using Raven.Client.Documents.Operations.Attachments;
+using Raven.Client.Exceptions;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+/// <summary>
+/// Creates a forked conversation from revision data referenced by a snapshot token.
+///
+/// The fork process:
+/// 1. Load all revisions referenced by the token — fail atomically if any are missing.
+/// 2. If the target ID already has a document, delete all its sub-conversations
+///    (using SubConversationIds recursively) to clean up orphans.
+/// 3. Write the forked documents with adjusted IDs (only the leading prefix is replaced).
+/// 4. Adjust SubConversationIds within each document to match the new prefix.
+/// </summary>
+internal sealed class ForkConversationCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+{
+    private readonly DocumentDatabase _database;
+    private readonly string _sourceConversationId;
+    private readonly string _newConversationId;
+    private readonly List<SnapshotRevisionEntry> _revisions;
+    private readonly string _expectedChangeVector;
+
+    public string ResultConversationId { get; private set; }
+    public string ResultChangeVector { get; private set; }
+
+    public ForkConversationCommand(
+        DocumentDatabase database,
+        string sourceConversationId,
+        string newConversationId,
+        List<SnapshotRevisionEntry> revisions,
+        string expectedChangeVector = null)
+    {
+        _database = database;
+        _sourceConversationId = sourceConversationId;
+        _newConversationId = newConversationId;
+        _revisions = revisions;
+        _expectedChangeVector = expectedChangeVector;
+    }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        // Step 1: Determine the target conversation ID
+        var targetId = _newConversationId;
+        if (string.IsNullOrEmpty(targetId))
+        {
+            targetId = Guid.NewGuid().ToString();
+        }
+        else if (targetId.EndsWith("/"))
+        {
+            targetId = _database.DocumentsStorage.DocumentPut.BuildDocumentId(targetId, _database.DocumentsStorage.GenerateNextEtag(), out _);
+        }
+        // Cluster identity ("|") must be resolved before reaching this command by the processor
+        Debug.Assert(targetId.EndsWith("|") == false, $"Cluster identity must be resolved before ForkConversationCommand. Got: {targetId}");
+
+        if (_expectedChangeVector != null)
+            VerifyExpectedChangeVector(context, targetId);
+
+        // Step 2: Load all revisions — fail atomically if any are missing.
+        // Note: we trust the token to an extent — there is no trust boundary between generating
+        // and consuming it. The scope validation below is a defense against accidental misuse
+        // or corruption, not a security boundary.
+        if (_revisions.Any(r => string.Equals(r.Id, _sourceConversationId, StringComparison.OrdinalIgnoreCase)) == false)
+        {
+            throw new InvalidOperationException(
+                $"The snapshot token does not contain a revision for the root conversation '{_sourceConversationId}'.");
+        }
+
+        var revisionDocs = new List<(string OriginalId, BlittableJsonReaderObject Data)>(_revisions.Count);
+        foreach (var rev in _revisions)
+        {
+            var revision = _database.DocumentsStorage.RevisionsStorage.GetRevision(context, rev.ChangeVector);
+            if (revision == null)
+            {
+                throw new InvalidOperationException(
+                    $"The snapshot token references a revision (document: '{rev.Id}', change vector: '{rev.ChangeVector}') that no longer exists. " +
+                    "The revision may have been purged by the revisions retention policy or by an explicit purge operation.");
+            }
+
+            // Verify the revision ID is within the source conversation's scope
+            if (rev.Id.StartsWith(_sourceConversationId, StringComparison.OrdinalIgnoreCase) == false ||
+                (rev.Id.Length > _sourceConversationId.Length && rev.Id[_sourceConversationId.Length] != '/'))
+            {
+                throw new InvalidOperationException(
+                    $"The snapshot token contains a revision for document '{rev.Id}' which is outside " +
+                    $"the scope of conversation '{_sourceConversationId}'. Only the root conversation " +
+                    "and its sub-conversations (prefixed with the root ID) are allowed.");
+            }
+
+            // Verify the revision belongs to the @conversations collection
+            if (revision.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) && metadata != null)
+            {
+                metadata.TryGet(Constants.Documents.Metadata.Collection, out string collection);
+                if (collection != null &&
+                    string.Equals(collection, Constants.Documents.Collections.AiAgentConversationCollection, StringComparison.OrdinalIgnoreCase) == false)
+                {
+                    throw new InvalidOperationException(
+                        $"The snapshot token references a revision for document '{rev.Id}' which belongs to collection '{collection}', " +
+                        $"not the expected '{Constants.Documents.Collections.AiAgentConversationCollection}' collection.");
+                }
+            }
+
+            revisionDocs.Add((rev.Id, revision.Data));
+        }
+
+        // Step 3: If the target already has a document, clean up all sub-conversation documents
+        // by reading SubConversationIds from the existing document and recursively deleting them.
+        CleanupExistingSubConversations(context, targetId, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        // Step 4: Write the forked documents with adjusted IDs
+        for (int i = 0; i < revisionDocs.Count; i++)
+        {
+            var (originalId, data) = revisionDocs[i];
+            var adjustedId = AdjustId(originalId, _sourceConversationId, targetId);
+
+            // Adjust SubConversationIds within the document to reflect the new prefix
+            var adjustedData = AdjustDocumentIds(context, data, _sourceConversationId, targetId);
+
+            // Update @expires metadata if the document has an Expires field
+            adjustedData = RefreshExpiration(context, adjustedData, _database.Time.GetUtcNow());
+
+            var putResult = _database.DocumentsStorage.Put(context, adjustedId, null, adjustedData,
+                nonPersistentFlags: NonPersistentDocumentFlags.SkipSchemaValidation);
+
+            // Delete existing attachments on the target (relevant for rewind-in-place),
+            // then copy attachments from the revision.
+            DeleteExistingAttachments(context, adjustedId);
+            CopyAttachmentsFromRevision(context, originalId, _revisions[i].ChangeVector, adjustedId);
+
+            if (string.Equals(originalId, _sourceConversationId, StringComparison.OrdinalIgnoreCase))
+            {
+                // Re-read to get the final change vector (may have changed due to attachment copies)
+                var final = _database.DocumentsStorage.Get(context, adjustedId);
+                ResultConversationId = final.Id;
+                ResultChangeVector = final.ChangeVector;
+            }
+        }
+
+        return revisionDocs.Count;
+    }
+
+    private void VerifyExpectedChangeVector(DocumentsOperationContext context, string targetId)
+    {
+        using var existingDoc = _database.DocumentsStorage.Get(context, targetId);
+        if (_expectedChangeVector == string.Empty)
+        {
+            if (existingDoc != null)
+            {
+                throw new ConcurrencyException(
+                    $"Expected the conversation '{targetId}' to not exist, but it already exists with change vector '{existingDoc.ChangeVector}'.")
+                {
+                    ExpectedChangeVector = _expectedChangeVector,
+                    ActualChangeVector = existingDoc.ChangeVector,
+                    Id = targetId
+                };
+            }
+        }
+        else if (existingDoc == null)
+        {
+            throw new ConcurrencyException(
+                $"The conversation '{targetId}' does not exist, but an expected change vector was provided.")
+            {
+                ExpectedChangeVector = _expectedChangeVector,
+                ActualChangeVector = string.Empty,
+                Id = targetId
+            };
+        }
+        else if (existingDoc.ChangeVector != _expectedChangeVector)
+        {
+            throw new ConcurrencyException(
+                $"The conversation '{targetId}' was updated and doesn't match the expected change vector. Reload the conversation and try again.")
+            {
+                ExpectedChangeVector = _expectedChangeVector,
+                ActualChangeVector = existingDoc.ChangeVector,
+                Id = targetId
+            };
+        }
+    }
+
+    private void DeleteExistingAttachments(DocumentsOperationContext context, string documentId)
+    {
+        using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out var lowerId))
+        {
+            var existing = _database.DocumentsStorage.AttachmentsStorage.GetAttachmentDetailsForDocument(context, lowerId);
+            if (existing == null || existing.Count == 0)
+                return;
+
+            foreach (var attachment in existing)
+            {
+                _database.DocumentsStorage.AttachmentsStorage.DeleteAttachment(context, documentId, attachment.Name, null, out _, updateDocument: false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Copies attachments from a revision to the target document using <c>CopyAttachment</c>,
+    /// which properly updates the target document's HasAttachments flag.
+    /// Reads the revision's <c>@metadata.@attachments</c> to find attachment names,
+    /// then copies each one from the revision's attachment storage.
+    /// </summary>
+    private void CopyAttachmentsFromRevision(DocumentsOperationContext context, string sourceId, string revisionChangeVector, string targetId)
+    {
+        // Get the revision's attachment list from its metadata
+        using var revision = _database.DocumentsStorage.RevisionsStorage.GetRevision(context, revisionChangeVector);
+        if (revision == null)
+            return;
+
+        if (revision.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false || metadata == null)
+            return;
+
+        if (metadata.TryGet(Constants.Documents.Metadata.Attachments, out BlittableJsonReaderArray attachments) == false || attachments == null)
+            return;
+
+        using var changeVectorLsv = context.GetLazyString(revisionChangeVector);
+
+        foreach (BlittableJsonReaderObject attachment in attachments)
+        {
+            if (attachment.TryGet(nameof(AttachmentName.Name), out string name) == false)
+                continue;
+
+            _database.DocumentsStorage.AttachmentsStorage.CopyAttachment(context, sourceId, name,
+                targetId, name, changeVectorLsv, AttachmentType.Revision);
+        }
+    }
+
+    /// <summary>
+    /// Recursively deletes sub-conversations tracked by the document at <paramref name="documentId"/>.
+    /// Reads the SubConversationIds array from the existing document and recurses into each
+    /// sub-conversation before deleting it, ensuring nested sub-conversations are also cleaned up.
+    /// Documents not tracked in SubConversationIds are left untouched.
+    /// </summary>
+    private void CleanupExistingSubConversations(DocumentsOperationContext context, string documentId, HashSet<string> visited)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        if (visited.Add(documentId) == false)
+            return;
+
+        List<string> subConversationIds = null;
+        using (var existingDoc = _database.DocumentsStorage.Get(context, documentId))
+        {
+            if (existingDoc == null)
+                return;
+
+            if (existingDoc.Data.TryGet(nameof(ConversationDocument.SubConversationIds), out BlittableJsonReaderArray subIds) && subIds != null)
+            {
+                subConversationIds = new List<string>(subIds.Length);
+                foreach (var subIdValue in subIds)
+                {
+                    subConversationIds.Add(subIdValue.ToString());
+                }
+            }
+        }
+
+        if (subConversationIds != null)
+        {
+            foreach (var subId in subConversationIds)
+            {
+                CleanupExistingSubConversations(context, subId, visited);
+                _database.DocumentsStorage.Delete(context, subId, null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces only the leading conversation ID prefix in a sub-conversation ID.
+    /// For example: "chats/42/Search/abc" with source "chats/42" and target "forked/1"
+    /// becomes "forked/1/Search/abc". A second occurrence of "chats/42" deeper in the ID
+    /// (e.g. "chats/42/chats/42/foo") is NOT replaced — only the leading prefix.
+    /// </summary>
+    internal static string AdjustId(string originalId, string sourcePrefix, string targetPrefix)
+    {
+        if (string.Equals(originalId, sourcePrefix, StringComparison.OrdinalIgnoreCase))
+            return targetPrefix;
+
+        if (originalId.StartsWith(sourcePrefix, StringComparison.OrdinalIgnoreCase) &&
+            originalId.Length > sourcePrefix.Length &&
+            originalId[sourcePrefix.Length] == '/')
+        {
+            return targetPrefix + originalId.Substring(sourcePrefix.Length);
+        }
+
+        return originalId;
+    }
+
+    private static BlittableJsonReaderObject AdjustDocumentIds(DocumentsOperationContext context, BlittableJsonReaderObject data,
+        string sourcePrefix, string targetPrefix)
+    {
+        if (string.Equals(sourcePrefix, targetPrefix, StringComparison.OrdinalIgnoreCase))
+            return data;
+
+        bool modified = false;
+        data.Modifications = new DynamicJsonValue(data);
+
+        // Adjust SubConversationIds
+        if (data.TryGet(nameof(ConversationDocument.SubConversationIds), out BlittableJsonReaderArray subIds) && subIds != null)
+        {
+            var adjustedSubIds = new DynamicJsonArray();
+            foreach (var item in subIds)
+                adjustedSubIds.Add(AdjustId(item.ToString(), sourcePrefix, targetPrefix));
+
+            data.Modifications[nameof(ConversationDocument.SubConversationIds)] = adjustedSubIds;
+            modified = true;
+        }
+
+        // Adjust OpenActionCalls — entries with SubConversationId need their IDs updated
+        if (data.TryGet(nameof(ConversationDocument.OpenActionCalls), out BlittableJsonReaderObject openCalls) && openCalls != null && openCalls.Count > 0)
+        {
+            var adjustedCalls = new DynamicJsonValue(openCalls);
+            bool callsModified = false;
+
+            foreach (var callId in openCalls.GetPropertyNames())
+            {
+                if (openCalls[callId] is BlittableJsonReaderObject callObj &&
+                    callObj.TryGet("SubConversationId", out string subConvId) &&
+                    string.IsNullOrEmpty(subConvId) == false)
+                {
+                    var adjustedSubConvId = AdjustId(subConvId, sourcePrefix, targetPrefix);
+                    if (adjustedSubConvId != subConvId)
+                    {
+                        var adjustedCall = new DynamicJsonValue(callObj);
+                        adjustedCall["SubConversationId"] = adjustedSubConvId;
+                        adjustedCalls[callId] = adjustedCall;
+                        callsModified = true;
+                    }
+                }
+            }
+
+            if (callsModified)
+            {
+                data.Modifications[nameof(ConversationDocument.OpenActionCalls)] = adjustedCalls;
+                modified = true;
+            }
+        }
+
+        if (modified == false)
+            return data;
+
+        return context.ReadObject(data, "adjusted-conversation");
+    }
+
+    private static BlittableJsonReaderObject RefreshExpiration(DocumentsOperationContext context, BlittableJsonReaderObject data, DateTime now)
+    {
+        if (data.TryGet(nameof(ConversationDocument.Expires), out TimeSpan? expires) == false || expires == null)
+            return data;
+
+        if (data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) == false || metadata == null)
+            return data;
+
+        data.Modifications ??= new DynamicJsonValue(data);
+        var metadataMod = new DynamicJsonValue(metadata);
+        metadataMod[Constants.Documents.Metadata.Expires] = now.Add(expires.Value);
+        data.Modifications[Constants.Documents.Metadata.Key] = metadataMod;
+
+        return context.ReadObject(data, "refreshed-expiration");
+    }
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+    {
+        return new ForkConversationCommandDto
+        {
+            SourceConversationId = _sourceConversationId,
+            NewConversationId = _newConversationId,
+            Revisions = _revisions,
+            ExpectedChangeVector = _expectedChangeVector
+        };
+    }
+
+    internal class ForkConversationCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, ForkConversationCommand>
+    {
+        public string SourceConversationId;
+        public string NewConversationId;
+        public List<SnapshotRevisionEntry> Revisions;
+        public string ExpectedChangeVector;
+
+        public ForkConversationCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new ForkConversationCommand(database, SourceConversationId, NewConversationId, Revisions, ExpectedChangeVector);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PurgeConversationSnapshotsCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PurgeConversationSnapshotsCommand.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Raven.Client;
+using Raven.Server.Documents.TransactionMerger.Commands;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Voron;
+
+namespace Raven.Server.Documents.Handlers.AI.Agents;
+
+/// <summary>
+/// Deletes revisions for a conversation and its sub-conversations (found via SubConversationIds recursively).
+/// When <c>Before</c> is specified, only revisions older than that date are deleted
+/// using per-revision <c>DeleteRevision</c> calls. When null, all revisions are deleted.
+/// All conversation documents belong to the <c>@conversations</c> collection.
+/// </summary>
+internal sealed class PurgeConversationSnapshotsCommand : MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>
+{
+    private readonly DocumentDatabase _database;
+    private readonly string _conversationId;
+    private readonly DateTime? _before;
+
+    public PurgeConversationSnapshotsCommand(DocumentDatabase database, string conversationId, DateTime? before = null)
+    {
+        _database = database;
+        _conversationId = conversationId;
+        _before = before;
+    }
+
+    protected override long ExecuteCmd(DocumentsOperationContext context)
+    {
+        // Validate the root document belongs to the @conversations collection
+        using (var rootDoc = _database.DocumentsStorage.Get(context, _conversationId))
+        {
+            if (rootDoc == null)
+                return 0;
+
+            if (rootDoc.Data.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject metadata) && metadata != null)
+            {
+                metadata.TryGet(Constants.Documents.Metadata.Collection, out string collection);
+                if (collection != null &&
+                    string.Equals(collection, Constants.Documents.Collections.AiAgentConversationCollection, StringComparison.OrdinalIgnoreCase) == false)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot purge snapshots for '{_conversationId}': document belongs to collection '{collection}', " +
+                        $"not '{Constants.Documents.Collections.AiAgentConversationCollection}'.");
+                }
+            }
+        }
+
+        // Collect all document IDs to purge: the main conversation + all sub-conversations.
+        var documentIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        CollectSubConversationIdsRecursive(context, _conversationId, documentIds);
+
+        foreach (var documentId in documentIds)
+            PurgeRevisionsFor(context, documentId);
+
+        return documentIds.Count;
+    }
+
+    /// <summary>
+    /// Recursively collects the document ID and all SubConversationIds from the current document.
+    /// </summary>
+    private void CollectSubConversationIdsRecursive(DocumentsOperationContext context, string documentId, HashSet<string> collected)
+    {
+        RuntimeHelpers.EnsureSufficientExecutionStack();
+
+        if (collected.Add(documentId) == false)
+            return;
+
+        List<string> subConversationIds = null;
+        using (var doc = _database.DocumentsStorage.Get(context, documentId))
+        {
+            if (doc?.Data.TryGet(nameof(ConversationDocument.SubConversationIds), out BlittableJsonReaderArray subIds) == true && subIds != null)
+            {
+                subConversationIds = new List<string>(subIds.Length);
+                foreach (var subIdValue in subIds)
+                {
+                    subConversationIds.Add(subIdValue.ToString());
+                }
+            }
+        }
+
+        if (subConversationIds != null)
+        {
+            foreach (var subId in subConversationIds)
+            {
+                CollectSubConversationIdsRecursive(context, subId, collected);
+            }
+        }
+    }
+
+    private void PurgeRevisionsFor(DocumentsOperationContext context, string documentId)
+    {
+        if (_before.HasValue == false)
+        {
+            _database.DocumentsStorage.RevisionsStorage.ForceDeleteAllRevisionsFor(context, documentId);
+            return;
+        }
+
+        // Collect change vectors of revisions older than the cutoff, then delete individually.
+        var changeVectorsToDelete = new List<string>();
+
+        foreach (var revision in _database.DocumentsStorage.RevisionsStorage.GetRevisionsByDate(context, documentId, before: _before))
+        {
+            changeVectorsToDelete.Add(revision.ChangeVector);
+        }
+
+        if (changeVectorsToDelete.Count == 0)
+            return;
+
+        var lastModifiedTicks = _database.Time.GetUtcNow().Ticks;
+        string collection = Constants.Documents.Collections.AiAgentConversationCollection;
+
+        foreach (string changeVector in changeVectorsToDelete)
+        {
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out var loweredKey))
+            using (Slice.From(context.Allocator, changeVector, out var cvSlice))
+            {
+                _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, loweredKey, collection,
+                    changeVector, lastModifiedTicks, cvSlice, fromReplication: false);
+            }
+        }
+    }
+
+    public override IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, MergedTransactionCommand<DocumentsOperationContext, DocumentsTransaction>> ToDto(DocumentsOperationContext context)
+    {
+        return new PurgeConversationSnapshotsCommandDto
+        {
+            ConversationId = _conversationId,
+            Before = _before
+        };
+    }
+
+    internal class PurgeConversationSnapshotsCommandDto : IReplayableCommandDto<DocumentsOperationContext, DocumentsTransaction, PurgeConversationSnapshotsCommand>
+    {
+        public string ConversationId;
+        public DateTime? Before;
+
+        public PurgeConversationSnapshotsCommand ToCommand(DocumentsOperationContext context, DocumentDatabase database)
+        {
+            return new PurgeConversationSnapshotsCommand(database, ConversationId, Before);
+        }
+    }
+}

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/PurgeConversationSnapshotsCommand.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/PurgeConversationSnapshotsCommand.cs
@@ -115,12 +115,7 @@ internal sealed class PurgeConversationSnapshotsCommand : MergedTransactionComma
 
         foreach (string changeVector in changeVectorsToDelete)
         {
-            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, documentId, out var loweredKey))
-            using (Slice.From(context.Allocator, changeVector, out var cvSlice))
-            {
-                _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, loweredKey, collection,
-                    changeVector, lastModifiedTicks, cvSlice, fromReplication: false);
-            }
+            _database.DocumentsStorage.RevisionsStorage.DeleteRevision(context, documentId, collection, changeVector, lastModifiedTicks);
         }
     }
 

--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ShardedAiAgentHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ShardedAiAgentHandler.cs
@@ -49,5 +49,29 @@ namespace Raven.Server.Documents.Handlers.AI.Agents
         {
             throw new NotSupportedInShardingException("AI Agents for a sharded database are currently not supported");
         }
+
+        [RavenShardedAction("/databases/*/ai/agent/fork", "POST")]
+        public Task ForkConversation()
+        {
+            throw new NotSupportedInShardingException("AI Agents for a sharded database are currently not supported");
+        }
+
+        [RavenShardedAction("/databases/*/ai/agent/snapshots", "POST")]
+        public Task CreateConversationSnapshot()
+        {
+            throw new NotSupportedInShardingException("AI Agents for a sharded database are currently not supported");
+        }
+
+        [RavenShardedAction("/databases/*/ai/agent/snapshots", "GET")]
+        public Task GetConversationSnapshots()
+        {
+            throw new NotSupportedInShardingException("AI Agents for a sharded database are currently not supported");
+        }
+
+        [RavenShardedAction("/databases/*/ai/agent/snapshots", "DELETE")]
+        public Task PurgeConversationSnapshots()
+        {
+            throw new NotSupportedInShardingException("AI Agents for a sharded database are currently not supported");
+        }
     }
 }

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2634,6 +2634,106 @@ namespace Raven.Server.Documents.Revisions
             }
         }
 
+        /// <summary>
+        /// Returns revisions for a document ordered by LastModified descending (newest first).
+        /// When <paramref name="before"/> is specified, only returns revisions with LastModified &lt; before.
+        ///
+        /// Because revisions from multiple cluster nodes may arrive out of order, the local etag
+        /// order can differ from the LastModified order. To provide correct date-based paging,
+        /// this method scans all revisions for the document (reading only LastModified from each
+        /// table entry without materializing full Documents), uses a PriorityQueue to collect the
+        /// top <paramref name="take"/> entries by newest date, then materializes only those.
+        /// </summary>
+        public IEnumerable<Document> GetRevisionsByDate(DocumentsOperationContext context, string id, int take = int.MaxValue, DateTime? before = null)
+        {
+            using (DocumentIdWorker.GetLoweredIdSliceFromId(context, id, out Slice lowerId))
+            using (GetKeyPrefix(context, lowerId, out Slice prefixSlice))
+            using (GetLastKey(context, lowerId, out Slice lastKey))
+            {
+                var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);
+
+                // Collect the top 'take' revisions by LastModified (newest first).
+                // We use a min-heap (PriorityQueue) so the smallest (oldest) date is always
+                // at the top. When the queue exceeds 'take', we dequeue the oldest, keeping
+                // only the newest 'take' entries. We store the change vector string to
+                // re-fetch the full Document only for the entries that made it through.
+                var heap = new PriorityQueue<string, DateTime>();
+
+                foreach (var tvr in table.SeekBackwardFrom(RevisionsSchema.Indexes[IdAndEtagSlice], prefixSlice, lastKey, 0))
+                {
+                    var lastModified = TableValueToDateTime((int)RevisionsTable.LastModified, ref tvr.Result.Reader);
+
+                    if (before.HasValue && lastModified >= before.Value)
+                        continue;
+
+                    var cv = TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr.Result.Reader);
+
+                    if (heap.Count < take)
+                    {
+                        heap.Enqueue(cv, lastModified);
+                    }
+                    else
+                    {
+                        heap.EnqueueDequeue(cv, lastModified);
+                    }
+                }
+
+                // Dequeue min-first into an array, filling from the end for newest-first order
+                var results = new string[heap.Count];
+                var idx = results.Length - 1;
+                while (heap.TryDequeue(out var cv, out _))
+                    results[idx--] = cv;
+
+                // Materialize only the selected revisions
+                foreach (var cv in results)
+                {
+                    var revision = GetRevision(context, cv);
+                    if (revision != null)
+                        yield return revision;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Force-creates a revision for the given document. If the document does not have
+        /// the <see cref="DocumentFlags.HasRevisions"/> flag, it is added first (with a put
+        /// that skips revision creation). Returns the document's change vector, or <c>null</c>
+        /// if the document does not exist.
+        /// </summary>
+        public string ForceCreateRevision(DocumentsOperationContext context, string documentId)
+        {
+            var document = _documentsStorage.Get(context, documentId);
+            if (document == null)
+                return null;
+
+            var clonedData = document.Data.Clone(context);
+
+            if (document.Flags.Contain(DocumentFlags.HasRevisions) == false)
+            {
+                document.Flags |= DocumentFlags.HasRevisions;
+
+                var putResult = _documentsStorage.Put(context, document.Id,
+                    document.ChangeVector,
+                    clonedData,
+                    flags: document.Flags,
+                    nonPersistentFlags: NonPersistentDocumentFlags.SkipRevisionCreation);
+
+                document.ChangeVector = putResult.ChangeVector;
+                document.LastModified = putResult.LastModified;
+
+                clonedData = document.Data.Clone(context);
+            }
+
+            Put(context, document.Id,
+                clonedData,
+                document.Flags,
+                nonPersistentFlags: NonPersistentDocumentFlags.ForceRevisionCreation,
+                context.GetChangeVector(document.ChangeVector),
+                document.LastModified.Ticks);
+
+            return document.ChangeVector;
+        }
+
         private IEnumerable<Document> GetRevisions(DocumentsOperationContext context, Slice prefixSlice, Slice lastKey, long start, long take)
         {
             var table = new Table(RevisionsSchema, context.Transaction.InnerTransaction);

--- a/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
+++ b/src/Raven.Server/Documents/Revisions/RevisionsStorage.cs
@@ -2666,7 +2666,7 @@ namespace Raven.Server.Documents.Revisions
                     if (before.HasValue && lastModified >= before.Value)
                         continue;
 
-                    var cv = TableValueToChangeVector(context, (int)RevisionsTable.ChangeVector, ref tvr.Result.Reader);
+                    var cv = ReadChangeVectorFromTvr(context, ref tvr.Result.Reader);
 
                     if (heap.Count < take)
                     {

--- a/src/Raven.Server/Json/JsonDeserializationServer.cs
+++ b/src/Raven.Server/Json/JsonDeserializationServer.cs
@@ -413,5 +413,7 @@ namespace Raven.Server.Json
             public static readonly Func<BlittableJsonReaderObject, AdoptOrphanedRevisionsOperation.Parameters> AdoptOrphanedRevisionsConfigurationOperationParameters = GenerateJsonDeserializationRoutine<AdoptOrphanedRevisionsOperation.Parameters>();
             public static readonly Func<BlittableJsonReaderObject, StartSchemaValidationOperation.Parameters> ValidateSchemaOperationParameters = GenerateJsonDeserializationRoutine<StartSchemaValidationOperation.Parameters>();
         }
+
+        internal static readonly Func<BlittableJsonReaderObject, Documents.Handlers.AI.Agents.SnapshotTokenDto> SnapshotTokenDto = GenerateJsonDeserializationRoutine<Documents.Handlers.AI.Agents.SnapshotTokenDto>();
     }
 }

--- a/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
+++ b/src/Raven.Studio/typescript/components/pages/database/aiHub/aiAgents/chat/store/chatAiAgentSlice.ts
@@ -166,6 +166,7 @@ const runChat = createAsyncThunk(
                         formValues.isDocumentExpireInCustomizeEnabled
                             ? formValues.persistenceExpiresInSeconds
                             : null,
+                    SnapshotBeforeRunning: false,
                 },
             },
             config.data?.Identifier,

--- a/test/FastTests/Client/RavenCommandTest.cs
+++ b/test/FastTests/Client/RavenCommandTest.cs
@@ -79,6 +79,7 @@ namespace FastTests.Client
                 "DeleteRevisionsCommand", "ConfigureRevisionsBinCleanerCommand",
                 "GetCollectionRevisionsStatisticsCommand", "AddGenAiCommand","UpdateGenAiCommand", "AddEmbeddingsGenerationCommand",
                 "AddOrUpdateAiAgentOperationCommand","DeleteAiAgentOperationCommand","RunConversationOperationCommand","GetAiAgentOperationCommand","GetConversationMessagesCommand",
+                "CreateConversationSnapshotCommand","ForkConversationCommand","GetConversationSnapshotsCommand","PurgeConversationSnapshotsCommand",
                 "ConfigureAttachmentsRemoteCommand", "GetRemoteAttachmentsConfigurationCommand", "DeleteAttachmentsCommand",
                 "ConfigureSchemaValidationCommand", "GetSchemaValidationCommand", "StartSchemaValidationCommand",
                 "AddCdcSinkCommand", "UpdateCdcSinkCommand",

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationBasicTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationBasicTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationBasicTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationBasicTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task A1_SnapshotToken_IsNull_OnFirstTurn()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var result = await RunTurnAsync(database, "chats/1", "Hello", snapshotBeforeRunning: true);
+            Assert.Null(result.SnapshotToken);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task A2_SnapshotToken_IsPopulated_OnSubsequentTurns()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var r1 = await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            Assert.Null(r1.SnapshotToken);
+
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            Assert.NotNull(r2.SnapshotToken);
+
+            var r3 = await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+            Assert.NotNull(r3.SnapshotToken);
+            Assert.NotEqual(r2.SnapshotToken, r3.SnapshotToken);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task A3_ForkToNewId_CreatesIndependentConversation()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+
+            Assert.Equal("forked/1", forkResult.ConversationId);
+            Assert.NotNull(forkResult.ChangeVector);
+
+            var forkedMessages = await GetDetailedMessagesAsync(store, "forked/1");
+            var originalMessages = await GetDetailedMessagesAsync(store, "chats/1");
+
+            Assert.NotNull(forkedMessages);
+            Assert.NotNull(originalMessages);
+
+            // Snapshot was taken before turn 2, so forked has 1 turn: system + 1*2 = 3 messages
+            AssertExactMessageCount(forkedMessages, 1, "forked from snapshot before turn 2");
+            // Original has 3 turns: system + 3*2 = 7 messages
+            AssertExactMessageCount(originalMessages, 3, "original after 3 turns");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task A4_ForkToExplicitId()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked-chats/my-fork");
+            Assert.Equal("forked-chats/my-fork", forkResult.ConversationId);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task A5_ForkToClusterIdentity()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forks|");
+
+            Assert.NotNull(forkResult.ConversationId);
+            Assert.StartsWith("forks/", forkResult.ConversationId);
+            Assert.NotNull(forkResult.ChangeVector);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<object>(forkResult.ConversationId);
+                Assert.NotNull(doc);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task A6_ForkPreservesParameters()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            {
+                var parameters = new Dictionary<string, object> { ["company"] = "companies/90-A" };
+
+                await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true, parameters: parameters);
+                var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true, parameters: parameters);
+
+                var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+                Assert.Equal("forked/1", forkResult.ConversationId);
+
+                var forkedDoc = GetDocumentAsJObject(store, "forked/1");
+                Assert.NotNull(forkedDoc);
+                var forkedParams = forkedDoc[nameof(ConversationDocument.Parameters)] as JObject;
+                Assert.NotNull(forkedParams);
+
+                var companyParam = forkedParams["company"] as JObject;
+                Assert.NotNull(companyParam);
+                Assert.Equal("companies/90-A", companyParam["Value"]?.ToString());
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationConcurrencyTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationConcurrencyTests.cs
@@ -1,0 +1,116 @@
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationConcurrencyTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationConcurrencyTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task G1_Fork_TwoClientsForkSameTokenToDifferentIds()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var task1 = store.AI.ForkConversationAsync(r2.SnapshotToken, "fork-a");
+            var task2 = store.AI.ForkConversationAsync(r2.SnapshotToken, "fork-b");
+
+            await Task.WhenAll(task1, task2);
+
+            var msgsA = await store.AI.GetConversationMessagesAsync("fork-a");
+            var msgsB = await store.AI.GetConversationMessagesAsync("fork-b");
+            Assert.NotNull(msgsA);
+            Assert.NotEmpty(msgsA.Messages);
+            Assert.NotNull(msgsB);
+            Assert.NotEmpty(msgsB.Messages);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task G2_Fork_TwoClientsForkToSameNewId()
+        {
+            // Both forks succeed because there's no change vector check — last writer wins.
+            // The result is effectively idempotent since both write the same revision data.
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var task1 = store.AI.ForkConversationAsync(r2.SnapshotToken, "same-target");
+            var task2 = store.AI.ForkConversationAsync(r2.SnapshotToken, "same-target");
+
+            await Task.WhenAll(task1, task2);
+
+            var msgs = await store.AI.GetConversationMessagesAsync("same-target");
+            Assert.NotNull(msgs);
+            Assert.NotEmpty(msgs.Messages);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task G3_Fork_FromOlderToken_ReturnsOlderState()
+        {
+            // Forking from an older snapshot token always returns the state at that snapshot,
+            // regardless of how many turns have been added since. The fork reads from the
+            // immutable revision, not the live document.
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            // Run more turns after the snapshot
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 4", snapshotBeforeRunning: true);
+
+            // Fork from the old token (before turn 2)
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+
+            // Fork should have turn 1 only (3 messages), original should have 4 turns (9 messages)
+            var forkedMessages = await GetDetailedMessagesAsync(store, "forked/1");
+            var originalMessages = await GetDetailedMessagesAsync(store, "chats/1");
+
+            AssertExactMessageCount(forkedMessages, 1, "fork from snapshot before turn 2");
+            AssertExactMessageCount(originalMessages, 4, "original after 4 turns");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task G4_Fork_ThenContinueOriginal()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            // Continue original
+            var r3 = await RunTurnAsync(database, "chats/1", "turn 3 on original", snapshotBeforeRunning: true);
+            Assert.NotNull(r3.SnapshotToken);
+
+            // Continue fork
+            var rf = await RunTurnAsync(database, "forked/1", "turn on fork", snapshotBeforeRunning: true);
+            Assert.NotNull(rf.Response);
+
+            var originalMessages = await GetDetailedMessagesAsync(store, "chats/1");
+            var forkedMessages = await GetDetailedMessagesAsync(store, "forked/1");
+
+            Assert.NotNull(originalMessages);
+            Assert.NotEmpty(originalMessages.Messages);
+            Assert.NotNull(forkedMessages);
+            Assert.NotEmpty(forkedMessages.Messages);
+
+            // Original has 3 turns, fork has 1 (from snapshot) + 1 new = 2 turns
+            AssertExactMessageCount(originalMessages, 3, "original after 3 turns");
+            AssertExactMessageCount(forkedMessages, 2, "forked with 1 restored + 1 new turn");
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationCrudTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationCrudTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationCrudTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationCrudTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K1_CreateSnapshot_WithoutRunAsync()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: false);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: false);
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+            Assert.NotNull(snapshot);
+            Assert.NotNull(snapshot.Token);
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "from-snapshot");
+            Assert.Equal("from-snapshot", forkResult.ConversationId);
+
+            var messages = await store.AI.GetConversationMessagesAsync("from-snapshot");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K2_GetConversationSnapshots_ReturnsAll()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+
+            var snapshots = await store.AI.GetConversationSnapshotsAsync("chats/1");
+
+            Assert.True(snapshots.Count >= 2, $"Expected at least 2 snapshots, got {snapshots.Count}");
+
+            foreach (var snapshot in snapshots)
+            {
+                Assert.NotNull(snapshot.Token);
+                Assert.True(snapshot.CreatedAt > DateTime.MinValue);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K3_GetConversationSnapshots_ExcludesPurgedRevisions()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+
+            var snapshotsBefore = await store.AI.GetConversationSnapshotsAsync("chats/1");
+            Assert.True(snapshotsBefore.Count > 0, "Should have snapshots before purge");
+
+            await store.AI.PurgeConversationSnapshotsAsync("chats/1");
+
+            var snapshotsAfter = await store.AI.GetConversationSnapshotsAsync("chats/1");
+            Assert.Equal(0, snapshotsAfter.Count);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K4_GetConversationSnapshots_EmptyForNoSnapshots()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: false);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: false);
+
+            var snapshots = await store.AI.GetConversationSnapshotsAsync("chats/1");
+            Assert.Empty(snapshots);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K5_PurgeConversationSnapshots_ConversationStillWorks()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+
+            await store.AI.PurgeConversationSnapshotsAsync("chats/1");
+
+            var messages = await store.AI.GetConversationMessagesAsync("chats/1");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+
+            var r4 = await RunTurnAsync(database, "chats/1", "turn 4 after purge", snapshotBeforeRunning: false);
+            Assert.NotNull(r4.Response);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K6_PurgeConversationSnapshots_DoesNotAffectOtherConversations()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/a", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/a", "turn 2", snapshotBeforeRunning: true);
+
+            await RunTurnAsync(database, "chats/b", "turn 1", snapshotBeforeRunning: true);
+            var rB2 = await RunTurnAsync(database, "chats/b", "turn 2", snapshotBeforeRunning: true);
+
+            await store.AI.PurgeConversationSnapshotsAsync("chats/a");
+
+            var forkResult = await store.AI.ForkConversationAsync(rB2.SnapshotToken, "forked-b");
+            Assert.Equal("forked-b", forkResult.ConversationId);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K7_PurgeConversationSnapshots_NonExistentConversation()
+        {
+            using var store = GetDocumentStore();
+
+            // Should not throw
+            await store.AI.PurgeConversationSnapshotsAsync("nonexistent/id");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K8_PurgeConversationSnapshots_DeletesRevisionsButPreservesConversation()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+
+            var r3 = await RunTurnAsync(database, "chats/1", "turn 3 for token", snapshotBeforeRunning: true);
+            Assert.NotNull(r3.SnapshotToken);
+
+            var preFork = await store.AI.ForkConversationAsync(r3.SnapshotToken, "pre-purge-fork");
+            Assert.Equal("pre-purge-fork", preFork.ConversationId);
+
+            await store.AI.PurgeConversationSnapshotsAsync("chats/1");
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                await store.AI.ForkConversationAsync(r3.SnapshotToken, "post-purge-fork"));
+            Assert.Contains("no longer exists", ex.Message);
+
+            var messages = await store.AI.GetConversationMessagesAsync("chats/1");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+
+            var r4 = await RunTurnAsync(database, "chats/1", "turn 4 after purge", snapshotBeforeRunning: false);
+            Assert.NotNull(r4.Response);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task K9_RevisionsRetention_LimitsSnapshotCount()
+        {
+            // Test: With revisions retention set to max 3, running 5 turns with snapshots
+            //        should result in only 3 snapshots being available (oldest are purged).
+            // Reasoning: The standard revisions retention policy on @conversations controls
+            //            how many snapshots are kept.
+
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // Configure revisions: keep at most 3 for the @conversations collection
+            await store.Maintenance.SendAsync(new Raven.Client.Documents.Operations.Revisions.ConfigureRevisionsOperation(
+                new Raven.Client.Documents.Operations.Revisions.RevisionsConfiguration
+                {
+                    Collections = new System.Collections.Generic.Dictionary<string, Raven.Client.Documents.Operations.Revisions.RevisionsCollectionConfiguration>
+                    {
+                        [Raven.Client.Constants.Documents.Collections.AiAgentConversationCollection] = new()
+                        {
+                            Disabled = false,
+                            MinimumRevisionsToKeep = 3
+                        }
+                    }
+                }));
+
+            // Run 5 turns with snapshots
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 4", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 5", snapshotBeforeRunning: true);
+
+            // Only 3 snapshots should be available (retention purged the oldest)
+            var snapshots = await store.AI.GetConversationSnapshotsAsync("chats/1");
+            Assert.Equal(3, snapshots.Count);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationFlagTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationFlagTests.cs
@@ -1,0 +1,73 @@
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationFlagTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationFlagTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task I1_SnapshotToken_IsNull_WhenFlagDisabled()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var r1 = await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: false);
+            Assert.Null(r1.SnapshotToken);
+
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: false);
+            Assert.Null(r2.SnapshotToken);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task I2_Flag_EnabledMidConversation()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var r1 = await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: false);
+            Assert.Null(r1.SnapshotToken);
+
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            Assert.NotNull(r2.SnapshotToken);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task I3_Flag_DisabledAfterEnabled_TokenStillValid()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            var r3 = await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: false);
+
+            Assert.NotNull(r2.SnapshotToken);
+            Assert.Null(r3.SnapshotToken);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task I4_Fork_ThenContinueWithoutFlag()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            var result = await RunTurnAsync(database, "forked/1", "new direction", snapshotBeforeRunning: false);
+            Assert.NotNull(result.Response);
+            Assert.Null(result.SnapshotToken);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationHistoryTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationHistoryTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationHistoryTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationHistoryTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task D1_Fork_SharesHistoryDocuments()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var agent = CreateTestAgentWithTruncation();
+
+            // Run enough turns to trigger truncation and populate LinkedConversations
+            for (int i = 1; i <= 4; i++)
+            {
+                await RunTurnAsync(database, "chats/1", $"turn {i}", snapshotBeforeRunning: true, agent: agent);
+            }
+
+            // Take a snapshot after history docs have been created
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+            Assert.NotNull(snapshot);
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            var originalLinked = GetLinkedConversations(store, "chats/1");
+            var forkedLinked = GetLinkedConversations(store, "forked/1");
+
+            Assert.NotEmpty(originalLinked);
+            Assert.NotEmpty(forkedLinked);
+
+            var originalSet = new HashSet<string>(originalLinked);
+            var forkedSet = new HashSet<string>(forkedLinked);
+
+            Assert.True(forkedSet.IsSubsetOf(originalSet),
+                "Forked history IDs should be a subset of the original's history IDs");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task D2_Fork_ThenDeleteOriginal_HistoryStillAccessible()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var agent = CreateTestAgentWithTruncation();
+
+            for (int i = 1; i <= 4; i++)
+            {
+                await RunTurnAsync(database, "chats/1", $"turn {i}", snapshotBeforeRunning: true, agent: agent);
+            }
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            List<string> forkHistoryIds = GetLinkedConversations(store, "forked/1");
+            Assert.NotEmpty(forkHistoryIds);
+
+            // Delete the original conversation
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("chats/1");
+                await session.SaveChangesAsync();
+            }
+
+            // History docs should still exist
+            foreach (string historyId in forkHistoryIds)
+            {
+                Assert.True(DocumentExists(store, historyId));
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task D3_Fork_TwiceFromSameToken_BothShareHistory()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var agent = CreateTestAgentWithTruncation();
+
+            for (int i = 1; i <= 4; i++)
+            {
+                await RunTurnAsync(database, "chats/1", $"turn {i}", snapshotBeforeRunning: true, agent: agent);
+            }
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+
+            var forkA = await store.AI.ForkConversationAsync(snapshot.Token, "fork-a");
+            Assert.Equal("fork-a", forkA.ConversationId);
+
+            var forkB = await store.AI.ForkConversationAsync(snapshot.Token, "fork-b");
+            Assert.Equal("fork-b", forkB.ConversationId);
+
+            var setA = new HashSet<string>(GetLinkedConversations(store, "fork-a"));
+            var setB = new HashSet<string>(GetLinkedConversations(store, "fork-b"));
+
+            Assert.NotEmpty(setA);
+            Assert.NotEmpty(setB);
+            Assert.True(setA.SetEquals(setB), "Both forks should share the same history documents");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task D4_Fork_WhenSomeHistoryDocsDeleted()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var agent = CreateTestAgentWithTruncation();
+
+            // Run enough turns to trigger truncation and create history documents
+            for (int i = 1; i <= 6; i++)
+            {
+                await RunTurnAsync(database, "chats/1", $"turn {i}", snapshotBeforeRunning: true, agent: agent);
+            }
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+
+            // Verify that truncation actually produced history documents
+            var historyIds = GetLinkedConversations(store, "chats/1");
+            Assert.NotEmpty(historyIds);
+
+            // Delete one history doc to simulate expiration
+            DeleteDocument(store, historyIds[0]);
+
+            // Fork should still work even with a missing history doc
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationIdTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationIdTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using Raven.Client.Documents.AI;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationIdTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationIdTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task J1_Fork_NewConversationIdIsNull_GetsGuid()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, null);
+
+            Assert.NotNull(forkResult.ConversationId);
+            Assert.NotEmpty(forkResult.ConversationId);
+            Assert.NotEqual("chats/1", forkResult.ConversationId);
+            Assert.True(Guid.TryParse(forkResult.ConversationId, out _),
+                $"Expected GUID format but got: {forkResult.ConversationId}");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task J2_Fork_ToIdThatAlreadyExists_Overwrites()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "conversation 1 turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "conversation 1 turn 2", snapshotBeforeRunning: true);
+
+            await RunTurnAsync(database, "chats/existing", "different conversation", snapshotBeforeRunning: false);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "chats/existing");
+
+            Assert.Equal("chats/existing", forkResult.ConversationId);
+            Assert.NotNull(forkResult.ChangeVector);
+
+            // Verify the document was overwritten and has the forked content via client API
+            var messages = await GetDetailedMessagesAsync(store, "chats/existing");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+            // Forked from before turn 2 = 1 turn: system + 2 = 3 messages
+            AssertExactMessageCount(messages, 1, "overwritten with fork from snapshot before turn 2");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task J3_Fork_ToIdWithDifferentPrefix()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/42", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/42", "turn 2", snapshotBeforeRunning: true);
+
+            CreateSubConversationDoc(store, "chats/42", "chats/42/Search/abc");
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/42");
+            Assert.NotNull(snapshot);
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "archives/fork-1");
+            Assert.Equal("archives/fork-1", forkResult.ConversationId);
+
+            Assert.True(DocumentExists(store, "archives/fork-1"));
+            Assert.True(DocumentExists(store, "archives/fork-1/Search/abc"));
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRealClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRealClientTests.cs
@@ -1,0 +1,157 @@
+using System.Threading.Tasks;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Client.Documents.Operations.ConnectionStrings;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    /// <summary>
+    /// End-to-end fork/snapshot tests that exercise the feature through the real Raven client API
+    /// (<see cref="AiConversation.RunAsync{TAnswer}"/>, <c>store.AI.CreateSnapshotAsync</c>,
+    /// <c>store.AI.ForkConversationAsync</c>, ...) against a live LLM connection.
+    ///
+    /// Unlike the <c>AiAgentForkConversation*Tests</c> classes — which drive the server-side
+    /// conversation handler directly with a mocked LLM (<c>RunTurnAsync</c>) — these tests go over
+    /// the wire exactly as a user would. They therefore require a configured AI integration and are
+    /// skipped automatically when no connection is available (see <see cref="RavenGenAiDataAttribute"/>).
+    /// </summary>
+    public class AiAgentForkConversationRealClientTests : RavenTestBase
+    {
+        public AiAgentForkConversationRealClientTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class AssistantAnswer
+        {
+            public static readonly AssistantAnswer Instance = new();
+
+            public string Answer = "A short answer to the user's question";
+        }
+
+        private static async Task<string> CreateAssistantAgentAsync(IDocumentStore store, GenAiConfiguration config)
+        {
+            var agent = new AiAgentConfiguration("assistant", config.ConnectionStringName,
+                "You are a helpful assistant. Reply with a short answer to the user's question.");
+
+            return (await store.AI.CreateAgentAsync(agent, AssistantAnswer.Instance)).Identifier;
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task SnapshotToken_IsPopulatedAcrossRunAsyncTurns(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+
+            var chat = store.AI.Conversation(agentId, "chats/",
+                new AiConversationCreationOptions { SnapshotBeforeRunning = true });
+
+            // Turn 1: brand-new conversation, there is nothing prior to snapshot.
+            chat.SetUserPrompt("Say hello.");
+            var r1 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r1.Status);
+            Assert.NotNull(r1.Answer);
+            Assert.Null(r1.SnapshotToken);
+
+            // Turn 2: the state before this turn (i.e. after turn 1) is snapshotted.
+            chat.SetUserPrompt("Say goodbye.");
+            var r2 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r2.Status);
+            Assert.False(string.IsNullOrEmpty(r2.SnapshotToken));
+
+            // Turn 3: another snapshot, distinct from the previous one.
+            chat.SetUserPrompt("Say thanks.");
+            var r3 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r3.Status);
+            Assert.False(string.IsNullOrEmpty(r3.SnapshotToken));
+            Assert.NotEqual(r2.SnapshotToken, r3.SnapshotToken);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task Fork_FromRunAsyncSnapshotToken_CreatesIndependentConversation(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+
+            var chat = store.AI.Conversation(agentId, "chats/",
+                new AiConversationCreationOptions { SnapshotBeforeRunning = true });
+
+            chat.SetUserPrompt("What is the capital of France?");
+            var r1 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r1.Status);
+
+            // The token returned on turn 2 captures the state after turn 1.
+            chat.SetUserPrompt("And the capital of Italy?");
+            var r2 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r2.Status);
+            Assert.False(string.IsNullOrEmpty(r2.SnapshotToken));
+
+            // Fork that point into a brand-new conversation id.
+            var fork = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", fork.ConversationId);
+            Assert.False(string.IsNullOrEmpty(fork.ChangeVector));
+
+            // The fork holds the earlier (fewer-turn) state; the original kept going.
+            var forkedMessages = await store.AI.GetConversationMessagesAsync("forked/1");
+            var originalMessages = await store.AI.GetConversationMessagesAsync(chat.Id);
+            Assert.NotEmpty(forkedMessages.Messages);
+            Assert.True(forkedMessages.Messages.Count < originalMessages.Messages.Count,
+                $"Expected fork ({forkedMessages.Messages.Count}) to have fewer messages than original ({originalMessages.Messages.Count}).");
+
+            // The fork is a real, independent conversation that can continue on its own.
+            var forkedChat = store.AI.Conversation(agentId, fork.ConversationId,
+                new AiConversationCreationOptions { SnapshotBeforeRunning = true }, fork.ChangeVector);
+            forkedChat.SetUserPrompt("What did I ask you first?");
+            var rf = await forkedChat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, rf.Status);
+            Assert.NotNull(rf.Answer);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CreateSnapshotThenFork_ThroughRealClient(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+
+            // Run a turn without the automatic snapshot flag ...
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+            chat.SetUserPrompt("Remember my favorite color is blue.");
+            var r = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r.Status);
+            Assert.Null(r.SnapshotToken);
+
+            // ... and snapshot the current state on demand instead.
+            var snapshot = await store.AI.CreateSnapshotAsync(chat.Id);
+            Assert.NotNull(snapshot);
+            Assert.False(string.IsNullOrEmpty(snapshot.Token));
+
+            var fork = await store.AI.ForkConversationAsync(snapshot.Token, "forked/2");
+            Assert.Equal("forked/2", fork.ConversationId);
+            Assert.False(string.IsNullOrEmpty(fork.ChangeVector));
+
+            var forkedMessages = await store.AI.GetConversationMessagesAsync("forked/2");
+            Assert.NotEmpty(forkedMessages.Messages);
+
+            // The forked conversation can continue from the snapshotted state.
+            var forkedChat = store.AI.Conversation(agentId, fork.ConversationId,
+                new AiConversationCreationOptions(), fork.ChangeVector);
+            forkedChat.SetUserPrompt("What is my favorite color?");
+            var rf = await forkedChat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, rf.Status);
+            Assert.NotNull(rf.Answer);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRealClientTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRealClientTests.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Threading.Tasks;
-using FastTests;
 using Raven.Client.Documents;
 using Raven.Client.Documents.AI;
 using Raven.Client.Documents.Operations.AI;
@@ -13,14 +13,14 @@ namespace SlowTests.Server.Documents.AI.AiAgent
     /// <summary>
     /// End-to-end fork/snapshot tests that exercise the feature through the real Raven client API
     /// (<see cref="AiConversation.RunAsync{TAnswer}"/>, <c>store.AI.CreateSnapshotAsync</c>,
-    /// <c>store.AI.ForkConversationAsync</c>, ...) against a live LLM connection.
+    /// <c>chat.CreateSnapshotAsync</c>, <c>store.AI.ForkConversationAsync</c>, ...) against a live LLM connection.
     ///
-    /// Unlike the <c>AiAgentForkConversation*Tests</c> classes — which drive the server-side
-    /// conversation handler directly with a mocked LLM (<c>RunTurnAsync</c>) — these tests go over
-    /// the wire exactly as a user would. They therefore require a configured AI integration and are
-    /// skipped automatically when no connection is available (see <see cref="RavenGenAiDataAttribute"/>).
+    /// Unlike the <c>AiAgentForkConversation*Tests</c> classes — which drive the server-side conversation
+    /// handler directly with a mocked LLM (<c>RunTurnAsync</c>) — these tests go over the wire exactly as a
+    /// user would. Tests that call <c>RunAsync</c> require a configured AI integration and are skipped
+    /// automatically when no connection is available (see <see cref="RavenGenAiDataAttribute"/>).
     /// </summary>
-    public class AiAgentForkConversationRealClientTests : RavenTestBase
+    public class AiAgentForkConversationRealClientTests : AiAgentForkConversationTestBase
     {
         public AiAgentForkConversationRealClientTests(ITestOutputHelper output) : base(output)
         {
@@ -152,6 +152,230 @@ namespace SlowTests.Server.Documents.AI.AiAgent
             var rf = await forkedChat.RunAsync<AssistantAnswer>();
             Assert.Equal(AiConversationResult.Done, rf.Status);
             Assert.NotNull(rf.Answer);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CreateSnapshotAsync_ReBaselinesChangeVector_AndContinuesOnSameInstance(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+
+            // Turn 1 creates the conversation document on the server.
+            chat.SetUserPrompt("Say hello.");
+            var r1 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r1.Status);
+
+            var cvBeforeSnapshot = chat.ChangeVector;
+
+            var snapshot = await chat.CreateSnapshotAsync();
+            Assert.NotNull(snapshot);
+            Assert.False(string.IsNullOrEmpty(snapshot.Token));
+            Assert.False(string.IsNullOrEmpty(snapshot.ChangeVector));
+            Assert.True(snapshot.CreatedAt > DateTime.MinValue);
+
+            // The (first) snapshot force-created a revision and advanced the server-side change vector,
+            // and the chat re-baselined its cached change vector to the returned value.
+            Assert.NotEqual(cvBeforeSnapshot, snapshot.ChangeVector);
+            Assert.Equal(snapshot.ChangeVector, chat.ChangeVector);
+
+            // Continuing on the SAME chat instance must succeed (no ConcurrencyException).
+            chat.SetUserPrompt("Say goodbye.");
+            var r2 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r2.Status);
+            Assert.NotNull(r2.Answer);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CreateSnapshotAsync_ReturnsForkableToken(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+
+            chat.SetUserPrompt("What is the capital of France?");
+            var r1 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r1.Status);
+
+            var snapshot = await chat.CreateSnapshotAsync();
+
+            // The token is well-formed and references this conversation.
+            var parsed = ParseToken(snapshot.Token);
+            Assert.Equal(chat.Id, parsed.ConversationId);
+            Assert.NotEmpty(parsed.Revisions);
+
+            // The token forks into an independent, non-empty conversation.
+            var fork = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", fork.ConversationId);
+            Assert.False(string.IsNullOrEmpty(fork.ChangeVector));
+
+            var forkedMessages = await store.AI.GetConversationMessagesAsync("forked/1");
+            Assert.NotEmpty(forkedMessages.Messages);
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CreateSnapshotAsync_RepeatedSnapshotsAndTurns_AllSucceed(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+
+            string previousToken = null;
+            for (int i = 0; i < 3; i++)
+            {
+                chat.SetUserPrompt($"Message number {i}.");
+                var r = await chat.RunAsync<AssistantAnswer>();
+                Assert.Equal(AiConversationResult.Done, r.Status);
+
+                var snapshot = await chat.CreateSnapshotAsync();
+                Assert.False(string.IsNullOrEmpty(snapshot.Token));
+
+                // Each snapshot keeps the chat's cached change vector in sync with the server.
+                Assert.Equal(snapshot.ChangeVector, chat.ChangeVector);
+
+                // Each snapshot (taken after a distinct turn) is a distinct fork point.
+                if (previousToken != null)
+                    Assert.NotEqual(previousToken, snapshot.Token);
+                previousToken = snapshot.Token;
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task CreateSnapshotAsync_BeforeFirstRun_Throws()
+        {
+            using var store = GetDocumentStore();
+
+            // A brand-new conversation has no server-side id until the first RunAsync, so there is
+            // nothing to snapshot yet — CreateSnapshotAsync must fail fast rather than hit the server.
+            var chat = store.AI.Conversation("some-agent", "chats/", new AiConversationCreationOptions());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => chat.CreateSnapshotAsync());
+        }
+
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task CreateSnapshot_RewindInPlace_ThenContinue_RealClient(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+            var chat = store.AI.Conversation(agentId, "chats/", new AiConversationCreationOptions());
+
+            // Turn 1: establish a checkpoint we can rewind back to.
+            chat.SetUserPrompt("Remember the secret word is 'apple'.");
+            var r1 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r1.Status);
+
+            // Snapshot the checkpoint via the conversation object.
+            var snapshot = await chat.CreateSnapshotAsync();
+            Assert.False(string.IsNullOrEmpty(snapshot.Token));
+
+            var messagesAtCheckpoint = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+
+            // Turn 2: advance the conversation past the checkpoint on the SAME instance.
+            chat.SetUserPrompt("Actually, change the secret word to 'banana'.");
+            var r2 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r2.Status);
+
+            var messagesAfterTurn2 = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+            Assert.True(messagesAfterTurn2 > messagesAtCheckpoint,
+                $"Expected turn 2 ({messagesAfterTurn2}) to have more messages than the checkpoint ({messagesAtCheckpoint}).");
+
+            // Rewind IN PLACE: fork the snapshot back onto the SAME conversation id.
+            var rewind = await store.AI.ForkConversationAsync(snapshot.Token, chat.Id);
+            Assert.Equal(chat.Id, rewind.ConversationId);
+            Assert.False(string.IsNullOrEmpty(rewind.ChangeVector));
+
+            // The conversation is restored to the checkpoint — turn 2 was dropped.
+            var messagesAfterRewind = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+            Assert.Equal(messagesAtCheckpoint, messagesAfterRewind);
+
+            // Continue AFTER the rewind, through the real client. The rewind wrote the document
+            // out-of-band, so bind a conversation handle to the rewound change vector and keep going.
+            var rewound = store.AI.Conversation(agentId, chat.Id, new AiConversationCreationOptions(), rewind.ChangeVector);
+            rewound.SetUserPrompt("What is the secret word?");
+            var r3 = await rewound.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r3.Status);
+            Assert.NotNull(r3.Answer);
+
+            // The continued turn extended the rewound conversation from the checkpoint.
+            var messagesAfterContinue = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+            Assert.True(messagesAfterContinue > messagesAfterRewind,
+                $"Expected the continued conversation ({messagesAfterContinue}) to have more messages than the rewound checkpoint ({messagesAfterRewind}).");
+        }
+
+        // The natural "pick a past message and rewind to it" flow: with SnapshotBeforeRunning on,
+        // every turn's answer carries the fork point for the state BEFORE that turn. To rewind to
+        // an earlier message, fork that turn's token back onto the same conversation id — dropping
+        // that turn and everything after it — then keep chatting.
+        [RavenMultiplatformTheory(RavenTestCategory.Ai, RavenArchitecture.AllX64)]
+        [RavenGenAiData(IntegrationType = RavenAiIntegration.OpenAi, DatabaseMode = RavenDatabaseMode.Single)]
+        public async Task SnapshotBeforeRunning_RewindToChosenTurn_ThenContinue_RealClient(Options options, GenAiConfiguration config)
+        {
+            using var store = GetDocumentStore(options);
+            await store.Maintenance.SendAsync(new PutConnectionStringOperation<AiConnectionString>(config.Connection));
+
+            var agentId = await CreateAssistantAgentAsync(store, config);
+
+            // Snapshots on: each turn's answer yields the fork point for the state before that turn.
+            var chat = store.AI.Conversation(agentId, "chats/",
+                new AiConversationCreationOptions { SnapshotBeforeRunning = true });
+
+            // Turn 1 — the point we will rewind back to. A brand-new conversation has no prior state,
+            // so its answer carries no snapshot token.
+            chat.SetUserPrompt("The secret word is 'apple'.");
+            var r1 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r1.Status);
+            Assert.Null(r1.SnapshotToken);
+
+            var messagesAfterTurn1 = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+
+            // Turn 2 — its token captures the state BEFORE turn 2 (i.e. right after turn 1): our rewind target.
+            chat.SetUserPrompt("Change the secret word to 'banana'.");
+            var r2 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r2.Status);
+            Assert.False(string.IsNullOrEmpty(r2.SnapshotToken));
+            var rewindPointToken = r2.SnapshotToken;
+
+            // Turn 3 — advance further, so the rewind has something to discard.
+            chat.SetUserPrompt("Change the secret word to 'cherry'.");
+            var r3 = await chat.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r3.Status);
+
+            var messagesAfterTurn3 = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+            Assert.True(messagesAfterTurn3 > messagesAfterTurn1,
+                $"Expected 3 turns ({messagesAfterTurn3}) to have more messages than 1 turn ({messagesAfterTurn1}).");
+
+            // Rewind to the chosen message: fork turn 2's token onto the same id, dropping turns 2 and 3.
+            var rewind = await store.AI.ForkConversationAsync(rewindPointToken, chat.Id);
+            Assert.Equal(chat.Id, rewind.ConversationId);
+            Assert.False(string.IsNullOrEmpty(rewind.ChangeVector));
+
+            // The conversation is restored to its state right after turn 1.
+            var messagesAfterRewind = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+            Assert.Equal(messagesAfterTurn1, messagesAfterRewind);
+
+            // Continue from the rewound point through the real client.
+            var rewound = store.AI.Conversation(agentId, chat.Id,
+                new AiConversationCreationOptions { SnapshotBeforeRunning = true }, rewind.ChangeVector);
+            rewound.SetUserPrompt("What is the secret word?");
+            var r4 = await rewound.RunAsync<AssistantAnswer>();
+            Assert.Equal(AiConversationResult.Done, r4.Status);
+            Assert.NotNull(r4.Answer);
+
+            var messagesAfterContinue = (await store.AI.GetConversationMessagesAsync(chat.Id)).Messages.Count;
+            Assert.True(messagesAfterContinue > messagesAfterRewind,
+                $"Expected the continued conversation ({messagesAfterContinue}) to have more messages than the rewound point ({messagesAfterRewind}).");
         }
     }
 }

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRevisionTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRevisionTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationRevisionTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationRevisionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task E1_Fork_WhenRevisionDoesNotExist_Fails()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // Create a fake token with a change vector that doesn't exist
+            var fakeRevisions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["chats/1"] = "FAKE:99-nonexistent"
+            };
+            var fakeToken = BuildFakeSnapshotToken(database, "chats/1", fakeRevisions);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                await store.AI.ForkConversationAsync(fakeToken, "forked/1"));
+
+            Assert.Contains("no longer exists", ex.Message);
+
+            // Verify no partial state was created via client API
+            using (var session = store.OpenAsyncSession())
+            {
+                var doc = await session.LoadAsync<object>("forked/1");
+                Assert.Null(doc);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task E3_Fork_AfterEnforceRevisionsConfiguration_Fails()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            await store.Maintenance.SendAsync(new Raven.Client.Documents.Operations.Revisions.ConfigureRevisionsOperation(
+                new Raven.Client.Documents.Operations.Revisions.RevisionsConfiguration
+                {
+                    Default = new Raven.Client.Documents.Operations.Revisions.RevisionsCollectionConfiguration
+                    {
+                        Disabled = false,
+                        MinimumRevisionsToKeep = 0
+                    }
+                }));
+
+            var enforceOp = await store.Operations.SendAsync(
+                new Raven.Client.Documents.Operations.Revisions.EnforceRevisionsConfigurationOperation(
+                    new Raven.Client.Documents.Operations.Revisions.EnforceRevisionsConfigurationOperation.Parameters
+                    {
+                        IncludeForceCreated = true
+                    }));
+
+            await enforceOp.WaitForCompletionAsync(TimeSpan.FromSeconds(30));
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1"));
+
+            Assert.Contains("no longer exists", ex.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task E5_Fork_FromDeletedConversation_Succeeds()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            // Delete the conversation via client API
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("chats/1");
+                await session.SaveChangesAsync();
+            }
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "restored/1");
+            Assert.Equal("restored/1", forkResult.ConversationId);
+
+            var messages = await store.AI.GetConversationMessagesAsync("restored/1");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task E6_Fork_FromDeletedConversation_ForkToSameId()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            // Delete via client API
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Delete("chats/1");
+                await session.SaveChangesAsync();
+            }
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "chats/1");
+            Assert.Equal("chats/1", forkResult.ConversationId);
+
+            var messages = await store.AI.GetConversationMessagesAsync("chats/1");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRewindTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationRewindTests.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationRewindTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationRewindTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task B1_RewindInPlace_RestoresConversationState()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+
+            var beforeRewind = await GetDetailedMessagesAsync(store, "chats/1");
+            AssertExactMessageCount(beforeRewind, 3, "before rewind: 3 turns");
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "chats/1");
+            Assert.Equal("chats/1", forkResult.ConversationId);
+
+            var afterRewind = await GetDetailedMessagesAsync(store, "chats/1");
+            // Snapshot was before turn 2, so rewound state has 1 turn
+            AssertExactMessageCount(afterRewind, 1, "after rewind to before turn 2");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task B2_RewindInPlace_DeletesOrphanedSubConversations()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            CreateSubConversationDoc(store, "chats/1", "chats/1/sub1");
+            CreateSubConversationDoc(store, "chats/1", "chats/1/sub2");
+
+            Assert.True(DocumentExists(store, "chats/1/sub1"));
+            Assert.True(DocumentExists(store, "chats/1/sub2"));
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "chats/1");
+            Assert.Equal("chats/1", forkResult.ConversationId);
+
+            Assert.False(DocumentExists(store, "chats/1/sub1"));
+            Assert.False(DocumentExists(store, "chats/1/sub2"));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task B4_RewindInPlace_PreservesHistoryDocuments()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            var agent = CreateTestAgentWithTruncation();
+
+            // Run enough turns to trigger truncation (threshold = 5 messages, after truncation = 3)
+            // System prompt = 1 msg, each turn = 2 msgs
+            // After 3 turns: 1 + 6 = 7 messages => exceeds 5 => truncation triggered => LinkedConversations populated
+            for (int i = 1; i <= 3; i++)
+            {
+                await RunTurnAsync(database, "chats/1", $"turn {i}", snapshotBeforeRunning: true, agent: agent);
+            }
+            var r4 = await RunTurnAsync(database, "chats/1", "turn 4", snapshotBeforeRunning: true, agent: agent);
+
+            List<string> historyIds = GetLinkedConversations(store, "chats/1");
+            Assert.NotEmpty(historyIds);
+
+            var forkResult = await store.AI.ForkConversationAsync(r4.SnapshotToken, "chats/1");
+            Assert.Equal("chats/1", forkResult.ConversationId);
+
+            // History documents should still exist after rewind
+            foreach (string historyId in historyIds)
+            {
+                Assert.True(DocumentExists(store, historyId));
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationStateTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationStateTests.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationStateTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationStateTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H1_Fork_ConversationWithOpenActionCalls()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            InjectOpenActionCall(store, "chats/1", "call_pending", "UserAction", "{\"query\":\"test\"}");
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+            Assert.NotNull(snapshot);
+            Assert.NotNull(snapshot.Token);
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            Assert.True(HasOpenActionCalls(store, "forked/1"), "Forked doc should have open action calls from the snapshot");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H1b_Fork_AdjustsOpenActionCallsSubConversationIds()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            InjectOpenActionCallWithSubConversation(store, "chats/1",
+                "call_sub", "SubAgentTool", "{}", "chats/1/SubAgent/hash123");
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+
+            var openCalls = GetOpenActionCalls(store, "forked/1");
+            Assert.NotNull(openCalls);
+            Assert.True(openCalls.Count > 0);
+
+            foreach (var (_, callFields) in openCalls)
+            {
+                if (callFields.TryGetValue("SubConversationId", out var subConvIdObj) && subConvIdObj is string subConvId)
+                {
+                    Assert.StartsWith("forked/1/", subConvId);
+                    Assert.DoesNotContain("chats/1/", subConvId);
+                }
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H2_Fork_ConversationWithMultipleTurns()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "first question", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "follow-up question", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "third question", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            // Fork should work and the conversation should be usable
+            var r = await RunTurnAsync(database, "forked/1", "new direction", snapshotBeforeRunning: false);
+            Assert.NotNull(r.Response);
+
+            // Verify message counts via client API
+            var forkedMessages = await GetDetailedMessagesAsync(store, "forked/1");
+            // Forked from before turn 2 = 1 turn, then ran 1 more turn = 2 turns total
+            AssertExactMessageCount(forkedMessages, 2, "forked from turn 1 snapshot + 1 new turn");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H2b_Fork_PreservesAttachments()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.Attachments.Store("chats/1", "file.txt",
+                    new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes("content")), "text/plain");
+                await session.SaveChangesAsync();
+            }
+
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            // Verify attachment exists on forked doc via client API
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = await session.LoadAsync<object>("forked/1");
+                Assert.NotNull(entity);
+                var attachmentNames = session.Advanced.Attachments.GetNames(entity);
+                Assert.NotNull(attachmentNames);
+                Assert.NotEmpty(attachmentNames);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H2c_Rewind_RemovesAttachmentsAddedAfterSnapshot()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+
+            // Add an attachment BEFORE the snapshot
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.Attachments.Store("chats/1", "original.txt",
+                    new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes("original")), "text/plain");
+                await session.SaveChangesAsync();
+            }
+
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            // Add a SECOND attachment AFTER the snapshot
+            using (var session = store.OpenAsyncSession())
+            {
+                session.Advanced.Attachments.Store("chats/1", "post-snapshot.txt",
+                    new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes("post-snapshot")), "text/plain");
+                await session.SaveChangesAsync();
+            }
+
+            // Verify both attachments exist before rewind via client API
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = await session.LoadAsync<object>("chats/1");
+                var names = session.Advanced.Attachments.GetNames(entity);
+                Assert.Equal(2, names.Length);
+            }
+
+            // Rewind to snapshot (which had only original.txt)
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "chats/1");
+            Assert.Equal("chats/1", forkResult.ConversationId);
+
+            // After rewind, only original.txt should remain
+            using (var session = store.OpenAsyncSession())
+            {
+                var entity = await session.LoadAsync<object>("chats/1");
+                var names = session.Advanced.Attachments.GetNames(entity);
+                Assert.Single(names);
+                Assert.Equal("original.txt", names[0].Name);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H3_Fork_ChainForking_ForkOfAFork()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var forkB = await store.AI.ForkConversationAsync(r2.SnapshotToken, "fork-b");
+            Assert.Equal("fork-b", forkB.ConversationId);
+
+            await RunTurnAsync(database, "fork-b", "turn on B", snapshotBeforeRunning: true);
+            var rB2 = await RunTurnAsync(database, "fork-b", "turn 2 on B", snapshotBeforeRunning: true);
+
+            var forkC = await store.AI.ForkConversationAsync(rB2.SnapshotToken, "fork-c");
+            Assert.Equal("fork-c", forkC.ConversationId);
+
+            // Verify all three exist via client API
+            var msgsOrig = await store.AI.GetConversationMessagesAsync("chats/1");
+            var msgsB = await store.AI.GetConversationMessagesAsync("fork-b");
+            var msgsC = await store.AI.GetConversationMessagesAsync("fork-c");
+            Assert.NotNull(msgsOrig);
+            Assert.NotEmpty(msgsOrig.Messages);
+            Assert.NotNull(msgsB);
+            Assert.NotEmpty(msgsB.Messages);
+            Assert.NotNull(msgsC);
+            Assert.NotEmpty(msgsC.Messages);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H4_Fork_TreeOfForks_MultipleBranchesFromSamePoint()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+            var r4 = await RunTurnAsync(database, "chats/1", "turn 4", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 5", snapshotBeforeRunning: true);
+
+            var forkB = await store.AI.ForkConversationAsync(r2.SnapshotToken, "fork-b");
+            Assert.Equal("fork-b", forkB.ConversationId);
+
+            var forkC = await store.AI.ForkConversationAsync(r2.SnapshotToken, "fork-c");
+            Assert.Equal("fork-c", forkC.ConversationId);
+
+            var forkD = await store.AI.ForkConversationAsync(r4.SnapshotToken, "fork-d");
+            Assert.Equal("fork-d", forkD.ConversationId);
+
+            var msgsB = await GetDetailedMessagesAsync(store, "fork-b");
+            var msgsC = await GetDetailedMessagesAsync(store, "fork-c");
+            var msgsD = await GetDetailedMessagesAsync(store, "fork-d");
+
+            Assert.NotNull(msgsB);
+            Assert.NotEmpty(msgsB.Messages);
+            Assert.NotNull(msgsC);
+            Assert.NotEmpty(msgsC.Messages);
+            Assert.NotNull(msgsD);
+            Assert.NotEmpty(msgsD.Messages);
+
+            // B and C from same snapshot point should have same count
+            Assert.Equal(msgsB.Messages.Count, msgsC.Messages.Count);
+            // B from turn 2 snapshot = 1 turn, D from turn 4 snapshot = 3 turns
+            AssertExactMessageCount(msgsB, 1, "fork from before turn 2");
+            AssertExactMessageCount(msgsD, 3, "fork from before turn 4");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H5_Fork_ConversationWithTotalUsage()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            await RunTurnAsync(database, "chats/1", "turn 3", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 4", snapshotBeforeRunning: true);
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            var originalResult = await GetDetailedMessagesAsync(store, "chats/1");
+            var forkedResult = await GetDetailedMessagesAsync(store, "forked/1");
+
+            Assert.True(forkedResult.TotalUsage.TotalTokens < originalResult.TotalUsage.TotalTokens,
+                $"Fork usage ({forkedResult.TotalUsage.TotalTokens}) should be less than original ({originalResult.TotalUsage.TotalTokens})");
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task H7_Fork_ConversationWithExpiration()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            {
+                // Use RunTurnAsync for the first turn, then set expiration on the doc via session
+                await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+
+                // Set Expires on the conversation document
+                using (var session = store.OpenSession())
+                {
+                    var doc = session.Load<JObject>("chats/1");
+                    doc["Expires"] = "01:00:00"; // 1 hour as TimeSpan string
+                    session.SaveChanges();
+                }
+
+                var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+                var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+                Assert.Equal("forked/1", forkResult.ConversationId);
+
+                var forkedDoc = GetDocumentAsJObject(store, "forked/1");
+                Assert.NotNull(forkedDoc);
+                var expiresValue = forkedDoc[nameof(ConversationDocument.Expires)]?.ToString();
+                Assert.NotNull(expiresValue);
+                var expires = TimeSpan.Parse(expiresValue);
+                Assert.Equal(TimeSpan.FromSeconds(3600), expires);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationSubConversationTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationSubConversationTests.cs
@@ -1,0 +1,105 @@
+using System.Threading.Tasks;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationSubConversationTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationSubConversationTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task C1_Fork_AdjustsSubConversationIds()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            CreateSubConversationDoc(store, "chats/1", "chats/1/Search/abc");
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+            Assert.NotNull(snapshot);
+            Assert.NotNull(snapshot.Token);
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            // Verify SubConversationIds via client API (exposed on GetConversationMessagesAsync)
+            var forkedMessages = await GetDetailedMessagesAsync(store, "forked/1");
+            Assert.NotNull(forkedMessages.SubConversationIds);
+            Assert.NotEmpty(forkedMessages.SubConversationIds);
+            Assert.Contains("forked/1/Search/abc", forkedMessages.SubConversationIds);
+            Assert.DoesNotContain("chats/1/Search/abc", forkedMessages.SubConversationIds);
+
+            Assert.True(DocumentExists(store, "forked/1/Search/abc"));
+            Assert.True(DocumentExists(store, "chats/1/Search/abc"));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public void C2_Fork_PrefixReplacementIsExact()
+        {
+            Assert.Equal("new/id", ForkConversationCommand.AdjustId("chats/42", "chats/42", "new/id"));
+            Assert.Equal("new/id/Search/abc", ForkConversationCommand.AdjustId("chats/42/Search/abc", "chats/42", "new/id"));
+            Assert.Equal("new/id/chats/42/Search/abc",
+                ForkConversationCommand.AdjustId("chats/42/chats/42/Search/abc", "chats/42", "new/id"));
+            Assert.Equal("other/1/sub", ForkConversationCommand.AdjustId("other/1/sub", "chats/42", "new/id"));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task C4_Fork_CleanupUsesSubConversationIds()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            // Create a rogue document not tracked in SubConversationIds
+            PutRogueDocument(store, "chats/1/Rogue/xyz");
+
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "chats/1");
+            Assert.Equal("chats/1", forkResult.ConversationId);
+
+            // Rogue document survives because it is not tracked in SubConversationIds
+            Assert.True(DocumentExists(store, "chats/1/Rogue/xyz"));
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task C6_Fork_NestedSubConversations()
+        {
+            Assert.Equal("new/A/hash", ForkConversationCommand.AdjustId("old/A/hash", "old", "new"));
+            Assert.Equal("new/A/hash/B/hash2", ForkConversationCommand.AdjustId("old/A/hash/B/hash2", "old", "new"));
+            Assert.Equal("forked/1/sub1/hash/sub2/hash2",
+                ForkConversationCommand.AdjustId("chats/1/sub1/hash/sub2/hash2", "chats/1", "forked/1"));
+
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            CreateSubConversationDoc(store, "chats/1", "chats/1/A");
+
+            var snapshot = await store.AI.CreateSnapshotAsync("chats/1");
+            Assert.NotNull(snapshot);
+            Assert.NotNull(snapshot.Token);
+
+            var forkResult = await store.AI.ForkConversationAsync(snapshot.Token, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            // Verify via client API that SubConversationIds is adjusted
+            var forkedMessages = await GetDetailedMessagesAsync(store, "forked/1");
+            Assert.NotNull(forkedMessages.SubConversationIds);
+            Assert.NotEmpty(forkedMessages.SubConversationIds);
+            Assert.Contains("forked/1/A", forkedMessages.SubConversationIds);
+
+            Assert.True(DocumentExists(store, "forked/1"));
+            Assert.True(DocumentExists(store, "forked/1/A"));
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationTestBase.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationTestBase.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents;
+using Raven.Client.Documents.AI;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Handlers.AI.Agents;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public abstract class AiAgentForkConversationTestBase : RavenTestBase
+    {
+        protected AiAgentForkConversationTestBase(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        internal SnapshotTokenDto ParseToken(string token)
+        {
+            using var ctx = JsonOperationContext.ShortTermSingleUse();
+            return SnapshotTokenDto.Parse(ctx, token);
+        }
+
+        protected void InjectOpenActionCallWithSubConversation(IDocumentStore store, string conversationId, string toolId, string toolName, string arguments, string subConversationId)
+        {
+            InjectOpenActionCall(store, conversationId, toolId, toolName, arguments, subConversationId);
+        }
+
+        protected void InjectOpenActionCall(IDocumentStore store, string conversationId, string toolId, string toolName, string arguments, string subConversationId = null)
+        {
+            using var session = store.OpenSession();
+            var doc = session.Load<JObject>(conversationId);
+            if (doc == null)
+                return;
+
+            var openCalls = doc[nameof(ConversationDocument.OpenActionCalls)] as JObject ?? new JObject();
+
+            var callValue = new JObject
+            {
+                ["ToolId"] = toolId,
+                ["Name"] = toolName,
+                ["Arguments"] = arguments
+            };
+
+            if (subConversationId != null)
+                callValue["SubConversationId"] = subConversationId;
+
+            openCalls[toolId] = callValue;
+            doc[nameof(ConversationDocument.OpenActionCalls)] = openCalls;
+
+            session.SaveChanges();
+        }
+
+        protected void CreateSubConversationDoc(IDocumentStore store, string parentId, string subConversationId)
+        {
+            using (var session = store.OpenSession())
+            {
+                var subDoc = new JObject
+                {
+                    ["Agent"] = "sub-agent",
+                    ["Messages"] = new JArray(),
+                    ["LinkedConversations"] = new JArray(),
+                    ["TotalUsage"] = new JObject { ["PromptTokens"] = 0, ["CompletionTokens"] = 0, ["TotalTokens"] = 0, ["CachedTokens"] = 0, ["ReasoningTokens"] = 0 },
+                    ["OpenActionCalls"] = new JObject(),
+                    ["LastMessageAt"] = DateTime.UtcNow,
+                    ["CreatedAt"] = DateTime.UtcNow,
+                    ["Expires"] = null,
+                    ["CurrentUsage"] = new JObject { ["PromptTokens"] = 0, ["CompletionTokens"] = 0, ["TotalTokens"] = 0, ["CachedTokens"] = 0, ["ReasoningTokens"] = 0 },
+                    ["RemainingToolIterations"] = 16,
+                    ["SubConversationIds"] = new JArray()
+                };
+                session.Store(subDoc, subConversationId);
+
+                var metadata = session.Advanced.GetMetadataFor(subDoc);
+                metadata[Raven.Client.Constants.Documents.Metadata.Collection] = Raven.Client.Constants.Documents.Collections.AiAgentConversationCollection;
+
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var parentDoc = session.Load<JObject>(parentId);
+                if (parentDoc != null)
+                {
+                    var subIds = parentDoc["SubConversationIds"] as JArray ?? new JArray();
+                    subIds.Add(subConversationId);
+                    parentDoc["SubConversationIds"] = subIds;
+                    session.SaveChanges();
+                }
+            }
+        }
+
+        protected static AiAgentConfiguration CreateTestAgent()
+        {
+            return new AiAgentConfiguration("test-agent", "fake-connection",
+                "You are a test AI agent.")
+            {
+                SampleObject = "{\"Answer\":\"response\"}"
+            };
+        }
+
+        protected static AiAgentConfiguration CreateTestAgentWithTruncation()
+        {
+            var agent = new AiAgentConfiguration("test-agent-truncation", "fake-connection",
+                "You are a test AI agent.")
+            {
+                SampleObject = "{\"Answer\":\"response\"}",
+                ChatTrimming = new AiAgentChatTrimmingConfiguration
+                {
+                    Truncate = new AiAgentTruncateChat
+                    {
+                        MessagesLengthBeforeTruncate = 5,
+                        MessagesLengthAfterTruncate = 3
+                    },
+                    History = new AiAgentHistoryConfiguration()
+                }
+            };
+            return agent;
+        }
+
+        protected async Task<AiInternalConversationResult> RunTurnAsync(
+            DocumentDatabase database, string conversationId, string prompt,
+            bool snapshotBeforeRunning = false,
+            AiAgentConfiguration agent = null,
+            Dictionary<string, object> parameters = null)
+        {
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
+            {
+                var creation = new AiConversationCreationOptions { SnapshotBeforeRunning = snapshotBeforeRunning };
+                if (parameters != null)
+                {
+                    foreach (var (key, value) in parameters)
+                        creation.AddParameter(key, value);
+                }
+
+                var blittable = context.ReadObject(creation.ToJson(), "params");
+                blittable.TryGet(nameof(AiConversationCreationOptions.Parameters), out BlittableJsonReaderObject blittableParams);
+
+                var handler = new MockLlmConversationHandler(Server.ServerStore, database,
+                    onRequest: _ => new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(MockLlm.CreateAnswerResponse($"\"{prompt} - response\""))
+                    })
+                {
+                    Authentication = null
+                };
+
+                handler.Initialize(agent ?? CreateTestAgent(), conversationId, new RequestBody
+                {
+                    Parameters = blittableParams,
+                    CreationOptions = creation,
+                    UserPrompt = prompt
+                }, changeVector: null);
+
+                return await handler.HandleRequestAsync(context, CancellationToken.None);
+            }
+        }
+
+        protected async Task<AiConversationMessagesResult> GetDetailedMessagesAsync(
+            Raven.Client.Documents.IDocumentStore store, string conversationId)
+        {
+            return await store.AI.GetConversationMessagesAsync(
+                new GetConversationMessagesOptions
+                {
+                    ConversationId = conversationId,
+                    DetailLevel = AiConversationDetailLevel.Detailed,
+                    PageSize = 100
+                });
+        }
+
+        protected static void AssertExactMessageCount(AiConversationMessagesResult result, int expectedTurnCount, string description)
+        {
+            // System prompt = 1 message, each turn = 2 messages (user + assistant)
+            int expected = 1 + 2 * expectedTurnCount;
+            Assert.Equal(expected, result.Messages.Count);
+        }
+
+        protected List<string> GetLinkedConversations(IDocumentStore store, string conversationId)
+        {
+            using var session = store.OpenSession();
+            var doc = session.Load<JObject>(conversationId);
+            if (doc == null)
+                return new List<string>();
+            var linked = doc[nameof(ConversationDocument.LinkedConversations)] as JArray;
+            return linked?.Select(x => x.ToString()).ToList() ?? new List<string>();
+        }
+
+        protected HashSet<string> GetSubConversationIds(IDocumentStore store, string conversationId)
+        {
+            using var session = store.OpenSession();
+            var doc = session.Load<JObject>(conversationId);
+            if (doc == null)
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var subs = doc[nameof(ConversationDocument.SubConversationIds)] as JArray;
+            if (subs == null)
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            return subs.Select(x => x.ToString()).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        protected bool DocumentExists(IDocumentStore store, string documentId)
+        {
+            using var session = store.OpenSession();
+            return session.Advanced.Exists(documentId);
+        }
+
+        protected bool HasOpenActionCalls(IDocumentStore store, string conversationId)
+        {
+            using var session = store.OpenSession();
+            var doc = session.Load<JObject>(conversationId);
+            if (doc == null)
+                return false;
+            var openCalls = doc[nameof(ConversationDocument.OpenActionCalls)] as JObject;
+            return openCalls != null && openCalls.Count > 0;
+        }
+
+        protected Dictionary<string, Dictionary<string, object>> GetOpenActionCalls(IDocumentStore store, string conversationId)
+        {
+            using var session = store.OpenSession();
+            var doc = session.Load<JObject>(conversationId);
+            var openCalls = doc?[nameof(ConversationDocument.OpenActionCalls)] as JObject;
+            if (openCalls == null)
+                return new Dictionary<string, Dictionary<string, object>>();
+
+            var result = new Dictionary<string, Dictionary<string, object>>();
+            foreach (var prop in openCalls.Properties())
+            {
+                var callObj = prop.Value as JObject;
+                if (callObj == null)
+                    continue;
+                var entry = new Dictionary<string, object>();
+                foreach (var inner in callObj.Properties())
+                    entry[inner.Name] = inner.Value.Type == JTokenType.String ? inner.Value.ToString() : (object)inner.Value;
+                result[prop.Name] = entry;
+            }
+            return result;
+        }
+
+        protected JObject GetDocumentAsJObject(IDocumentStore store, string documentId)
+        {
+            using var session = store.OpenSession();
+            return session.Load<JObject>(documentId);
+        }
+
+        protected void PutRogueDocument(IDocumentStore store, string documentId)
+        {
+            using var session = store.OpenSession();
+            session.Store(new JObject { ["Rogue"] = true }, documentId);
+            session.SaveChanges();
+        }
+
+        protected void DeleteDocument(IDocumentStore store, string documentId)
+        {
+            using var session = store.OpenSession();
+            session.Delete(documentId);
+            session.SaveChanges();
+        }
+
+        protected string BuildFakeSnapshotToken(DocumentDatabase database, string conversationId, Dictionary<string, string> revisions)
+        {
+            using (database.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+            {
+                return SnapshotTokenDto.Build(ctx, conversationId, DateTime.UtcNow, revisions);
+            }
+        }
+    }
+}

--- a/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationTokenTests.cs
+++ b/test/SlowTests/Server/Documents/AI/AiAgent/AiAgentForkConversationTokenTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Raven.Client.Documents.Operations.AI.Agents;
+using Tests.Infrastructure;
+using Xunit;
+
+namespace SlowTests.Server.Documents.AI.AiAgent
+{
+    public class AiAgentForkConversationTokenTests : AiAgentForkConversationTestBase
+    {
+        public AiAgentForkConversationTokenTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public void F_SnapshotToken_Parsing_Validation()
+        {
+            // Empty
+            Assert.Throws<InvalidOperationException>(() => ParseToken(""));
+
+            // Not JSON
+            var ex1 = Assert.Throws<InvalidOperationException>(() => ParseToken("not json"));
+            Assert.Contains("Invalid snapshot token format", ex1.Message);
+
+            // Null Revisions
+            var ex2 = Assert.Throws<InvalidOperationException>(() =>
+                ParseToken("{\"ConversationId\":\"x\",\"Revisions\":null}"));
+            Assert.Contains("missing or empty", ex2.Message);
+
+            // Empty Revisions
+            var ex3 = Assert.Throws<InvalidOperationException>(() =>
+                ParseToken("{\"ConversationId\":\"x\",\"Revisions\":[]}"));
+            Assert.Contains("missing or empty", ex3.Message);
+
+            // Missing ConversationId
+            var ex4 = Assert.Throws<InvalidOperationException>(() =>
+                ParseToken("{\"Revisions\":[{\"Id\":\"x\",\"ChangeVector\":\"cv\"}]}"));
+            Assert.Contains("missing ConversationId", ex4.Message);
+
+            // Valid token parses correctly
+            var token = "{\"ConversationId\":\"chats/42\",\"CreatedAt\":\"2026-04-23T14:30:00Z\",\"Revisions\":[{\"Id\":\"chats/42\",\"ChangeVector\":\"A:10-abc\"}]}";
+            var parsed = ParseToken(token);
+            Assert.Equal("chats/42", parsed.ConversationId);
+            Assert.Single(parsed.Revisions);
+            Assert.Equal("chats/42", parsed.Revisions[0].Id);
+            Assert.Equal("A:10-abc", parsed.Revisions[0].ChangeVector);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task F6_Fork_WithTamperedChangeVector_Throws()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var tokenJson = JObject.Parse(r2.SnapshotToken);
+            tokenJson["Revisions"][0]["ChangeVector"] = "TAMPERED:99-fake";
+            var tamperedToken = tokenJson.ToString();
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                await store.AI.ForkConversationAsync(tamperedToken, "forked/1"));
+
+            Assert.Contains("no longer exists", ex.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task F7_Fork_WithTokenFromDifferentDatabase_Throws()
+        {
+            using var storeA = GetDocumentStore();
+            using var storeB = GetDocumentStore();
+
+            var databaseA = await Databases.GetDocumentDatabaseInstanceFor(storeA);
+
+            await RunTurnAsync(databaseA, "chats/1", "turn 1", snapshotBeforeRunning: true);
+            var r2 = await RunTurnAsync(databaseA, "chats/1", "turn 2", snapshotBeforeRunning: true);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+                await storeB.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1"));
+
+            Assert.Contains("no longer exists", ex.Message);
+        }
+
+        [RavenFact(RavenTestCategory.Ai)]
+        public async Task F8_Fork_WithTokenFromDifferentAgent_Succeeds()
+        {
+            using var store = GetDocumentStore();
+            var database = await Databases.GetDocumentDatabaseInstanceFor(store);
+
+            // Create two distinct agent configurations with different names and system prompts
+            var agentA = new AiAgentConfiguration("agent-alpha", "fake-connection",
+                "You are agent alpha.")
+            {
+                Identifier = "agent-alpha-id",
+                SampleObject = "{\"Answer\":\"response\"}"
+            };
+
+            // Create and run the conversation with agentA
+            await RunTurnAsync(database, "chats/1", "turn 1", snapshotBeforeRunning: true, agent: agentA);
+            var r2 = await RunTurnAsync(database, "chats/1", "turn 2", snapshotBeforeRunning: true, agent: agentA);
+
+            // Fork succeeds because the token references revisions, not agent configurations.
+            var forkResult = await store.AI.ForkConversationAsync(r2.SnapshotToken, "forked/1");
+            Assert.Equal("forked/1", forkResult.ConversationId);
+
+            // Verify the forked doc preserves the original agent identifier
+            var forkedDoc = GetDocumentAsJObject(store, "forked/1");
+            Assert.NotNull(forkedDoc);
+            Assert.Equal(agentA.Identifier, forkedDoc["Agent"]?.ToString());
+
+            var messages = await store.AI.GetConversationMessagesAsync("forked/1");
+            Assert.NotNull(messages);
+            Assert.NotEmpty(messages.Messages);
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26452

### Additional description

*NOTE*: This is based off of https://github.com/ravendb/ravendb/pull/22619 and require it.
You can see just those changes on top of that PR here: https://github.com/ayende/ravendb/pull/4709


#### What

Adds the ability to snapshot AI conversation state and fork (or rewind) conversations from those snapshots. Users can branch a conversation from any previous turn, creating "what-if" explorations without losing the original conversation history.

#### How snapshots work

When `SnapshotBeforeRunning` is enabled on `AiConversationCreationOptions`, the server creates a forced revision of the conversation document and all sub-conversation documents (recursively via `SubConversationIds`) before processing each user prompt. Snapshot creation happens after request validation (`TryHandleActionResponses`) but before the LLM call — invalid requests (e.g., action responses combined with a user prompt) are rejected without creating orphan revisions. Snapshots only apply to user prompts, attachments, and artificial actions — not to action response handling.

The revision change vectors are collected into an opaque JSON token (`SnapshotToken`) returned on `AiAnswer<T>`. The token contains the conversation ID, a timestamp from the root revision's `LastModified`, and a flat list of revision entries for the root and all transitive sub-conversations. 

Snapshots can also be created independently via `CreateSnapshotAsync()` without running a turn.

`ForceCreateRevision()` was added to `RevisionsStorage` as a public method, consolidating the force-revision logic.

#### How forking works

`ForkConversationAsync(snapshotToken, newConversationId, expectedChangeVector)` loads the revisions referenced by the token and validates them:
- **Scope check**: each revision ID must be the root conversation or start with `{rootId}/`
- **Collection check**: must belong to `@conversations`
- **Root presence**: the token must contain the root conversation revision

The fork then writes new documents with adjusted sub-conversation ID prefixes (only the leading prefix is replaced — deeper occurrences are preserved). `OpenActionCalls` entries referencing sub-conversations via `SubConversationId` are also adjusted. Attachments are copied from each revision using `CopyAttachment` with `AttachmentType.Revision`. Existing attachments on the target are deleted.

When forking to an existing conversation ID (rewind-in-place), orphaned sub-conversations are deleted recursively via `SubConversationIds` traversal with a visited set to handle cycles. The fork supports an optional `expectedChangeVector` parameter, verified only on the root document. The token itself is trusted — there is no trust boundary between generation and consumption.

#### Snapshot listing

`GetConversationSnapshotsAsync()` returns available snapshots with cursor-based paging by date. It lists all revisions (not just force-created ones) since users may also have collection-level revisions configured. Sub-conversation revisions are collected recursively; missing ones are skipped, producing partial but usable tokens.

#### Purging

`PurgeConversationSnapshotsAsync()` deletes revisions for the conversation and all its sub-conversations (discovered via `SubConversationIds` recursion). The root document is validated to belong to `@conversations`. Supports an optional `before` date for selective purge — revisions older than the cutoff are collected during iteration, then deleted individually via `DeleteRevision` with a single `lastModifiedTicks` for the batch. Without a date, `ForceDeleteAllRevisionsFor` is used.

Snapshot retention is managed by the standard `RevisionsConfiguration` on the `@conversations` collection — no separate retention mechanism.

#### Client API

- `AiConversationCreationOptions.SnapshotBeforeRunning` — flag to create snapshots before each turn (equivalent to `CreateSnapshotAsync()` + `RunAsync()` in a single roundtrip)
- `AiAnswer<T>.SnapshotToken` — opaque token for forking
- `AiOperations.ForkConversationAsync(snapshotToken, newConversationId, expectedChangeVector)` — fork or rewind
- `AiOperations.CreateSnapshotAsync(conversationId)` — snapshot without running a turn (throws if conversation doesn't exist)
- `AiOperations.GetConversationSnapshotsAsync(conversationId, before, pageSize)` — list with cursor paging
- `AiOperations.PurgeConversationSnapshotsAsync(conversationId)` / `PurgeConversationSnapshotsAsync(conversationId, before)` — delete all or before a date (exclusive)
- `AiForkConversationResult` — returns `ConversationId` + `ChangeVector`
- `AiConversationSnapshot` — returns `Token` + `CreatedAt`

#### Server endpoints

- `POST /databases/*/ai/agent/fork` — fork a conversation
- `POST /databases/*/ai/agent/snapshots` — create a snapshot
- `GET /databases/*/ai/agent/snapshots` — list snapshots (with `before` and `pageSize` query params)
- `DELETE /databases/*/ai/agent/snapshots` — purge snapshots (with optional `before` query param)
- Sharded handler stubs for all endpoints

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [x] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [ ] No documentation update is needed

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`)
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [x] No

### UI work

- [x] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
