### PR TITLE
RavenDB-26559 Skip EnsureMinimumSize on branch envs in shared-journal mode

### DIFF
--- a/src/Voron/StorageEnvironmentOptions.cs
+++ b/src/Voron/StorageEnvironmentOptions.cs
@@ -811,7 +811,7 @@ namespace Voron
             {
                 var fileInfo = GetJournalFileInfo(journalNumber, journalInfo);
 
-                if (fileInfo.Length < InitialLogFileSize)
+                if (fileInfo.Length < InitialLogFileSize && RootJournal == null)
                 {
                     EnsureMinimumSize(fileInfo);
                 }
@@ -826,7 +826,7 @@ namespace Voron
                 if (ForceUsing32BitsPager || PlatformDetails.Is32Bits)
                     flags |= Pal.OpenFileFlags.DoNotMap;
                 return Pager.Create(this, filename, 0, flags, pageSize: Constants.Storage.JournalPageSize);
-                    }
+            }
 
             private FileInfo GetJournalFileInfo(long journalNumber, JournalInfo journalInfo)
             {
@@ -836,10 +836,10 @@ namespace Voron
                 if (fileInfo.Exists == false)
                     throw new InvalidJournalException(journalNumber, path.FullPath, journalInfo);
                 return fileInfo;
-                }
+            }
 
             private void EnsureMinimumSize(FileInfo fileInfo)
-                {
+            {
                 try
                 {
                     using (var stream = fileInfo.Open(FileMode.OpenOrCreate))

--- a/test/SlowTests.Issues/Issues/RavenDB_26559.cs
+++ b/test/SlowTests.Issues/Issues/RavenDB_26559.cs
@@ -1,0 +1,108 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FastTests;
+using FastTests.Voron.SharedJournal;
+using Raven.Server.Utils;
+using Tests.Infrastructure;
+using Voron;
+using Xunit;
+
+namespace SlowTests.Issues;
+
+public class RavenDB_26559 : RavenTestBase
+{
+    public RavenDB_26559(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [RavenFact(RavenTestCategory.Voron)]
+    public void BranchOpenSucceeds_WhenLinkedJournalIsSmallerThanBranchInitialLogFileSize()
+    {
+        // Reproduces a production hazard with shared journals:
+        //   - Root is configured with MaxLogFileSize smaller than the default 64KB
+        //     InitialLogFileSize (the setter also caps Initial down). On-disk journals
+        //     end up smaller than 64KB.
+        //   - On reopen, branch options use the 64KB InitialLogFileSize default.
+        //     EnsureMinimumSize during branch recovery sees journalLength < 64KB and tries
+        //     to extend the file via FileInfo.Open(FileMode.OpenOrCreate), which uses the
+        //     restrictive FileShare.None.
+        //   - Root has the same hard-linked file open through its Pager, so on Windows
+        //     this fails with IOException ("file is being used by another process").
+        // A branch should not extend journals owned by root - branches in shared mode
+        // should either skip EnsureMinimumSize or use share-friendly flags.
+
+        string rootPath = NewDataPath(suffix: "root");
+        IOExtensions.DeleteDirectory(rootPath);
+        string branchPath = NewDataPath(suffix: "branch");
+        IOExtensions.DeleteDirectory(branchPath);
+
+        // ----- setup: create a 12KB linked journal -----
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+            rootOptions.MaxLogFileSize = 3 * 4096; // 12KB; the setter caps InitialLogFileSize down
+
+            using var root = new StorageEnvironment(rootOptions);
+            using var _ = root.Journal.SharedJournalsScope();
+
+            var mre = new ManualResetEventSlim(false);
+            root.Journal.BranchJournalMerger = new SharedJournalTests.MyJournalMerger(mre);
+
+            StorageEnvironmentOptions branchOptions = null;
+            StorageEnvironment branch = null;
+            try
+            {
+                var setupTask = Task.Run(() =>
+                {
+                    branchOptions = StorageEnvironmentOptions.ForPathForTests(branchPath);
+                    branchOptions.ManualFlushing = true;
+                    branchOptions.ManualSyncing = true;
+                    branchOptions.MaxLogFileSize = 3 * 4096;
+                    branchOptions.RootJournal = root.Journal;
+                    branch = new StorageEnvironment(branchOptions);
+
+                    using var branchTx = branch.WriteTransaction();
+                    branchTx.CreateTree("branchTree").Add("k", "v");
+                    branchTx.Commit();
+                });
+                setupTask.ContinueWith(_ => mre.Set());
+                SharedJournalTests.WaitForTaskAndExecuteBranchTransactions(setupTask, mre, root);
+            }
+            finally
+            {
+                branch?.Dispose();
+                branchOptions?.Dispose();
+            }
+        }
+
+        // ----- trigger: root keeps the 12KB cap so it doesn't pre-extend; branch open
+        //                uses the default 64KB InitialLogFileSize and tries to extend
+        //                the file root currently holds -----
+        {
+            using var rootOptions = StorageEnvironmentOptions.ForPathForTests(rootPath);
+            rootOptions.ManualFlushing = true;
+            rootOptions.ManualSyncing = true;
+            rootOptions.MaxLogFileSize = 3 * 4096; // root's recovery skips EnsureMinimumSize
+
+            using var root = new StorageEnvironment(rootOptions);
+            using var _ = root.Journal.SharedJournalsScope();
+
+            using var branchOptions = StorageEnvironmentOptions.ForPathForTests(branchPath);
+            branchOptions.ManualFlushing = true;
+            branchOptions.ManualSyncing = true;
+            // Deliberately do NOT mirror root's MaxLogFileSize - branch's InitialLogFileSize
+            // stays at the 64KB default while the on-disk journal is 12KB.
+            branchOptions.RootJournal = root.Journal;
+
+            // Branch ctor should succeed. Currently fails with InvalidOperationException
+            // wrapping IOException ("file is being used by another process").
+            using var branch = new StorageEnvironment(branchOptions);
+
+            using (var branchTx = branch.ReadTransaction())
+            {
+                Assert.Equal("v", branchTx.ReadTree("branchTree").Read("k").Reader.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Issue link

https://issues.hibernatingrhinos.com/issue/RavenDB-26559

### Additional description

Branches don't own root's hard-linked journals - root already sized them during its own recovery.

### Type of change

- [x] Bug fix
- [ ] Regression bug fix
- [ ] Optimization
- [ ] New feature

### How risky is the change?

- [x] Low 
- [ ] Moderate 
- [ ] High
- [ ] Not relevant

### Backward compatibility

- [ ] Non breaking change
- [ ] Ensured. Please explain how has it been implemented?
- [ ] Breaking change
- [x] Not relevant

### Is it platform specific issue?

- [ ] Yes. Please list the affected platforms.
- [x] No

### Documentation update

- [ ] This change requires a documentation update. Please mark the issue on YouTrack using `Documentation Required` tag.
- [x] No documentation update is needed 

### Testing by Contributor

- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] Internal classes added to the test class (e.g. entity or index definition classes) have the lowest possible access modifier (preferable `private`) 
- [ ] It has been verified by manual testing
- [ ] Existing tests verify the correct behavior

### Testing by RavenDB QA team

- [ ] This change requires a special QA testing due to possible performance or resources usage implications (CPU, memory, IO). Please mark the issue on YouTrack using `QA Required` tag.
- [x] No special testing by RavenDB QA team is needed

### Is there any existing behavior change of other features due to this change?

- [ ] Yes. Please list the affected features/subsystems and provide appropriate explanation
- [x] No

### UI work

- [ ] It requires further work in the Studio. Please mark the issue on YouTrack using `Studio Required` tag.
- [x] No UI work is needed
