### PR TITLE
RavenDB-26232 - Fix premature disposal of blittable objects in `MergedTransactionCommand.ExecuteCmd`

### DIFF
--- a/src/Raven.Server/Documents/Handlers/CountersHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/CountersHandler.cs
@@ -401,12 +401,13 @@ namespace Raven.Server.Documents.Handlers
                 {
                     var etag = _database.DocumentsStorage.GenerateNextEtag();
                     var localCv = _database.DocumentsStorage.GetNewChangeVector(context, etag);
-                    using (cgd.Values)
                     using (var lazyCv = context.GetLazyString(localCv))
                     {
                         cgd.ChangeVector = lazyCv;
                         PutCounters(context, cgd);
                     }
+
+                    _toDispose.Add(cgd.Values);
                 }
 
                 UpdateDocumentsMetadata(context);
@@ -419,11 +420,9 @@ namespace Raven.Server.Documents.Handlers
             {
                 foreach (var toUpdate in _counterUpdates)
                 {
-                    var doc = toUpdate.Value;
-                    using (doc.Data)
-                    {
-                        UpdateDocumentCountersAfterImportBatch(context, toUpdate.Key, doc);
-                    }
+                    UpdateDocumentCountersAfterImportBatch(context, toUpdate.Key, toUpdate.Value);
+
+                    _toDispose.Add(toUpdate.Value.Data);
                 }
             }
 

--- a/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/TimeSeriesHandler.cs
@@ -316,18 +316,17 @@ namespace Raven.Server.Documents.Handlers
                 {
                     foreach (var item in items)
                     {
-                        using (item)
+                        var deletionRangeRequest = new TimeSeriesStorage.DeletionRangeRequest
                         {
-                            var deletionRangeRequest = new TimeSeriesStorage.DeletionRangeRequest
-                            {
-                                DocumentId = docId,
-                                Collection = item.Collection,
-                                Name = item.Name,
-                                From = item.From,
-                                To = item.To
-                            };
-                            tss.DeleteTimestampRange(context, deletionRangeRequest, remoteChangeVector: null, updateMetadata: false);
-                        }
+                            DocumentId = docId,
+                            Collection = item.Collection,
+                            Name = item.Name,
+                            From = item.From,
+                            To = item.To
+                        };
+                        tss.DeleteTimestampRange(context, deletionRangeRequest, remoteChangeVector: null, updateMetadata: false);
+
+                        _toDispose.Add(item);
                     }
 
                     changes += items.Count;
@@ -339,21 +338,20 @@ namespace Raven.Server.Documents.Handlers
 
                     foreach (var item in items)
                     {
-                        using (item)
+                        using (var slicer = new TimeSeriesSliceHolder(context, docId, item.Name).WithBaseline(item.Baseline))
                         {
-                            using (var slicer = new TimeSeriesSliceHolder(context, docId, item.Name).WithBaseline(item.Baseline))
+                            if (tss.TryAppendEntireSegmentFromSmuggler(context, slicer.TimeSeriesKeySlice, collectionName, item))
                             {
-                                if (tss.TryAppendEntireSegmentFromSmuggler(context, slicer.TimeSeriesKeySlice, collectionName, item))
-                                {
-                                    // on import we remove all @time-series from the document, so we need to re-add them
-                                    tss.AddTimeSeriesNameToMetadata(context, item.DocId, item.Name, NonPersistentDocumentFlags.FromSmuggler);
-                                    continue;
-                                }
+                                // on import we remove all @time-series from the document, so we need to re-add them
+                                tss.AddTimeSeriesNameToMetadata(context, item.DocId, item.Name, NonPersistentDocumentFlags.FromSmuggler);
+                                continue;
                             }
-
-                            var values = item.Segment.YieldAllValues(context, context.Allocator, item.Baseline);
-                            tss.AppendTimestamp(context, docId, item.Collection, item.Name, values, AppendOptionsForSmuggler);
                         }
+
+                        var values = item.Segment.YieldAllValues(context, context.Allocator, item.Baseline);
+                        tss.AppendTimestamp(context, docId, item.Collection, item.Name, values, AppendOptionsForSmuggler);
+
+                        _toDispose.Add(item);
                     }
 
                     changes += items.Count;

--- a/src/Raven.Server/Documents/QueueSink/Commands/BatchQueueSinkScriptCommand.cs
+++ b/src/Raven.Server/Documents/QueueSink/Commands/BatchQueueSinkScriptCommand.cs
@@ -53,7 +53,6 @@ public sealed class BatchQueueSinkScriptCommand : DocumentMergedTransactionComma
                 {
                     processed++;
 
-                    using (message)
                     using (documentScript.Run(context, context, "execute", new object[] {message}))
                     {
                     }

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -280,6 +280,11 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
 
                                 Database.TxMerger.EnqueueSync(command);
 
+                                foreach (var message in messages)
+                                {
+                                    message.Dispose();
+                                }
+
                                 processedSuccessfully = command.ProcessedSuccessfully;
 
                                 _consumer.Commit();


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26232/Document-ID-corruption

### Additional description

## Problem

When the `TransactionOperationsMerger` runs multiple commands in a single merged transaction and that transaction fails, it retries each command independently via `RunEachOperationIndependently`. Each retry reuses the **same command object** but opens a **new transaction context**.

Several `MergedTransactionCommand` subclasses were disposing blittable objects (or other `IDisposable` items) that live in the command's own fields **during `ExecuteCmd`**. On retry the fields still held references to the already-disposed objects, causing failures.

## Affected commands

| Command | What was disposed early |
|---|---|
| `SmugglerCounterBatchCommand` | `cgd.Values` (`BlittableJsonReaderObject`) and `doc.Data` from `_counterGroups` / `_counterUpdates` |
| `SmugglerTimeSeriesBatchCommand` | `TimeSeriesItem` / `TimeSeriesDeletedRangeItemForSmuggler` entries from `_dictionary` / `_deletedRanges` |
| `BatchQueueSinkScriptCommand` | `BlittableJsonReaderObject` entries from the injected `_messages` list |

## Fix

- **`SmugglerCounterBatchCommand` / `SmugglerTimeSeriesBatchCommand`**: removed the `using` wrappers around field-owned objects inside `ExecuteCmd`; the objects are now added to the existing `_toDispose` list and cleaned up in the command's `Dispose()`, which is called only after the transaction commits successfully.
- **`BatchQueueSinkScriptCommand`**: removed `using (message)` from the execution loop; `QueueSinkProcess` now disposes the messages after `EnqueueSync` returns (i.e. after commit).

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
