### PR TITLE
RavenDB-26485 Memoization match - memory management.

### DIFF
--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -77,7 +77,14 @@ namespace Corax.Querying.Matches
 
         private void InitializeInner()
         {
-            _buffer.Init(_ctx, _inner.Count, _indexSearcher.MaxMemoizationSizeInBytes);
+            var maxItemsInBudget = _indexSearcher.MaxMemoizationSizeInBytes / sizeof(long);
+            var initialSize = _inner.Confidence switch
+            {
+                QueryCountConfidence.High => _inner.Count,
+                QueryCountConfidence.Normal => Math.Min(_inner.Count / 2, maxItemsInBudget),
+                _ => 16,
+            };
+            _buffer.Init(_ctx, initialSize, _indexSearcher.MaxMemoizationSizeInBytes);
 
             while (true)
             {

--- a/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
+++ b/src/Corax/Querying/Matches/MemoizationMatch.Provider.cs
@@ -84,7 +84,9 @@ namespace Corax.Querying.Matches
                 QueryCountConfidence.Normal => Math.Min(_inner.Count / 2, maxItemsInBudget),
                 _ => 16,
             };
-            _buffer.Init(_ctx, initialSize, _indexSearcher.MaxMemoizationSizeInBytes);
+            
+            if (_buffer.TryInit(_ctx, initialSize, _indexSearcher.MaxMemoizationSizeInBytes) == false)
+                ThrowExceededMemoizationSize();
 
             while (true)
             {

--- a/src/Corax/Querying/Matches/Meta/SortHelper.cs
+++ b/src/Corax/Querying/Matches/Meta/SortHelper.cs
@@ -36,6 +36,7 @@ internal sealed unsafe class SortHelper
         long* leftEndPtr = leftPtr + leftLength;
         long* rightEndPtr = rightPtr + rightLength;
 
+        Debug.Assert(leftLength <= rightLength);
         //We've to assert in good order, so lets check which array is "first" (lowest first item)
         var cmp = (*leftPtr & long.MaxValue) - (*rightPtr & long.MaxValue);
         switch (cmp)
@@ -62,6 +63,10 @@ internal sealed unsafe class SortHelper
             long leftValue = *leftPtr++;
             var inc = GallopSearch(leftValue);
             rightPtr += inc;
+            
+            if (rightPtr >= rightEndPtr)
+                break;
+            
             if (leftValue != *rightPtr) 
                 continue;
 

--- a/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
+++ b/src/Corax/Querying/Matches/SpatialMatch/SpatialMatch.cs
@@ -86,7 +86,7 @@ public sealed class SpatialMatch<TBoosting> : IQueryMatch
         return false;
     }
 
-    public long Count => long.MaxValue;
+    public long Count => _indexSearcher.NumberOfEntries;
 
     public SkipSortingResult AttemptToSkipSorting() => SkipSortingResult.WillSkipSorting;
     public QueryCountConfidence Confidence => QueryCountConfidence.Low;

--- a/src/Sparrow.Server/Utils/GrowableBuffer.cs
+++ b/src/Sparrow.Server/Utils/GrowableBuffer.cs
@@ -141,7 +141,7 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
     }
 
     private static void ThrowFailedToInitialize(long initialSize, long maxAllocationInBytes) =>
-        throw new InvalidOperationException($"GrowableBuffer cannot allocate the requested buffer: initialSize={initialSize} items would exceed maxAllocationInBytes={maxAllocationInBytes}. You might want to increase `Indexing.Corax.MaxMemoizationSizeInMb`.");
+        throw new InvalidOperationException($"GrowableBuffer cannot allocate the requested buffer: initialSize={initialSize} items would exceed the configured maximum allocation of {maxAllocationInBytes} bytes.");
 
     private void Grow()
     {

--- a/src/Sparrow.Server/Utils/GrowableBuffer.cs
+++ b/src/Sparrow.Server/Utils/GrowableBuffer.cs
@@ -3,17 +3,17 @@ using Sparrow.Platform;
 
 namespace Sparrow.Server.Utils;
 
-public interface IBufferGrowth
+public unsafe interface IBufferGrowth
 {
+    public static readonly int MaxBufferSizeInBytes = int.MaxValue - sizeof(ByteStringStorage);
+
     public int GetInitialSize(in long initialSize);
     public int GetNewSize(in int currentSizeInBytes);
     public bool GrowingThresholdExceed(in int count, in int sizeInBytes);
 }
 
-public readonly unsafe struct Progressive : IBufferGrowth
+public readonly struct Progressive : IBufferGrowth
 {
-    public static readonly int MaxBufferSizeInBytes = int.MaxValue - sizeof(ByteStringStorage);
-
     public int GetNewSize(in int currentSizeInBytes)
     {
         // Slower growth on 32-bit platforms
@@ -23,8 +23,8 @@ public readonly unsafe struct Progressive : IBufferGrowth
             ? (long)(currentSizeInBytes * platformScalar)
             : (long)currentSizeInBytes * 2;
 
-        if (size > MaxBufferSizeInBytes)
-            size = MaxBufferSizeInBytes;
+        if (size > IBufferGrowth.MaxBufferSizeInBytes)
+            size = IBufferGrowth.MaxBufferSizeInBytes;
 
         int truncated = (int)size;
 
@@ -36,15 +36,15 @@ public readonly unsafe struct Progressive : IBufferGrowth
     {
         // 1/16 left
         var amountOfLongs = (sizeInBytes / sizeof(long));
-        return (amountOfLongs - count) < amountOfLongs / 16;
+        return (amountOfLongs - count) < Math.Max(1, amountOfLongs / 16);
     }
 
     public int GetInitialSize(in long initialSize)
     {
         long suggested = 4 * Math.Min(Math.Max(Sparrow.Global.Constants.Size.Kilobyte, initialSize), 16 * Sparrow.Global.Constants.Size.Kilobyte);
         long size = Math.Max(suggested, initialSize);
-        if (size > MaxBufferSizeInBytes)
-            size = MaxBufferSizeInBytes;
+        if (size > IBufferGrowth.MaxBufferSizeInBytes)
+            size = IBufferGrowth.MaxBufferSizeInBytes;
 
         int truncated = (int)size;
 
@@ -108,22 +108,40 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
 
     public void Init(ByteStringContext context, in long initialSize, long maxAllocationInBytes = long.MaxValue)
     {
+        if (TryInit(context, initialSize, maxAllocationInBytes) == false)
+            ThrowFailedToInitialize(initialSize, maxAllocationInBytes);
+    }
+
+    public bool TryInit(ByteStringContext context, in long initialSize, long maxAllocationInBytes = long.MaxValue)
+    {
         _context = context;
 
-        long clampedMax = Math.Min(Math.Max(0, maxAllocationInBytes), Progressive.MaxBufferSizeInBytes);
+        long clampedMax = Math.Min(Math.Max(0, maxAllocationInBytes), IBufferGrowth.MaxBufferSizeInBytes);
         _maxAllocationInBytes = (int)(clampedMax - (clampedMax % sizeof(long)));
 
-        long initialSizeInBytes = initialSize >= Progressive.MaxBufferSizeInBytes / sizeof(long)
-            ? Progressive.MaxBufferSizeInBytes
-            : initialSize * sizeof(long);
+        int initial;
+        if (initialSize <= 0)
+        {
+            initial = _growthCalculator.GetInitialSize(0);
+        }
+        else
+        {
+            long requested = initialSize >= IBufferGrowth.MaxBufferSizeInBytes / sizeof(long)
+                ? IBufferGrowth.MaxBufferSizeInBytes
+                : initialSize * sizeof(long);
+            initial = (int)(requested - (requested % sizeof(long)));
+        }
 
-        var initial = _growthCalculator.GetInitialSize(initialSizeInBytes);
         if (initial > _maxAllocationInBytes)
-            initial = _maxAllocationInBytes;
+            return false;
 
         _context.Allocate(initial, out _buffer);
         IsInitialized = true;
+        return true;
     }
+
+    private static void ThrowFailedToInitialize(long initialSize, long maxAllocationInBytes) =>
+        throw new InvalidOperationException($"GrowableBuffer cannot allocate the requested buffer: initialSize={initialSize} items would exceed maxAllocationInBytes={maxAllocationInBytes}. You might want to increase `Indexing.Corax.MaxMemoizationSizeInMb`.");
 
     private void Grow()
     {
@@ -142,7 +160,9 @@ public unsafe struct GrowableBuffer<TGrowth> : IDisposable
 
     public void Dispose()
     {
-        _context.Release(ref _buffer);
+        if (_buffer.HasValue)
+            _context.Release(ref _buffer);
         _buffer = default;
+        IsInitialized = false;
     }
 }

--- a/test/FastTests/Corax/Bugs/RavenDB-26485.cs
+++ b/test/FastTests/Corax/Bugs/RavenDB-26485.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Corax.Querying.Matches.Meta;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace FastTests.Corax.Bugs;
+
+public class RavenDB_26485(ITestOutputHelper output) : NoDisposalNeeded(output)
+{
+    [RavenFact(RavenTestCategory.Corax)]
+    public void FindMatchesWillNotGoOutsideTheRanges()
+    {
+        const long different = 123;
+        Span<long> dest = new long[2] { 1, 2 };
+        Span<long> rightSourceBuffer = new long [5] { 1, 2, 3, 4, different };
+
+        
+        Span<long> left = new long [2] { 1, different };
+        Span<long> right = rightSourceBuffer.Slice(0, 4); // we're using native memory inside corax
+        Assert.Equal([1,2,3,4], right);
+        
+        var matches = SortHelper.FindMatches(dest, left, right);
+        Assert.Equal(1, matches);
+    }
+}

--- a/test/SlowTests/Corax/GrowableBufferTests.cs
+++ b/test/SlowTests/Corax/GrowableBufferTests.cs
@@ -18,12 +18,12 @@ public class GrowableBufferTests : NoDisposalNoOutputNeeded
     [InlineData(4 * Sparrow.Global.Constants.Size.Megabyte)]
     [InlineData(8 * Sparrow.Global.Constants.Size.Megabyte)]
     public void CanExtendAndNotLooseAnything(int size) => CanExtendAndNotLooseAnythingBase(size);
-    
+
     [RavenMultiplatformTheory(RavenTestCategory.Corax, RavenArchitecture.AllX64)]
     [InlineData(16 * Sparrow.Global.Constants.Size.Megabyte)]
     [InlineData(32 * Sparrow.Global.Constants.Size.Megabyte)]
     public void CanExtendAndNotLooseAnythingExtended(int size) => CanExtendAndNotLooseAnythingBase(size);
-    
+
     private void CanExtendAndNotLooseAnythingBase(int size)
     {
         using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
@@ -37,14 +37,14 @@ public class GrowableBufferTests : NoDisposalNoOutputNeeded
         {
             growableBuffer.AddUsage(read);
         }
-        
+
         Assert.Equal(size, growableBuffer.Results.Length);
         var results = growableBuffer.Results;
         for (var i = 0; i < size; ++i)
         {
             Assert.Equal(random2.NextInt64(), results[i]);
         }
-        
+
         int Fill(Span<long> buffer)
         {
             var i = 0;
@@ -53,5 +53,47 @@ public class GrowableBufferTests : NoDisposalNoOutputNeeded
 
             return i;
         }
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void TryInitWithNoHintFallsBackToGrowthStrategyDefaultProgressive()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var buffer = new GrowableBuffer<Progressive>();
+
+        Assert.True(buffer.TryInit(bsc, initialSize: 0));
+
+        // Progressive.GetInitialSize(0) yields 4 KB (4 * Constants.Size.Kilobyte).
+        Assert.Equal(4 * Sparrow.Global.Constants.Size.Kilobyte, buffer.AllocatedSizeInBytes);
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void TryInitFailsWhenHintExceedsBudget()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var buffer = new GrowableBuffer<Progressive>();
+
+        Assert.False(buffer.TryInit(bsc, initialSize: 1000, maxAllocationInBytes: 512));
+        Assert.False(buffer.IsInitialized);
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void TryInitFailsWhenStrategyDefaultExceedsBudget()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var buffer = new GrowableBuffer<Progressive>();
+
+        Assert.False(buffer.TryInit(bsc, initialSize: 0, maxAllocationInBytes: 64));
+        Assert.False(buffer.IsInitialized);
+    }
+
+    [RavenFact(RavenTestCategory.Corax)]
+    public void InitThrowsWhenHintExceedsBudget()
+    {
+        using var bsc = new ByteStringContext(SharedMultipleUseFlag.None);
+        using var buffer = new GrowableBuffer<Progressive>();
+
+        Assert.Throws<InvalidOperationException>(() => buffer.Init(bsc, initialSize: 1000, maxAllocationInBytes: 512));
+        Assert.False(buffer.IsInitialized);
     }
 }


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26485 

### Additional description

The main issue here was relying on the Count property of the inner object and not checking the confidentiality of the result. As a result, we allocated too much even when we did not have to, leading to overallocation.

https://github.com/ravendb/ravendb/pull/22700

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
