### PR TITLE
RavenDB-26494 HNSW vector insert: derive concurrency cap from L3 cache footprint

### DIFF
--- a/src/Sparrow.Server/Platform/CpuTopology.cs
+++ b/src/Sparrow.Server/Platform/CpuTopology.cs
@@ -1,0 +1,162 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Sparrow.Global;
+using Sparrow.Platform;
+using Sparrow.Server.Platform.Posix;
+using Sparrow.Server.Platform.Posix.macOS;
+
+namespace Sparrow.Server.Platform
+{
+    public static class CpuTopology
+    {
+        // Conservative default for boxes where probing fails or returns nothing useful
+        // (older kernels, ARM64 Linux without sysfs cache nodes, Apple Silicon's unified
+        // memory hierarchy that does not expose a classical L3, Windows on ARM64, etc.).
+        private const long DefaultL3CacheSize = 8L * Constants.Size.Megabyte;
+
+        private static readonly Lazy<long> L3CacheSizeLazy = new(ProbeL3CacheSize, LazyThreadSafetyMode.PublicationOnly);
+
+        public static long L3CacheSize => L3CacheSizeLazy.Value;
+
+        private static long ProbeL3CacheSize()
+        {
+            try
+            {
+                if (PlatformDetails.RunningOnLinux)
+                    return ProbeLinux();
+                if (PlatformDetails.RunningOnMacOsx)
+                    return ProbeMacOs();
+                if (PlatformDetails.RunningOnWindows)
+                    return ProbeWindows();
+            }
+            catch
+            {
+                // best-effort: fall through to the default
+            }
+
+            return DefaultL3CacheSize;
+        }
+
+        private static long ProbeLinux()
+        {
+            // Prefer sysconf: it works without /sys mounted (containers with restricted
+            // filesystem views) and on x86_64 glibc returns the host L3 in bytes directly.
+            // sysconf returns 0 on ARM64 kernels and on musl, so fall back to sysfs there.
+            long fromSysconf = Syscall.sysconf(PerPlatformValues.SysconfNames._SC_LEVEL3_CACHE_SIZE);
+            if (fromSysconf > 0)
+                return fromSysconf;
+
+            const string path = "/sys/devices/system/cpu/cpu0/cache/index3/size";
+            if (File.Exists(path) == false)
+                return DefaultL3CacheSize;
+
+            return ParseSizeWithUnit(File.ReadAllText(path));
+        }
+
+        private static long ParseSizeWithUnit(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return DefaultL3CacheSize;
+
+            var s = raw.Trim();
+            long multiplier = 1;
+            var suffix = s[^1];
+            if (suffix is 'K' or 'k') { multiplier = Constants.Size.Kilobyte; s = s[..^1]; }
+            else if (suffix is 'M' or 'm') { multiplier = Constants.Size.Megabyte; s = s[..^1]; }
+            else if (suffix is 'G' or 'g') { multiplier = Constants.Size.Gigabyte; s = s[..^1]; }
+
+            return long.TryParse(s, out var value) && value > 0
+                ? value * multiplier
+                : DefaultL3CacheSize;
+        }
+
+        private static unsafe long ProbeMacOs()
+        {
+            long value = 0;
+            int len = sizeof(long);
+            int rc = macSyscall.sysctlbyname("hw.l3cachesize", &value, &len, null, UIntPtr.Zero);
+            if (rc == 0 && value > 0)
+                return value;
+
+            // Apple Silicon reports 0 here: the SoC exposes a system-level cache instead
+            // of a per-die L3, and its size varies by chip and is not surfaced via sysctl.
+            // The 8 MiB default is conservative for every shipping M-series part.
+            return DefaultL3CacheSize;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct CacheDescriptor
+        {
+            public byte Level;
+            public byte Associativity;
+            public ushort LineSize;
+            public uint Size;
+            public int Type;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        private struct ProcessorInfoUnion
+        {
+            [FieldOffset(0)] public CacheDescriptor Cache;
+            [FieldOffset(0)] public ulong Reserved0;
+            [FieldOffset(8)] public ulong Reserved1;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct SystemLogicalProcessorInformation
+        {
+            public nuint ProcessorMask;
+            public int Relationship;
+            public ProcessorInfoUnion Info;
+        }
+
+        private const int RelationCache = 2;
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetLogicalProcessorInformation(IntPtr buffer, out uint returnedLength);
+
+        private static unsafe long ProbeWindows()
+        {
+            // First call probes the required buffer size; success is signalled by setting
+            // length even though the call returns false with ERROR_INSUFFICIENT_BUFFER.
+            // If length is still zero the API is unavailable (e.g. ARM64 host); bail out.
+            GetLogicalProcessorInformation(IntPtr.Zero, out uint length);
+            if (length == 0)
+                return DefaultL3CacheSize;
+
+            var buffer = Marshal.AllocHGlobal((int)length);
+            try
+            {
+                if (GetLogicalProcessorInformation(buffer, out length) == false)
+                    return DefaultL3CacheSize;
+
+                int entrySize = sizeof(SystemLogicalProcessorInformation);
+                int count = (int)length / entrySize;
+                // Take the smallest L3 reported. On asymmetric topologies (multi-CCD AMD,
+                // future hybrid Windows-on-ARM split-LLC, etc.) a task may land on the
+                // smaller cache; sizing for that cache is conservative and safe. Symmetric
+                // hosts report the same size in every entry, so min == max in the common case.
+                long smallest = long.MaxValue;
+                var ptr = (SystemLogicalProcessorInformation*)buffer;
+                for (int i = 0; i < count; i++)
+                {
+                    ref var entry = ref ptr[i];
+                    if (entry.Relationship != RelationCache)
+                        continue;
+                    if (entry.Info.Cache.Level != 3)
+                        continue;
+                    if (entry.Info.Cache.Size > 0 && entry.Info.Cache.Size < smallest)
+                        smallest = entry.Info.Cache.Size;
+                }
+
+                return smallest != long.MaxValue ? smallest : DefaultL3CacheSize;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+}

--- a/src/Sparrow.Server/Platform/Posix/PerPlatformValues.cs
+++ b/src/Sparrow.Server/Platform/Posix/PerPlatformValues.cs
@@ -64,6 +64,9 @@ namespace Sparrow.Server.Platform.Posix
                 PlatformDetails.RunningOnMacOsx
                     ? 0x1d
                     : 0x1e;
+
+            // Linux glibc only (macOS sysconf has no cache-size names; we use sysctlbyname there).
+            public const int _SC_LEVEL3_CACHE_SIZE = 194;
         }
     }
 }

--- a/src/Voron/Data/Graphs/Hnsw.Parallel.cs
+++ b/src/Voron/Data/Graphs/Hnsw.Parallel.cs
@@ -134,10 +134,9 @@ public partial class Hnsw
                 _searchState.RegisterNodeLocation(EntryPointId, entryPointNode);
             }
 
-            // Run 1..MaxConcurrentBatches batches here, depending on how much work we have to run
-            int numberOfBatches = Math.Max(1, _searchState.CreatedNodes / MaxConcurrentBatches);
-            // but not too much...
-            int maxTasks = Math.Min(numberOfBatches, MaxConcurrentBatches);
+            int batchSize = Math.Max(MaxConcurrentBatches, _searchState.CreatedNodes / _targetPlacementTasks);
+            int numberOfBatches = Math.Max(1, _searchState.CreatedNodes / batchSize);
+            int maxTasks = Math.Min(numberOfBatches, _targetPlacementTasks);
             NodePlacementRunner runner = new(this, maxTasks, token);
             runner.Run();
         }

--- a/src/Voron/Data/Graphs/Hnsw.cs
+++ b/src/Voron/Data/Graphs/Hnsw.cs
@@ -11,6 +11,7 @@ using Sparrow.Binary;
 using Sparrow.Compression;
 using Sparrow.Platform;
 using Sparrow.Server;
+using Sparrow.Server.Platform;
 using Sparrow.Server.Utils;
 using Voron.Data.BTrees;
 using Voron.Data.CompactTrees;
@@ -632,16 +633,33 @@ public unsafe partial class Hnsw
         public Random Random;
         private readonly CompactTree _vectorsByHash;
         private readonly int _vectorBatchSizeInPages;
+        private readonly int _targetPlacementTasks;
         private readonly ContainerId _globalVectorsContainerId;
         private PostingList _largePostingListSet;
 
         public int AmountOfModifiedVectorsInTransaction => _vectorHashCache.Count;
+
+        // The hot working set per concurrent placement task during distance compute is
+        // the query vector plus the NumberOfCandidates neighbor vectors being scored
+        // against it. Once the aggregate of that across all in-flight tasks spills L3
+        // the comparison loop becomes memory bound. Reserving a quarter of L3 for the
+        // candidate-vector footprint leaves enough budget for code, per-task scratch
+        // (visited bitmaps, candidate queues), and unrelated working data.
+        private static int ComputeTargetPlacementTasks(in Options options)
+        {
+            const int L3FractionForCandidateVectors = 4;
+            long perTaskCandidateBytes = (long)options.NumberOfCandidates * options.VectorSizeBytes;
+            if (perTaskCandidateBytes <= 0)
+                return 1;
+            return (int)Math.Max(1, CpuTopology.L3CacheSize / (L3FractionForCandidateVectors * perTaskCandidateBytes));
+        }
 
         public Registration(LowLevelTransaction llt, Slice name, Random random = null)
         {
             Random = random ?? Random.Shared;
             _searchState = new SearchState(llt, name);
             _vectorBatchSizeInPages = _searchState.Options.VectorBatchInPages;
+            _targetPlacementTasks = ComputeTargetPlacementTasks(in _searchState.Options);
             _globalVectorsContainerId = ReadGlobalVectorsContainerId(llt);
             _nodesByVectorId = _searchState.Tree.LookupFor<Int64LookupKey>(NodesByVectorIdSlice);
             _vectorsByHash = llt.Transaction.CompactTreeFor(VectorsIdByHashSlice);


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26494

### Additional description

The parallel HNSW insert path used a fixed per-call concurrency cap that ignored the cache footprint of the active working set. Each concurrent `NodePlacement` task keeps a query vector and the `NumberOfCandidates` neighbor vectors it is scoring resident during distance compute, and once the aggregate of that across all in-flight tasks spills L3 the comparison loop becomes memory bound. Throughput is left on the table on workloads with large vectors and on machines with non-trivial cache hierarchies.

**Changes:**

- **`Sparrow.Server.Platform.CpuTopology`** (new): cross-platform L3 size probe. Linux reads sysfs (`/sys/devices/system/cpu/cpu0/cache/index3/size`, works on x86_64 and AArch64); macOS uses `sysctlbyname("hw.l3cachesize")` with a fallback for Apple Silicon's system-level cache; Windows uses `GetLogicalProcessorInformation`. A conservative 8 MiB default applies when the probe fails.
- **`Hnsw.Registration.ComputeTargetPlacementTasks`** (new, static): derives the target concurrent task count from `L3 / (4 * NumberOfCandidates * VectorSizeBytes)`. The 1/4 fraction reserves L3 budget for code, per-task scratch (visited bitmaps, candidate queues), and unrelated working data.
- **`Hnsw.Registration` ctor**: caches the target as `_targetPlacementTasks` alongside `_vectorBatchSizeInPages`, since it depends only on `Options` and host L3, both stable for the lifetime of a `Registration`.
- **`Hnsw.Parallel.InsertVectorsToGraph`**: reads the precomputed target instead of computing per-call.

### Benchmark results (DBpedia-OpenAI 1536D, Int8, M=16, efC=64)

| Workload                    |  Before |   After |    Delta |
|-----------------------------|--------:|--------:|---------:|
| Insert vec/s, N=100K        |    5614 |    5785 |    +3.0% |
| Insert vec/s, N=300K        |    3386 |    4831 |  **+42.7%** |

Recall and QPS within noise across all configurations.

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low
- [x] Moderate
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using \`Documentation Required\` tag.
- [x] No documentation update is needed

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable \`private\`)
- [x] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [x] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using \`QA Required\` tag.
- [ ] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using \`Studio Required\` tag.
- [x] No UI work is needed