### PR TITLE
RavenDB-25823 Resolve custom certificate path from settings.json if provided, attempt to create a directory for target path

### DIFF
--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -6,6 +6,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -939,12 +940,19 @@ namespace Raven.Server.Commercial
                 onProgress(progress);
             }
 
-            var certPath = serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath)) ?? Path.Combine(AppContext.BaseDirectory, certificateFileName);
+            settingsJsonObject.TryGet(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath), out string setupResultingCertPath);
+
+            var certPath = setupResultingCertPath
+                           ?? serverStore.Configuration.GetSetting(RavenConfiguration.GetKey(x => x.Core.SetupResultingServerCertificatePath))
+                           ?? Path.Combine(AppContext.BaseDirectory, certificateFileName);
 
             try
             {
                 progress.AddInfo($"Saving server certificate at {certPath}.");
                 onProgress(progress);
+
+                var certDirectory = Path.GetDirectoryName(certPath);
+                Directory.CreateDirectory(certDirectory);
 
                 await using (var certFile = SafeFileStream.Create(certPath, FileMode.Create))
                 {
@@ -957,6 +965,12 @@ namespace Raven.Server.Commercial
                 {
                     PosixHelper.EnsureRWPermissionsForOwnerAndGroup(certPath);
                 }
+            }
+            catch (Exception e) when (e is UnauthorizedAccessException or SecurityException)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to save server certificate at '{certPath}'. The RavenDB process does not have the required permissions to write to this location. " +
+                    $"Either grant the process write access to the target directory or choose a different certificate path.", e);
             }
             catch (Exception e)
             {

--- a/src/Raven.Server/Commercial/SetupManager.cs
+++ b/src/Raven.Server/Commercial/SetupManager.cs
@@ -952,7 +952,7 @@ namespace Raven.Server.Commercial
                 onProgress(progress);
 
                 var certDirectory = Path.GetDirectoryName(certPath);
-                Directory.CreateDirectory(certDirectory);
+                IOExtensions.CreateDirectory(certDirectory);
 
                 await using (var certFile = SafeFileStream.Create(certPath, FileMode.Create))
                 {


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-25823/Setup-Wizard-Copy-the-certificate-to-a-given-custom-certificate-path-when-loading-the-setup-package

### Additional description

If user provides a custom server certificate path when creating cluster from setup package, we want to create relevant directory that we copy the certificate to

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
