### PR TITLE
RavenDB-26507 - tasks die in fallback mode after initial load when source table contains a DATE column

### DIFF
--- a/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
+++ b/src/Raven.Server/Documents/CdcSink/MySqlCdcSinkProcess.cs
@@ -112,7 +112,9 @@ public class MySqlCdcSinkProcess : CdcSinkProcess
         ["varbinary"]  = 15,  // MYSQL_TYPE_VARCHAR
 
         // Date/time types
-        ["date"]       = 14,  // MYSQL_TYPE_NEWDATE
+        // MYSQL_TYPE_NEWDATE (14) is an internal storage optimization; binlog row
+        // events emit the legacy MYSQL_TYPE_DATE (10) for `DATE` columns.
+        ["date"]       = 10,  // MYSQL_TYPE_DATE
         ["time"]       = 19,  // MYSQL_TYPE_TIME2
         ["datetime"]   = 18,  // MYSQL_TYPE_DATETIME2
         ["timestamp"]  = 17,  // MYSQL_TYPE_TIMESTAMP2

--- a/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceMySqlTests.cs
+++ b/test/SlowTests/Server/Documents/CdcSink/CdcSinkResilienceMySqlTests.cs
@@ -215,5 +215,68 @@ namespace SlowTests.Server.Documents.CdcSink
             Assert.NotNull(doc2);
             Assert.Equal("During Stop", doc2.Name);
         }
+
+        [RavenFact(RavenTestCategory.Sinks, MySqlRequired = true)]
+        public async Task SchemaChange_FalsePositive_OnStableSchemaWithDateColumn()
+        {
+
+            using var store = GetDocumentStore();
+            using var __ = WithSqlDatabase(Raven.Server.SqlMigration.MigrationProvider.MySQL_MySqlConnector, out var connectionString, out _, dataSet: null, includeData: false);
+
+            ExecuteMySql(connectionString, @"
+                CREATE TABLE items (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    d  DATE
+                )");
+
+            ExecuteMySql(connectionString, "INSERT INTO items (d) VALUES ('2026-01-01')");
+
+            var sqlCs = SetupSqlConnectionString(store, connectionString);
+            var config = new CdcSinkConfiguration
+            {
+                Name = "test-schema-false-positive-date",
+                ConnectionStringName = sqlCs.Name,
+                Tables = new List<CdcSinkTableConfig>
+                {
+                    new CdcSinkTableConfig
+                    {
+                        CollectionName = "Items",
+                        SourceTableName = "items",
+                        PrimaryKeyColumns = new List<string> { "id" },
+                        Columns = new List<CdcColumnMapping>
+                        {
+                            new CdcColumnMapping { Column = "id", Name = "DbId" },
+                            new CdcColumnMapping { Column = "d",  Name = "Date" }
+                        }
+                    }
+                }
+            };
+
+            AddCdcSink(store, config);
+
+            // Initial load arrives — proves the sink is healthy at this point.
+            var firstDoc = await WaitForDocumentAsync<dynamic>(store, "Items/1", timeoutMs: 60_000);
+            Assert.NotNull(firstDoc);
+
+            // Subscribe to ProcessError before the post-init INSERT to catch the bug
+            // deterministically; race it against the document arriving.
+            var errorTask = await WaitForNextProcessError(store, config.Name);
+
+            ExecuteMySql(connectionString, "INSERT INTO items (d) VALUES ('2026-02-02')");
+
+            var docTask = WaitForDocumentAsync<dynamic>(store, "Items/2", timeoutMs: 60_000);
+            var winner = await Task.WhenAny(errorTask, docTask);
+
+            if (winner == errorTask)
+            {
+                var ex = await errorTask;
+                Assert.Fail(
+                    "Schema-change false-positive on stable schema with DATE column. " +
+                    "MySqlDataTypeToBinlogType[\"date\"] disagrees with the binlog wire format. " +
+                    $"Exception: {ex}");
+            }
+
+            Assert.NotNull(await docTask);
+        }
     }
 }


### PR DESCRIPTION

### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26507/CdcSink-MariaDB-tasks-die-in-fallback-mode-after-initial-load-when-source-table-contains-a-DATE-column

### Additional description

This pull request addresses an issue with MySQL `DATE` column handling in the CDC (Change Data Capture) sink, ensuring that schema change false-positives do not occur due to a mismatch between MySQL's internal type codes and the binlog wire format. The main change corrects the mapping for the `date` type, and a new test is added to verify the fix.

**MySQL DATE type handling:**

* Corrected the mapping for the `date` type in `TableInfo` to use `MYSQL_TYPE_DATE` (10) instead of the internal `MYSQL_TYPE_NEWDATE` (14), matching the type code actually emitted in binlog row events.

**Testing and validation:**

* Added a new test, `SchemaChange_FalsePositive_OnStableSchemaWithDateColumn`, to ensure that no schema-change false-positive occurs when syncing tables with a `DATE` column. The test verifies that documents are correctly synced and that no process error is raised due to a type code mismatch.


### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
