### PR TITLE
RavenDB-26447 Fix cut select options for Font Select

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
@@ -223,6 +223,7 @@ export default function StudioGlobalConfiguration() {
                                                 options={predefinedFontOptions}
                                                 formatOptionLabel={formatFontOptionLabel}
                                                 components={tableFontSelectComponents}
+                                                styles={fontSelectStyles}
                                                 onMenuClose={() => setTableHoveredFont(null)}
                                             />
                                         </FontHoverContext.Provider>
@@ -249,6 +250,7 @@ export default function StudioGlobalConfiguration() {
                                                 options={predefinedFontOptions}
                                                 formatOptionLabel={formatFontOptionLabel}
                                                 components={codeFontSelectComponents}
+                                                styles={fontSelectStyles}
                                                 onMenuClose={() => setCodeHoveredFont(null)}
                                             />
                                         </FontHoverContext.Provider>
@@ -453,6 +455,10 @@ function CodePreview({ fontFamily }: { fontFamily: string }) {
         </div>
     );
 }
+
+const fontSelectStyles = {
+    menuList: (base: Record<string, unknown>) => ({ ...base, maxHeight: "none" }),
+};
 
 const tableFontSelectComponents = { Menu: TableFontMenu, Option: FontPreviewOption };
 const codeFontSelectComponents = { Menu: CodeFontMenu, Option: FontPreviewOption };

--- a/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
+++ b/src/Raven.Studio/typescript/components/pages/resources/manageServer/studioConfiguration/StudioGlobalConfiguration.tsx
@@ -34,7 +34,7 @@ import { useLimitedFeatureAvailability } from "components/utils/licenseLimitsUti
 import FeatureNotAvailableInYourLicensePopoverBody from "components/common/FeatureNotAvailableInYourLicensePopoverBody";
 import PopoverWithHoverWrapper from "components/common/PopoverWithHoverWrapper";
 import { ConditionalPopover } from "components/common/ConditionalPopover";
-import { components as rsComponents, MenuProps, OptionProps } from "react-select";
+import { components as rsComponents, MenuProps, OptionProps, StylesConfig } from "react-select";
 import { ColumnDef, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import VirtualTable from "components/common/virtualTable/VirtualTable";
 import { CellValueWrapper } from "components/common/virtualTable/cells/CellValue";
@@ -456,8 +456,8 @@ function CodePreview({ fontFamily }: { fontFamily: string }) {
     );
 }
 
-const fontSelectStyles = {
-    menuList: (base: Record<string, unknown>) => ({ ...base, maxHeight: "none" }),
+const fontSelectStyles: StylesConfig = {
+    menuList: (base) => ({ ...base, maxHeight: "none" }),
 };
 
 const tableFontSelectComponents = { Menu: TableFontMenu, Option: FontPreviewOption };


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26447

### Additional description

Fix for cut select options dropdown in Font Select section

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
