### PR TITLE
RavenDB-26557 Removes invalid assertion.

### DIFF
--- a/src/Corax/Querying/Matches/Meta/SortHelper.cs
+++ b/src/Corax/Querying/Matches/Meta/SortHelper.cs
@@ -20,8 +20,6 @@ internal sealed unsafe class SortHelper
     private static int FindMatches(long* dst, long* left, int leftLength, long* right, int rightLength)
     {
         // assumptions:
-        // The left is <= than the right, since the left if up to 4K and we'll only get the right
-        // on > 4K elements.
         // 
         // We are called *multiple* times with the same right element, switching the left each time.
         //
@@ -36,7 +34,6 @@ internal sealed unsafe class SortHelper
         long* leftEndPtr = leftPtr + leftLength;
         long* rightEndPtr = rightPtr + rightLength;
 
-        Debug.Assert(leftLength <= rightLength);
         //We've to assert in good order, so lets check which array is "first" (lowest first item)
         var cmp = (*leftPtr & long.MaxValue) - (*rightPtr & long.MaxValue);
         switch (cmp)


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26557

### Additional description

In #22721, I introduced an assertion based on a comment; however, that assumption was incorrect. We use that method when sorting by index, where left is bounded by `SortBatchSize` (8K) and right must be at least `IndexSortingThreshold` (4K) (so it's totally possible to have left > right). The code itself is correct and handles this scenario properly.

### Type of change

- [ ] Bug fix
- [x] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [ ] Low 
- [ ] Moderate 
- [ ] High
- [x] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [x] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [ ] No UI work is needed
