### PR TITLE
RavenDB-26250 Fix Statistics() not populated when called after ToDocumentQuery()

### DIFF
--- a/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
+++ b/src/Raven.Client/Documents/Linq/RavenQueryInspector.cs
@@ -201,7 +201,7 @@ namespace Raven.Client.Documents.Linq
             return new RavenQueryProviderProcessor<T>(
                 _provider.QueryGenerator,
                 _provider.CustomizeQuery,
-                null,
+                AfterQueryExecuted,
                 _highlightings,
                 _indexName,
                 _collectionName,

--- a/test/SlowTests/Issues/RavenDB_26250.cs
+++ b/test/SlowTests/Issues/RavenDB_26250.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using FastTests;
+using Raven.Client.Documents;
+using Raven.Client.Documents.Session;
+using Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SlowTests.Issues
+{
+    public class RavenDB_26250 : RavenTestBase
+    {
+        public RavenDB_26250(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private class Person
+        {
+            public string FirstName { get; set; }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void Statistics_ShouldBePopulated_WhenCalledAfterToDocumentQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Person { FirstName = "Anne" });
+                session.Store(new Person { FirstName = "Robert" });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<Person>()
+                    .Where(x => x.FirstName == "Anne")
+                    .ToDocumentQuery()
+                    .WaitForNonStaleResults()
+                    .Statistics(out QueryStatistics stats)
+                    .ToList();
+
+                Assert.NotNull(stats.IndexName);
+                Assert.Equal(1, results.Count);
+            }
+        }
+
+        [RavenFact(RavenTestCategory.Querying | RavenTestCategory.ClientApi)]
+        public void Statistics_ShouldBePopulated_WhenCalledOnBothSidesOfToDocumentQuery()
+        {
+            using var store = GetDocumentStore();
+
+            using (var session = store.OpenSession())
+            {
+                session.Store(new Person { FirstName = "Anne" });
+                session.Store(new Person { FirstName = "Robert" });
+                session.SaveChanges();
+            }
+
+            using (var session = store.OpenSession())
+            {
+                var results = session.Query<Person>()
+                    .Statistics(out QueryStatistics stats5)
+                    .ToDocumentQuery()
+                    .WaitForNonStaleResults()
+                    .WhereEquals(x => x.FirstName, "Anne")
+                    .OrElse()
+                    .WhereEquals(x => x.FirstName, "Robert")
+                    .Statistics(out QueryStatistics stats6)
+                    .ToList();
+
+                Assert.NotNull(stats5.IndexName);
+                Assert.NotNull(stats6.IndexName);
+                Assert.Equal(2, results.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26250

### Additional description

Added missing `AfterQueryExecuted` which updates query stats

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [x] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [ ] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
