### PR TITLE
RavenDB-26493 HNSW vector insert: skip preload scan when working set is resident

### DIFF
--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -619,7 +619,7 @@ public partial class Hnsw
             {
                 if (currentNodeIndex is -1)
                     return _indexes.Count > 0; // has work
-                
+
                 ref var n = ref _searchState.GetNodeByIndex(currentNodeIndex);
                 _indexes.Clear();
                 _vectors.Clear();
@@ -628,7 +628,13 @@ public partial class Hnsw
                     _indexes.Add(currentNodeIndex);
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
-                
+
+                // The slow path runs RegisterForPreloading first, which sizes both lists.
+                // The all-in-memory fast path skips that step, so we must guarantee the slot
+                // exists before we ref into it. SetCapacity is a no-op when already sized.
+                n.EdgesPerLevel.SetCapacity(_searchState.Llt.Allocator, level + 1);
+                n.EdgesIndexesPerLevel.SetCapacity(_searchState.Llt.Allocator, level + 1);
+
                 ref var edgesList = ref n.EdgesPerLevel[level];
                 ref var edgesIndexes = ref n.EdgesIndexesPerLevel[level];
                 if (edgesIndexes.Count != edgesList.Count)
@@ -672,6 +678,14 @@ public partial class Hnsw
             private readonly CancellationTokenSource _mainCts;
             private readonly List<Exception> _errors = [];
             private readonly LinkedList<int> _inFlightIndexes = [];
+
+            // Latches to true once an iteration completes with nothing left to preload, meaning
+            // every node touched so far is resident. From that point we skip the RegisterForPreloading
+            // scan (its O(items * edgesPerNode) VectorLoaded / TryGetNodeById sweep) and call
+            // AfterPreloading directly. The fast path stays correct even if the heuristic is wrong
+            // for a future item: GetVectorUnmanagedSpan falls back to a single-vector load on miss,
+            // so the worst case is degrading to one cold load instead of a batched one.
+            private bool _allVectorsInMemory;
 
             public bool IsCancelled => _mainCts.IsCancellationRequested;
             
@@ -739,17 +753,39 @@ public partial class Hnsw
                         return; // done
                     }
                     
+                    if (_allVectorsInMemory)
+                    {
+                        // Fast path: every previously touched node is resident, so the bulk preload
+                        // scan has nothing to find. Dispatch each item directly through AfterPreloading
+                        // and skip RegisterForPreloading entirely.
+                        for (int index = 0; index < _items.Count; index++)
+                        {
+                            WorkItem item = _items[index];
+                            if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level))
+                            {
+                                ThreadPool.UnsafeQueueUserWorkItem(item, preferLocal: false);
+                            }
+                            else
+                            {
+                                Enqueue(item.Iterator);
+                            }
+                        }
+
+                        _items.Clear();
+                        continue;
+                    }
+
                     // we executed all that we could, now let's check if we have
                     // any edges to load that we can do in bulk
                     batch.Clear();
                     for (int index = 0; index < _items.Count; index++)
                     {
                         WorkItem item = _items[index];
-                        if (item.RegisterForPreloading(_searchState, batch)) 
+                        if (item.RegisterForPreloading(_searchState, batch))
                             continue;
-                        
+
                         // we can run this directly, since there is nothing to preload
-                        
+
                         _items[index] = null; // skip it in the rest of the process
                         if (item.Owner.AfterPreloading(item.CurrentNodeIndex, item.Level) is false)
                         {
@@ -765,6 +801,11 @@ public partial class Hnsw
                     if (used > 0)
                     {
                         _searchState.PreloadNodesVectors(batchSpan[..used]);
+                    }
+                    else
+                    {
+                        // The whole working set is resident, switch to the fast path on the next iteration.
+                        _allVectorsInMemory = true;
                     }
 
                     foreach (var item in _items)

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -626,6 +626,11 @@ public partial class Hnsw
                 if (MarkVisited(currentNodeIndex))
                 {
                     _indexes.Add(currentNodeIndex);
+                    // Self-disarm signal: the resident-set fast path skipped RegisterForPreloading
+                    // and reached a vector that was not in fact loaded. Drop the latch so the next
+                    // iteration goes back through the bulk preload scan.
+                    if (n.VectorLoaded is false)
+                        runner.NotifyColdLoad();
                     _vectors.Add(n.GetVectorUnmanagedSpan(_searchState));
                 }
 
@@ -651,6 +656,8 @@ public partial class Hnsw
                         continue; // already checked
                     _indexes.Add(idx);
                     ref var edge = ref _searchState.GetNodeByIndex(idx);
+                    if (edge.VectorLoaded is false)
+                        runner.NotifyColdLoad();
                     _vectors.Add(edge.GetVectorUnmanagedSpan(_searchState));
                 }
 
@@ -679,13 +686,14 @@ public partial class Hnsw
             private readonly List<Exception> _errors = [];
             private readonly LinkedList<int> _inFlightIndexes = [];
 
-            // Latches to true once an iteration completes with nothing left to preload, meaning
-            // every node touched so far is resident. From that point we skip the RegisterForPreloading
-            // scan (its O(items * edgesPerNode) VectorLoaded / TryGetNodeById sweep) and call
-            // AfterPreloading directly. The fast path stays correct even if the heuristic is wrong
-            // for a future item: GetVectorUnmanagedSpan falls back to a single-vector load on miss,
-            // so the worst case is degrading to one cold load instead of a batched one.
+            // Latches to true once an iteration completes with positive residency evidence:
+            // at least one item with CurrentNodeIndex != -1 was scanned, and the resulting
+            // preload batch was empty. Cleared by NotifyColdLoad() the moment AfterPreloading
+            // observes a vector that was not actually resident, so the next iteration falls back
+            // to the bulk preload scan automatically.
             private bool _allVectorsInMemory;
+
+            internal void NotifyColdLoad() => _allVectorsInMemory = false;
 
             public bool IsCancelled => _mainCts.IsCancellationRequested;
             
@@ -778,11 +786,19 @@ public partial class Hnsw
                     // we executed all that we could, now let's check if we have
                     // any edges to load that we can do in bulk
                     batch.Clear();
+                    bool scannedAny = false;
                     for (int index = 0; index < _items.Count; index++)
                     {
                         WorkItem item = _items[index];
-                        if (item.RegisterForPreloading(_searchState, batch))
-                            continue;
+                        // RegisterForPreloading short-circuits on CurrentNodeIndex == -1 without
+                        // touching the batch. Track real residency scans separately so an iteration
+                        // dominated by -1 items cannot falsely latch the resident-set fast path.
+                        if (item.CurrentNodeIndex != -1)
+                        {
+                            scannedAny = true;
+                            if (item.RegisterForPreloading(_searchState, batch))
+                                continue;
+                        }
 
                         // we can run this directly, since there is nothing to preload
 
@@ -802,9 +818,10 @@ public partial class Hnsw
                     {
                         _searchState.PreloadNodesVectors(batchSpan[..used]);
                     }
-                    else
+                    else if (scannedAny)
                     {
                         // The whole working set is resident, switch to the fast path on the next iteration.
+                        // Requires scannedAny so an all-(-1) iteration cannot latch without evidence.
                         _allVectorsInMemory = true;
                     }
 


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26493

### Additional description

The parallel HNSW insert path runs `RegisterForPreloading` on every work item in every `NodePlacementRunner.Run` iteration. That sweep walks each item's edges and checks `Node.VectorLoaded` to decide what needs batched loading. Once the working set is fully resident the sweep finds nothing to load but still pays its full cost on every iteration.

This change latches a flag the first time an iteration completes with an empty preload batch, and from that point dispatches work items straight through `AfterPreloading`. `AfterPreloading` takes over sizing `Node.EdgesPerLevel` and `Node.EdgesIndexesPerLevel`, since the slow path was the only caller that previously guaranteed those slots existed.

The fast path is correctness preserving: if the heuristic latches early for a node whose vector is not yet loaded, `Node.GetVectorUnmanagedSpan` falls back to a single container read on miss. Worst case is one cold load instead of a batched one. Recall is unaffected.

**Stacked on #22717 (RavenDB-26492).** The mirror sync there is what makes the fast path's lazy `EdgesIndexesPerLevel` rebuild in `AfterPreloading` cheap. This PR will show both commits until #22717 merges.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [x] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed