### PR TITLE
RavenDB-26492 HNSW vector insert: sync EdgesIndexesPerLevel mirror at write sites

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -276,6 +276,17 @@ public partial class Hnsw
                         ref var edgeList = ref edge.EdgesPerLevel[level];
                         edgeList.Add(_searchState.Llt.Allocator, node.NodeId);
 
+                        // Mirror the append into EdgesIndexesPerLevel so RegisterForPreloading
+                        // can skip its O(M) NodeId -> index rebuild. We only update when the
+                        // cache is already populated for this level and was in sync before this
+                        // append; otherwise we leave the lazy rebuild to fix it.
+                        if (edge.EdgesIndexesPerLevel.Count > level)
+                        {
+                            ref var edgeIndexes = ref edge.EdgesIndexesPerLevel[level];
+                            if (edgeIndexes.Count == edgeList.Count - 1)
+                                edgeIndexes.Add(_searchState.Llt.Allocator, currentNodeIndex);
+                        }
+
                         if (edgeList.Count <= _searchState.Options.NumberOfEdges)
                             continue;
 
@@ -303,6 +314,18 @@ public partial class Hnsw
                             foreach (var idx in _candidates)
                             {
                                 edgeList.AddUnsafe(_searchState.GetNodeByIndex(idx).NodeId);
+                            }
+
+                            // _candidates already holds node indexes, so we can rewrite the
+                            // mirrored cache directly without touching the node id table.
+                            if (edge.EdgesIndexesPerLevel.Count > level)
+                            {
+                                ref var edgeIndexes = ref edge.EdgesIndexesPerLevel[level];
+                                edgeIndexes.ResetAndEnsureCapacity(_searchState.Llt.Allocator, _candidates.Count);
+                                foreach (var idx in _candidates)
+                                {
+                                    edgeIndexes.AddUnsafe(idx);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26492

### Additional description

Each `Node` keeps `EdgesIndexesPerLevel` as a node-index mirror of `EdgesPerLevel`, so `RegisterForPreloading` can skip `TryGetNodeById` lookups. The two edge-write sites in `NodePlacement.FindGraphPlacementForNode` (single-edge append and heuristic-filtered rewrite) mutate `EdgesPerLevel` without updating the mirror. `RegisterForPreloading` then sees the `Count` mismatch and rebuilds the mirror by walking every edge through `TryGetNodeById`, an O(M) pass that repeats on every registration.

**Changes:**

- **`FindGraphPlacementForNode`, single-edge append site**: after `edgeList.Add(node.NodeId)`, append `currentNodeIndex` to `EdgesIndexesPerLevel[level]` when the cache is already populated for that level and was in sync before this append.
- **`FindGraphPlacementForNode`, heuristic-rewrite site**: after the filtered rewrite, reset and repopulate `EdgesIndexesPerLevel[level]` from `_candidates`, which already holds node indexes.

When the cache is not yet initialized for a level (`Count <= level`), the writes are skipped and the existing lazy rebuild in `RegisterForPreloading` handles it. Only the parallel batch path is affected; the single-insert path is unchanged.

### Benchmark results (DBpedia-OpenAI 1536D, M=16, efC=64)

| Workload                     | Delta |
|------------------------------|------:|
| Insert vec/s, N=25K, Single  | **+5.4%** (2610 -> 2751) |
| Insert vec/s, N=100K, Single | **+3.8%** |
| Insert vec/s, N=100K, Int8   | **+6.4%** |

Recall and QPS within noise across all configurations.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low
- [ ] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using Documentation Required tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable private)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using QA Required tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using Studio Required tag.
- [x] No UI work is needed
