### PR TITLE
RavenDB-22881 Use per-test unique queue names in Azure Queue Storage ETL tests

### DIFF
--- a/test/SlowTests/Server/Documents/ETL/Queue/AzureQueueStorageEtlTestBase.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/AzureQueueStorageEtlTestBase.cs
@@ -13,11 +13,16 @@ namespace SlowTests.Server.Documents.ETL.Queue;
 
 public abstract class AzureQueueStorageEtlTestBase : QueueEtlTestBase
 {
+    private readonly HashSet<string> _definedQueues = new(StringComparer.OrdinalIgnoreCase);
+
     protected AzureQueueStorageEtlTestBase(ITestOutputHelper output) : base(output)
     {
+        QueueNameSuffix = Guid.NewGuid().ToString("N");
     }
 
-    protected string OrdersQueueName => "orders";
+    protected string QueueNameSuffix { get; }
+
+    protected string OrdersQueueName => "orders" + QueueNameSuffix;
 
     protected readonly string[] DefaultCollections = { "orders" };
 
@@ -34,10 +39,10 @@ var orderData = {
 
 for (var i = 0; i < this.OrderLines.length; i++) {
     var line = this.OrderLines[i];
-    orderData.TotalCost += line.Cost*line.Quantity;    
+    orderData.TotalCost += line.Cost*line.Quantity;
 }
-loadToOrders" + @"(orderData, {
-                                                            Id: id(this),                                                            
+loadToOrders" + QueueNameSuffix + @"(orderData, {
+                                                            Id: id(this),
                                                             Type: 'com.github.users',
                                                             Source: '/registrations/direct-signup'
                                                      });
@@ -68,7 +73,14 @@ output('test output')";
             BrokerType = QueueBrokerType.AzureQueueStorage,
             SkipAutomaticQueueDeclaration = skipAutomaticQueueDeclaration
         };
-        
+
+        var queueNames = queues?.Select(x => x.Name).ToArray() ?? transformation.GetCollectionsFromScript();
+        if (queueNames != null)
+        {
+            foreach (var queue in queueNames)
+                _definedQueues.Add(queue.ToLower());
+        }
+
         Etl.AddEtl(store, config,
             new QueueConnectionString
             {
@@ -110,12 +122,21 @@ output('test output')";
     
     private void CleanupQueues()
     {
-        QueueServiceClient client = new(AzureQueueStorageConnectionString);
-        var queues = client.GetQueues();
+        if (_definedQueues.Count == 0 || string.IsNullOrEmpty(AzureQueueStorageConnectionString))
+            return;
 
-        foreach (var queue in queues)
+        QueueServiceClient client = new(AzureQueueStorageConnectionString);
+
+        foreach (var queueName in _definedQueues)
         {
-            client.DeleteQueue(queue.Name);
+            try
+            {
+                client.DeleteQueueAsync(queueName).GetAwaiter().GetResult();
+            }
+            catch (Azure.RequestFailedException ex) when (ex.ErrorCode == "QueueNotFound")
+            {
+                // queue may have never been created (e.g. configuration error tests) - ignore
+            }
         }
     }
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/AzureQueueStorageEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/AzureQueueStorageEtlTests.cs
@@ -67,9 +67,10 @@ public class AzureQueueStorageEtlTests : AzureQueueStorageEtlTestBase
     {
         using (var store = GetDocumentStore())
         {
+            var usersQueueName = "users" + QueueNameSuffix;
             var config = SetupQueueEtlToAzureQueueStorageOnline(store,
-                @$"loadToUsers(this)", new[] { "users" },
-                new[] { new EtlQueue { Name = $"users" } });
+                @$"loadToUsers{QueueNameSuffix}(this)", new[] { "users" },
+                new[] { new EtlQueue { Name = usersQueueName } });
 
             using (var session = store.OpenSession())
             {
@@ -324,9 +325,10 @@ public class AzureQueueStorageEtlTests : AzureQueueStorageEtlTestBase
     {
         using (var store = GetDocumentStore())
         {
+            var usersQueueName = "users" + QueueNameSuffix;
             var config = SetupQueueEtlToAzureQueueStorageOnline(store,
-                @$"loadToUsers(this)", new[] { "Users" },
-                new[] { new EtlQueue { Name = $"Users", DeleteProcessedDocuments = true } });
+                @$"loadToUsers{QueueNameSuffix}(this)", new[] { "Users" },
+                new[] { new EtlQueue { Name = usersQueueName, DeleteProcessedDocuments = true } });
 
             var etlDone = Etl.WaitForEtlToComplete(store);
 
@@ -338,7 +340,7 @@ public class AzureQueueStorageEtlTests : AzureQueueStorageEtlTestBase
 
             await AssertEtlDoneAsync(etlDone, TimeSpan.FromMinutes(1), store.Database, config);
 
-            QueueClient queueClient = CreateAzureQueueStorageClient(AzureQueueStorageConnectionString, "users");
+            QueueClient queueClient = CreateAzureQueueStorageClient(AzureQueueStorageConnectionString, usersQueueName);
             var message = await queueClient.ReceiveMessageAsync();
             var user = JsonConvert.DeserializeObject<CloudEventUserData>(message.Value.MessageText).Data;
 

--- a/test/SlowTests/Server/Documents/ETL/Queue/AzureQueueStorageEtlTests.cs
+++ b/test/SlowTests/Server/Documents/ETL/Queue/AzureQueueStorageEtlTests.cs
@@ -290,7 +290,7 @@ public class AzureQueueStorageEtlTests : AzureQueueStorageEtlTestBase
                         {
                             Name = "simulate",
                             ConnectionStringName = "simulate",
-                            Queues = { new EtlQueue() { Name = "Orders" } },
+                            Queues = { new EtlQueue() { Name = "Orders" + QueueNameSuffix } },
                             BrokerType = QueueBrokerType.AzureQueueStorage,
                             Transforms =
                             {
@@ -308,7 +308,7 @@ public class AzureQueueStorageEtlTests : AzureQueueStorageEtlTestBase
 
                     Assert.Equal(1, result.Summary.Count);
 
-                    Assert.Equal("Orders", result.Summary[0].QueueName);
+                    Assert.Equal("Orders" + QueueNameSuffix, result.Summary[0].QueueName);
                     Assert.Equal("orders/1-A", result.Summary[0].Messages[0].Attributes.Id);
                     Assert.Equal("com.github.users", result.Summary[0].Messages[0].Attributes.Type);
                     Assert.Equal("/registrations/direct-signup",


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-22881

### Additional description

Similar approach to what we do in Kafka ETL tests

### Type of change

- [ ] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
