### PR TITLE
RavenDB-26396 Fix transient cluster formation failure in ETL failover test

### DIFF
--- a/test/RachisTests/DatabaseCluster/EtlFailover.cs
+++ b/test/RachisTests/DatabaseCluster/EtlFailover.cs
@@ -245,7 +245,10 @@ namespace RachisTests.DatabaseCluster
             var srcDb = "ETL-src";
             var dstDb = "ETL-dst";
 
-            var (_, srcRaft) = await CreateRaftCluster(3, shouldRunInMemory: false);
+            var (_, srcRaft) = await CreateRaftCluster(3, shouldRunInMemory: false, customSettings: new Dictionary<string, string>(DefaultClusterSettings)
+            {
+                [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "600"
+            });
             var (_, dstRaft) = await CreateRaftCluster(1);
             var srcNodes = await CreateDatabaseInCluster(srcDb, 2, srcRaft.WebUrl);
             var destNode = await CreateDatabaseInCluster(dstDb, 1, dstRaft.WebUrl);

--- a/test/RachisTests/DatabaseCluster/EtlFailover.cs
+++ b/test/RachisTests/DatabaseCluster/EtlFailover.cs
@@ -245,10 +245,7 @@ namespace RachisTests.DatabaseCluster
             var srcDb = "ETL-src";
             var dstDb = "ETL-dst";
 
-            var (_, srcRaft) = await CreateRaftCluster(3, shouldRunInMemory: false, customSettings: new Dictionary<string, string>(DefaultClusterSettings)
-            {
-                [RavenConfiguration.GetKey(x => x.Cluster.ElectionTimeout)] = "600"
-            });
+            var (_, srcRaft) = await CreateRaftCluster(3, shouldRunInMemory: false);
             var (_, dstRaft) = await CreateRaftCluster(1);
             var srcNodes = await CreateDatabaseInCluster(srcDb, 2, srcRaft.WebUrl);
             var destNode = await CreateDatabaseInCluster(dstDb, 1, dstRaft.WebUrl);
@@ -334,7 +331,7 @@ namespace RachisTests.DatabaseCluster
                 // start server which originally was handling ETL task
                 GetNewServer(new ServerCreationOptions
                 {
-                    CustomSettings = new Dictionary<string, string>
+                    CustomSettings = new Dictionary<string, string>(DefaultClusterSettings)
                         {
                             {RavenConfiguration.GetKey(x => x.Core.ServerUrls), originalResult.Url}
                         },

--- a/test/RachisTests/RavenDB_18013.cs
+++ b/test/RachisTests/RavenDB_18013.cs
@@ -17,7 +17,9 @@ public class RavenDB_18013 : ClusterTestBase
     public RavenDB_18013(ITestOutputHelper output) : base(output)
     {
     }
-    private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(40);
+    private readonly TimeSpan _reasonableWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromSeconds(60);
+    // handler waits must outlive the test orchestration so they don't timeout before the test signals them
+    private readonly TimeSpan _handlerWaitTime = Debugger.IsAttached ? TimeSpan.FromMinutes(15) : TimeSpan.FromMinutes(2);
     [RavenFact(RavenTestCategory.ClusterTransactions)]
     public async Task ShouldHandleDatabaseDeleteWhileItsBeingDeleted()
     {
@@ -51,7 +53,7 @@ public class RavenDB_18013 : ClusterTestBase
                 Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: waiting for '{nameof(deleteDatabaseCommandMre)}'");
 
                 deleteDatabaseCommandHasWaiterMre.Set();
-                var result = deleteDatabaseCommandMre.WaitOne(_reasonableWaitTime);
+                var result = deleteDatabaseCommandMre.WaitOne(_handlerWaitTime);
 
                 Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: '{nameof(deleteDatabaseCommandMre)}' got signaled. Result: {result}");
 
@@ -70,7 +72,7 @@ public class RavenDB_18013 : ClusterTestBase
                 }
                 Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: waiting for '{nameof(removeNodeFromDatabaseCommandMre)}' (1)");
 
-                var result = removeNodeFromDatabaseCommandMre.WaitOne(_reasonableWaitTime);
+                var result = removeNodeFromDatabaseCommandMre.WaitOne(_handlerWaitTime);
                 removeNodeFromDatabaseCommandMre.Reset();
 
                 Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: result of waiting for '{nameof(removeNodeFromDatabaseCommandMre)}': {result} (1)");
@@ -86,7 +88,7 @@ public class RavenDB_18013 : ClusterTestBase
                     Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: incremented '{nameof(c)}', current value: {c}");
                     Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: waiting for '{nameof(removeNodeFromDatabaseCommandMre)}' (2)");
 
-                    result = removeNodeFromDatabaseCommandMre.WaitOne(_reasonableWaitTime);
+                    result = removeNodeFromDatabaseCommandMre.WaitOne(_handlerWaitTime);
 
                     Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: result of waiting for '{nameof(removeNodeFromDatabaseCommandMre)}': {result} (2)");
                 }
@@ -100,7 +102,7 @@ public class RavenDB_18013 : ClusterTestBase
                    documentDatabaseDisposeHasWaiterMre.Set();
                    Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: waiting for '{nameof(documentDatabaseDisposeMre)}'");
 
-                   var result = documentDatabaseDisposeMre.WaitOne(_reasonableWaitTime);
+                   var result = documentDatabaseDisposeMre.WaitOne(_handlerWaitTime);
 
                    Output.WriteLine($"{SystemTime.UtcNow} RavenDB-18013: result of waiting for '{nameof(documentDatabaseDisposeMre)}': {result}");
                }))

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -111,11 +111,11 @@ namespace SlowTests.Issues
 
                 // wait for the failed database instance to be fully unloaded on the target node
                 // (its DisposeInternal may still be running in a background task, holding the db.lock)
-                await WaitForValueAsync(() =>
+                var isLoaded = await WaitForValueAsync(() =>
                 {
-                    var loaded = notInDbGroupServer.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out _);
-                    return Task.FromResult(loaded);
+                    return notInDbGroupServer.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out _);
                 }, false, timeout: 30_000);
+                Assert.False(isLoaded, $"Database '{databaseName}' is still loaded on node '{notInDbGroupServer.ServerStore.NodeTag}' after waiting for it to unload.");
 
                 notInDbGroupServer.ServerStore.PutSecretKey(copy, databaseName, overwrite: true);
                 await AddNodeToGroup(store);

--- a/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
+++ b/test/SlowTests/Issues/EncryptedDatabaseGroup.cs
@@ -109,6 +109,14 @@ namespace SlowTests.Issues
 
                 await DeleteNodeFromGroup(store, notInDbGroupServer);
 
+                // wait for the failed database instance to be fully unloaded on the target node
+                // (its DisposeInternal may still be running in a background task, holding the db.lock)
+                await WaitForValueAsync(() =>
+                {
+                    var loaded = notInDbGroupServer.ServerStore.DatabasesLandlord.DatabasesCache.TryGetValue(databaseName, out _);
+                    return Task.FromResult(loaded);
+                }, false, timeout: 30_000);
+
                 notInDbGroupServer.ServerStore.PutSecretKey(copy, databaseName, overwrite: true);
                 await AddNodeToGroup(store);
                 await TrySavingDocument(store, 2);

--- a/test/SlowTests/Issues/RavenDB-24797.cs
+++ b/test/SlowTests/Issues/RavenDB-24797.cs
@@ -232,9 +232,10 @@ namespace SlowTests.Issues
             EnsureReplicating(storeA, storeB);
 
             // counter conflict (delete + blob) should be resolved to blob
-            AssertTestCounter(storeA, expectedValue: 5);
-            AssertTestCounter(storeB, expectedValue: 5);
-            AssertTestCounter(storeC, expectedValue: 5);
+            // use WaitForValue since replication convergence may take time after conflict resolution
+            Assert.Equal(5, WaitForValue(() => GetTestCounter(storeA), 5L, timeout: 30_000));
+            Assert.Equal(5, WaitForValue(() => GetTestCounter(storeB), 5L, timeout: 30_000));
+            Assert.Equal(5, WaitForValue(() => GetTestCounter(storeC), 5L, timeout: 30_000));
         }
 
         [RavenFact(RavenTestCategory.Counters | RavenTestCategory.Replication)]
@@ -744,6 +745,15 @@ namespace SlowTests.Issues
                 Assert.Equal(expectedValue, counter.Value);
             }
         }
+
+        private static long GetTestCounter(DocumentStore store)
+        {
+            using (var session = store.OpenSession())
+            {
+                return session.CountersFor(TestDocumentId).Get(TestCounterName) ?? -1;
+            }
+        }
+
         private static async Task DisableExternalReplication(ReplicationCreationResult replicationCreationResult)
         {
             replicationCreationResult.Configuration.Disabled = true;


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26396

v6.2 of https://github.com/ravendb/ravendb/pull/22643

### Additional description

Cherry-pick of #22643 to v6.2 (per [review comment](https://github.com/ravendb/ravendb/pull/22643#issuecomment-4312053460)).

The test `WillWorkAfterResponsibleNodeRestart_RavenDB_13237` creates a 3-node disk-based cluster (`shouldRunInMemory: false`) using the default election timeout of 300ms. On slow CI machines (Win x86), disk I/O delays cause heartbeat confirmations to exceed this timeout during cluster formation, making the leader step down.

  Root Cause: The restarted server at line 333 was created with only Core.ServerUrls — it was missing DefaultClusterSettings. This meant it used production defaults:
  - MoveToRehabGraceTime = 60s (vs 1s in tests)
  - StabilizationTime = 5s (vs 1s)
  - AddReplicaTimeout = 15min (vs 1s)

  After the second node disposal (line 370), the restarted server waited 60 seconds to move the disposed node to rehab and reassign the ETL task — far exceeding the 30-second WaitForDocument timeout.

Fix: pass DefaultClusterSettings to the restarted node. Also fixes several other transient test failures:
- RavenDB_18013: use longer handler timeouts (2min) vs test orchestration timeouts (60s)
- EncryptedDatabaseGroup: wait for database to be fully unloaded after DeleteNodeFromGroup
- RavenDB_24797: use WaitForValue for counter conflict resolution assertions


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed