### PR TITLE
RavenDB-26538 - Fix PostgreSQL integration memory usage by streaming query results

### DIFF
--- a/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
+++ b/src/Raven.Server/Documents/Queries/Dynamic/CollectionQueryRunner.cs
@@ -64,7 +64,7 @@ namespace Raven.Server.Documents.Queries.Dynamic
 
             QueryRunner.AssertValidQuery(query, result);
 
-            using (queryContext.OpenReadTransaction())
+            using (queryContext.AreTransactionsOpened() == false ? queryContext.OpenReadTransaction() : null)
             {
                 FillCountOfResultsAndIndexEtag(result, query.Metadata, queryContext);
 

--- a/src/Raven.Server/Documents/Queries/StreamDocumentQueryResult.cs
+++ b/src/Raven.Server/Documents/Queries/StreamDocumentQueryResult.cs
@@ -10,6 +10,7 @@ namespace Raven.Server.Documents.Queries
     public sealed class StreamDocumentQueryResult : StreamQueryResult<Document>
     {
         private readonly DocumentsOperationContext _context;
+        private readonly bool _hasTokenTimeout;
 
         public override async ValueTask AddResultAsync(Document result, CancellationToken token)
         {
@@ -19,7 +20,8 @@ namespace Raven.Server.Documents.Queries
             using (result)
                 await GetWriter().AddResultAsync(result, token).ConfigureAwait(false);
 
-            GetToken().Delay();
+            if (_hasTokenTimeout)
+                GetToken().Delay();
         }
 
         public StreamDocumentQueryResult(HttpResponse response, IStreamQueryResultWriter<Document> writer, DocumentsOperationContext context,
@@ -28,6 +30,7 @@ namespace Raven.Server.Documents.Queries
             if (response.HasStarted)
                 throw new InvalidOperationException("You cannot start streaming because response has already started.");
             _context = context;
+            _hasTokenTimeout = token.HasTimeout;
         }
     }
 }

--- a/src/Raven.Server/Integrations/PostgreSQL/Messages/Parse.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/Messages/Parse.cs
@@ -81,7 +81,6 @@ namespace Raven.Server.Integrations.PostgreSQL.Messages
             {
                 if (transaction.Session.NamedStatements.TryAdd(StatementName, transaction._currentQuery) == false)
                     throw new ArgumentException($"Failed to store statement under the name '{StatementName}', there is already a statement with such name.");
-                transaction._currentQuery.IsNamedStatement = true;
             }
             await writer.WriteAsync(messageBuilder.ParseComplete(), token);
         }

--- a/src/Raven.Server/Integrations/PostgreSQL/NopHttpResponse.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/NopHttpResponse.cs
@@ -20,7 +20,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
         public override HttpContext HttpContext => throw new NotSupportedException();
         public override int StatusCode { get; set; }
-        public override IHeaderDictionary Headers => throw new NotSupportedException();
+        public override IHeaderDictionary Headers => new HeaderDictionary();
         public override Stream Body { get; set; } = Stream.Null;
         public override long? ContentLength { get; set; }
         public override string ContentType { get; set; }

--- a/src/Raven.Server/Integrations/PostgreSQL/NopHttpResponse.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/NopHttpResponse.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Raven.Server.Integrations.PostgreSQL
+{
+    /// <summary>
+    /// A no-op HttpResponse used when invoking the streaming query pipeline outside of an HTTP context
+    /// (e.g. from the PostgreSQL wire-protocol integration). HasStarted always returns false so the
+    /// StreamQueryResult guard never throws.
+    /// </summary>
+    internal sealed class NopHttpResponse : HttpResponse
+    {
+        public static readonly NopHttpResponse Instance = new();
+
+        private NopHttpResponse() { }
+
+        public override bool HasStarted => false;
+
+        public override HttpContext HttpContext => throw new NotSupportedException();
+        public override int StatusCode { get; set; }
+        public override IHeaderDictionary Headers => throw new NotSupportedException();
+        public override Stream Body { get; set; } = Stream.Null;
+        public override long? ContentLength { get; set; }
+        public override string ContentType { get; set; }
+        public override IResponseCookies Cookies => throw new NotSupportedException();
+
+        public override void OnStarting(Func<object, Task> callback, object state) { }
+        public override void OnCompleted(Func<object, Task> callback, object state) { }
+        public override void Redirect(string location, bool permanent) { }
+    }
+}

--- a/src/Raven.Server/Integrations/PostgreSQL/NopHttpResponse.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/NopHttpResponse.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 
 namespace Raven.Server.Integrations.PostgreSQL
 {

--- a/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgQuery.cs
@@ -23,7 +23,6 @@ namespace Raven.Server.Integrations.PostgreSQL
         public Dictionary<string, object> Parameters;
         protected readonly Dictionary<string, PgColumn> Columns;
         private short[] _resultColumnFormatCodes;
-        public bool IsNamedStatement { get; set; } = false;
 
         protected PgQuery(string queryString, int[] parametersDataTypes)
         {

--- a/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
@@ -62,6 +62,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         {
             var jsonResult = result.Data;
 
+            // ArrayPool.Rent may return an array larger than _columns.Count; clear only the used portion.
             Array.Clear(_row, 0, _columns.Count);
 
             if (_idIndex != null && result.Id != null)

--- a/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
@@ -24,6 +24,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         private readonly short? _idIndex;
         private readonly short _jsonIndex;
         private readonly ReadOnlyMemory<byte>?[] _row;
+        private readonly Action<string, BlittableJsonReaderObject.PropertyDetails, object, ReadOnlyMemory<byte>?[]> _handleSpecialColumns;
 
         public bool SupportStatistics => false;
         public int Count { get; private set; }
@@ -32,11 +33,13 @@ namespace Raven.Server.Integrations.PostgreSQL
             PipeWriter pipeWriter,
             MessageBuilder builder,
             Dictionary<string, PgColumn> columns,
+            Action<string, BlittableJsonReaderObject.PropertyDetails, object, ReadOnlyMemory<byte>?[]> handleSpecialColumns,
             DocumentDatabase documentDatabase)
         {
             _pipeWriter = pipeWriter;
             _builder = builder;
             _columns = columns;
+            _handleSpecialColumns = handleSpecialColumns;
             _documentDatabase = documentDatabase;
             _row = ArrayPool<ReadOnlyMemory<byte>?>.Shared.Rent(columns.Count);
 
@@ -79,6 +82,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 jsonResult.GetPropertyByIndex(index, ref prop);
 
                 _row[pgColumn.ColumnIndex] = RqlQuery.GetValueByType(prop, prop.Value, pgColumn);
+                _handleSpecialColumns.Invoke(columnName, prop, prop.Value, _row);
 
                 jsonResult.Modifications.Remove(columnName);
             }

--- a/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
 using Raven.Server.Documents;
+using Raven.Server.Documents.Indexes;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Integrations.PostgreSQL.Messages;
 using Raven.Server.ServerWide.Context;
@@ -20,11 +21,11 @@ namespace Raven.Server.Integrations.PostgreSQL
         private readonly PipeWriter _pipeWriter;
         private readonly MessageBuilder _builder;
         private readonly Dictionary<string, PgColumn> _columns;
-        private readonly DocumentDatabase _documentDatabase;
         private readonly short? _idIndex;
         private readonly short _jsonIndex;
         private readonly ReadOnlyMemory<byte>?[] _row;
         private readonly Action<string, BlittableJsonReaderObject.PropertyDetails, object, ReadOnlyMemory<byte>?[]> _handleSpecialColumns;
+        private readonly DocumentsOperationContext _context;
 
         public bool SupportStatistics => false;
         public int Count { get; private set; }
@@ -34,13 +35,13 @@ namespace Raven.Server.Integrations.PostgreSQL
             MessageBuilder builder,
             Dictionary<string, PgColumn> columns,
             Action<string, BlittableJsonReaderObject.PropertyDetails, object, ReadOnlyMemory<byte>?[]> handleSpecialColumns,
-            DocumentDatabase documentDatabase)
+            DocumentsOperationContext context)
         {
             _pipeWriter = pipeWriter;
             _builder = builder;
             _columns = columns;
             _handleSpecialColumns = handleSpecialColumns;
-            _documentDatabase = documentDatabase;
+            _context = context;
             _row = ArrayPool<ReadOnlyMemory<byte>?>.Shared.Rent(columns.Count);
 
             if (columns.TryGetValue(Constants.Documents.Indexing.Fields.DocumentIdFieldName, out var idCol))
@@ -89,12 +90,8 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             if (jsonResult.Modifications.Removals.Count != jsonResult.Count)
             {
-                using (_documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
-                using (ctx.OpenReadTransaction())
-                {
-                    var modified = ctx.ReadObject(jsonResult, "renew");
-                    _row[_jsonIndex] = Encoding.UTF8.GetBytes(modified.ToString());
-                }
+                using var modified = _context.ReadObject(jsonResult, "renew");
+                _row[_jsonIndex] = Encoding.UTF8.GetBytes(modified.ToString());
             }
 
             await _pipeWriter.WriteAsync(_builder.DataRow(_row[.._columns.Count]), token);

--- a/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Raven.Client;
+using Raven.Server.Documents;
+using Raven.Server.Documents.Queries;
+using Raven.Server.Integrations.PostgreSQL.Messages;
+using Raven.Server.Integrations.PostgreSQL.Types;
+using Raven.Server.ServerWide.Context;
+using Sparrow.Json;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Server.Integrations.PostgreSQL
+{
+    internal sealed class PgStreamDocumentQueryResultWriter : IStreamQueryResultWriter<Document>
+    {
+        private readonly PipeWriter _pipeWriter;
+        private readonly MessageBuilder _builder;
+        private readonly Dictionary<string, PgColumn> _columns;
+        private readonly DocumentDatabase _documentDatabase;
+        private readonly short? _idIndex;
+        private readonly short _jsonIndex;
+        private readonly ReadOnlyMemory<byte>?[] _row;
+
+        public bool SupportStatistics => false;
+        public int Count { get; private set; }
+
+        public PgStreamDocumentQueryResultWriter(
+            PipeWriter pipeWriter,
+            MessageBuilder builder,
+            Dictionary<string, PgColumn> columns,
+            DocumentDatabase documentDatabase)
+        {
+            _pipeWriter = pipeWriter;
+            _builder = builder;
+            _columns = columns;
+            _documentDatabase = documentDatabase;
+            _row = ArrayPool<ReadOnlyMemory<byte>?>.Shared.Rent(columns.Count);
+
+            if (columns.TryGetValue(Constants.Documents.Indexing.Fields.DocumentIdFieldName, out var idCol))
+                _idIndex = idCol.ColumnIndex;
+
+            _jsonIndex = columns[Constants.Documents.Querying.Fields.PowerBIJsonFieldName].ColumnIndex;
+        }
+
+        public void StartResponse() { }
+        public void StartResults() { }
+        public void EndResults() { }
+        public void EndResponse() { }
+        public void WriteQueryStatistics(long resultEtag, bool isStale, string indexName, long totalResults, DateTime timestamp) { }
+        public ValueTask WriteErrorAsync(Exception e) => default;
+        public ValueTask WriteErrorAsync(string error) => default;
+
+        public async ValueTask AddResultAsync(Document result, CancellationToken token)
+        {
+            var jsonResult = result.Data;
+
+            Array.Clear(_row, 0, _columns.Count);
+
+            if (_idIndex != null && result.Id != null)
+                _row[_idIndex.Value] = Encoding.UTF8.GetBytes(result.Id.ToString());
+
+            jsonResult.Modifications = new DynamicJsonValue(jsonResult);
+
+            if (jsonResult.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject _))
+                jsonResult.Modifications.Remove(Constants.Documents.Metadata.Key);
+
+            BlittableJsonReaderObject.PropertyDetails prop = default;
+
+            foreach (var (columnName, pgColumn) in _columns)
+            {
+                var index = jsonResult.GetPropertyIndex(columnName);
+                if (index == -1)
+                    continue;
+
+                jsonResult.GetPropertyByIndex(index, ref prop);
+
+                _row[pgColumn.ColumnIndex] = RqlQuery.GetValueByType(prop, prop.Value, pgColumn);
+
+                jsonResult.Modifications.Remove(columnName);
+            }
+
+            if (jsonResult.Modifications.Removals.Count != jsonResult.Count)
+            {
+                using (_documentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext ctx))
+                using (ctx.OpenReadTransaction())
+                {
+                    var modified = ctx.ReadObject(jsonResult, "renew");
+                    _row[_jsonIndex] = Encoding.UTF8.GetBytes(modified.ToString());
+                }
+            }
+
+            await _pipeWriter.WriteAsync(_builder.DataRow(_row[.._columns.Count]), token);
+            Count++;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            ArrayPool<ReadOnlyMemory<byte>?>.Shared.Return(_row);
+            return default;
+        }
+    }
+}

--- a/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PgStreamDocumentQueryResultWriter.cs
@@ -9,7 +9,6 @@ using Raven.Client;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Queries;
 using Raven.Server.Integrations.PostgreSQL.Messages;
-using Raven.Server.Integrations.PostgreSQL.Types;
 using Raven.Server.ServerWide.Context;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -100,7 +99,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
         public ValueTask DisposeAsync()
         {
-            ArrayPool<ReadOnlyMemory<byte>?>.Shared.Return(_row);
+            ArrayPool<ReadOnlyMemory<byte>?>.Shared.Return(_row, clearArray: true);
             return default;
         }
     }

--- a/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIRqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIRqlQuery.cs
@@ -35,7 +35,7 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
             return Columns.Values;
         }
 
-        protected override void HandleSpecialColumnsIfNeeded(string columnName, BlittableJsonReaderObject.PropertyDetails property, object value, ref ReadOnlyMemory<byte>?[] row)
+        protected override void HandleSpecialColumnsIfNeeded(string columnName, BlittableJsonReaderObject.PropertyDetails property, object value, ReadOnlyMemory<byte>?[] row)
         {
             if (_replaces == null) 
                 return;
@@ -71,7 +71,7 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
 
                 row[replaceColumn.ColumnIndex] = replaceValueBytes;
 
-                HandleSpecialColumnsIfNeeded(replace.DstColumnName, property, replacedValue, ref row);
+                HandleSpecialColumnsIfNeeded(replace.DstColumnName, property, replacedValue, row);
             }
         }
     }

--- a/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIRqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIRqlQuery.cs
@@ -16,10 +16,8 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
             _replaces = replaces;
         }
 
-        protected override async Task<ICollection<PgColumn>> GenerateSchema()
+        protected override Task<ICollection<PgColumn>> GenerateSchema(List<Document> samples)
         {
-            await base.GenerateSchema();
-
             if (_replaces != null)
             {
                 foreach (var replace in _replaces.Values)
@@ -32,7 +30,7 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
                 }
             }
 
-            return Columns.Values;
+            return Task.FromResult<ICollection<PgColumn>>(Columns.Values);
         }
 
         protected override void HandleSpecialColumnsIfNeeded(string columnName, BlittableJsonReaderObject.PropertyDetails property, object value, ref ReadOnlyMemory<byte>?[] row)

--- a/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIRqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/PowerBI/PowerBIRqlQuery.cs
@@ -16,8 +16,10 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
             _replaces = replaces;
         }
 
-        protected override Task<ICollection<PgColumn>> GenerateSchema(List<Document> samples)
+        protected override async Task<ICollection<PgColumn>> GenerateSchema()
         {
+            await base.GenerateSchema();
+
             if (_replaces != null)
             {
                 foreach (var replace in _replaces.Values)
@@ -30,7 +32,7 @@ namespace Raven.Server.Integrations.PostgreSQL.PowerBI
                 }
             }
 
-            return Task.FromResult<ICollection<PgColumn>>(Columns.Values);
+            return Columns.Values;
         }
 
         protected override void HandleSpecialColumnsIfNeeded(string columnName, BlittableJsonReaderObject.PropertyDetails property, object value, ref ReadOnlyMemory<byte>?[] row)

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -236,7 +236,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 if (_limit.HasValue)
                     indexQuery.PageSize = _limit.Value;
 
-                await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, DocumentDatabase);
+                await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, HandleSpecialColumnsIfNeeded, DocumentDatabase);
 
                 using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown, token);
                 await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, cancelToken);
@@ -250,7 +250,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             
         }
 
-        protected virtual void HandleSpecialColumnsIfNeeded(string columnName, BlittableJsonReaderObject.PropertyDetails property, object value, ref ReadOnlyMemory<byte>?[] row)
+        protected virtual void HandleSpecialColumnsIfNeeded(string columnName, BlittableJsonReaderObject.PropertyDetails property, object value, ReadOnlyMemory<byte>?[] row)
         {
         }
 

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -23,6 +23,7 @@ namespace Raven.Server.Integrations.PostgreSQL
     {
         protected readonly DocumentDatabase DocumentDatabase;
         private QueryOperationContext _queryOperationContext;
+        private List<Document> _samples;
         private readonly int? _limit;
         private bool _queryWasRun;
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<PgSession>("Postgres RqlQuery");
@@ -56,8 +57,8 @@ namespace Raven.Server.Integrations.PostgreSQL
             if (IsEmptyQuery)
                 return default;
 
-            var sample = await RunRqlQuery();
-            return await GenerateSchema(sample);
+            _samples = await RunRqlQuery();
+            return await GenerateSchema();
         }
 
         private async Task<List<Document>> RunRqlQuery(string forcedQueryToRun = null)
@@ -80,9 +81,9 @@ namespace Raven.Server.Integrations.PostgreSQL
             return documentQueryResult.Results;
         }
 
-        protected virtual async Task<ICollection<PgColumn>> GenerateSchema(List<Document> samples)
+        protected virtual async Task<ICollection<PgColumn>> GenerateSchema()
         {
-            if (samples == null || samples.Count == 0)
+            if (_samples == null || _samples.Count == 0)
             {
                 var query = QueryMetadata.ParseQuery(QueryString, QueryType.Select);
 
@@ -90,15 +91,15 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 var queryWithoutFiltering = query.ToString();
 
-                samples = await RunRqlQuery(queryWithoutFiltering);
+                _samples = await RunRqlQuery(queryWithoutFiltering);
 
-                if (samples == null || samples.Count == 0)
+                if (_samples == null || _samples.Count == 0)
                     return Array.Empty<PgColumn>();
             }
 
             var resultsFormat = GetDefaultResultsFormat();
 
-            if (samples[0].Id != null)
+            if (_samples[0].Id != null)
                 Columns[Constants.Documents.Indexing.Fields.DocumentIdFieldName] = new PgColumn(Constants.Documents.Indexing.Fields.DocumentIdFieldName, (short)Columns.Count, PgText.Default, resultsFormat);
 
             BlittableJsonReaderObject.PropertyDetails prop = default;
@@ -106,7 +107,7 @@ namespace Raven.Server.Integrations.PostgreSQL
             // If there's a null value in a particular column of the record, don't write null type to the schema.
             // Instead, iterate over results trying to find a record with the value filled in this column.
             // Keep 'unchecked type' columns names in the list below. 
-            var uncheckedTypePropertiesNames = samples[0].Data.GetPropertyNames().ToList();
+            var uncheckedTypePropertiesNames = _samples[0].Data.GetPropertyNames().ToList();
             
             // Skip metadata() column, so it will be added later to json() column
             uncheckedTypePropertiesNames.Remove(Constants.Documents.Metadata.Key);
@@ -117,9 +118,9 @@ namespace Raven.Server.Integrations.PostgreSQL
                 Columns.TryAdd(property, new PgColumn(property, (short)Columns.Count, PgJson.Default, resultsFormat));
             
             // Go through results - we'll try to find all properties types.
-            for (int sampleIndex = 0; sampleIndex < samples.Count && sampleIndex < 1000; sampleIndex++)
+            for (int sampleIndex = 0; sampleIndex < _samples.Count && sampleIndex < 1000; sampleIndex++)
             {
-                Document sample = samples[sampleIndex];
+                Document sample = _samples[sampleIndex];
                 
                 // Iterate over the columns which type hasn't been figured out yet
                 var uncheckedTypePropertiesNamesCopy = uncheckedTypePropertiesNames.ToArray();
@@ -220,7 +221,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                     return;
                 }
 
-                if (_limit == 0)
+                if (_limit == 0 || _samples == null || _samples.Count == 0)
                 {
                     await writer.WriteAsync(builder.CommandComplete($"SELECT 0"), token);
                     return;
@@ -329,6 +330,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         {
             _queryOperationContext?.Dispose();
             _queryOperationContext = null;
+            _samples = null;
         }
         
         public override void Dispose()

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -243,7 +243,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 if (_limit.HasValue)
                     indexQuery.PageSize = _limit.Value;
 
-                await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, HandleSpecialColumnsIfNeeded, DocumentDatabase);
+                await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, HandleSpecialColumnsIfNeeded, _queryOperationContext.Documents);
 
                 using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown, token);
                 await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, cancelToken);

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -28,7 +28,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         private bool _queryWasRun;
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<PgSession>("Postgres RqlQuery");
 
-        private const int SchemaInferenceSampleSize = 100;
+        private const int SchemaInferenceSampleSize = 1024;
 
         ~RqlQuery()
         {

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -23,7 +23,6 @@ namespace Raven.Server.Integrations.PostgreSQL
     {
         protected readonly DocumentDatabase DocumentDatabase;
         private QueryOperationContext _queryOperationContext;
-        private List<Document> _result;
         private readonly int? _limit;
         private bool _queryWasRun;
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<PgSession>("Postgres RqlQuery");
@@ -49,8 +48,6 @@ namespace Raven.Server.Integrations.PostgreSQL
         public RqlQuery(string queryString, int[] parametersDataTypes, DocumentDatabase documentDatabase, int? limit = null) : base(queryString, parametersDataTypes)
         {
             DocumentDatabase = documentDatabase;
-
-            _result = null;
             _limit = limit;
         }
 
@@ -59,11 +56,8 @@ namespace Raven.Server.Integrations.PostgreSQL
             if (IsEmptyQuery)
                 return default;
 
-            // Sample only a small number of documents for schema inference.
-            // The full result set is streamed during Execute().
-            _result = await RunRqlQuery();
-
-            return await GenerateSchema();
+            var sample = await RunRqlQuery();
+            return await GenerateSchema(sample);
         }
 
         private async Task<List<Document>> RunRqlQuery(string forcedQueryToRun = null)
@@ -86,11 +80,9 @@ namespace Raven.Server.Integrations.PostgreSQL
             return documentQueryResult.Results;
         }
 
-        protected virtual async Task<ICollection<PgColumn>> GenerateSchema()
+        protected virtual async Task<ICollection<PgColumn>> GenerateSchema(List<Document> samples)
         {
-            List<Document> samples;
-
-            if (_result == null || _result?.Count == 0)
+            if (samples == null || samples.Count == 0)
             {
                 var query = QueryMetadata.ParseQuery(QueryString, QueryType.Select);
 
@@ -98,16 +90,10 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 var queryWithoutFiltering = query.ToString();
 
-                var results = await RunRqlQuery(queryWithoutFiltering);
+                samples = await RunRqlQuery(queryWithoutFiltering);
 
-                if (results == null || results.Count == 0)
+                if (samples == null || samples.Count == 0)
                     return Array.Empty<PgColumn>();
-
-                samples = results;
-            }
-            else
-            {
-                samples = _result;
             }
 
             var resultsFormat = GetDefaultResultsFormat();
@@ -234,14 +220,6 @@ namespace Raven.Server.Integrations.PostgreSQL
                     return;
                 }
 
-                if (_result == null)
-                {
-                    if (IsNamedStatement)
-                        _result = await RunRqlQuery();
-                    else
-                        throw new InvalidOperationException("RqlQuery.Execute was called when _results = null");
-                }
-
                 if (_limit == 0)
                 {
                     await writer.WriteAsync(builder.CommandComplete($"SELECT 0"), token);
@@ -351,7 +329,6 @@ namespace Raven.Server.Integrations.PostgreSQL
         {
             _queryOperationContext?.Dispose();
             _queryOperationContext = null;
-            _result = null;
         }
         
         public override void Dispose()

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -69,8 +69,13 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             var indexQuery = new IndexQueryServerSide(forcedQueryToRun ?? QueryString, queryParameters);
 
-            // if limit is 0, fetch one document for schema generation
-            indexQuery.PageSize = _limit == 0 ? 1 : SchemaInferenceSampleSize;
+            // if limit is 0, fetch one document for schema generation; otherwise cap to the query limit
+            indexQuery.PageSize = _limit switch
+            {
+                0 => 1,
+                > 0 => Math.Min(_limit.Value, SchemaInferenceSampleSize),
+                _ => SchemaInferenceSampleSize
+            };
 
             using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown);
 

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Linq;
@@ -13,7 +12,6 @@ using Raven.Server.Documents.Queries.AST;
 using Raven.Server.Integrations.PostgreSQL.Messages;
 using Raven.Server.Integrations.PostgreSQL.Types;
 using Raven.Server.ServerWide;
-using Raven.Server.ServerWide.Context;
 using Raven.Server.Utils;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -36,7 +34,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         {
             try
             {
-                if(Logger.IsOperationsEnabled)
+                if (Logger.IsOperationsEnabled)
                     Logger.Operations($"Query '{QueryString ?? "null"}' wasn't disposed properly.{Environment.NewLine}" +
                                       $"Query was run: {_queryWasRun}{Environment.NewLine}" +
                                       $"Are transactions still opened: {_queryOperationContext?.AreTransactionsOpened() ?? false}{Environment.NewLine}");
@@ -63,12 +61,12 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             // Sample only a small number of documents for schema inference.
             // The full result set is streamed during Execute().
-            _result = await RunRqlQuery(pageSize: SchemaInferenceSampleSize);
+            _result = await RunRqlQuery();
 
             return await GenerateSchema();
         }
 
-        public async Task<List<Document>> RunRqlQuery(string forcedQueryToRun = null, int? pageSize = null)
+        private async Task<List<Document>> RunRqlQuery(string forcedQueryToRun = null)
         {
             _queryOperationContext ??= QueryOperationContext.Allocate(DocumentDatabase);
             var parameters = DynamicJsonValue.Convert(Parameters);
@@ -76,15 +74,8 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             var indexQuery = new IndexQueryServerSide(forcedQueryToRun ?? QueryString, queryParameters);
 
-            if (pageSize.HasValue)
-            {
-                // If limit is 0, fetch one document for schema generation
-                indexQuery.PageSize = _limit == 0 ? 1 : pageSize.Value;
-            }
-            else if (_limit != null)
-            {
-                indexQuery.PageSize = _limit.Value == 0 ? 1 : _limit.Value;
-            }
+            // if limit is 0, fetch one document for schema generation
+            indexQuery.PageSize = _limit == 0 ? 1 : SchemaInferenceSampleSize;
 
             _queryWasRun = true;
             var documentQueryResult =
@@ -105,7 +96,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 var queryWithoutFiltering = query.ToString();
 
-                var results = await RunRqlQuery(queryWithoutFiltering, pageSize: SchemaInferenceSampleSize);
+                var results = await RunRqlQuery(queryWithoutFiltering);
 
                 if (results == null || results.Count == 0)
                     return Array.Empty<PgColumn>();
@@ -244,7 +235,7 @@ namespace Raven.Server.Integrations.PostgreSQL
                 if (_result == null)
                 {
                     if (IsNamedStatement)
-                        _result = await RunRqlQuery(pageSize: SchemaInferenceSampleSize);
+                        _result = await RunRqlQuery();
                     else
                         throw new InvalidOperationException("RqlQuery.Execute was called when _results = null");
                 }
@@ -266,7 +257,8 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, DocumentDatabase);
 
-                await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, OperationCancelToken.None);
+                using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown, token);
+                await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, cancelToken);
 
                 await writer.WriteAsync(builder.CommandComplete($"SELECT {streamWriter.Count}"), token);
             }

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -77,9 +77,11 @@ namespace Raven.Server.Integrations.PostgreSQL
             // if limit is 0, fetch one document for schema generation
             indexQuery.PageSize = _limit == 0 ? 1 : SchemaInferenceSampleSize;
 
+            using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown);
+
             _queryWasRun = true;
             var documentQueryResult =
-                await DocumentDatabase.QueryRunner.ExecuteQuery(indexQuery, _queryOperationContext, null, OperationCancelToken.None);
+                await DocumentDatabase.QueryRunner.ExecuteQuery(indexQuery, _queryOperationContext, null, cancelToken);
 
             return documentQueryResult.Results;
         }

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -238,10 +238,6 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, DocumentDatabase);
 
-                // close any transaction left open from schema sampling in Init() / RunRqlQuery()
-                // before ExecuteStreamQuery opens its own read transaction on the same context.
-                _queryOperationContext.CloseTransaction();
-
                 using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown, token);
                 await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, cancelToken);
 

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -257,6 +257,10 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, DocumentDatabase);
 
+                // close any transaction left open from schema sampling in Init() / RunRqlQuery()
+                // before ExecuteStreamQuery opens its own read transaction on the same context.
+                _queryOperationContext.CloseTransaction();
+
                 using var cancelToken = new OperationCancelToken(DocumentDatabase.DatabaseShutdown, token);
                 await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, cancelToken);
 

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -221,11 +221,13 @@ namespace Raven.Server.Integrations.PostgreSQL
                     return;
                 }
 
-                if (_limit == 0 || _samples == null || _samples.Count == 0)
+                if (_limit == 0 || (_samples != null && _samples.Count == 0))
                 {
                     await writer.WriteAsync(builder.CommandComplete($"SELECT 0"), token);
                     return;
                 }
+
+                // _samples == null means resources were released after a previous Execute (named statement re-execution) — proceed normally
 
                 _queryOperationContext ??= QueryOperationContext.Allocate(DocumentDatabase);
 

--- a/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
+++ b/src/Raven.Server/Integrations/PostgreSQL/RqlQuery.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Buffers;
+using System;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Raven.Client;
@@ -30,6 +29,8 @@ namespace Raven.Server.Integrations.PostgreSQL
         private readonly int? _limit;
         private bool _queryWasRun;
         private static readonly Logger Logger = LoggingSource.Instance.GetLogger<PgSession>("Postgres RqlQuery");
+
+        private const int SchemaInferenceSampleSize = 100;
 
         ~RqlQuery()
         {
@@ -60,12 +61,14 @@ namespace Raven.Server.Integrations.PostgreSQL
             if (IsEmptyQuery)
                 return default;
 
-            _result = await RunRqlQuery();
+            // Sample only a small number of documents for schema inference.
+            // The full result set is streamed during Execute().
+            _result = await RunRqlQuery(pageSize: SchemaInferenceSampleSize);
 
             return await GenerateSchema();
         }
 
-        public async Task<List<Document>> RunRqlQuery(string forcedQueryToRun = null)
+        public async Task<List<Document>> RunRqlQuery(string forcedQueryToRun = null, int? pageSize = null)
         {
             _queryOperationContext ??= QueryOperationContext.Allocate(DocumentDatabase);
             var parameters = DynamicJsonValue.Convert(Parameters);
@@ -73,8 +76,12 @@ namespace Raven.Server.Integrations.PostgreSQL
 
             var indexQuery = new IndexQueryServerSide(forcedQueryToRun ?? QueryString, queryParameters);
 
-            // If limit is 0, fetch one document for the schema generation
-            if (_limit != null)
+            if (pageSize.HasValue)
+            {
+                // If limit is 0, fetch one document for schema generation
+                indexQuery.PageSize = _limit == 0 ? 1 : pageSize.Value;
+            }
+            else if (_limit != null)
             {
                 indexQuery.PageSize = _limit.Value == 0 ? 1 : _limit.Value;
             }
@@ -98,7 +105,7 @@ namespace Raven.Server.Integrations.PostgreSQL
 
                 var queryWithoutFiltering = query.ToString();
 
-                var results = await RunRqlQuery(queryWithoutFiltering);
+                var results = await RunRqlQuery(queryWithoutFiltering, pageSize: SchemaInferenceSampleSize);
 
                 if (results == null || results.Count == 0)
                     return Array.Empty<PgColumn>();
@@ -237,86 +244,31 @@ namespace Raven.Server.Integrations.PostgreSQL
                 if (_result == null)
                 {
                     if (IsNamedStatement)
-                        _result = await RunRqlQuery();
+                        _result = await RunRqlQuery(pageSize: SchemaInferenceSampleSize);
                     else
                         throw new InvalidOperationException("RqlQuery.Execute was called when _results = null");
                 }
 
-                if (_limit == 0 || _result == null || _result.Count == 0)
+                if (_limit == 0)
                 {
                     await writer.WriteAsync(builder.CommandComplete($"SELECT 0"), token);
                     return;
                 }
 
-                BlittableJsonReaderObject.PropertyDetails prop = default;
-                var row = ArrayPool<ReadOnlyMemory<byte>?>.Shared.Rent(Columns.Count);
+                _queryOperationContext ??= QueryOperationContext.Allocate(DocumentDatabase);
 
-                try
-                {
-                    short? idIndex = null;
-                    if (Columns.TryGetValue(Constants.Documents.Indexing.Fields.DocumentIdFieldName, out var col))
-                    {
-                        idIndex = col.ColumnIndex;
-                    }
+                var parameters = DynamicJsonValue.Convert(Parameters);
+                var queryParameters = _queryOperationContext.Documents.ReadObject(parameters, "query/parameters");
+                var indexQuery = new IndexQueryServerSide(QueryString, queryParameters);
 
-                    var jsonIndex = Columns[Constants.Documents.Querying.Fields.PowerBIJsonFieldName].ColumnIndex;
+                if (_limit.HasValue)
+                    indexQuery.PageSize = _limit.Value;
 
-                    foreach (var result in _result)
-                    {
-                        var jsonResult = result.Data;
+                await using var streamWriter = new PgStreamDocumentQueryResultWriter(writer, builder, Columns, DocumentDatabase);
 
-                        Array.Clear(row, 0, row.Length);
+                await DocumentDatabase.QueryRunner.ExecuteStreamQuery(indexQuery, _queryOperationContext, NopHttpResponse.Instance, streamWriter, OperationCancelToken.None);
 
-                        if (idIndex != null && result.Id != null)
-                        {
-                            row[idIndex.Value] = Encoding.UTF8.GetBytes(result.Id.ToString());
-                        }
-
-                        jsonResult.Modifications = new DynamicJsonValue(jsonResult);
-
-                        if (jsonResult.TryGet(Constants.Documents.Metadata.Key, out BlittableJsonReaderObject _))
-                        {
-                            // remove @metadata
-                            jsonResult.Modifications.Remove(Constants.Documents.Metadata.Key);
-                        }
-
-                        foreach (var (columnName, pgColumn) in Columns)
-                        {
-                            var index = jsonResult.GetPropertyIndex(columnName);
-                            if (index == -1)
-                                continue;
-
-                            jsonResult.GetPropertyByIndex(index, ref prop);
-
-                            var value = GetValueByType(prop, prop.Value, pgColumn);
-
-                            row[pgColumn.ColumnIndex] = value;
-
-                            HandleSpecialColumnsIfNeeded(columnName, prop, prop.Value, ref row);
-                            
-                            jsonResult.Modifications.Remove(columnName);
-                        }
-
-
-                        if (jsonResult.Modifications.Removals.Count != jsonResult.Count)
-                        {
-                            using (DocumentDatabase.DocumentsStorage.ContextPool.AllocateOperationContext(out DocumentsOperationContext context))
-                            using (context.OpenReadTransaction())
-                            {
-                                var modified = context.ReadObject(jsonResult, "renew");
-                                row[jsonIndex] = Encoding.UTF8.GetBytes(modified.ToString());
-                            }
-                        }
-
-                        await writer.WriteAsync(builder.DataRow(row[..Columns.Count]), token);
-                    }
-                }
-                finally
-                {
-                    ArrayPool<ReadOnlyMemory<byte>?>.Shared.Return(row);
-                }
-
-                await writer.WriteAsync(builder.CommandComplete($"SELECT {_result.Count}"), token);
+                await writer.WriteAsync(builder.CommandComplete($"SELECT {streamWriter.Count}"), token);
             }
             finally
             {
@@ -329,7 +281,7 @@ namespace Raven.Server.Integrations.PostgreSQL
         {
         }
 
-        protected ReadOnlyMemory<byte>? GetValueByType(BlittableJsonReaderObject.PropertyDetails propertyDetails, object value, PgColumn pgColumn)
+        internal static ReadOnlyMemory<byte>? GetValueByType(BlittableJsonReaderObject.PropertyDetails propertyDetails, object value, PgColumn pgColumn)
         {
             switch (propertyDetails.Token & BlittableJsonReaderBase.TypesMask, pgColumn.PgType.Oid)
             {

--- a/src/Raven.Server/ServerWide/OperationCancelToken.cs
+++ b/src/Raven.Server/ServerWide/OperationCancelToken.cs
@@ -73,7 +73,7 @@ namespace Raven.Server.ServerWide
                 return;
 
             if (_cancelAfter == Timeout.InfiniteTimeSpan)
-                throw new InvalidOperationException("Cannot delay cancellation without timeout set.");
+                return; // no timeout set, nothing to delay
 
             if (_sw?.ElapsedMilliseconds < _minimumDelayTimeInMs)
                 return;

--- a/src/Raven.Server/ServerWide/OperationCancelToken.cs
+++ b/src/Raven.Server/ServerWide/OperationCancelToken.cs
@@ -16,6 +16,8 @@ namespace Raven.Server.ServerWide
         public readonly CancellationToken Token;
         private readonly long _minimumDelayTimeInMs;
 
+        public bool HasTimeout => _cancelAfter != Timeout.InfiniteTimeSpan;
+
         public OperationCancelToken(TimeSpan cancelAfter, CancellationToken token)
         {
             ValidateCancelAfter(cancelAfter);
@@ -73,7 +75,7 @@ namespace Raven.Server.ServerWide
                 return;
 
             if (_cancelAfter == Timeout.InfiniteTimeSpan)
-                return; // no timeout set, nothing to delay
+                throw new InvalidOperationException("Cannot delay cancellation without timeout set.");
 
             if (_sw?.ElapsedMilliseconds < _minimumDelayTimeInMs)
                 return;

--- a/test/EmbeddedTests/Server/Integrations/PostgreSQL/RavenDB_26538.cs
+++ b/test/EmbeddedTests/Server/Integrations/PostgreSQL/RavenDB_26538.cs
@@ -1,0 +1,107 @@
+#if NET8_0
+using System.Threading.Tasks;
+using Npgsql;
+using Xunit;
+
+namespace EmbeddedTests.Server.Integrations.PostgreSQL
+{
+    public class RavenDB_26538 : PostgreSqlIntegrationTestBase
+    {
+        [Theory]
+        [InlineData(1024)]
+        [InlineData(20 * 1024)]
+        [InlineData(128 * 1024)]
+        public async Task StreamingLargeDataset_ShouldReturnAllRows(int documentCount)
+        {
+            const string query = "from Items";
+
+            using var store = GetDocumentStore();
+
+            using (var bulkInsert = store.BulkInsert())
+            {
+                for (int i = 0; i < documentCount; i++)
+                    bulkInsert.Store(new Item { Name = $"Item_{i}" }, $"items/{i}");
+            }
+
+            var result = await Act(store, query);
+
+            Assert.NotNull(result);
+            Assert.Equal(documentCount, result.Rows.Count);
+        }
+
+        [Fact]
+        public async Task NamedStatement_ReExecuteWithoutDescribe_ShouldReturnCorrectResults()
+        {
+            const int documentCount = 10;
+            const string query = "from Items";
+
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                for (int i = 0; i < documentCount; i++)
+                    session.Store(new Item { Name = $"Item_{i}" }, $"items/{i}");
+                session.SaveChanges();
+            }
+
+            var connectionString = GetConnectionString(store);
+            await using var connection = new NpgsqlConnection(connectionString);
+            await connection.OpenAsync();
+
+            await using var cmd = new NpgsqlCommand(query, connection);
+
+            // First execution: Parse + Describe + Bind + Execute
+            cmd.Prepare();
+            int firstCount = CountRows(cmd);
+
+            // Second execution: Bind + Execute only (no Describe) — tests named statement re-execution path
+            int secondCount = CountRows(cmd);
+
+            Assert.Equal(documentCount, firstCount);
+            Assert.Equal(documentCount, secondCount);
+        }
+
+        [Fact]
+        public async Task QueryWithNoMatchingResults_ShouldReturnNoRows()
+        {
+            // Tests the streaming path when the query produces zero rows (not the _limit==0 early-exit)
+            const string query = "from Employees where id() = 'employees/nonexistent'";
+
+            using var store = GetDocumentStore();
+            await store.Maintenance.SendAsync(new CreateSampleDataOperation());
+
+            var result = await Act(store, query);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Rows.Count);
+        }
+
+        [Fact]
+        public async Task QueryEmptyCollection_ShouldReturnNoRows()
+        {
+            const string query = "from Items";
+
+            using var store = GetDocumentStore();
+
+            var result = await Act(store, query);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Rows.Count);
+        }
+
+        private class Item
+        {
+            public string Name { get; set; }
+        }
+
+        private static int CountRows(NpgsqlCommand cmd)
+        {
+            int count = 0;
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+                count++;
+            return count;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26538/PostgreSQL-integration-loads-entire-collection-into-memory-when-streaming-results-to-clients

### Additional description

## Problem
The PostgreSQL/PowerBI wire-protocol integration was buffering the **entire query result set** into a `List<Document>` before writing any rows to the client. For large collections this caused unbounded memory growth proportional to the collection size.

## Changes

### `RqlQuery`
- `Init()` now fetches at most `SchemaInferenceSampleSize` (1024) documents for column type inference - no full collection load at schema time.
- `Execute()` now calls `QueryRunner.ExecuteStreamQuery()` instead of `ExecuteQuery()`, so documents flow directly to the Postgres `PipeWriter` one at a time.
- `GetValueByType` promoted to `internal static` to allow reuse in the new writer.

### `PgStreamDocumentQueryResultWriter` _(new)_
Implements `IStreamQueryResultWriter<Document>`. Called by the streaming pipeline for each document — converts it to a Postgres `DataRow` message and writes it straight to the `PipeWriter`. Uses `ArrayPool<T>` for the per-row buffer.

### `NopHttpResponse` _(new)_
A minimal concrete subclass of `HttpResponse` that always returns `false` for `HasStarted`. Used as a singleton (`NopHttpResponse.Instance`) when invoking the streaming pipeline from outside an HTTP context. No existing signatures were changed.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [x] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
