### PR TITLE
RavenDB-26520 Enhance deletion warning for Map-Reduce indexes with Output Collections in a cluster

### DIFF
--- a/src/Raven.Studio/typescript/components/pages/database/indexes/shared/DeleteIndexesConfirmBody.tsx
+++ b/src/Raven.Studio/typescript/components/pages/database/indexes/shared/DeleteIndexesConfirmBody.tsx
@@ -62,13 +62,23 @@ export default function DeleteIndexesConfirmBody({
             {showWarning && (
                 <>
                     <hr />
-                    <RichAlert variant="warning">
-                        Note: <br />
-                        &apos;Reduce Results Collections&apos; were created by above index(es).
-                        <br />
-                        Clicking &apos;Delete&apos; will delete the index(es) but Not the Results Collection(s).
-                        <br />
-                        Go to the collection itself to manually remove documents.
+                    <RichAlert variant="warning" className="align-items-start">
+                        <div>
+                            &apos;Reduce Results Collections&apos; were created by the index(es).
+                            <ul className="mt-2 mb-2 ps-3">
+                                <li>
+                                    <strong>Note</strong>:<br />
+                                    Clicking &apos;Delete&apos; will remove the index(es), but not the Reduce Results
+                                    Collection(s). You need to manually remove the documents from these collections.
+                                </li>
+                                <li className="mt-1">
+                                    <strong>Important</strong>:<br />
+                                    If running in a cluster, these documents must be deleted from{" "}
+                                    <strong>each node individually</strong>, because their deletion is not replicated
+                                    between nodes.
+                                </li>
+                            </ul>
+                        </div>
                     </RichAlert>
                 </>
             )}

--- a/src/Raven.Studio/wwwroot/App/views/database/indexes/deleteIndexesConfirm.html
+++ b/src/Raven.Studio/wwwroot/App/views/database/indexes/deleteIndexesConfirm.html
@@ -6,10 +6,10 @@
                 <i class="icon-cancel"></i>
             </button>
         </div>
-        <div class="modal-body force-text-wrap">
+        <div class="modal-body">
             <p data-bind="visible: indexesInfoForDelete?.length > 0, html: subTitleHtml"></p>
             <ul data-bind="foreach: indexesInfoForDelete" style="max-height: 200px; overflow-y: auto;">
-                <li class="padding padding-xs">
+                <li class="padding padding-xs force-text-wrap">
                     <strong data-bind="text: indexName"></strong>
                     <small data-bind="if: reduceOutputCollection">
                         <span data-bind="visible: referenceCollection, text: '(Reduce Results Collections: ' + reduceOutputCollection + ', ' + referenceCollection + ')'" class="margin-left margin-left-sm"></span>
@@ -19,20 +19,29 @@
             </ul>
             <p data-bind="visible: lockedIndexNames?.length > 0">Skipping locked indexes:</p>
             <ul data-bind="foreach: lockedIndexNames" style="max-height: 200px; overflow-y: auto;">
-                <li class="padding padding-xs">
+                <li class="padding padding-xs force-text-wrap">
                     <strong data-bind="text: $data"></strong>
                 </li>
             </ul>
             <hr data-bind="visible: showWarning">
             <div data-bind="if: showWarning, visible: showWarning" class="flex-horizontal text-warning bg-warning margin">
-                <span class="flex-start padding padding-xs">
+                <span class="flex-start padding padding-sm">
                     <i class="icon-warning"></i>
                 </span>
-                <span class="padding padding-xs">
-                     Note: <br>  
-                    'Reduce Results Collections' were created by above index(es).<br>  
-                     Clicking 'Delete' will delete the index(es) but Not the Results Collection(s).<br>
-                     Go to the collection itself to manually remove documents.                    
+                <span class="padding padding-sm">
+                    'Reduce Results Collections' were created by the index(es).
+                    <ul class="margin-top-sm margin-bottom-sm padding-left-sm padding-right-xs">
+                        <li>
+                            <strong>Note</strong>:<br/>
+                            Clicking 'Delete' will remove the index(es), but not the Reduce Results Collection(s).
+                            You need to manually remove the documents from these collections.
+                        </li>
+                        <li class="margin-top-xs">
+                            <strong>Important</strong>:<br/>
+                            If running in a cluster, these documents must be deleted from <strong>each node individually</strong>,
+                            because their deletion is not replicated between nodes.
+                        </li>
+                    </ul>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
### Issue link
https://issues.hibernatingrhinos.com/issue/RavenDB-26520

### Additional description
* Enhance the deletion warning for map-reduce indexes with output collections.
* Fixed both html & tsx file.

### Type of change
- [x] Bug fix => Usability
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?
- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility
- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?
- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update
- [x] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag. (https://issues.hibernatingrhinos.com/issue/RDoc-3833/Map-Reduce-output-collection-clarify-manual-deletion)
- [ ] No documentation update is needed 

### Testing by Contributor
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [x] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team
- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?
- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work
- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
